### PR TITLE
Add original title support for movies and TV shows

### DIFF
--- a/frontend/src/components/TitleCard.tsx
+++ b/frontend/src/components/TitleCard.tsx
@@ -53,6 +53,9 @@ export default function TitleCard({ title, onTrackToggle }: Props) {
           <Link to={`/title/${title.id}`} className="hover:text-indigo-400 transition-colors">
             <h3 className="font-semibold text-sm leading-tight line-clamp-2">{title.title}</h3>
           </Link>
+          {title.original_title && title.original_title !== title.title && (
+            <p className="text-xs text-gray-500 mt-0.5 line-clamp-1 italic">{title.original_title}</p>
+          )}
           <p className="text-xs text-gray-500 mt-0.5">
             {title.release_year}
             {title.runtime_minutes ? ` \u00B7 ${title.runtime_minutes}m` : ""}

--- a/frontend/src/pages/TitleDetailPage.tsx
+++ b/frontend/src/pages/TitleDetailPage.tsx
@@ -222,10 +222,14 @@ function MovieDetail({ data }: { data: MovieDetailsResponse }) {
               {tmdb?.tagline && (
                 <p className="text-sm text-indigo-400 italic mb-1">{tmdb.tagline}</p>
               )}
-              <h1 className="text-3xl font-bold text-white">{title.title}</h1>
-              {tmdb?.original_title && tmdb.original_title !== title.title && (
-                <p className="text-sm text-gray-400 mt-1">{tmdb.original_title}</p>
-              )}
+              <h1 className="text-3xl font-bold text-white">{tmdb?.title || title.title}</h1>
+              {(() => {
+                const displayTitle = tmdb?.title || title.title;
+                const originalTitle = tmdb?.original_title || title.original_title;
+                return originalTitle && originalTitle !== displayTitle ? (
+                  <p className="text-sm text-gray-400 mt-1">{originalTitle}</p>
+                ) : null;
+              })()}
             </div>
 
             <div className="flex flex-wrap items-center gap-2 text-sm text-gray-400">
@@ -484,10 +488,14 @@ function ShowDetail({ data }: { data: ShowDetailsResponse }) {
               {tmdb?.tagline && (
                 <p className="text-sm text-indigo-400 italic mb-1">{tmdb.tagline}</p>
               )}
-              <h1 className="text-3xl font-bold text-white">{title.title}</h1>
-              {tmdb?.original_name && tmdb.original_name !== title.title && (
-                <p className="text-sm text-gray-400 mt-1">{tmdb.original_name}</p>
-              )}
+              <h1 className="text-3xl font-bold text-white">{tmdb?.name || title.title}</h1>
+              {(() => {
+                const displayTitle = tmdb?.name || title.title;
+                const originalTitle = tmdb?.original_name || title.original_title;
+                return originalTitle && originalTitle !== displayTitle ? (
+                  <p className="text-sm text-gray-400 mt-1">{originalTitle}</p>
+                ) : null;
+              })()}
             </div>
 
             <div className="flex flex-wrap items-center gap-2 text-sm text-gray-400">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -17,6 +17,7 @@ export interface Title {
   id: string;
   object_type: "MOVIE" | "SHOW";
   title: string;
+  original_title: string | null;
   release_year: number | null;
   release_date: string | null;
   runtime_minutes: number | null;
@@ -56,6 +57,7 @@ export interface SearchTitle {
   id: string;
   objectType: "MOVIE" | "SHOW";
   title: string;
+  originalTitle: string | null;
   releaseYear: number | null;
   releaseDate: string | null;
   runtimeMinutes: number | null;
@@ -298,6 +300,7 @@ export function normalizeSearchTitle(t: SearchTitle): Title {
     id: t.id,
     object_type: t.objectType,
     title: t.title,
+    original_title: t.originalTitle,
     release_year: t.releaseYear,
     release_date: t.releaseDate,
     runtime_minutes: t.runtimeMinutes,

--- a/server/db/repository.test.ts
+++ b/server/db/repository.test.ts
@@ -66,6 +66,18 @@ describe("upsertTitles", () => {
     expect(result!.title).toBe("Updated");
   });
 
+  it("stores and retrieves original_title", () => {
+    upsertTitles([makeParsedTitle({ originalTitle: "Film Original" })]);
+    const result = getTitleById("movie-123");
+    expect(result!.original_title).toBe("Film Original");
+  });
+
+  it("stores null original_title when not provided", () => {
+    upsertTitles([makeParsedTitle({ originalTitle: null })]);
+    const result = getTitleById("movie-123");
+    expect(result!.original_title).toBeNull();
+  });
+
   it("upserts providers and offers", () => {
     const title = makeParsedTitle({
       offers: [

--- a/server/db/repository.ts
+++ b/server/db/repository.ts
@@ -54,6 +54,7 @@ export function upsertTitles(parsedTitles: ParsedTitle[]) {
           id: t.id,
           objectType: t.objectType,
           title: t.title,
+          originalTitle: t.originalTitle,
           releaseYear: t.releaseYear,
           releaseDate: t.releaseDate,
           runtimeMinutes: t.runtimeMinutes,
@@ -70,6 +71,7 @@ export function upsertTitles(parsedTitles: ParsedTitle[]) {
           target: titles.id,
           set: {
             title: sql`excluded.title`,
+            originalTitle: sql`excluded.original_title`,
             releaseYear: sql`excluded.release_year`,
             releaseDate: sql`excluded.release_date`,
             runtimeMinutes: sql`excluded.runtime_minutes`,
@@ -139,6 +141,7 @@ export function getTitleById(titleId: string, userId?: string) {
       id: titles.id,
       object_type: titles.objectType,
       title: titles.title,
+      original_title: titles.originalTitle,
       release_year: titles.releaseYear,
       release_date: titles.releaseDate,
       runtime_minutes: titles.runtimeMinutes,
@@ -218,6 +221,7 @@ export function getRecentTitles(filters: TitleFilters = {}, userId?: string) {
       id: titles.id,
       object_type: titles.objectType,
       title: titles.title,
+      original_title: titles.originalTitle,
       release_year: titles.releaseYear,
       release_date: titles.releaseDate,
       runtime_minutes: titles.runtimeMinutes,
@@ -300,6 +304,7 @@ export function getTrackedTitles(userId: string) {
       id: titles.id,
       object_type: titles.objectType,
       title: titles.title,
+      original_title: titles.originalTitle,
       release_year: titles.releaseYear,
       release_date: titles.releaseDate,
       runtime_minutes: titles.runtimeMinutes,
@@ -347,6 +352,7 @@ export function searchLocalTitles(query: string, limit = 50, userId?: string) {
       id: titles.id,
       object_type: titles.objectType,
       title: titles.title,
+      original_title: titles.originalTitle,
       release_year: titles.releaseYear,
       release_date: titles.releaseDate,
       runtime_minutes: titles.runtimeMinutes,
@@ -444,6 +450,7 @@ export function getTitlesByMonth(filters: MonthFilters, userId?: string) {
       id: titles.id,
       object_type: titles.objectType,
       title: titles.title,
+      original_title: titles.originalTitle,
       release_year: titles.releaseYear,
       release_date: titles.releaseDate,
       runtime_minutes: titles.runtimeMinutes,
@@ -560,6 +567,7 @@ export function getEpisodesByMonth(filters: MonthFilters, userId?: string) {
       still_path: episodes.stillPath,
       updated_at: episodes.updatedAt,
       show_title: titles.title,
+      show_original_title: titles.originalTitle,
       poster_url: titles.posterUrl,
       is_watched: sql<boolean>`EXISTS(
         SELECT 1 FROM watched_episodes we
@@ -599,6 +607,7 @@ export function getEpisodesByDateRange(startDate: string, endDate: string, userI
       still_path: episodes.stillPath,
       updated_at: episodes.updatedAt,
       show_title: titles.title,
+      show_original_title: titles.originalTitle,
       poster_url: titles.posterUrl,
       is_watched: sql<boolean>`EXISTS(
         SELECT 1 FROM watched_episodes we
@@ -643,6 +652,7 @@ export function getUnwatchedEpisodes(userId: string) {
       still_path: episodes.stillPath,
       updated_at: episodes.updatedAt,
       show_title: titles.title,
+      show_original_title: titles.originalTitle,
       poster_url: titles.posterUrl,
     })
     .from(episodes)

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -20,6 +20,7 @@ export const titles = sqliteTable(
     id: text("id").primaryKey(),
     objectType: text("object_type").notNull(),
     title: text("title").notNull(),
+    originalTitle: text("original_title"),
     releaseYear: integer("release_year"),
     releaseDate: text("release_date"),
     runtimeMinutes: integer("runtime_minutes"),
@@ -264,6 +265,7 @@ function initSchema(db: Database) {
       id TEXT PRIMARY KEY,
       object_type TEXT NOT NULL,
       title TEXT NOT NULL,
+      original_title TEXT,
       release_year INTEGER,
       release_date TEXT,
       runtime_minutes INTEGER,
@@ -467,6 +469,18 @@ function migrateSchema(db: Database) {
 
     console.log("[Migration v3] Migration complete. Data cleared for TMDB re-sync.");
     setSchemaVersion(db, 3);
+  }
+
+  // Migration v4: Add original_title column to titles
+  if (getSchemaVersion(db) < 4) {
+    const titlesInfo = db.prepare(
+      "SELECT sql FROM sqlite_master WHERE type='table' AND name='titles'"
+    ).get() as any;
+    if (titlesInfo && !titlesInfo.sql.includes("original_title")) {
+      db.run("ALTER TABLE titles ADD COLUMN original_title TEXT");
+      console.log("[Migration v4] Added original_title column to titles table.");
+    }
+    setSchemaVersion(db, 4);
   }
 }
 

--- a/server/jobs/migrate-titles.ts
+++ b/server/jobs/migrate-titles.ts
@@ -1,0 +1,67 @@
+import { getRawDb } from "../db/schema";
+import { fetchMovieDetails, fetchTvDetails } from "../tmdb/client";
+import { CONFIG } from "../config";
+
+const DELAY_MS = 500;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * One-time migration: fetches English titles and original titles from TMDB
+ * for all existing titles that don't have original_title set yet.
+ */
+export async function migrateTitles(): Promise<{ updated: number; failed: number }> {
+  if (!CONFIG.TMDB_API_KEY) {
+    console.log("[MigrateTitles] Skipping — TMDB_API_KEY not configured");
+    return { updated: 0, failed: 0 };
+  }
+
+  const db = getRawDb();
+  const rows = db
+    .prepare(
+      "SELECT id, object_type, tmdb_id FROM titles WHERE original_title IS NULL AND tmdb_id IS NOT NULL"
+    )
+    .all() as { id: string; object_type: string; tmdb_id: string }[];
+
+  if (rows.length === 0) {
+    console.log("[MigrateTitles] No titles need migration");
+    return { updated: 0, failed: 0 };
+  }
+
+  console.log(`[MigrateTitles] Migrating ${rows.length} titles...`);
+  let updated = 0;
+  let failed = 0;
+
+  for (const row of rows) {
+    try {
+      const tmdbId = parseInt(row.tmdb_id, 10);
+      let englishTitle: string;
+      let originalTitle: string;
+
+      if (row.object_type === "MOVIE" || row.id.startsWith("movie-")) {
+        const details = await fetchMovieDetails(tmdbId);
+        englishTitle = details.title;
+        originalTitle = details.original_title;
+      } else {
+        const details = await fetchTvDetails(tmdbId);
+        englishTitle = details.name;
+        originalTitle = details.original_name;
+      }
+
+      db.prepare(
+        "UPDATE titles SET title = ?, original_title = ? WHERE id = ?"
+      ).run(englishTitle, originalTitle, row.id);
+      updated++;
+    } catch (err) {
+      console.error(`[MigrateTitles] Failed to migrate ${row.id}:`, err);
+      failed++;
+    }
+
+    await delay(DELAY_MS);
+  }
+
+  console.log(`[MigrateTitles] Done: ${updated} updated, ${failed} failed`);
+  return { updated, failed };
+}

--- a/server/jobs/sync.ts
+++ b/server/jobs/sync.ts
@@ -1,9 +1,10 @@
 import { registerHandler } from "./worker";
-import { registerCron } from "./queue";
+import { registerCron, enqueueJob } from "./queue";
 import { CONFIG } from "../config";
 import { fetchNewReleases } from "../tmdb/sync-titles";
 import { upsertTitles } from "../db/repository";
 import { syncEpisodes } from "../tmdb/sync";
+import { migrateTitles } from "./migrate-titles";
 
 export function registerSyncJobs() {
   // ─── Handlers ───────────────────────────────────────────────────────────
@@ -23,8 +24,15 @@ export function registerSyncJobs() {
     console.log(`[Sync] Synced ${result.synced} episodes from ${result.shows} shows`);
   });
 
+  registerHandler("migrate-titles", async () => {
+    await migrateTitles();
+  });
+
   // ─── Cron Schedules ────────────────────────────────────────────────────
 
   registerCron("sync-titles", CONFIG.SYNC_TITLES_CRON);
   registerCron("sync-episodes", CONFIG.SYNC_EPISODES_CRON);
+
+  // Enqueue one-time title migration (will no-op if all titles already have original_title)
+  enqueueJob("migrate-titles", undefined, { maxAttempts: 1 });
 }

--- a/server/routes/track.ts
+++ b/server/routes/track.ts
@@ -19,6 +19,7 @@ function toParsedTitle(t: any): ParsedTitle {
     id: t.id,
     objectType: t.object_type,
     title: t.title,
+    originalTitle: t.original_title || null,
     releaseYear: t.release_year,
     releaseDate: t.release_date,
     runtimeMinutes: t.runtime_minutes,

--- a/server/test-utils/fixtures.ts
+++ b/server/test-utils/fixtures.ts
@@ -6,6 +6,7 @@ export function makeParsedTitle(overrides?: Partial<ParsedTitle>): ParsedTitle {
     id: "movie-123",
     objectType: "MOVIE",
     title: "Test Movie",
+    originalTitle: null,
     releaseYear: 2024,
     releaseDate: "2024-06-15",
     runtimeMinutes: 120,
@@ -43,6 +44,7 @@ export function makeTmdbMovieDetails(overrides?: Partial<TmdbMovieDetails>): Tmd
   return {
     id: 123,
     title: "Test Movie",
+    original_title: "Test Movie",
     overview: "A test movie",
     release_date: "2024-06-15",
     runtime: 120,
@@ -62,6 +64,7 @@ export function makeTmdbTvDetails(overrides?: Partial<TmdbTvDetails>): TmdbTvDet
   return {
     id: 456,
     name: "Test Show",
+    original_name: "Test Show",
     overview: "A test show",
     first_air_date: "2024-01-10",
     episode_run_time: [45],
@@ -82,6 +85,7 @@ export function makeTmdbDiscoverMovie(overrides?: Partial<TmdbDiscoverMovieResul
   return {
     id: 789,
     title: "Discover Movie",
+    original_title: "Discover Movie",
     overview: "A discovered movie",
     release_date: "2024-03-20",
     poster_path: "/discover.jpg",
@@ -99,6 +103,7 @@ export function makeTmdbDiscoverTv(overrides?: Partial<TmdbDiscoverTvResult>): T
   return {
     id: 101,
     name: "Discover Show",
+    original_name: "Discover Show",
     overview: "A discovered show",
     first_air_date: "2024-05-01",
     poster_path: "/discovershow.jpg",

--- a/server/tmdb/parser.test.ts
+++ b/server/tmdb/parser.test.ts
@@ -56,6 +56,12 @@ describe("parseMovieDetails", () => {
     expect(result.scores.tmdbScore).toBeNull();
   });
 
+  it("parses original_title", () => {
+    const movie = makeTmdbMovieDetails({ original_title: "Film Original" });
+    const result = parseMovieDetails(movie);
+    expect(result.originalTitle).toBe("Film Original");
+  });
+
   it("parses watch providers for configured country", () => {
     const movie = makeTmdbMovieDetails({
       "watch/providers": {
@@ -102,6 +108,12 @@ describe("parseTvDetails", () => {
     const result = parseTvDetails(tv);
     expect(result.runtimeMinutes).toBeNull();
   });
+
+  it("parses original_name", () => {
+    const tv = makeTmdbTvDetails({ original_name: "Original Show Name" });
+    const result = parseTvDetails(tv);
+    expect(result.originalTitle).toBe("Original Show Name");
+  });
 });
 
 describe("parseDiscoverMovie", () => {
@@ -124,6 +136,13 @@ describe("parseDiscoverMovie", () => {
     const result = parseDiscoverMovie(movie, genreMap);
     expect(result.genres).toEqual(["Action"]);
   });
+
+  it("parses original_title", () => {
+    const genreMap = new Map([[28, "Action"]]);
+    const movie = makeTmdbDiscoverMovie({ original_title: "Pelicula" });
+    const result = parseDiscoverMovie(movie, genreMap);
+    expect(result.originalTitle).toBe("Pelicula");
+  });
 });
 
 describe("parseDiscoverTv", () => {
@@ -136,6 +155,13 @@ describe("parseDiscoverTv", () => {
     expect(result.objectType).toBe("SHOW");
     expect(result.title).toBe("Discover Show");
     expect(result.genres).toEqual(["Drama"]);
+  });
+
+  it("parses original_name", () => {
+    const genreMap = new Map([[18, "Drama"]]);
+    const tv = makeTmdbDiscoverTv({ original_name: "Serie Original" });
+    const result = parseDiscoverTv(tv, genreMap);
+    expect(result.originalTitle).toBe("Serie Original");
   });
 });
 

--- a/server/tmdb/parser.ts
+++ b/server/tmdb/parser.ts
@@ -15,6 +15,7 @@ export interface ParsedTitle {
   id: string;
   objectType: "MOVIE" | "SHOW";
   title: string;
+  originalTitle: string | null;
   releaseYear: number | null;
   releaseDate: string | null;
   runtimeMinutes: number | null;
@@ -131,6 +132,7 @@ export function parseMovieDetails(movie: TmdbMovieDetails): ParsedTitle {
     id,
     objectType: "MOVIE",
     title: movie.title,
+    originalTitle: movie.original_title || null,
     releaseYear: parseYear(movie.release_date),
     releaseDate: movie.release_date || null,
     runtimeMinutes: movie.runtime,
@@ -159,6 +161,7 @@ export function parseTvDetails(tv: TmdbTvDetails): ParsedTitle {
     id,
     objectType: "SHOW",
     title: tv.name,
+    originalTitle: tv.original_name || null,
     releaseYear: parseYear(tv.first_air_date),
     releaseDate: tv.first_air_date || null,
     runtimeMinutes: runtime,
@@ -189,6 +192,7 @@ export function parseDiscoverMovie(
     id,
     objectType: "MOVIE",
     title: movie.title,
+    originalTitle: movie.original_title || null,
     releaseYear: parseYear(movie.release_date),
     releaseDate: movie.release_date || null,
     runtimeMinutes: null,
@@ -217,6 +221,7 @@ export function parseDiscoverTv(
     id,
     objectType: "SHOW",
     title: tv.name,
+    originalTitle: tv.original_name || null,
     releaseYear: parseYear(tv.first_air_date),
     releaseDate: tv.first_air_date || null,
     runtimeMinutes: null,
@@ -248,6 +253,7 @@ export function parseSearchResult(
       id,
       objectType: "MOVIE",
       title: result.title || "",
+      originalTitle: null,
       releaseYear: parseYear(result.release_date),
       releaseDate: result.release_date || null,
       runtimeMinutes: null,
@@ -273,6 +279,7 @@ export function parseSearchResult(
     id,
     objectType: "SHOW",
     title: result.name || "",
+    originalTitle: null,
     releaseYear: parseYear(result.first_air_date),
     releaseDate: result.first_air_date || null,
     runtimeMinutes: null,

--- a/server/tmdb/types.ts
+++ b/server/tmdb/types.ts
@@ -61,6 +61,7 @@ export interface TmdbWatchProviderResponse {
 export interface TmdbMovieDetails {
   id: number;
   title: string;
+  original_title: string;
   overview: string | null;
   release_date: string;
   runtime: number | null;
@@ -79,6 +80,7 @@ export interface TmdbMovieDetails {
 export interface TmdbTvDetails {
   id: number;
   name: string;
+  original_name: string;
   overview: string | null;
   first_air_date: string;
   episode_run_time: number[];
@@ -100,6 +102,7 @@ export interface TmdbTvDetails {
 export interface TmdbDiscoverMovieResult {
   id: number;
   title: string;
+  original_title: string;
   overview: string | null;
   release_date: string;
   poster_path: string | null;
@@ -114,6 +117,7 @@ export interface TmdbDiscoverMovieResult {
 export interface TmdbDiscoverTvResult {
   id: number;
   name: string;
+  original_name: string;
   overview: string | null;
   first_air_date: string;
   poster_path: string | null;


### PR DESCRIPTION
## Summary
This PR adds support for storing and displaying original titles (in their native language) for movies and TV shows, alongside the English titles. This includes database schema updates, TMDB data parsing, a one-time migration job, and UI enhancements to display original titles when they differ from English titles.

## Key Changes

- **Database Schema**: Added `original_title` column to the `titles` table with migration v4 to handle existing databases
- **TMDB Integration**: Updated type definitions and parsers to extract `original_title` (movies) and `original_name` (TV shows) from TMDB API responses
- **Data Parsing**: Modified `parseMovieDetails`, `parseTvDetails`, `parseDiscoverMovie`, `parseDiscoverTv`, and `parseSearchResult` to capture original titles
- **Migration Job**: Created `migrate-titles.ts` job that fetches and backfills original titles for existing titles from TMDB (with 500ms rate limiting)
- **Repository Layer**: Updated all database queries to include `original_title` field in results
- **Frontend Display**: 
  - Updated `TitleDetailPage` to display original titles when they differ from English titles
  - Enhanced `TitleCard` to show original titles in a smaller, italicized format
  - Updated type definitions to include `original_title` field
- **Testing**: Added comprehensive test coverage for original title parsing across all parser functions

## Implementation Details

- The migration job is enqueued once on startup and automatically skips if all titles already have original titles populated
- Original titles are only displayed in the UI when they differ from the English title to avoid redundancy
- The TMDB API calls in the migration job include a 500ms delay between requests to respect rate limits
- All existing database queries were updated to maintain consistency across the codebase

https://claude.ai/code/session_01QAHR6QNZMngVnFpo96M5im