### PR TITLE
Prevent marking unreleased episodes as watched

### DIFF
--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -164,14 +164,28 @@ export default function CalendarPage() {
     }
   };
 
+  const isEpisodeReleased = (ep: Episode) => {
+    if (!ep.air_date) return false;
+    return ep.air_date <= today;
+  };
+
   const toggleBulkWatched = async (episodeIds: number[], markWatched: boolean) => {
+    // When marking as watched, filter to only released episodes
+    const effectiveIds = markWatched
+      ? episodeIds.filter((id) => {
+          const ep = episodes.find((e) => e.id === id);
+          return ep && isEpisodeReleased(ep);
+        })
+      : episodeIds;
+    if (effectiveIds.length === 0) return;
+
     // Optimistic update
-    const idSet = new Set(episodeIds);
+    const idSet = new Set(effectiveIds);
     setEpisodes((prev) =>
       prev.map((ep) => (idSet.has(ep.id) ? { ...ep, is_watched: markWatched } : ep))
     );
     try {
-      await watchEpisodesBulk(episodeIds, markWatched);
+      await watchEpisodesBulk(effectiveIds, markWatched);
     } catch (err) {
       setEpisodes((prev) =>
         prev.map((ep) => (idSet.has(ep.id) ? { ...ep, is_watched: !markWatched } : ep))
@@ -397,21 +411,30 @@ export default function CalendarPage() {
                             <div className="min-w-0 flex-1">
                               <div className="flex items-center justify-between gap-2">
                                 <div className="text-sm font-medium text-white">{ep.show_title}</div>
-                                <button
-                                  onClick={() => toggleWatched(ep.id, !!ep.is_watched)}
-                                  className={`flex-shrink-0 p-1 rounded-md transition-colors cursor-pointer ${
-                                    ep.is_watched
-                                      ? "text-emerald-400 hover:text-emerald-300"
-                                      : "text-gray-600 hover:text-gray-400"
-                                  }`}
-                                  title={ep.is_watched ? "Mark as unwatched" : "Mark as watched"}
-                                >
-                                  {ep.is_watched ? (
-                                    <CheckCircleIcon className="size-5" />
-                                  ) : (
+                                {isEpisodeReleased(ep) ? (
+                                  <button
+                                    onClick={() => toggleWatched(ep.id, !!ep.is_watched)}
+                                    className={`flex-shrink-0 p-1 rounded-md transition-colors cursor-pointer ${
+                                      ep.is_watched
+                                        ? "text-emerald-400 hover:text-emerald-300"
+                                        : "text-gray-600 hover:text-gray-400"
+                                    }`}
+                                    title={ep.is_watched ? "Mark as unwatched" : "Mark as watched"}
+                                  >
+                                    {ep.is_watched ? (
+                                      <CheckCircleIcon className="size-5" />
+                                    ) : (
+                                      <CircleIcon className="size-5" />
+                                    )}
+                                  </button>
+                                ) : (
+                                  <span
+                                    className="flex-shrink-0 p-1 text-gray-700 cursor-not-allowed"
+                                    title="Not yet released"
+                                  >
                                     <CircleIcon className="size-5" />
-                                  )}
-                                </button>
+                                  </span>
+                                )}
                               </div>
                               <div className="text-xs text-emerald-400 mt-0.5">
                                 S{String(ep.season_number).padStart(2, "0")}E{String(ep.episode_number).padStart(2, "0")}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -53,7 +53,23 @@ function formatUpcomingDate(dateStr: string): string {
   return date.toLocaleDateString(undefined, { weekday: "long", month: "short", day: "numeric" });
 }
 
-function WatchedIcon({ watched, onClick }: { watched: boolean; onClick: () => void }) {
+function isEpisodeReleased(ep: Episode): boolean {
+  if (!ep.air_date) return false;
+  const today = new Date().toISOString().slice(0, 10);
+  return ep.air_date <= today;
+}
+
+function WatchedIcon({ watched, onClick, disabled }: { watched: boolean; onClick: () => void; disabled?: boolean }) {
+  if (disabled) {
+    return (
+      <span className="flex-shrink-0 text-gray-700 cursor-not-allowed" title="Not yet released">
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
+          <circle cx="12" cy="12" r="9" />
+        </svg>
+      </span>
+    );
+  }
+
   return (
     <button
       onClick={(e) => { e.stopPropagation(); onClick(); }}
@@ -78,10 +94,12 @@ function WatchedIcon({ watched, onClick }: { watched: boolean; onClick: () => vo
 function EpisodeCard({ episode, compact, onToggleWatched }: { episode: Episode; compact?: boolean; onToggleWatched: (id: number, current: boolean) => void }) {
   const providers = getUniqueProviders(episode.offers);
 
+  const unreleased = !isEpisodeReleased(episode);
+
   if (compact) {
     return (
       <div className="flex items-center gap-3 bg-gray-900 rounded-lg border border-gray-800 p-3">
-        <WatchedIcon watched={!!episode.is_watched} onClick={() => onToggleWatched(episode.id, !!episode.is_watched)} />
+        <WatchedIcon watched={!!episode.is_watched} onClick={() => onToggleWatched(episode.id, !!episode.is_watched)} disabled={unreleased} />
         {episode.poster_url && (
           <img
             src={episode.poster_url}
@@ -113,7 +131,7 @@ function EpisodeCard({ episode, compact, onToggleWatched }: { episode: Episode; 
   return (
     <div className="bg-gray-900 rounded-xl overflow-hidden border border-gray-800 hover:border-gray-700 transition-colors">
       <div className="flex gap-4 p-4">
-        <WatchedIcon watched={!!episode.is_watched} onClick={() => onToggleWatched(episode.id, !!episode.is_watched)} />
+        <WatchedIcon watched={!!episode.is_watched} onClick={() => onToggleWatched(episode.id, !!episode.is_watched)} disabled={unreleased} />
         {episode.poster_url && (
           <img
             src={episode.poster_url}
@@ -170,7 +188,7 @@ function ShowEpisodeGroup({ showTitle, episodes, posterUrl, compact, onToggleWat
           <div className="flex flex-wrap gap-x-3 gap-y-0.5 mt-0.5">
             {episodes.map((ep) => (
               <div key={ep.id} className="flex items-center gap-1">
-                <WatchedIcon watched={!!ep.is_watched} onClick={() => onToggleWatched(ep.id, !!ep.is_watched)} />
+                <WatchedIcon watched={!!ep.is_watched} onClick={() => onToggleWatched(ep.id, !!ep.is_watched)} disabled={!isEpisodeReleased(ep)} />
                 <span className="text-xs text-gray-400">{formatEpisodeCode(ep)}</span>
               </div>
             ))}
@@ -200,7 +218,7 @@ function ShowEpisodeGroup({ showTitle, episodes, posterUrl, compact, onToggleWat
           <div className="mt-2 space-y-1">
             {episodes.map((ep) => (
               <div key={ep.id} className="flex items-center gap-2 text-sm">
-                <WatchedIcon watched={!!ep.is_watched} onClick={() => onToggleWatched(ep.id, !!ep.is_watched)} />
+                <WatchedIcon watched={!!ep.is_watched} onClick={() => onToggleWatched(ep.id, !!ep.is_watched)} disabled={!isEpisodeReleased(ep)} />
                 <span className="text-indigo-400 font-medium">{formatEpisodeCode(ep)}</span>
                 {ep.name && <span className="text-gray-400"> · {ep.name}</span>}
               </div>

--- a/server/db/repository.ts
+++ b/server/db/repository.ts
@@ -633,6 +633,33 @@ export function getUnwatchedEpisodes(userId: string) {
 
 // ─── Watched Episodes ─────────────────────────────────────────────────────────
 
+export function getEpisodeAirDate(episodeId: number): string | null {
+  const db = getDb();
+  const row = db
+    .select({ airDate: episodes.airDate })
+    .from(episodes)
+    .where(eq(episodes.id, episodeId))
+    .get();
+  return row?.airDate ?? null;
+}
+
+export function getReleasedEpisodeIds(episodeIds: number[]): number[] {
+  const today = new Date().toISOString().slice(0, 10);
+  const db = getDb();
+  const rows = db
+    .select({ id: episodes.id })
+    .from(episodes)
+    .where(
+      and(
+        sql`${episodes.id} IN (${sql.join(episodeIds.map((id) => sql`${id}`), sql`, `)})`,
+        sql`${episodes.airDate} IS NOT NULL`,
+        sql`${episodes.airDate} <= ${today}`
+      )
+    )
+    .all();
+  return rows.map((r) => r.id);
+}
+
 export function watchEpisode(episodeId: number, userId: string) {
   const db = getDb();
   db.insert(watchedEpisodes)

--- a/server/routes/watched.ts
+++ b/server/routes/watched.ts
@@ -1,8 +1,14 @@
 import { Hono } from "hono";
-import { watchEpisode, unwatchEpisode, watchEpisodesBulk, unwatchEpisodesBulk } from "../db/repository";
+import { watchEpisode, unwatchEpisode, watchEpisodesBulk, unwatchEpisodesBulk, getEpisodeAirDate, getReleasedEpisodeIds } from "../db/repository";
 import type { AppEnv } from "../types";
 
 const app = new Hono<AppEnv>();
+
+function isReleased(airDate: string | null): boolean {
+  if (!airDate) return false;
+  const today = new Date().toISOString().slice(0, 10);
+  return airDate <= today;
+}
 
 app.post("/bulk", async (c) => {
   const user = c.get("user")!;
@@ -14,7 +20,11 @@ app.post("/bulk", async (c) => {
   }
 
   if (watched) {
-    watchEpisodesBulk(episodeIds, user.id);
+    const releasedIds = getReleasedEpisodeIds(episodeIds);
+    if (releasedIds.length === 0) {
+      return c.json({ error: "Cannot mark unreleased episodes as watched" }, 400);
+    }
+    watchEpisodesBulk(releasedIds, user.id);
   } else {
     unwatchEpisodesBulk(episodeIds, user.id);
   }
@@ -25,6 +35,10 @@ app.post("/bulk", async (c) => {
 app.post("/:episodeId", (c) => {
   const user = c.get("user")!;
   const episodeId = Number(c.req.param("episodeId"));
+  const airDate = getEpisodeAirDate(episodeId);
+  if (!isReleased(airDate)) {
+    return c.json({ error: "Cannot mark an unreleased episode as watched" }, 400);
+  }
   watchEpisode(episodeId, user.id);
   return c.json({ success: true });
 });


### PR DESCRIPTION
## Summary
This PR adds validation to prevent users from marking episodes as watched before their air date. The changes include both frontend UI updates to disable the watch button for unreleased episodes and backend validation to enforce this constraint.

## Key Changes

**Frontend (CalendarPage.tsx & HomePage.tsx):**
- Added `isEpisodeReleased()` helper function to check if an episode has aired based on its air_date
- Updated `toggleBulkWatched()` to filter out unreleased episodes when marking as watched
- Modified UI to disable/hide the watch button for unreleased episodes with a "Not yet released" tooltip
- Updated `WatchedIcon` component to accept a `disabled` prop and render a non-interactive state for unreleased episodes

**Backend (repository.ts & watched.ts):**
- Added `getEpisodeAirDate()` function to retrieve an episode's air date
- Added `getReleasedEpisodeIds()` function to filter episode IDs to only those that have been released
- Added server-side validation in the `/bulk` endpoint to filter unreleased episodes before marking as watched
- Added server-side validation in the `/:episodeId` endpoint to reject requests to mark unreleased episodes as watched
- Returns 400 error with descriptive message when attempting to mark unreleased episodes as watched

## Implementation Details
- The release check compares the episode's `air_date` against today's date (ISO 8601 format)
- Validation occurs on both client and server side for defense-in-depth
- Bulk operations silently filter unreleased episodes on the client, but the server validates and rejects if no released episodes remain
- Single episode operations are rejected with an error response

https://claude.ai/code/session_01EaiiUTcBZ51rjVMgJfA2ec