### PR TITLE
Migrate data source from JustWatch to TMDB API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ bun run dev:frontend     # Vite dev server (port 5173, proxies /api to :3000)
 bun run build            # Builds frontend to frontend/dist/
 bun run start            # Runs production server
 
-# Sync data from JustWatch
+# Sync data from TMDB
 bun run sync                              # Default sync
 bun run server/cli/sync.ts [daysBack] [type]  # CLI with args
 
@@ -43,7 +43,7 @@ docker compose up --build
 
 ## Architecture
 
-**Remindarr** — a full-stack app for tracking streaming media releases using JustWatch as the data source. Locale is configurable via env vars (defaults to hr_HR).
+**Remindarr** — a full-stack app for tracking streaming media releases using TMDB as the data source. Locale is configurable via env vars.
 
 ### Stack
 - **Runtime**: Bun (with built-in SQLite)
@@ -53,13 +53,12 @@ docker compose up --build
 
 ### Server (`server/`)
 - `index.ts` — Entry point, Hono app setup, serves static frontend in production
-- `config.ts` — JustWatch API config, DB path, image URLs, pagination settings
+- `config.ts` — TMDB API config, DB path, image URLs, pagination settings
 - `db/schema.ts` — SQLite schema (5 tables: titles, providers, offers, tracked, scores)
 - `db/repository.ts` — All database queries (upsert, search, track/untrack, filters)
-- `justwatch/client.ts` — GraphQL client for JustWatch API (releases + search)
-- `justwatch/parser.ts` — Transforms JW API responses to internal types
-- `justwatch/queries.ts` — GraphQL query definitions
-- `imdb/resolver.ts` — Resolves IMDB URLs/IDs via autocomplete API, matches to JW titles
+- `tmdb/client.ts` — TMDB API client (releases + search + watch providers)
+- `tmdb/parser.ts` — Transforms TMDB API responses to internal types
+- `imdb/resolver.ts` — Resolves IMDB URLs/IDs via autocomplete API, matches to TMDB titles
 - `routes/` — API endpoints: sync, titles, search, track, imdb
 
 ### Frontend (`frontend/src/`)
@@ -69,7 +68,7 @@ docker compose up --build
 - `components/` — TitleCard, TitleList, FilterBar, SearchBar, TrackButton, NewReleases
 
 ### Key Patterns
-- DB titles use snake_case, JustWatch API search results use camelCase — `normalizeSearchTitle()` bridges the gap
+- DB titles use snake_case, TMDB API search results use camelCase — `normalizeSearchTitle()` bridges the gap
 - Offers are deduplicated by provider ID with priority: FLATRATE > FREE > ADS
 - The SearchBar auto-detects IMDB URLs/IDs and routes to a separate resolution flow
 - All DB writes use transactions for consistency
@@ -77,7 +76,7 @@ docker compose up --build
 ### API Routes
 - `GET /api/titles` — Recent titles with filters (daysBack, objectType, provider)
 - `GET /api/titles/providers` — Available streaming services
-- `GET /api/search?q=` — Live search via JustWatch
-- `POST /api/sync` — Trigger data sync from JustWatch
+- `GET /api/search?q=` — Live search via TMDB
+- `POST /api/sync` — Trigger data sync from TMDB
 - `GET/POST/DELETE /api/track/:id` — Watchlist management
 - `POST /api/imdb` — Resolve IMDB URL, save to DB, auto-track

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Remindarr
 
-A full-stack app for tracking streaming media releases using JustWatch as the data source.
+A full-stack app for tracking streaming media releases using TMDB as the data source.
 
 ## Stack
 
@@ -64,9 +64,9 @@ Set the locale via environment variables (defaults to Croatia):
 
 | Variable | Default | Example |
 |----------|---------|---------|
-| `JUSTWATCH_COUNTRY` | `HR` | `US`, `DE`, `GB` |
-| `JUSTWATCH_LANGUAGE` | `hr` | `en`, `de` |
-| `JUSTWATCH_LOCALE` | `hr_HR` | `en_US`, `de_DE` |
+| `TMDB_API_KEY` | (required) | Your TMDB API key |
+| `TMDB_COUNTRY` | `HR` | `US`, `DE`, `GB` |
+| `TMDB_LANGUAGE` | `en` | `hr`, `de` |
 
 ## Syncing Data
 
@@ -80,14 +80,13 @@ bun run server/cli/sync.ts [daysBack] [type]   # Custom: days back, object type
 ```
 server/
   index.ts              # Hono app entry point
-  config.ts             # JustWatch API config, DB path, pagination
+  config.ts             # TMDB API config, DB path, pagination
   db/
     schema.ts           # SQLite schema (titles, providers, offers, tracked, scores)
     repository.ts       # All database queries
-  justwatch/
-    client.ts           # GraphQL client for JustWatch API
+  tmdb/
+    client.ts           # TMDB API client
     parser.ts           # API response → internal types
-    queries.ts          # GraphQL query definitions
   imdb/
     resolver.ts         # IMDB URL/ID resolution via autocomplete API
   routes/               # API route handlers
@@ -107,7 +106,7 @@ frontend/src/
 |--------|-------|-------------|
 | `GET` | `/api/titles` | Recent titles (filters: `daysBack`, `objectType`, `provider`) |
 | `GET` | `/api/titles/providers` | Available streaming providers |
-| `GET` | `/api/search?q=` | Live search via JustWatch |
+| `GET` | `/api/search?q=` | Live search via TMDB |
 | `POST` | `/api/sync` | Trigger data sync |
 | `GET/POST/DELETE` | `/api/track/:id` | Watchlist management |
 | `POST` | `/api/imdb` | Resolve IMDB URL, save & auto-track |

--- a/frontend/src/pages/TitleDetailPage.tsx
+++ b/frontend/src/pages/TitleDetailPage.tsx
@@ -350,10 +350,10 @@ function MovieDetail({ data }: { data: MovieDetailsResponse }) {
             <ProviderRow label="Rent" providers={watchProviders.rent || []} />
             <ProviderRow label="Buy" providers={watchProviders.buy || []} />
           </div>
-          {/* Also show existing JW offers */}
+          {/* Also show existing offers */}
           {title.offers.length > 0 && (
             <div className="mt-4 pt-4 border-t border-gray-800">
-              <p className="text-xs text-gray-500 mb-2">Direct links via JustWatch</p>
+              <p className="text-xs text-gray-500 mb-2">Direct links</p>
               <div className="flex flex-wrap gap-2">
                 {dedupeOffers(title.offers).map((offer) => (
                   <a
@@ -635,7 +635,7 @@ function ShowDetail({ data }: { data: ShowDetailsResponse }) {
           </div>
           {title.offers.length > 0 && (
             <div className="mt-4 pt-4 border-t border-gray-800">
-              <p className="text-xs text-gray-500 mb-2">Direct links via JustWatch</p>
+              <p className="text-xs text-gray-500 mb-2">Direct links</p>
               <div className="flex flex-wrap gap-2">
                 {dedupeOffers(title.offers).map((offer) => (
                   <a

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,10 +1,10 @@
 export const CONFIG = {
-  COUNTRY: process.env.TMDB_COUNTRY || process.env.JUSTWATCH_COUNTRY || "HR",
+  COUNTRY: process.env.TMDB_COUNTRY || "HR",
   FALLBACK_COUNTRIES: (process.env.TMDB_FALLBACK_COUNTRIES || "")
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean),
-  LANGUAGE: process.env.TMDB_LANGUAGE || process.env.JUSTWATCH_LANGUAGE || "en",
+  LANGUAGE: process.env.TMDB_LANGUAGE || "en",
   DEFAULT_DAYS_BACK: 30,
   PAGE_SIZE: 20,
   PAGE_DELAY_MS: 300,


### PR DESCRIPTION
## Summary
This PR completes the migration from JustWatch GraphQL API to TMDB REST API as the primary data source for streaming media releases and metadata. All documentation, configuration, and UI references have been updated to reflect this change.

## Key Changes
- **Documentation updates**: Updated CLAUDE.md and README.md to reference TMDB instead of JustWatch throughout architecture, setup, and API documentation
- **Configuration**: Removed legacy JustWatch environment variables (`JUSTWATCH_COUNTRY`, `JUSTWATCH_LANGUAGE`, `JUSTWATCH_LOCALE`) and replaced with TMDB equivalents (`TMDB_COUNTRY`, `TMDB_LANGUAGE`, `TMDB_API_KEY`)
- **Server architecture docs**: Updated references to reflect new module structure (`tmdb/` instead of `justwatch/`) with TMDB REST client and parser
- **UI text updates**: Removed JustWatch-specific branding from frontend components (TitleDetailPage) - changed "Direct links via JustWatch" to generic "Direct links"
- **Code comments**: Updated inline comments to reference TMDB instead of JustWatch
- **Config fallbacks**: Removed backward compatibility fallbacks to old JustWatch environment variables in `server/config.ts`

## Implementation Details
- The actual TMDB client implementation (`tmdb/client.ts`, `tmdb/parser.ts`) was already in place; this PR updates all references and documentation
- Environment variable schema is now cleaner with TMDB-specific naming conventions
- Default language changed from `hr` to `en` to align with TMDB API defaults
- Locale configuration is now simpler (removed `JUSTWATCH_LOCALE` requirement)

https://claude.ai/code/session_01PGaHEfqfe5rRmUMwiLhkPk