### PR TITLE
Add OIDC-first login flow with fallback to local auth

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -11,6 +11,9 @@ export default function LoginPage() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const [showLocalLogin, setShowLocalLogin] = useState(false);
+
+  const oidcConfigured = !!providers?.oidc;
 
   // Redirect if already logged in
   useEffect(() => {
@@ -48,61 +51,77 @@ export default function LoginPage() {
           </div>
         )}
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label htmlFor="username" className="block text-sm font-medium text-gray-300 mb-1">
-              Username
-            </label>
-            <input
-              id="username"
-              type="text"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
-              placeholder="admin"
-              autoComplete="username"
-              required
-            />
-          </div>
-
-          <div>
-            <label htmlFor="password" className="block text-sm font-medium text-gray-300 mb-1">
-              Password
-            </label>
-            <input
-              id="password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
-              autoComplete="current-password"
-              required
-            />
-          </div>
-
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full py-2.5 px-4 bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded-lg transition-colors disabled:opacity-50 cursor-pointer"
-          >
-            {loading ? "Signing in..." : "Sign In"}
-          </button>
-        </form>
-
-        {providers?.oidc && (
+        {oidcConfigured && (
           <>
-            <div className="my-6 flex items-center gap-3">
-              <div className="flex-1 h-px bg-gray-700" />
-              <span className="text-xs text-gray-500 uppercase">or</span>
-              <div className="flex-1 h-px bg-gray-700" />
-            </div>
-
             <a
               href="/api/auth/oidc/authorize"
-              className="block w-full py-2.5 px-4 bg-gray-700 hover:bg-gray-600 text-white font-medium rounded-lg transition-colors text-center"
+              className="block w-full py-3 px-4 bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded-lg transition-colors text-center"
             >
-              Sign in with {providers.oidc.name}
+              Sign in with {providers.oidc!.name}
             </a>
+
+            {!showLocalLogin && (
+              <button
+                type="button"
+                onClick={() => setShowLocalLogin(true)}
+                className="mt-4 w-full text-center text-sm text-gray-500 hover:text-gray-300 transition-colors cursor-pointer"
+              >
+                Sign in with username instead
+              </button>
+            )}
+          </>
+        )}
+
+        {(!oidcConfigured || showLocalLogin) && (
+          <>
+            {oidcConfigured && (
+              <div className="my-6 flex items-center gap-3">
+                <div className="flex-1 h-px bg-gray-700" />
+                <span className="text-xs text-gray-500 uppercase">or</span>
+                <div className="flex-1 h-px bg-gray-700" />
+              </div>
+            )}
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label htmlFor="username" className="block text-sm font-medium text-gray-300 mb-1">
+                  Username
+                </label>
+                <input
+                  id="username"
+                  type="text"
+                  value={username}
+                  onChange={(e) => setUsername(e.target.value)}
+                  className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+                  placeholder="admin"
+                  autoComplete="username"
+                  required
+                />
+              </div>
+
+              <div>
+                <label htmlFor="password" className="block text-sm font-medium text-gray-300 mb-1">
+                  Password
+                </label>
+                <input
+                  id="password"
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+                  autoComplete="current-password"
+                  required
+                />
+              </div>
+
+              <button
+                type="submit"
+                disabled={loading}
+                className="w-full py-2.5 px-4 bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded-lg transition-colors disabled:opacity-50 cursor-pointer"
+              >
+                {loading ? "Signing in..." : "Sign In"}
+              </button>
+            </form>
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary
Refactored the LoginPage to prioritize OIDC authentication when configured, while maintaining local username/password login as a fallback option. This improves the user experience for deployments using OIDC by making it the primary authentication method.

## Key Changes
- Added `showLocalLogin` state to toggle between OIDC and local authentication forms
- Introduced `oidcConfigured` computed variable to check if OIDC provider is available
- Restructured conditional rendering to show OIDC button as the primary login method when configured
- Added "Sign in with username instead" link to allow users to switch to local authentication when OIDC is available
- Local login form now only displays when OIDC is not configured or user explicitly chooses local login
- Updated OIDC button styling to match primary action (indigo-600) instead of secondary (gray-700)
- Added divider between OIDC and local login forms only when both are visible

## Implementation Details
- The login flow now follows a progressive disclosure pattern: OIDC first, with local auth available on demand
- When OIDC is not configured, the local login form displays immediately as before
- The divider between authentication methods only appears when showing both options
- Non-null assertion added to OIDC provider name access since it's guaranteed to exist in that context

https://claude.ai/code/session_014XFT2M3jK7b264wDsktjhW