### PR TITLE
Replace JustWatch URL and rating with TMDB data in title queries

### DIFF
--- a/server/db/repository.ts
+++ b/server/db/repository.ts
@@ -148,12 +148,11 @@ export function getTitleById(titleId: string, userId?: string) {
       tmdb_id: titles.tmdbId,
       poster_url: titles.posterUrl,
       age_certification: titles.ageCertification,
-      jw_url: titles.jwUrl,
+      tmdb_url: titles.tmdbUrl,
       updated_at: titles.updatedAt,
       imdb_score: scores.imdbScore,
       imdb_votes: scores.imdbVotes,
       tmdb_score: scores.tmdbScore,
-      jw_rating: scores.jwRating,
       is_tracked: trackedSubquery,
     })
     .from(titles)


### PR DESCRIPTION
## Summary
Updated the `getTitleById` repository function to use TMDB data instead of JustWatch data for URL and rating information.

## Key Changes
- Replaced `jw_url` field with `tmdb_url` field to provide TMDB links instead of JustWatch links
- Removed `jw_rating` field from the scores selection, as JustWatch rating data is no longer needed
- Updated the corresponding database column references (`titles.jwUrl` → `titles.tmdbUrl`)

## Implementation Details
This change consolidates the external data sources used in title queries, removing the dependency on JustWatch ratings while maintaining TMDB as the primary source for both URLs and rating information. The modification affects the API response structure for title details, so consumers of this endpoint should be updated accordingly.

https://claude.ai/code/session_01P2a4j3KFSnWnYHMbzGTeqs