### PR TITLE
Add background job queue with cron scheduling support

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -13,6 +13,8 @@ export const CONFIG = {
   TMDB_API_KEY: process.env.TMDB_API_KEY || "",
   TMDB_BASE_URL: "https://api.themoviedb.org/3",
   EPISODE_SYNC_DELAY_MS: 500,
+  SYNC_TITLES_CRON: process.env.SYNC_TITLES_CRON || "0 3 * * *",
+  SYNC_EPISODES_CRON: process.env.SYNC_EPISODES_CRON || "30 3 * * *",
 
   // Auth
   SESSION_DURATION_HOURS: Number(process.env.SESSION_DURATION_HOURS) || 24 * 7,

--- a/server/index.ts
+++ b/server/index.ts
@@ -15,7 +15,10 @@ import calendarRoutes from "./routes/calendar";
 import episodesRoutes from "./routes/episodes";
 import authRoutes from "./routes/auth";
 import adminRoutes from "./routes/admin";
+import jobsRoutes from "./routes/jobs";
 import type { AppEnv } from "./types";
+import { registerSyncJobs } from "./jobs/sync";
+import { startWorker, stopWorker } from "./jobs/worker";
 
 // Initialize DB on startup
 getDb();
@@ -72,6 +75,10 @@ app.use("/api/admin/*", requireAuth, requireAdmin);
 app.use("/api/admin", requireAuth, requireAdmin);
 app.route("/api/admin", adminRoutes);
 
+app.use("/api/jobs/*", requireAuth, requireAdmin);
+app.use("/api/jobs", requireAuth, requireAdmin);
+app.route("/api/jobs", jobsRoutes);
+
 // Sync (public — typically triggered by cron)
 app.route("/api/sync", syncRoutes);
 
@@ -88,6 +95,15 @@ app.use("/*", serveStatic({ root: "./frontend/dist", path: "/index.html" }));
 setInterval(() => {
   deleteExpiredSessions();
 }, 60 * 60 * 1000);
+
+// Start background job queue
+registerSyncJobs();
+startWorker();
+
+process.on("SIGTERM", () => {
+  stopWorker();
+  process.exit(0);
+});
 
 console.log(`Remindarr server running on http://localhost:${CONFIG.PORT}`);
 

--- a/server/jobs/queue.ts
+++ b/server/jobs/queue.ts
@@ -1,0 +1,340 @@
+import { getRawDb } from "../db/schema";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type JobStatus = "pending" | "running" | "completed" | "failed";
+
+export interface Job {
+  id: number;
+  name: string;
+  data: string | null;
+  status: JobStatus;
+  attempts: number;
+  max_attempts: number;
+  error: string | null;
+  run_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+  created_at: string;
+}
+
+export interface CronJob {
+  name: string;
+  cron: string;
+  last_run: string | null;
+  next_run: string;
+  enabled: number;
+}
+
+export type JobHandler = (job: Job) => Promise<void>;
+
+// ─── Schema ─────────────────────────────────────────────────────────────────
+
+export function initJobsSchema() {
+  const db = getRawDb();
+
+  db.run(`
+    CREATE TABLE IF NOT EXISTS jobs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      data TEXT,
+      status TEXT NOT NULL DEFAULT 'pending',
+      attempts INTEGER NOT NULL DEFAULT 0,
+      max_attempts INTEGER NOT NULL DEFAULT 3,
+      error TEXT,
+      run_at TEXT NOT NULL DEFAULT (datetime('now')),
+      started_at TEXT,
+      completed_at TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
+
+  db.run("CREATE INDEX IF NOT EXISTS idx_jobs_status_run_at ON jobs(status, run_at)");
+  db.run("CREATE INDEX IF NOT EXISTS idx_jobs_name ON jobs(name)");
+
+  db.run(`
+    CREATE TABLE IF NOT EXISTS cron_jobs (
+      name TEXT PRIMARY KEY,
+      cron TEXT NOT NULL,
+      last_run TEXT,
+      next_run TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1
+    )
+  `);
+}
+
+// ─── Cron Expression Parser ─────────────────────────────────────────────────
+
+// Supports: * , - / and standard 5-field cron (minute hour day month weekday)
+function parseCronField(field: string, min: number, max: number): number[] {
+  const values = new Set<number>();
+
+  for (const part of field.split(",")) {
+    const stepMatch = part.match(/^(.+)\/(\d+)$/);
+    let range: string;
+    let step = 1;
+
+    if (stepMatch) {
+      range = stepMatch[1];
+      step = parseInt(stepMatch[2], 10);
+    } else {
+      range = part;
+    }
+
+    let start: number, end: number;
+
+    if (range === "*") {
+      start = min;
+      end = max;
+    } else if (range.includes("-")) {
+      const [a, b] = range.split("-").map(Number);
+      start = a;
+      end = b;
+    } else {
+      start = parseInt(range, 10);
+      end = start;
+    }
+
+    for (let i = start; i <= end; i += step) {
+      values.add(i);
+    }
+  }
+
+  return [...values].sort((a, b) => a - b);
+}
+
+export function getNextCronDate(cron: string, after: Date = new Date()): Date {
+  const parts = cron.trim().split(/\s+/);
+  if (parts.length !== 5) throw new Error(`Invalid cron expression: ${cron}`);
+
+  const minutes = parseCronField(parts[0], 0, 59);
+  const hours = parseCronField(parts[1], 0, 23);
+  const daysOfMonth = parseCronField(parts[2], 1, 31);
+  const months = parseCronField(parts[3], 1, 12);
+  const daysOfWeek = parseCronField(parts[4], 0, 6);
+
+  const isWildcardDom = parts[2] === "*";
+  const isWildcardDow = parts[4] === "*";
+
+  // Start searching from the next minute
+  const candidate = new Date(after);
+  candidate.setSeconds(0, 0);
+  candidate.setMinutes(candidate.getMinutes() + 1);
+
+  // Search up to 2 years out
+  const limit = new Date(after);
+  limit.setFullYear(limit.getFullYear() + 2);
+
+  while (candidate < limit) {
+    const month = candidate.getMonth() + 1;
+    if (!months.includes(month)) {
+      candidate.setMonth(candidate.getMonth() + 1, 1);
+      candidate.setHours(0, 0, 0, 0);
+      continue;
+    }
+
+    const dom = candidate.getDate();
+    const dow = candidate.getDay();
+
+    const domMatch = isWildcardDom || daysOfMonth.includes(dom);
+    const dowMatch = isWildcardDow || daysOfWeek.includes(dow);
+
+    // Standard cron: if both are specified (not wildcard), either can match
+    // If only one is specified, that one must match
+    const dayMatch =
+      isWildcardDom && isWildcardDow
+        ? true
+        : isWildcardDom
+          ? dowMatch
+          : isWildcardDow
+            ? domMatch
+            : domMatch || dowMatch;
+
+    if (!dayMatch) {
+      candidate.setDate(candidate.getDate() + 1);
+      candidate.setHours(0, 0, 0, 0);
+      continue;
+    }
+
+    const hour = candidate.getHours();
+    if (!hours.includes(hour)) {
+      candidate.setHours(candidate.getHours() + 1, 0, 0, 0);
+      continue;
+    }
+
+    const minute = candidate.getMinutes();
+    if (!minutes.includes(minute)) {
+      candidate.setMinutes(candidate.getMinutes() + 1, 0, 0);
+      continue;
+    }
+
+    return new Date(candidate);
+  }
+
+  throw new Error(`Could not find next cron date for: ${cron}`);
+}
+
+// ─── Queue Operations ───────────────────────────────────────────────────────
+
+export function enqueueJob(
+  name: string,
+  data?: Record<string, unknown>,
+  options?: { runAt?: Date; maxAttempts?: number }
+): number {
+  const db = getRawDb();
+  const runAt = (options?.runAt ?? new Date()).toISOString();
+  const maxAttempts = options?.maxAttempts ?? 3;
+  const dataStr = data ? JSON.stringify(data) : null;
+
+  const result = db
+    .prepare(
+      "INSERT INTO jobs (name, data, run_at, max_attempts) VALUES (?, ?, ?, ?)"
+    )
+    .run(name, dataStr, runAt, maxAttempts);
+
+  return Number(result.lastInsertRowid);
+}
+
+export function claimNextJob(name: string): Job | null {
+  const db = getRawDb();
+  const now = new Date().toISOString();
+
+  // Atomically claim one pending job that's ready to run
+  const row = db
+    .prepare(
+      `UPDATE jobs
+       SET status = 'running', started_at = ?, attempts = attempts + 1
+       WHERE id = (
+         SELECT id FROM jobs
+         WHERE name = ? AND status = 'pending' AND run_at <= ?
+         ORDER BY run_at ASC
+         LIMIT 1
+       )
+       RETURNING *`
+    )
+    .get(now, name, now) as Job | null;
+
+  return row;
+}
+
+export function completeJob(id: number) {
+  const db = getRawDb();
+  db.prepare(
+    "UPDATE jobs SET status = 'completed', completed_at = datetime('now') WHERE id = ?"
+  ).run(id);
+}
+
+export function failJob(id: number, error: string) {
+  const db = getRawDb();
+  const job = db.prepare("SELECT * FROM jobs WHERE id = ?").get(id) as Job;
+
+  if (job && job.attempts < job.max_attempts) {
+    // Re-queue with exponential backoff: 2^attempts * 30 seconds
+    const delaySec = Math.pow(2, job.attempts) * 30;
+    db.prepare(
+      `UPDATE jobs SET status = 'pending', error = ?,
+       run_at = datetime('now', '+' || ? || ' seconds')
+       WHERE id = ?`
+    ).run(error, delaySec, id);
+  } else {
+    db.prepare(
+      "UPDATE jobs SET status = 'failed', error = ?, completed_at = datetime('now') WHERE id = ?"
+    ).run(error, id);
+  }
+}
+
+export function cleanupOldJobs(retentionDays: number = 30) {
+  const db = getRawDb();
+  const result = db
+    .prepare(
+      `DELETE FROM jobs
+       WHERE status IN ('completed', 'failed')
+       AND completed_at < datetime('now', '-' || ? || ' days')`
+    )
+    .run(retentionDays);
+  return result.changes;
+}
+
+// Reset jobs that were left running (e.g., after a crash)
+export function recoverStaleJobs(staleMinutes: number = 30) {
+  const db = getRawDb();
+  const result = db
+    .prepare(
+      `UPDATE jobs SET status = 'pending', error = 'Recovered after stale timeout'
+       WHERE status = 'running'
+       AND started_at < datetime('now', '-' || ? || ' minutes')`
+    )
+    .run(staleMinutes);
+  if (result.changes > 0) {
+    console.log(`[Jobs] Recovered ${result.changes} stale jobs`);
+  }
+}
+
+export function getJobStats(): Record<string, { pending: number; running: number; completed: number; failed: number }> {
+  const db = getRawDb();
+  const rows = db
+    .prepare(
+      `SELECT name, status, COUNT(*) as count FROM jobs GROUP BY name, status`
+    )
+    .all() as { name: string; status: JobStatus; count: number }[];
+
+  const stats: Record<string, { pending: number; running: number; completed: number; failed: number }> = {};
+  for (const row of rows) {
+    if (!stats[row.name]) {
+      stats[row.name] = { pending: 0, running: 0, completed: 0, failed: 0 };
+    }
+    stats[row.name][row.status] = row.count;
+  }
+  return stats;
+}
+
+// ─── Cron Registration ──────────────────────────────────────────────────────
+
+export function registerCron(name: string, cron: string) {
+  const db = getRawDb();
+  const nextRun = getNextCronDate(cron).toISOString();
+
+  db.prepare(
+    `INSERT INTO cron_jobs (name, cron, next_run)
+     VALUES (?, ?, ?)
+     ON CONFLICT(name) DO UPDATE SET cron = excluded.cron, next_run = excluded.next_run`
+  ).run(name, cron, nextRun);
+
+  console.log(`[Jobs] Registered cron "${name}": ${cron} (next: ${nextRun})`);
+}
+
+export function tickCrons() {
+  const db = getRawDb();
+  const now = new Date().toISOString();
+
+  const dueCrons = db
+    .prepare(
+      "SELECT * FROM cron_jobs WHERE enabled = 1 AND next_run <= ?"
+    )
+    .all(now) as CronJob[];
+
+  for (const cron of dueCrons) {
+    // Check if there's already a pending/running job for this cron
+    const existing = db
+      .prepare(
+        "SELECT id FROM jobs WHERE name = ? AND status IN ('pending', 'running') LIMIT 1"
+      )
+      .get(cron.name);
+
+    if (!existing) {
+      enqueueJob(cron.name);
+      console.log(`[Jobs] Cron "${cron.name}" enqueued`);
+    }
+
+    // Advance to next run
+    const nextRun = getNextCronDate(cron.cron, new Date()).toISOString();
+    db.prepare(
+      "UPDATE cron_jobs SET last_run = ?, next_run = ? WHERE name = ?"
+    ).run(now, nextRun, cron.name);
+  }
+}
+
+export function getCronJobs(): CronJob[] {
+  const db = getRawDb();
+  return db.prepare("SELECT * FROM cron_jobs ORDER BY name").all() as CronJob[];
+}

--- a/server/jobs/sync.ts
+++ b/server/jobs/sync.ts
@@ -1,0 +1,30 @@
+import { registerHandler } from "./worker";
+import { registerCron } from "./queue";
+import { CONFIG } from "../config";
+import { fetchNewReleases } from "../justwatch/client";
+import { upsertTitles } from "../db/repository";
+import { syncEpisodes } from "../tmdb/sync";
+
+export function registerSyncJobs() {
+  // ─── Handlers ───────────────────────────────────────────────────────────
+
+  registerHandler("sync-titles", async () => {
+    const titles = await fetchNewReleases({ daysBack: CONFIG.DEFAULT_DAYS_BACK });
+    const count = upsertTitles(titles);
+    console.log(`[Sync] Synced ${count} titles from JustWatch`);
+  });
+
+  registerHandler("sync-episodes", async () => {
+    if (!CONFIG.TMDB_API_KEY) {
+      console.log("[Sync] Skipping episode sync — TMDB_API_KEY not configured");
+      return;
+    }
+    const result = await syncEpisodes();
+    console.log(`[Sync] Synced ${result.synced} episodes from ${result.shows} shows`);
+  });
+
+  // ─── Cron Schedules ────────────────────────────────────────────────────
+
+  registerCron("sync-titles", CONFIG.SYNC_TITLES_CRON);
+  registerCron("sync-episodes", CONFIG.SYNC_EPISODES_CRON);
+}

--- a/server/jobs/worker.ts
+++ b/server/jobs/worker.ts
@@ -1,0 +1,70 @@
+import {
+  initJobsSchema,
+  claimNextJob,
+  completeJob,
+  failJob,
+  tickCrons,
+  recoverStaleJobs,
+  cleanupOldJobs,
+  type JobHandler,
+} from "./queue";
+
+const POLL_INTERVAL_MS = 30_000; // Check for jobs every 30s
+const CRON_TICK_INTERVAL_MS = 60_000; // Check cron schedules every 60s
+const CLEANUP_INTERVAL_MS = 24 * 60 * 60_000; // Clean old jobs daily
+
+const handlers = new Map<string, JobHandler>();
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+let cronTimer: ReturnType<typeof setInterval> | null = null;
+let cleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+export function registerHandler(name: string, handler: JobHandler) {
+  handlers.set(name, handler);
+}
+
+async function processJobs() {
+  for (const [name, handler] of handlers) {
+    const job = claimNextJob(name);
+    if (!job) continue;
+
+    try {
+      await handler(job);
+      completeJob(job.id);
+      console.log(`[Jobs] Completed "${name}" (job #${job.id})`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      failJob(job.id, message);
+      console.error(`[Jobs] Failed "${name}" (job #${job.id}, attempt ${job.attempts}/${job.max_attempts}): ${message}`);
+    }
+  }
+}
+
+export function startWorker() {
+  initJobsSchema();
+  recoverStaleJobs();
+
+  // Poll for pending jobs
+  pollTimer = setInterval(processJobs, POLL_INTERVAL_MS);
+
+  // Tick cron schedules
+  cronTimer = setInterval(tickCrons, CRON_TICK_INTERVAL_MS);
+
+  // Clean up old completed/failed jobs daily
+  cleanupTimer = setInterval(() => cleanupOldJobs(30), CLEANUP_INTERVAL_MS);
+
+  // Run an initial tick immediately
+  tickCrons();
+  processJobs();
+
+  console.log("[Jobs] Worker started");
+}
+
+export function stopWorker() {
+  if (pollTimer) clearInterval(pollTimer);
+  if (cronTimer) clearInterval(cronTimer);
+  if (cleanupTimer) clearInterval(cleanupTimer);
+  pollTimer = null;
+  cronTimer = null;
+  cleanupTimer = null;
+  console.log("[Jobs] Worker stopped");
+}

--- a/server/routes/jobs.ts
+++ b/server/routes/jobs.ts
@@ -1,0 +1,22 @@
+import { Hono } from "hono";
+import { getJobStats, getCronJobs, enqueueJob } from "../jobs/queue";
+import type { AppEnv } from "../types";
+
+const app = new Hono<AppEnv>();
+
+// GET /api/jobs — job stats and cron schedules
+app.get("/", (c) => {
+  return c.json({
+    stats: getJobStats(),
+    crons: getCronJobs(),
+  });
+});
+
+// POST /api/jobs/:name — manually trigger a job
+app.post("/:name", (c) => {
+  const name = c.req.param("name");
+  const id = enqueueJob(name);
+  return c.json({ success: true, jobId: id });
+});
+
+export default app;

--- a/server/tmdb/sync.ts
+++ b/server/tmdb/sync.ts
@@ -1,9 +1,8 @@
 import { CONFIG } from "../config";
 import { getDb } from "../db/schema";
 import { titles, episodes, tracked } from "../db/schema";
-import { upsertEpisodes, deleteEpisodesForTitle } from "../db/repository";
+import { upsertEpisodes } from "../db/repository";
 import { fetchShowDetails, fetchSeasonEpisodes } from "./client";
-import type { TmdbEpisode } from "./types";
 import { eq, and, count, isNotNull } from "drizzle-orm";
 
 function delay(ms: number): Promise<void> {
@@ -41,40 +40,36 @@ export async function syncEpisodesForShow(
     }
   }
 
-  // 7 days ago for filtering
-  const cutoff = new Date();
-  cutoff.setDate(cutoff.getDate() - 7);
-  const cutoffStr = cutoff.toISOString().split("T")[0];
+  // Fetch all seasons (1 through number_of_seasons)
+  const allEpisodes: EpisodeRow[] = [];
 
-  // Determine which season to fetch: use next_episode or last_episode season, or latest
-  let seasonToFetch = details.number_of_seasons;
-  if (details.next_episode_to_air) {
-    seasonToFetch = details.next_episode_to_air.season_number;
-  } else if (details.last_episode_to_air) {
-    seasonToFetch = details.last_episode_to_air.season_number;
+  for (let season = 1; season <= details.number_of_seasons; season++) {
+    if (season > 1) await delay(CONFIG.EPISODE_SYNC_DELAY_MS);
+
+    try {
+      const seasonData = await fetchSeasonEpisodes(tmdbId, season);
+      for (const ep of seasonData.episodes) {
+        allEpisodes.push({
+          title_id: titleId,
+          season_number: ep.season_number,
+          episode_number: ep.episode_number,
+          name: ep.name || null,
+          overview: ep.overview || null,
+          air_date: ep.air_date,
+          still_path: ep.still_path,
+        });
+      }
+    } catch (err) {
+      console.error(`[TMDB] Failed to fetch S${String(season).padStart(2, "0")} for "${title}":`, err);
+    }
   }
 
-  const seasonData = await fetchSeasonEpisodes(tmdbId, seasonToFetch);
-
-  // Filter to recent/upcoming episodes
-  const episodeList: EpisodeRow[] = seasonData.episodes
-    .filter((ep: TmdbEpisode) => ep.air_date && ep.air_date >= cutoffStr)
-    .map((ep: TmdbEpisode) => ({
-      title_id: titleId,
-      season_number: ep.season_number,
-      episode_number: ep.episode_number,
-      name: ep.name || null,
-      overview: ep.overview || null,
-      air_date: ep.air_date,
-      still_path: ep.still_path,
-    }));
-
-  if (episodeList.length > 0) {
-    upsertEpisodes(episodeList);
+  if (allEpisodes.length > 0) {
+    upsertEpisodes(allEpisodes);
   }
 
-  console.log(`[TMDB] Synced ${episodeList.length} episodes for "${title}" (S${String(seasonToFetch).padStart(2, "0")})`);
-  return episodeList.length;
+  console.log(`[TMDB] Synced ${allEpisodes.length} episodes across ${details.number_of_seasons} seasons for "${title}"`);
+  return allEpisodes.length;
 }
 
 export async function syncEpisodes(): Promise<{ synced: number; shows: number }> {


### PR DESCRIPTION
## Summary
Introduces a robust background job queue system with cron scheduling capabilities, replacing ad-hoc sync operations with a managed, persistent job queue backed by SQLite.

## Key Changes

- **New Job Queue System** (`server/jobs/queue.ts`)
  - Persistent job storage with status tracking (pending, running, completed, failed)
  - Atomic job claiming to prevent duplicate processing
  - Exponential backoff retry logic (2^attempts × 30 seconds)
  - Automatic recovery of stale jobs (e.g., after crashes)
  - Job cleanup with configurable retention periods

- **Cron Expression Parser**
  - Full 5-field cron support (minute, hour, day, month, weekday)
  - Supports `*`, ranges (`-`), lists (`,`), and steps (`/`)
  - Proper day-of-month vs day-of-week logic matching standard cron behavior
  - Searches up to 2 years ahead for next execution time

- **Background Worker** (`server/jobs/worker.ts`)
  - Polls for pending jobs every 30 seconds
  - Evaluates cron schedules every 60 seconds
  - Cleans up old jobs daily
  - Graceful shutdown on SIGTERM
  - Automatic recovery of stale jobs on startup

- **Job Registration & Sync** (`server/jobs/sync.ts`)
  - Registers handlers for `sync-titles` and `sync-episodes` jobs
  - Configurable cron schedules via environment variables
  - Integrated with existing JustWatch and TMDB sync logic

- **Admin API** (`server/routes/jobs.ts`)
  - `GET /api/jobs` — view job statistics and cron schedules
  - `POST /api/jobs/:name` — manually trigger a job

- **Episode Sync Improvements** (`server/tmdb/sync.ts`)
  - Now fetches all seasons instead of just the next/last episode season
  - Removes 7-day cutoff filter to capture complete episode history
  - Better error handling for individual season failures

- **Configuration** (`server/config.ts`)
  - New `SYNC_TITLES_CRON` and `SYNC_EPISODES_CRON` environment variables
  - Defaults to 3 AM daily for both sync operations

## Implementation Details

- Jobs are stored in SQLite with indexed lookups on status and run time for efficient polling
- Atomic UPDATE...RETURNING ensures only one worker claims each job
- Cron jobs are tracked separately with last_run and next_run timestamps
- Failed jobs automatically re-queue with exponential backoff until max_attempts is reached
- Worker integrates with existing authentication/admin middleware for API access

https://claude.ai/code/session_012S3aYhrQ4WA3f3zA9uirh4