### PR TITLE
Rename project from JWSync to Remindarr

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ docker compose up --build
 
 ## Architecture
 
-**JWSync** — a full-stack app for tracking streaming media releases using JustWatch as the data source. Locale is configurable via env vars (defaults to hr_HR).
+**Remindarr** — a full-stack app for tracking streaming media releases using JustWatch as the data source. Locale is configurable via env vars (defaults to hr_HR).
 
 ### Stack
 - **Runtime**: Bun (with built-in SQLite)

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,5 @@ COPY --from=server-build /app/ ./
 COPY --from=frontend-build /app/frontend/dist ./frontend/dist
 EXPOSE 3000
 VOLUME /app/data
-ENV DB_PATH=/app/data/jwsync.db
+ENV DB_PATH=/app/data/remindarr.db
 CMD ["bun", "run", "server/index.ts"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JWSync
+# Remindarr
 
 A full-stack app for tracking streaming media releases using JustWatch as the data source.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,15 @@
 services:
-  jwsync:
+  remindarr:
     build: .
     ports:
       - "3000:3000"
     volumes:
-      - jwsync-data:/app/data
+      - remindarr-data:/app/data
     environment:
-      - DB_PATH=/app/data/jwsync.db
+      - DB_PATH=/app/data/remindarr.db
       - OIDC_ISSUER_URL=${OIDC_ISSUER_URL:-}
       - OIDC_CLIENT_ID=${OIDC_CLIENT_ID:-}
       - OIDC_CLIENT_SECRET=${OIDC_CLIENT_SECRET:-}
       - OIDC_REDIRECT_URI=${OIDC_REDIRECT_URI:-}
 volumes:
-  jwsync-data:
+  remindarr-data:

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   schema: "./server/db/schema.ts",
   out: "./drizzle",
   dbCredentials: {
-    url: process.env.DB_PATH || "./jwsync.db",
+    url: process.env.DB_PATH || "./remindarr.db",
   },
 });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>JWSync</title>
+    <title>Remindarr</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,7 +14,7 @@ export default function App() {
     <div className="min-h-screen bg-gray-950 text-gray-100">
       <nav className="bg-gray-900 border-b border-gray-800 sticky top-0 z-50">
         <div className="max-w-7xl mx-auto px-4 flex items-center justify-between h-14">
-          <h1 className="text-lg font-bold text-white tracking-tight">JWSync</h1>
+          <h1 className="text-lg font-bold text-white tracking-tight">Remindarr</h1>
           <div className="flex gap-1">
             <NavLink
               to="/"

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -40,7 +40,7 @@ export default function LoginPage() {
   return (
     <div className="min-h-[70vh] flex items-center justify-center">
       <div className="w-full max-w-sm">
-        <h2 className="text-2xl font-bold text-white text-center mb-8">Sign in to JWSync</h2>
+        <h2 className="text-2xl font-bold text-white text-center mb-8">Sign in to Remindarr</h2>
 
         {error && (
           <div className="mb-4 p-3 rounded-lg bg-red-900/50 border border-red-700 text-red-200 text-sm">

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jwsync",
+  "name": "remindarr",
   "version": "1.0.0",
   "scripts": {
     "dev": "concurrently \"bun run dev:server\" \"bun run dev:frontend\"",

--- a/server/config.ts
+++ b/server/config.ts
@@ -7,7 +7,7 @@ export const CONFIG = {
   PAGE_SIZE: 40,
   PAGE_DELAY_MS: 1000,
   PORT: Number(process.env.PORT) || 3000,
-  DB_PATH: process.env.DB_PATH || "./jwsync.db",
+  DB_PATH: process.env.DB_PATH || "./remindarr.db",
   POSTER_BASE_URL: "https://images.justwatch.com/poster",
   ICON_BASE_URL: "https://images.justwatch.com/icon",
   TMDB_API_KEY: process.env.TMDB_API_KEY || "",
@@ -16,7 +16,7 @@ export const CONFIG = {
 
   // Auth
   SESSION_DURATION_HOURS: Number(process.env.SESSION_DURATION_HOURS) || 24 * 7,
-  SESSION_COOKIE_NAME: "jwsync_session",
+  SESSION_COOKIE_NAME: "remindarr_session",
 
   // OIDC (env vars take precedence over DB settings)
   OIDC_ISSUER_URL: process.env.OIDC_ISSUER_URL || "",

--- a/server/index.ts
+++ b/server/index.ts
@@ -80,7 +80,7 @@ setInterval(() => {
   deleteExpiredSessions();
 }, 60 * 60 * 1000);
 
-console.log(`JWSync server running on http://localhost:${CONFIG.PORT}`);
+console.log(`Remindarr server running on http://localhost:${CONFIG.PORT}`);
 
 export default {
   port: CONFIG.PORT,


### PR DESCRIPTION
## Summary
This PR renames the project from "JWSync" to "Remindarr" across all configuration files, documentation, and source code.

## Changes
- Updated project name in `package.json`, `README.md`, and `CLAUDE.md`
- Renamed Docker service, volume, and database references from `jwsync` to `remindarr`
- Updated database file paths from `jwsync.db` to `remindarr.db` in:
  - `docker-compose.yml`
  - `Dockerfile`
  - `server/config.ts`
  - `drizzle.config.ts`
- Updated session cookie name from `jwsync_session` to `remindarr_session`
- Updated UI text in:
  - `frontend/index.html` (page title)
  - `frontend/src/App.tsx` (navigation header)
  - `frontend/src/pages/LoginPage.tsx` (login page heading)
- Updated server startup log message in `server/index.ts`

## Notes
All references to the old project name have been consistently updated throughout the codebase to maintain coherence across configuration, documentation, and user-facing interfaces.

https://claude.ai/code/session_01S1Uu4AUQedFADNgF15gHzw