### PR TITLE
Initialize job queue schema before registering sync jobs

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -19,6 +19,7 @@ import jobsRoutes from "./routes/jobs";
 import type { AppEnv } from "./types";
 import { registerSyncJobs } from "./jobs/sync";
 import { startWorker, stopWorker } from "./jobs/worker";
+import { initJobsSchema } from "./jobs/queue";
 
 // Initialize DB on startup
 getDb();
@@ -97,6 +98,7 @@ setInterval(() => {
 }, 60 * 60 * 1000);
 
 // Start background job queue
+initJobsSchema();
 registerSyncJobs();
 startWorker();
 


### PR DESCRIPTION
## Summary
Added initialization of the job queue schema during server startup to ensure the database schema is properly set up before any background jobs are registered or executed.

## Key Changes
- Import `initJobsSchema` from the jobs/queue module
- Call `initJobsSchema()` before `registerSyncJobs()` in the server startup sequence

## Implementation Details
The schema initialization is now explicitly called during the background job queue setup phase, ensuring that any required database tables or indexes for the job queue are created before the sync jobs are registered and the worker is started. This prevents potential runtime errors that could occur if jobs attempt to use the queue before its schema is initialized.

https://claude.ai/code/session_01Ybz2uBTHqaNHC6sMsp9Yqi