### PR TITLE
Add OIDC admin claim support for automatic role assignment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,7 @@ services:
       - OIDC_CLIENT_ID=${OIDC_CLIENT_ID:-}
       - OIDC_CLIENT_SECRET=${OIDC_CLIENT_SECRET:-}
       - OIDC_REDIRECT_URI=${OIDC_REDIRECT_URI:-}
+      - OIDC_ADMIN_CLAIM=${OIDC_ADMIN_CLAIM:-}
+      - OIDC_ADMIN_VALUE=${OIDC_ADMIN_VALUE:-}
 volumes:
   remindarr-data:

--- a/server/auth/oidc.ts
+++ b/server/auth/oidc.ts
@@ -84,6 +84,7 @@ export async function exchangeCode(code: string, redirectUri: string) {
       sub: claims.sub as string,
       username: (claims.preferred_username || claims.email || claims.sub) as string,
       displayName: (claims.name || claims.preferred_username || null) as string | null,
+      claims,
     };
   }
 
@@ -98,5 +99,6 @@ export async function exchangeCode(code: string, redirectUri: string) {
     sub: userinfo.sub as string,
     username: (userinfo.preferred_username || userinfo.email || userinfo.sub) as string,
     displayName: (userinfo.name || null) as string | null,
+    claims: userinfo as Record<string, unknown>,
   };
 }

--- a/server/config.ts
+++ b/server/config.ts
@@ -23,4 +23,6 @@ export const CONFIG = {
   OIDC_CLIENT_ID: process.env.OIDC_CLIENT_ID || "",
   OIDC_CLIENT_SECRET: process.env.OIDC_CLIENT_SECRET || "",
   OIDC_REDIRECT_URI: process.env.OIDC_REDIRECT_URI || "",
+  OIDC_ADMIN_CLAIM: process.env.OIDC_ADMIN_CLAIM || "",
+  OIDC_ADMIN_VALUE: process.env.OIDC_ADMIN_VALUE || "",
 };

--- a/server/db/repository.ts
+++ b/server/db/repository.ts
@@ -623,6 +623,14 @@ export function updateUserPassword(userId: string, passwordHash: string) {
     .run();
 }
 
+export function updateUserAdmin(userId: string, isAdmin: boolean) {
+  const db = getDb();
+  db.update(users)
+    .set({ isAdmin: isAdmin ? 1 : 0 })
+    .where(eq(users.id, userId))
+    .run();
+}
+
 // ─── Sessions ────────────────────────────────────────────────────────────────
 
 export function createSession(userId: string): string {
@@ -727,7 +735,12 @@ export function getOidcConfig() {
   const redirectUri =
     CONFIG.OIDC_REDIRECT_URI || getSetting("oidc_redirect_uri") || "";
 
-  return { issuerUrl, clientId, clientSecret, redirectUri };
+  const adminClaim =
+    CONFIG.OIDC_ADMIN_CLAIM || getSetting("oidc_admin_claim") || "";
+  const adminValue =
+    CONFIG.OIDC_ADMIN_VALUE || getSetting("oidc_admin_value") || "";
+
+  return { issuerUrl, clientId, clientSecret, redirectUri, adminClaim, adminValue };
 }
 
 export function isOidcConfigured(): boolean {

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -13,7 +13,7 @@ import type { AppEnv } from "../types";
 
 const app = new Hono<AppEnv>();
 
-const OIDC_SETTING_KEYS = ["oidc_issuer_url", "oidc_client_id", "oidc_client_secret", "oidc_redirect_uri"];
+const OIDC_SETTING_KEYS = ["oidc_issuer_url", "oidc_client_id", "oidc_client_secret", "oidc_redirect_uri", "oidc_admin_claim", "oidc_admin_value"];
 
 // GET /api/admin/settings
 app.get("/settings", (c) => {
@@ -36,6 +36,14 @@ app.get("/settings", (c) => {
     redirect_uri: {
       value: getOidcConfig().redirectUri,
       source: CONFIG.OIDC_REDIRECT_URI ? "env" : (dbSettings.oidc_redirect_uri ? "db" : "unset"),
+    },
+    admin_claim: {
+      value: getOidcConfig().adminClaim,
+      source: CONFIG.OIDC_ADMIN_CLAIM ? "env" : (dbSettings.oidc_admin_claim ? "db" : "unset"),
+    },
+    admin_value: {
+      value: getOidcConfig().adminValue,
+      source: CONFIG.OIDC_ADMIN_VALUE ? "env" : (dbSettings.oidc_admin_value ? "db" : "unset"),
     },
   };
 

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -11,6 +11,7 @@ import {
   getUserByProviderSubject,
   createUser,
   updateUserPassword,
+  updateUserAdmin,
 } from "../db/repository";
 import { getDiscovery, generateState, validateState, exchangeCode } from "../auth/oidc";
 import type { AppEnv } from "../types";
@@ -168,8 +169,11 @@ app.get("/oidc/callback", async (c) => {
   }
 
   try {
-    const { redirectUri } = getOidcConfig();
+    const { redirectUri, adminClaim, adminValue } = getOidcConfig();
     const userInfo = await exchangeCode(code, redirectUri);
+
+    // Determine admin status from claims
+    const isAdmin = checkAdminClaim(userInfo.claims, adminClaim, adminValue);
 
     // Find or create user
     let user = getUserByProviderSubject("oidc", userInfo.sub);
@@ -179,8 +183,11 @@ app.get("/oidc/callback", async (c) => {
       if (getUserByUsername(username)) {
         username = `${username}_oidc`;
       }
-      const id = createUser(username, null, userInfo.displayName || undefined, "oidc", userInfo.sub);
+      const id = createUser(username, null, userInfo.displayName || undefined, "oidc", userInfo.sub, isAdmin);
       user = getUserByProviderSubject("oidc", userInfo.sub);
+    } else {
+      // Sync admin status on every login
+      updateUserAdmin(user.id, isAdmin);
     }
 
     const token = createSession(user!.id);
@@ -192,5 +199,25 @@ app.get("/oidc/callback", async (c) => {
     return c.redirect(`/login?error=${encodeURIComponent(err.message)}`);
   }
 });
+
+/** Check if OIDC claims grant admin status based on configured claim/value. */
+function checkAdminClaim(
+  claims: Record<string, unknown>,
+  claimName: string,
+  claimValue: string
+): boolean {
+  if (!claimName || !claimValue) return false;
+
+  const value = claims[claimName];
+  if (value === undefined || value === null) return false;
+
+  // Array claim (e.g. groups: ["admin", "users"])
+  if (Array.isArray(value)) {
+    return value.some((v) => String(v) === claimValue);
+  }
+
+  // String claim (e.g. role: "admin")
+  return String(value) === claimValue;
+}
 
 export default app;


### PR DESCRIPTION
## Summary
This PR adds support for automatically assigning admin status to users based on OIDC claims. Users can now be granted admin privileges during login if their OIDC provider includes a configured claim with a specific value.

## Key Changes
- **OIDC Configuration**: Added two new configuration options (`OIDC_ADMIN_CLAIM` and `OIDC_ADMIN_VALUE`) to specify which claim and value indicate admin status
- **User Creation & Sync**: Modified user creation to set initial admin status based on claims, and added logic to sync admin status on every login
- **Claims Extraction**: Updated OIDC token exchange to return full claims object for evaluation
- **Admin Status Check**: Implemented `checkAdminClaim()` function that supports both array-based claims (e.g., groups) and string-based claims (e.g., role)
- **Database**: Added `updateUserAdmin()` function to update user admin status
- **Admin Settings**: Exposed new OIDC admin configuration options in the admin settings API
- **Environment Configuration**: Added support for `OIDC_ADMIN_CLAIM` and `OIDC_ADMIN_VALUE` environment variables and docker-compose configuration

## Implementation Details
- The `checkAdminClaim()` function handles both array and string claim values, converting values to strings for comparison
- Admin status is synced on every login for existing users, ensuring changes in the OIDC provider are reflected
- Configuration can be set via environment variables or database settings, with environment variables taking precedence
- The feature is optional and safe to leave unconfigured (returns false if claim/value not specified)

https://claude.ai/code/session_01F6ALLkaUfZws5Pf6icQFVp