### PR TITLE
Add episode watch tracking functionality

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -89,6 +89,23 @@ export async function syncEpisodes(): Promise<{ success: boolean; synced: number
   return fetchJson("/episodes/sync", { method: "POST" });
 }
 
+// ─── Watched Episodes ─────────────────────────────────────────────────────────
+
+export async function watchEpisode(episodeId: number): Promise<void> {
+  await fetchJson(`/watched/${episodeId}`, { method: "POST" });
+}
+
+export async function unwatchEpisode(episodeId: number): Promise<void> {
+  await fetchJson(`/watched/${episodeId}`, { method: "DELETE" });
+}
+
+export async function watchEpisodesBulk(episodeIds: number[], watched: boolean): Promise<void> {
+  await fetchJson("/watched/bulk", {
+    method: "POST",
+    body: JSON.stringify({ episodeIds, watched }),
+  });
+}
+
 // ─── Auth ────────────────────────────────────────────────────────────────────
 
 export async function changePassword(currentPassword: string, newPassword: string): Promise<void> {

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from "react";
-import { ChevronLeftIcon, ChevronRightIcon, RefreshCwIcon } from "lucide-react";
-import { getCalendarTitles, syncEpisodes } from "../api";
+import { ChevronLeftIcon, ChevronRightIcon, RefreshCwIcon, CheckCircleIcon, CircleIcon } from "lucide-react";
+import { getCalendarTitles, syncEpisodes, watchEpisode, unwatchEpisode, watchEpisodesBulk } from "../api";
 import TitleList from "../components/TitleList";
 import type { Title, Episode, Offer } from "../types";
 
@@ -144,6 +144,42 @@ export default function CalendarPage() {
   const nextMonth = () => setCurrentMonth(new Date(year, month + 1, 1));
   const today = formatDateKey(new Date());
 
+  const toggleWatched = async (episodeId: number, currentlyWatched: boolean) => {
+    // Optimistic update
+    setEpisodes((prev) =>
+      prev.map((ep) => (ep.id === episodeId ? { ...ep, is_watched: !currentlyWatched } : ep))
+    );
+    try {
+      if (currentlyWatched) {
+        await unwatchEpisode(episodeId);
+      } else {
+        await watchEpisode(episodeId);
+      }
+    } catch (err) {
+      // Revert on error
+      setEpisodes((prev) =>
+        prev.map((ep) => (ep.id === episodeId ? { ...ep, is_watched: currentlyWatched } : ep))
+      );
+      console.error("Failed to toggle watched:", err);
+    }
+  };
+
+  const toggleBulkWatched = async (episodeIds: number[], markWatched: boolean) => {
+    // Optimistic update
+    const idSet = new Set(episodeIds);
+    setEpisodes((prev) =>
+      prev.map((ep) => (idSet.has(ep.id) ? { ...ep, is_watched: markWatched } : ep))
+    );
+    try {
+      await watchEpisodesBulk(episodeIds, markWatched);
+    } catch (err) {
+      setEpisodes((prev) =>
+        prev.map((ep) => (idSet.has(ep.id) ? { ...ep, is_watched: !markWatched } : ep))
+      );
+      console.error("Failed to bulk toggle watched:", err);
+    }
+  };
+
   const handleSyncEpisodes = async () => {
     setSyncing(true);
     try {
@@ -253,7 +289,9 @@ export default function CalendarPage() {
                           key={item.type === "title" ? `t-${item.data.id}` : `e-${item.data.id}-${idx}`}
                           className={`text-[10px] leading-tight rounded px-1 py-0.5 flex items-center gap-1 ${
                             item.type === "episode"
-                              ? "bg-emerald-900/40 text-emerald-300"
+                              ? item.data.is_watched
+                                ? "bg-emerald-900/20 text-emerald-600"
+                                : "bg-emerald-900/40 text-emerald-300"
                               : item.data.object_type === "MOVIE"
                                 ? "bg-blue-900/40 text-blue-300"
                                 : "bg-purple-900/40 text-purple-300"
@@ -314,52 +352,105 @@ export default function CalendarPage() {
           {selectedEpisodes.length > 0 && (
             <div className="mb-6">
               <h4 className="text-sm font-medium text-emerald-400 mb-3">Episodes</h4>
-              <div className="space-y-3">
-                {selectedEpisodes.map((ep) => (
-                  <div key={ep.id} className="flex gap-3 p-3 rounded-lg bg-gray-900/60 border border-gray-800">
-                    {ep.poster_url && (
-                      <img
-                        src={ep.poster_url}
-                        alt={ep.show_title}
-                        className="w-12 h-18 rounded object-cover flex-shrink-0"
-                      />
-                    )}
-                    <div className="min-w-0 flex-1">
-                      <div className="text-sm font-medium text-white">{ep.show_title}</div>
-                      <div className="text-xs text-emerald-400 mt-0.5">
-                        S{String(ep.season_number).padStart(2, "0")}E{String(ep.episode_number).padStart(2, "0")}
-                        {ep.name && ` — ${ep.name}`}
-                      </div>
-                      {ep.overview && (
-                        <p className="text-xs text-gray-400 mt-1 line-clamp-2">{ep.overview}</p>
+              {(() => {
+                // Group episodes by show
+                const showGroups = new Map<string, typeof selectedEpisodes>();
+                for (const ep of selectedEpisodes) {
+                  const key = ep.title_id;
+                  const group = showGroups.get(key);
+                  if (group) group.push(ep);
+                  else showGroups.set(key, [ep]);
+                }
+
+                return Array.from(showGroups.entries()).map(([titleId, showEps]) => {
+                  const allWatched = showEps.every((ep) => ep.is_watched);
+                  return (
+                    <div key={titleId} className="mb-4">
+                      {showGroups.size > 1 && showEps.length > 1 && (
+                        <div className="flex items-center justify-between mb-2">
+                          <span className="text-xs font-medium text-gray-400">{showEps[0].show_title}</span>
+                          <button
+                            onClick={() => toggleBulkWatched(showEps.map((ep) => ep.id), !allWatched)}
+                            className="text-xs text-gray-500 hover:text-gray-300 transition-colors cursor-pointer"
+                          >
+                            {allWatched ? "Mark all unwatched" : "Mark all watched"}
+                          </button>
+                        </div>
                       )}
-                      {(() => {
-                        const providers = getUniqueProviders(ep.offers);
-                        return providers.length > 0 ? (
-                          <div className="flex flex-wrap gap-1.5 mt-2">
-                            {providers.map((p) => (
-                              <a
-                                key={p.provider_id}
-                                href={p.url}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                title={p.provider_name}
-                              >
-                                <img
-                                  src={p.provider_icon_url}
-                                  alt={p.provider_name}
-                                  className="w-6 h-6 rounded-md"
-                                  loading="lazy"
-                                />
-                              </a>
-                            ))}
+                      <div className="space-y-3">
+                        {showEps.map((ep) => (
+                          <div
+                            key={ep.id}
+                            className={`flex gap-3 p-3 rounded-lg border transition-colors ${
+                              ep.is_watched
+                                ? "bg-gray-900/30 border-gray-800/60 opacity-60"
+                                : "bg-gray-900/60 border-gray-800"
+                            }`}
+                          >
+                            {ep.poster_url && (
+                              <img
+                                src={ep.poster_url}
+                                alt={ep.show_title}
+                                className="w-12 h-18 rounded object-cover flex-shrink-0"
+                              />
+                            )}
+                            <div className="min-w-0 flex-1">
+                              <div className="flex items-center justify-between gap-2">
+                                <div className="text-sm font-medium text-white">{ep.show_title}</div>
+                                <button
+                                  onClick={() => toggleWatched(ep.id, !!ep.is_watched)}
+                                  className={`flex-shrink-0 p-1 rounded-md transition-colors cursor-pointer ${
+                                    ep.is_watched
+                                      ? "text-emerald-400 hover:text-emerald-300"
+                                      : "text-gray-600 hover:text-gray-400"
+                                  }`}
+                                  title={ep.is_watched ? "Mark as unwatched" : "Mark as watched"}
+                                >
+                                  {ep.is_watched ? (
+                                    <CheckCircleIcon className="size-5" />
+                                  ) : (
+                                    <CircleIcon className="size-5" />
+                                  )}
+                                </button>
+                              </div>
+                              <div className="text-xs text-emerald-400 mt-0.5">
+                                S{String(ep.season_number).padStart(2, "0")}E{String(ep.episode_number).padStart(2, "0")}
+                                {ep.name && ` — ${ep.name}`}
+                              </div>
+                              {ep.overview && (
+                                <p className="text-xs text-gray-400 mt-1 line-clamp-2">{ep.overview}</p>
+                              )}
+                              {(() => {
+                                const providers = getUniqueProviders(ep.offers);
+                                return providers.length > 0 ? (
+                                  <div className="flex flex-wrap gap-1.5 mt-2">
+                                    {providers.map((p) => (
+                                      <a
+                                        key={p.provider_id}
+                                        href={p.url}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        title={p.provider_name}
+                                      >
+                                        <img
+                                          src={p.provider_icon_url}
+                                          alt={p.provider_name}
+                                          className="w-6 h-6 rounded-md"
+                                          loading="lazy"
+                                        />
+                                      </a>
+                                    ))}
+                                  </div>
+                                ) : null;
+                              })()}
+                            </div>
                           </div>
-                        ) : null;
-                      })()}
+                        ))}
+                      </div>
                     </div>
-                  </div>
-                ))}
-              </div>
+                  );
+                });
+              })()}
             </div>
           )}
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -48,6 +48,7 @@ export interface Episode {
   still_path: string | null;
   show_title: string;
   poster_url: string | null;
+  is_watched?: boolean;
   offers?: Offer[];
 }
 

--- a/server/db/repository.ts
+++ b/server/db/repository.ts
@@ -10,6 +10,7 @@ import {
   sessions,
   settings,
   tracked,
+  watchedEpisodes,
 } from "./schema";
 import type { ParsedTitle } from "../justwatch/parser";
 import { extractProviders } from "../justwatch/parser";
@@ -521,6 +522,10 @@ export function getEpisodesByMonth(filters: MonthFilters, userId?: string) {
       updated_at: episodes.updatedAt,
       show_title: titles.title,
       poster_url: titles.posterUrl,
+      is_watched: sql<boolean>`EXISTS(
+        SELECT 1 FROM watched_episodes we
+        WHERE we.episode_id = ${episodes.id} AND we.user_id = ${userId}
+      )`,
     })
     .from(episodes)
     .innerJoin(titles, eq(titles.id, episodes.titleId))
@@ -534,6 +539,7 @@ export function getEpisodesByMonth(filters: MonthFilters, userId?: string) {
 
   return rows.map((row) => ({
     ...row,
+    is_watched: !!row.is_watched,
     offers: getOffersForTitle(row.title_id),
   }));
 }
@@ -541,6 +547,48 @@ export function getEpisodesByMonth(filters: MonthFilters, userId?: string) {
 export function deleteEpisodesForTitle(titleId: string) {
   const db = getDb();
   db.delete(episodes).where(eq(episodes.titleId, titleId)).run();
+}
+
+// ─── Watched Episodes ─────────────────────────────────────────────────────────
+
+export function watchEpisode(episodeId: number, userId: string) {
+  const db = getDb();
+  db.insert(watchedEpisodes)
+    .values({ episodeId, userId })
+    .onConflictDoNothing()
+    .run();
+}
+
+export function unwatchEpisode(episodeId: number, userId: string) {
+  const db = getDb();
+  db.delete(watchedEpisodes)
+    .where(and(eq(watchedEpisodes.episodeId, episodeId), eq(watchedEpisodes.userId, userId)))
+    .run();
+}
+
+export function watchEpisodesBulk(episodeIds: number[], userId: string) {
+  const raw = getRawDb();
+  const db = getDb();
+  raw.transaction(() => {
+    for (const episodeId of episodeIds) {
+      db.insert(watchedEpisodes)
+        .values({ episodeId, userId })
+        .onConflictDoNothing()
+        .run();
+    }
+  })();
+}
+
+export function unwatchEpisodesBulk(episodeIds: number[], userId: string) {
+  const raw = getRawDb();
+  const db = getDb();
+  raw.transaction(() => {
+    for (const episodeId of episodeIds) {
+      db.delete(watchedEpisodes)
+        .where(and(eq(watchedEpisodes.episodeId, episodeId), eq(watchedEpisodes.userId, userId)))
+        .run();
+    }
+  })();
 }
 
 // ─── Users ───────────────────────────────────────────────────────────────────

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -153,6 +153,20 @@ export const tracked = sqliteTable(
   (table) => [primaryKey({ columns: [table.titleId, table.userId] })]
 );
 
+export const watchedEpisodes = sqliteTable(
+  "watched_episodes",
+  {
+    episodeId: integer("episode_id")
+      .notNull()
+      .references(() => episodes.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    watchedAt: text("watched_at").default(sql`(datetime('now'))`),
+  },
+  (table) => [primaryKey({ columns: [table.episodeId, table.userId] })]
+);
+
 export const schemaVersion = sqliteTable("schema_version", {
   version: integer("version").primaryKey(),
 });
@@ -200,12 +214,17 @@ export const trackedRelations = relations(tracked, ({ one }) => ({
   user: one(users, { fields: [tracked.userId], references: [users.id] }),
 }));
 
+export const watchedEpisodesRelations = relations(watchedEpisodes, ({ one }) => ({
+  episode: one(episodes, { fields: [watchedEpisodes.episodeId], references: [episodes.id] }),
+  user: one(users, { fields: [watchedEpisodes.userId], references: [users.id] }),
+}));
+
 // ─── Database Instance ──────────────────────────────────────────────────────
 
 const schemaExports = {
-  titles, providers, offers, scores, episodes, users, sessions, settings, tracked, schemaVersion,
+  titles, providers, offers, scores, episodes, users, sessions, settings, tracked, watchedEpisodes, schemaVersion,
   titlesRelations, providersRelations, offersRelations, scoresRelations, episodesRelations,
-  usersRelations, sessionsRelations, trackedRelations,
+  usersRelations, sessionsRelations, trackedRelations, watchedEpisodesRelations,
 };
 
 export type DrizzleDb = BunSQLiteDatabase<typeof schemaExports>;
@@ -332,6 +351,15 @@ function initSchema(db: Database) {
   `);
 
   db.run(`
+    CREATE TABLE IF NOT EXISTS watched_episodes (
+      episode_id INTEGER NOT NULL REFERENCES episodes(id) ON DELETE CASCADE,
+      user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      watched_at TEXT DEFAULT (datetime('now')),
+      PRIMARY KEY (episode_id, user_id)
+    )
+  `);
+
+  db.run(`
     CREATE TABLE IF NOT EXISTS schema_version (
       version INTEGER PRIMARY KEY
     )
@@ -389,6 +417,18 @@ function migrateSchema(db: Database) {
     }
 
     setSchemaVersion(db, 1);
+  }
+
+  if (getSchemaVersion(db) < 2) {
+    db.run(`
+      CREATE TABLE IF NOT EXISTS watched_episodes (
+        episode_id INTEGER NOT NULL REFERENCES episodes(id) ON DELETE CASCADE,
+        user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        watched_at TEXT DEFAULT (datetime('now')),
+        PRIMARY KEY (episode_id, user_id)
+      )
+    `);
+    setSchemaVersion(db, 2);
   }
 }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,6 +9,7 @@ import syncRoutes from "./routes/sync";
 import titlesRoutes from "./routes/titles";
 import searchRoutes from "./routes/search";
 import trackRoutes from "./routes/track";
+import watchedRoutes from "./routes/watched";
 import imdbRoutes from "./routes/imdb";
 import calendarRoutes from "./routes/calendar";
 import episodesRoutes from "./routes/episodes";
@@ -57,6 +58,10 @@ app.route("/api/calendar", calendarRoutes);
 app.use("/api/track/*", requireAuth);
 app.use("/api/track", requireAuth);
 app.route("/api/track", trackRoutes);
+
+app.use("/api/watched/*", requireAuth);
+app.use("/api/watched", requireAuth);
+app.route("/api/watched", watchedRoutes);
 
 app.use("/api/imdb/*", requireAuth);
 app.use("/api/imdb", requireAuth);

--- a/server/routes/watched.ts
+++ b/server/routes/watched.ts
@@ -1,0 +1,39 @@
+import { Hono } from "hono";
+import { watchEpisode, unwatchEpisode, watchEpisodesBulk, unwatchEpisodesBulk } from "../db/repository";
+import type { AppEnv } from "../types";
+
+const app = new Hono<AppEnv>();
+
+app.post("/bulk", async (c) => {
+  const user = c.get("user")!;
+  const body = await c.req.json();
+  const { episodeIds, watched } = body as { episodeIds: number[]; watched: boolean };
+
+  if (!Array.isArray(episodeIds) || episodeIds.length === 0) {
+    return c.json({ error: "episodeIds must be a non-empty array" }, 400);
+  }
+
+  if (watched) {
+    watchEpisodesBulk(episodeIds, user.id);
+  } else {
+    unwatchEpisodesBulk(episodeIds, user.id);
+  }
+
+  return c.json({ success: true });
+});
+
+app.post("/:episodeId", (c) => {
+  const user = c.get("user")!;
+  const episodeId = Number(c.req.param("episodeId"));
+  watchEpisode(episodeId, user.id);
+  return c.json({ success: true });
+});
+
+app.delete("/:episodeId", (c) => {
+  const user = c.get("user")!;
+  const episodeId = Number(c.req.param("episodeId"));
+  unwatchEpisode(episodeId, user.id);
+  return c.json({ success: true });
+});
+
+export default app;


### PR DESCRIPTION
## Summary
This PR adds the ability for users to mark individual episodes as watched or unwatched, with support for bulk operations on multiple episodes. The watched status is persisted to the database and reflected in the UI with visual indicators.

## Key Changes

**Database Schema**
- Added `watched_episodes` table to track which episodes users have marked as watched
- Includes `episodeId`, `userId`, and `watchedAt` timestamp
- Implemented schema migration (version 1 → 2) for database compatibility

**Backend**
- Created new `/api/watched` routes for episode watch management:
  - `POST /watched/:episodeId` - Mark episode as watched
  - `DELETE /watched/:episodeId` - Mark episode as unwatched
  - `POST /watched/bulk` - Bulk mark multiple episodes as watched/unwatched
- Added repository functions: `watchEpisode()`, `unwatchEpisode()`, `watchEpisodesBulk()`, `unwatchEpisodesBulk()`
- Updated `getEpisodesByMonth()` query to include `is_watched` status via SQL EXISTS subquery

**Frontend**
- Added `watchEpisode`, `unwatchEpisode`, and `watchEpisodesBulk` API client functions
- Implemented `toggleWatched()` and `toggleBulkWatched()` handlers with optimistic UI updates and error recovery
- Enhanced episode display in calendar:
  - Visual distinction for watched episodes (dimmed styling)
  - Individual watch/unwatch toggle buttons with CheckCircle/Circle icons
  - "Mark all watched/unwatched" bulk action for episodes grouped by show
- Updated episode type to include optional `is_watched` field
- Improved episode list grouping by show title in the sidebar

## Implementation Details
- Optimistic UI updates provide immediate feedback while API calls complete in the background
- Failed operations automatically revert the UI state
- Bulk operations use database transactions for consistency
- Watched episodes display with reduced opacity and different color scheme for visual clarity

https://claude.ai/code/session_01GfKf7rQ1HcrFkoNVMBZVUn