### PR TITLE
Add navigation links to episode and show titles

### DIFF
--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
+import { Link } from "react-router-dom";
 import { ChevronLeftIcon, ChevronRightIcon, RefreshCwIcon, CheckCircleIcon, CircleIcon } from "lucide-react";
 import { getCalendarTitles, syncEpisodes, watchEpisode, unwatchEpisode, watchEpisodesBulk } from "../api";
 import TitleList from "../components/TitleList";
@@ -402,15 +403,19 @@ export default function CalendarPage() {
                             }`}
                           >
                             {ep.poster_url && (
-                              <img
-                                src={ep.poster_url}
-                                alt={ep.show_title}
-                                className="w-12 h-18 rounded object-cover flex-shrink-0"
-                              />
+                              <Link to={`/title/${ep.title_id}`} className="flex-shrink-0">
+                                <img
+                                  src={ep.poster_url}
+                                  alt={ep.show_title}
+                                  className="w-12 h-18 rounded object-cover"
+                                />
+                              </Link>
                             )}
                             <div className="min-w-0 flex-1">
                               <div className="flex items-center justify-between gap-2">
-                                <div className="text-sm font-medium text-white">{ep.show_title}</div>
+                                <Link to={`/title/${ep.title_id}`} className="hover:text-indigo-400 transition-colors">
+                                  <div className="text-sm font-medium text-white">{ep.show_title}</div>
+                                </Link>
                                 {isEpisodeReleased(ep) ? (
                                   <button
                                     onClick={() => toggleWatched(ep.id, !!ep.is_watched)}
@@ -436,10 +441,12 @@ export default function CalendarPage() {
                                   </span>
                                 )}
                               </div>
-                              <div className="text-xs text-emerald-400 mt-0.5">
-                                S{String(ep.season_number).padStart(2, "0")}E{String(ep.episode_number).padStart(2, "0")}
-                                {ep.name && ` — ${ep.name}`}
-                              </div>
+                              <Link to={`/title/${ep.title_id}/season/${ep.season_number}/episode/${ep.episode_number}`} className="block hover:text-indigo-400 transition-colors">
+                                <div className="text-xs text-emerald-400 mt-0.5">
+                                  S{String(ep.season_number).padStart(2, "0")}E{String(ep.episode_number).padStart(2, "0")}
+                                  {ep.name && ` — ${ep.name}`}
+                                </div>
+                              </Link>
                               {ep.overview && (
                                 <p className="text-xs text-gray-400 mt-1 line-clamp-2">{ep.overview}</p>
                               )}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import * as api from "../api";
 import type { Episode, Offer } from "../types";
@@ -101,19 +102,25 @@ function EpisodeCard({ episode, compact, onToggleWatched }: { episode: Episode; 
       <div className="flex items-center gap-3 bg-gray-900 rounded-lg border border-gray-800 p-3">
         <WatchedIcon watched={!!episode.is_watched} onClick={() => onToggleWatched(episode.id, !!episode.is_watched)} disabled={unreleased} />
         {episode.poster_url && (
-          <img
-            src={episode.poster_url}
-            alt={episode.show_title}
-            className="w-10 h-15 rounded object-cover flex-shrink-0"
-            loading="lazy"
-          />
+          <Link to={`/title/${episode.title_id}`} className="flex-shrink-0">
+            <img
+              src={episode.poster_url}
+              alt={episode.show_title}
+              className="w-10 h-15 rounded object-cover"
+              loading="lazy"
+            />
+          </Link>
         )}
         <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium text-white truncate">{episode.show_title}</p>
-          <p className="text-xs text-gray-400">
-            {formatEpisodeCode(episode)}
-            {episode.name && ` · ${episode.name}`}
-          </p>
+          <Link to={`/title/${episode.title_id}`} className="hover:text-indigo-400 transition-colors">
+            <p className="text-sm font-medium text-white truncate">{episode.show_title}</p>
+          </Link>
+          <Link to={`/title/${episode.title_id}/season/${episode.season_number}/episode/${episode.episode_number}`} className="hover:text-indigo-400 transition-colors">
+            <p className="text-xs text-gray-400">
+              {formatEpisodeCode(episode)}
+              {episode.name && ` · ${episode.name}`}
+            </p>
+          </Link>
         </div>
         {providers.length > 0 && (
           <div className="flex gap-1 flex-shrink-0">
@@ -133,19 +140,25 @@ function EpisodeCard({ episode, compact, onToggleWatched }: { episode: Episode; 
       <div className="flex gap-4 p-4">
         <WatchedIcon watched={!!episode.is_watched} onClick={() => onToggleWatched(episode.id, !!episode.is_watched)} disabled={unreleased} />
         {episode.poster_url && (
-          <img
-            src={episode.poster_url}
-            alt={episode.show_title}
-            className="w-16 h-24 rounded-lg object-cover flex-shrink-0"
-            loading="lazy"
-          />
+          <Link to={`/title/${episode.title_id}`} className="flex-shrink-0">
+            <img
+              src={episode.poster_url}
+              alt={episode.show_title}
+              className="w-16 h-24 rounded-lg object-cover"
+              loading="lazy"
+            />
+          </Link>
         )}
         <div className="flex-1 min-w-0">
-          <h3 className="font-semibold text-white">{episode.show_title}</h3>
-          <p className="text-sm text-indigo-400 font-medium mt-0.5">
-            {formatEpisodeCode(episode)}
-            {episode.name && ` · ${episode.name}`}
-          </p>
+          <Link to={`/title/${episode.title_id}`} className="hover:text-indigo-400 transition-colors">
+            <h3 className="font-semibold text-white">{episode.show_title}</h3>
+          </Link>
+          <Link to={`/title/${episode.title_id}/season/${episode.season_number}/episode/${episode.episode_number}`} className="hover:text-indigo-400 transition-colors">
+            <p className="text-sm text-indigo-400 font-medium mt-0.5">
+              {formatEpisodeCode(episode)}
+              {episode.name && ` · ${episode.name}`}
+            </p>
+          </Link>
           {episode.overview && (
             <p className="text-sm text-gray-400 mt-2 line-clamp-2">{episode.overview}</p>
           )}
@@ -181,15 +194,21 @@ function ShowEpisodeGroup({ showTitle, episodes, posterUrl, compact, onToggleWat
     return (
       <div className="flex items-center gap-3 bg-gray-900 rounded-lg border border-gray-800 p-3">
         {posterUrl && (
-          <img src={posterUrl} alt={showTitle} className="w-10 h-15 rounded object-cover flex-shrink-0" loading="lazy" />
+          <Link to={`/title/${episodes[0].title_id}`} className="flex-shrink-0">
+            <img src={posterUrl} alt={showTitle} className="w-10 h-15 rounded object-cover" loading="lazy" />
+          </Link>
         )}
         <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium text-white truncate">{showTitle}</p>
+          <Link to={`/title/${episodes[0].title_id}`} className="hover:text-indigo-400 transition-colors">
+            <p className="text-sm font-medium text-white truncate">{showTitle}</p>
+          </Link>
           <div className="flex flex-wrap gap-x-3 gap-y-0.5 mt-0.5">
             {episodes.map((ep) => (
               <div key={ep.id} className="flex items-center gap-1">
                 <WatchedIcon watched={!!ep.is_watched} onClick={() => onToggleWatched(ep.id, !!ep.is_watched)} disabled={!isEpisodeReleased(ep)} />
-                <span className="text-xs text-gray-400">{formatEpisodeCode(ep)}</span>
+                <Link to={`/title/${ep.title_id}/season/${ep.season_number}/episode/${ep.episode_number}`} className="hover:text-indigo-400 transition-colors">
+                  <span className="text-xs text-gray-400">{formatEpisodeCode(ep)}</span>
+                </Link>
               </div>
             ))}
           </div>
@@ -211,16 +230,22 @@ function ShowEpisodeGroup({ showTitle, episodes, posterUrl, compact, onToggleWat
     <div className="bg-gray-900 rounded-xl overflow-hidden border border-gray-800 hover:border-gray-700 transition-colors">
       <div className="flex gap-4 p-4">
         {posterUrl && (
-          <img src={posterUrl} alt={showTitle} className="w-16 h-24 rounded-lg object-cover flex-shrink-0" loading="lazy" />
+          <Link to={`/title/${episodes[0].title_id}`} className="flex-shrink-0">
+            <img src={posterUrl} alt={showTitle} className="w-16 h-24 rounded-lg object-cover" loading="lazy" />
+          </Link>
         )}
         <div className="flex-1 min-w-0">
-          <h3 className="font-semibold text-white">{showTitle}</h3>
+          <Link to={`/title/${episodes[0].title_id}`} className="hover:text-indigo-400 transition-colors">
+            <h3 className="font-semibold text-white">{showTitle}</h3>
+          </Link>
           <div className="mt-2 space-y-1">
             {episodes.map((ep) => (
               <div key={ep.id} className="flex items-center gap-2 text-sm">
                 <WatchedIcon watched={!!ep.is_watched} onClick={() => onToggleWatched(ep.id, !!ep.is_watched)} disabled={!isEpisodeReleased(ep)} />
-                <span className="text-indigo-400 font-medium">{formatEpisodeCode(ep)}</span>
-                {ep.name && <span className="text-gray-400"> · {ep.name}</span>}
+                <Link to={`/title/${ep.title_id}/season/${ep.season_number}/episode/${ep.episode_number}`} className="hover:text-indigo-400 transition-colors">
+                  <span className="text-indigo-400 font-medium">{formatEpisodeCode(ep)}</span>
+                  {ep.name && <span className="text-gray-400"> · {ep.name}</span>}
+                </Link>
               </div>
             ))}
           </div>
@@ -253,11 +278,15 @@ function UnwatchedShowGroup({ showTitle, seasonNumber, episodes, posterUrl, onTo
     <div className="bg-gray-900 rounded-xl overflow-hidden border border-gray-800 hover:border-gray-700 transition-colors">
       <div className="flex gap-4 p-4">
         {posterUrl && (
-          <img src={posterUrl} alt={showTitle} className="w-16 h-24 rounded-lg object-cover flex-shrink-0" loading="lazy" />
+          <Link to={`/title/${episodes[0].title_id}`} className="flex-shrink-0">
+            <img src={posterUrl} alt={showTitle} className="w-16 h-24 rounded-lg object-cover" loading="lazy" />
+          </Link>
         )}
         <div className="flex-1 min-w-0">
           <div className="flex items-center justify-between gap-2">
-            <h3 className="font-semibold text-white">{showTitle}</h3>
+            <Link to={`/title/${episodes[0].title_id}`} className="hover:text-indigo-400 transition-colors">
+              <h3 className="font-semibold text-white">{showTitle}</h3>
+            </Link>
             {episodes.length > 1 && (
               <button
                 onClick={() => onMarkSeasonWatched(episodes.map((ep) => ep.id))}
@@ -272,8 +301,10 @@ function UnwatchedShowGroup({ showTitle, seasonNumber, episodes, posterUrl, onTo
             {episodes.map((ep) => (
               <div key={ep.id} className="flex items-center gap-2 text-sm">
                 <WatchedIcon watched={!!ep.is_watched} onClick={() => onToggleWatched(ep.id, !!ep.is_watched)} />
-                <span className="text-indigo-400 font-medium">{formatEpisodeCode(ep)}</span>
-                {ep.name && <span className="text-gray-400 truncate"> · {ep.name}</span>}
+                <Link to={`/title/${ep.title_id}/season/${ep.season_number}/episode/${ep.episode_number}`} className="hover:text-indigo-400 transition-colors truncate">
+                  <span className="text-indigo-400 font-medium">{formatEpisodeCode(ep)}</span>
+                  {ep.name && <span className="text-gray-400"> · {ep.name}</span>}
+                </Link>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
This PR adds clickable navigation links to episode and show titles throughout the HomePage and CalendarPage, allowing users to navigate to detailed title and episode pages directly from list views.

## Key Changes
- **HomePage.tsx**: 
  - Wrapped episode poster images with links to the title detail page (`/title/{title_id}`)
  - Wrapped show titles with links to the title detail page
  - Wrapped episode codes and names with links to the specific episode page (`/title/{title_id}/season/{season_number}/episode/{episode_number}`)
  - Applied these changes across all episode card variants (compact and full) and show episode group components
  - Added hover effects with `hover:text-indigo-400 transition-colors` styling for better UX

- **CalendarPage.tsx**:
  - Added similar navigation links to episode posters, show titles, and episode information
  - Wrapped episode details with links to the specific episode page
  - Maintained consistent styling with hover effects

## Implementation Details
- Used React Router's `Link` component for client-side navigation
- Removed `flex-shrink-0` class from images and applied it to the Link wrapper instead to maintain proper layout
- Added `block` class to one Link wrapper to ensure proper display behavior
- Maintained all existing styling and functionality while adding navigation capabilities
- Links are contextually appropriate: poster/title links go to title page, episode code/name links go to specific episode page

https://claude.ai/code/session_015q5FwMkALNeiBd2Dny7Wou