### PR TITLE
Change default language from Croatian to English

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -1,6 +1,6 @@
 export const CONFIG = {
   COUNTRY: process.env.TMDB_COUNTRY || process.env.JUSTWATCH_COUNTRY || "HR",
-  LANGUAGE: process.env.TMDB_LANGUAGE || process.env.JUSTWATCH_LANGUAGE || "hr",
+  LANGUAGE: process.env.TMDB_LANGUAGE || process.env.JUSTWATCH_LANGUAGE || "en",
   DEFAULT_DAYS_BACK: 30,
   PAGE_SIZE: 20,
   PAGE_DELAY_MS: 300,


### PR DESCRIPTION
## Summary
Updated the default language configuration from Croatian (`hr`) to English (`en`) when no language environment variables are specified.

## Changes
- Modified `CONFIG.LANGUAGE` default fallback value from `"hr"` to `"en"` in `server/config.ts`
- This affects the language used when neither `TMDB_LANGUAGE` nor `JUSTWATCH_LANGUAGE` environment variables are set

## Details
The configuration now prioritizes explicitly set environment variables but defaults to English instead of Croatian, making the application more universally accessible by default.

https://claude.ai/code/session_013uAncrERGeuBGsMKp5BkFU