### PR TITLE
Add fallback country support for watch provider lookups

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -1,5 +1,9 @@
 export const CONFIG = {
   COUNTRY: process.env.TMDB_COUNTRY || process.env.JUSTWATCH_COUNTRY || "HR",
+  FALLBACK_COUNTRIES: (process.env.TMDB_FALLBACK_COUNTRIES || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean),
   LANGUAGE: process.env.TMDB_LANGUAGE || process.env.JUSTWATCH_LANGUAGE || "en",
   DEFAULT_DAYS_BACK: 30,
   PAGE_SIZE: 20,

--- a/server/tmdb/parser.test.ts
+++ b/server/tmdb/parser.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, afterEach } from "bun:test";
+import { CONFIG } from "../config";
 import {
   parseMovieDetails,
   parseTvDetails,
@@ -166,6 +167,176 @@ describe("parseSearchResult", () => {
       new Map()
     );
     expect(result).toBeNull();
+  });
+});
+
+describe("parseWatchProviders fallback", () => {
+  const origCountry = CONFIG.COUNTRY;
+  const origFallback = CONFIG.FALLBACK_COUNTRIES;
+
+  afterEach(() => {
+    CONFIG.COUNTRY = origCountry;
+    CONFIG.FALLBACK_COUNTRIES = origFallback;
+  });
+
+  it("uses primary country when available", () => {
+    CONFIG.COUNTRY = "HR";
+    CONFIG.FALLBACK_COUNTRIES = ["US"];
+
+    const movie = makeTmdbMovieDetails({
+      "watch/providers": {
+        id: 123,
+        results: {
+          HR: {
+            link: "https://tmdb.org",
+            flatrate: [
+              {
+                logo_path: "/netflix.jpg",
+                provider_id: 8,
+                provider_name: "Netflix",
+                display_priority: 1,
+              },
+            ],
+          },
+          US: {
+            link: "https://tmdb.org",
+            flatrate: [
+              {
+                logo_path: "/apple.jpg",
+                provider_id: 350,
+                provider_name: "Apple TV Plus",
+                display_priority: 1,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const result = parseMovieDetails(movie);
+    expect(result.offers).toHaveLength(1);
+    expect(result.offers[0].providerName).toBe("Netflix");
+  });
+
+  it("falls back to first matching fallback country", () => {
+    CONFIG.COUNTRY = "HR";
+    CONFIG.FALLBACK_COUNTRIES = ["US", "GB"];
+
+    const movie = makeTmdbMovieDetails({
+      "watch/providers": {
+        id: 123,
+        results: {
+          US: {
+            link: "https://tmdb.org",
+            flatrate: [
+              {
+                logo_path: "/apple.jpg",
+                provider_id: 350,
+                provider_name: "Apple TV Plus",
+                display_priority: 1,
+              },
+            ],
+          },
+          GB: {
+            link: "https://tmdb.org",
+            flatrate: [
+              {
+                logo_path: "/apple.jpg",
+                provider_id: 350,
+                provider_name: "Apple TV+",
+                display_priority: 1,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const result = parseMovieDetails(movie);
+    expect(result.offers).toHaveLength(1);
+    expect(result.offers[0].providerName).toBe("Apple TV Plus");
+  });
+
+  it("falls back to second country when first also has no data", () => {
+    CONFIG.COUNTRY = "HR";
+    CONFIG.FALLBACK_COUNTRIES = ["US", "GB"];
+
+    const movie = makeTmdbMovieDetails({
+      "watch/providers": {
+        id: 123,
+        results: {
+          GB: {
+            link: "https://tmdb.org",
+            flatrate: [
+              {
+                logo_path: "/apple.jpg",
+                provider_id: 350,
+                provider_name: "Apple TV+",
+                display_priority: 1,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const result = parseMovieDetails(movie);
+    expect(result.offers).toHaveLength(1);
+    expect(result.offers[0].providerName).toBe("Apple TV+");
+  });
+
+  it("returns empty when no country matches", () => {
+    CONFIG.COUNTRY = "HR";
+    CONFIG.FALLBACK_COUNTRIES = ["US", "GB"];
+
+    const movie = makeTmdbMovieDetails({
+      "watch/providers": {
+        id: 123,
+        results: {
+          DE: {
+            link: "https://tmdb.org",
+            flatrate: [
+              {
+                logo_path: "/apple.jpg",
+                provider_id: 350,
+                provider_name: "Apple TV Plus",
+                display_priority: 1,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const result = parseMovieDetails(movie);
+    expect(result.offers).toHaveLength(0);
+  });
+
+  it("works with empty fallback list (default behavior)", () => {
+    CONFIG.COUNTRY = "HR";
+    CONFIG.FALLBACK_COUNTRIES = [];
+
+    const movie = makeTmdbMovieDetails({
+      "watch/providers": {
+        id: 123,
+        results: {
+          US: {
+            link: "https://tmdb.org",
+            flatrate: [
+              {
+                logo_path: "/apple.jpg",
+                provider_id: 350,
+                provider_name: "Apple TV Plus",
+                display_priority: 1,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const result = parseMovieDetails(movie);
+    expect(result.offers).toHaveLength(0);
   });
 });
 

--- a/server/tmdb/parser.ts
+++ b/server/tmdb/parser.ts
@@ -87,7 +87,12 @@ function parseWatchProviders(
   tmdbLink: string
 ): ParsedOffer[] {
   if (!wpResponse) return [];
-  const countryData = wpResponse.results[CONFIG.COUNTRY];
+  const countries = [CONFIG.COUNTRY, ...CONFIG.FALLBACK_COUNTRIES];
+  let countryData: TmdbWatchProviderCountry | undefined;
+  for (const country of countries) {
+    countryData = wpResponse.results[country];
+    if (countryData) break;
+  }
   if (!countryData) return [];
 
   const offers: ParsedOffer[] = [];


### PR DESCRIPTION
## Summary
This PR adds support for fallback countries when looking up streaming provider information. If watch provider data is not available for the primary country, the system will now check a configurable list of fallback countries in order.

## Key Changes
- **Config**: Added `FALLBACK_COUNTRIES` configuration option that reads from `TMDB_FALLBACK_COUNTRIES` environment variable (comma-separated list)
- **Parser**: Updated `parseWatchProviders()` to iterate through primary country and fallback countries in order, using the first match found
- **Tests**: Added comprehensive test suite covering:
  - Primary country preference when available
  - Fallback to first matching fallback country
  - Fallback to subsequent countries when earlier ones have no data
  - Empty result when no countries match
  - Default behavior with empty fallback list

## Implementation Details
- The fallback logic uses a simple linear search through `[CONFIG.COUNTRY, ...CONFIG.FALLBACK_COUNTRIES]`
- Configuration parsing safely handles empty strings and whitespace in the comma-separated list
- Tests properly restore original config values using `afterEach` hook to prevent test pollution

https://claude.ai/code/session_01XBdr4ZYBAL6gNrPgZPaPpG