### PR TITLE
Update GitHub Actions and migrate to react-router v7

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,13 +21,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -46,7 +46,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { ChevronLeftIcon, ChevronRightIcon, RefreshCwIcon, CheckCircleIcon, CircleIcon } from "lucide-react";
 import { getCalendarTitles, syncEpisodes, watchEpisode, unwatchEpisode, watchEpisodesBulk } from "../api";
 import TitleList from "../components/TitleList";

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { useAuth } from "../context/AuthContext";
 import * as api from "../api";
 import type { Episode, Offer } from "../types";


### PR DESCRIPTION
## Summary
This PR updates GitHub Actions workflows to use the latest versions and migrates the frontend from `react-router-dom` to the new `react-router` package structure.

## Key Changes
- **GitHub Actions Updates:**
  - Updated `actions/checkout` from v4 to v6
  - Updated `docker/setup-buildx-action` from v3 to v4
  - Updated `docker/login-action` from v3 to v4
  - Updated `docker/build-push-action` from v6 to v7

- **React Router Migration:**
  - Changed import statements in `CalendarPage.tsx` and `HomePage.tsx` from `react-router-dom` to `react-router`
  - This aligns with the new unified package structure in react-router v7

## Implementation Details
The react-router migration is a straightforward import path update. The `Link` component and other router utilities are now exported directly from the `react-router` package rather than the `react-router-dom` subpackage, reflecting the simplified API in the latest major version.

https://claude.ai/code/session_01F751MFTMCsJCeYamF3UG6M