### PR TITLE
Refactor unwatched episodes UI to carousel with collapsible seasons

### DIFF
--- a/frontend/src/pages/HomePage.test.ts
+++ b/frontend/src/pages/HomePage.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "bun:test";
+import { groupByShowAndSeason, EPISODES_PER_PAGE } from "./HomePage";
+import type { Episode } from "../types";
+
+function makeEpisode(overrides: Partial<Episode> & { id: number; title_id: string; season_number: number; episode_number: number }): Episode {
+  return {
+    name: `Episode ${overrides.episode_number}`,
+    overview: null,
+    air_date: "2025-01-01",
+    still_path: null,
+    show_title: "Test Show",
+    poster_url: null,
+    ...overrides,
+  };
+}
+
+describe("groupByShowAndSeason", () => {
+  it("groups episodes by show and season", () => {
+    const episodes: Episode[] = [
+      makeEpisode({ id: 1, title_id: "show-1", season_number: 1, episode_number: 1 }),
+      makeEpisode({ id: 2, title_id: "show-1", season_number: 1, episode_number: 2 }),
+      makeEpisode({ id: 3, title_id: "show-1", season_number: 2, episode_number: 1 }),
+      makeEpisode({ id: 4, title_id: "show-2", season_number: 1, episode_number: 1 }),
+    ];
+
+    const result = groupByShowAndSeason(episodes);
+
+    expect(result.size).toBe(2);
+    expect(result.get("show-1")!.size).toBe(2);
+    expect(result.get("show-1")!.get(1)!.length).toBe(2);
+    expect(result.get("show-1")!.get(2)!.length).toBe(1);
+    expect(result.get("show-2")!.size).toBe(1);
+    expect(result.get("show-2")!.get(1)!.length).toBe(1);
+  });
+
+  it("returns empty map for empty input", () => {
+    const result = groupByShowAndSeason([]);
+    expect(result.size).toBe(0);
+  });
+
+  it("handles single episode", () => {
+    const episodes: Episode[] = [
+      makeEpisode({ id: 1, title_id: "show-1", season_number: 3, episode_number: 5 }),
+    ];
+
+    const result = groupByShowAndSeason(episodes);
+    expect(result.size).toBe(1);
+    expect(result.get("show-1")!.get(3)!.length).toBe(1);
+    expect(result.get("show-1")!.get(3)![0].episode_number).toBe(5);
+  });
+});
+
+describe("EPISODES_PER_PAGE", () => {
+  it("is set to 5", () => {
+    expect(EPISODES_PER_PAGE).toBe(5);
+  });
+});
+
+describe("progressive reveal logic", () => {
+  it("slice(0, EPISODES_PER_PAGE) shows first 5 of a longer list", () => {
+    const episodes = Array.from({ length: 10 }, (_, i) =>
+      makeEpisode({ id: i + 1, title_id: "show-1", season_number: 1, episode_number: i + 1 })
+    );
+
+    const visible = episodes.slice(0, EPISODES_PER_PAGE);
+    expect(visible.length).toBe(5);
+    expect(visible[0].episode_number).toBe(1);
+    expect(visible[4].episode_number).toBe(5);
+  });
+
+  it("removing a watched episode reveals the next one in the window", () => {
+    const episodes = Array.from({ length: 8 }, (_, i) =>
+      makeEpisode({ id: i + 1, title_id: "show-1", season_number: 1, episode_number: i + 1 })
+    );
+
+    // Simulate marking episode 1 as watched (removed from array)
+    const afterWatch = episodes.filter((ep) => ep.id !== 1);
+    const visible = afterWatch.slice(0, EPISODES_PER_PAGE);
+
+    expect(visible.length).toBe(5);
+    expect(visible[0].episode_number).toBe(2);
+    expect(visible[4].episode_number).toBe(6); // episode 6 is now visible
+  });
+
+  it("shows all episodes when list is shorter than limit", () => {
+    const episodes = Array.from({ length: 3 }, (_, i) =>
+      makeEpisode({ id: i + 1, title_id: "show-1", season_number: 1, episode_number: i + 1 })
+    );
+
+    const visible = episodes.slice(0, EPISODES_PER_PAGE);
+    expect(visible.length).toBe(3);
+  });
+});
+
+describe("season ordering for deck-of-cards", () => {
+  it("earliest season appears first when sorting season map entries", () => {
+    const episodes: Episode[] = [
+      makeEpisode({ id: 1, title_id: "show-1", season_number: 3, episode_number: 1 }),
+      makeEpisode({ id: 2, title_id: "show-1", season_number: 1, episode_number: 1 }),
+      makeEpisode({ id: 3, title_id: "show-1", season_number: 2, episode_number: 1 }),
+    ];
+
+    const grouped = groupByShowAndSeason(episodes);
+    const seasonMap = grouped.get("show-1")!;
+    const sortedSeasons = Array.from(seasonMap.entries()).sort(([a], [b]) => a - b);
+
+    expect(sortedSeasons[0][0]).toBe(1);
+    expect(sortedSeasons[1][0]).toBe(2);
+    expect(sortedSeasons[2][0]).toBe(3);
+  });
+
+  it("counts extra seasons correctly for deck effect", () => {
+    const episodes: Episode[] = [
+      makeEpisode({ id: 1, title_id: "show-1", season_number: 1, episode_number: 1 }),
+      makeEpisode({ id: 2, title_id: "show-1", season_number: 2, episode_number: 1 }),
+      makeEpisode({ id: 3, title_id: "show-1", season_number: 3, episode_number: 1 }),
+      makeEpisode({ id: 4, title_id: "show-1", season_number: 4, episode_number: 1 }),
+    ];
+
+    const grouped = groupByShowAndSeason(episodes);
+    const seasonMap = grouped.get("show-1")!;
+    const sortedSeasons = Array.from(seasonMap.entries()).sort(([a], [b]) => a - b);
+    const extraSeasons = sortedSeasons.length - 1;
+
+    expect(extraSeasons).toBe(3);
+  });
+
+  it("when all episodes of first season are removed, second season becomes first", () => {
+    const episodes: Episode[] = [
+      makeEpisode({ id: 1, title_id: "show-1", season_number: 1, episode_number: 1 }),
+      makeEpisode({ id: 2, title_id: "show-1", season_number: 1, episode_number: 2 }),
+      makeEpisode({ id: 3, title_id: "show-1", season_number: 2, episode_number: 1 }),
+      makeEpisode({ id: 4, title_id: "show-1", season_number: 2, episode_number: 2 }),
+    ];
+
+    // Simulate watching all of season 1
+    const afterWatch = episodes.filter((ep) => ep.season_number !== 1);
+    const regrouped = groupByShowAndSeason(afterWatch);
+    const seasonMap = regrouped.get("show-1")!;
+    const sortedSeasons = Array.from(seasonMap.entries()).sort(([a], [b]) => a - b);
+
+    expect(sortedSeasons.length).toBe(1);
+    expect(sortedSeasons[0][0]).toBe(2); // Season 2 is now earliest
+  });
+});

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { Link } from "react-router";
 import { useAuth } from "../context/AuthContext";
 import * as api from "../api";
@@ -31,7 +31,7 @@ function groupByShow(episodes: Episode[]): Map<string, Episode[]> {
   return map;
 }
 
-function groupByShowAndSeason(episodes: Episode[]): Map<string, Map<number, Episode[]>> {
+export function groupByShowAndSeason(episodes: Episode[]): Map<string, Map<number, Episode[]>> {
   const map = new Map<string, Map<number, Episode[]>>();
   for (const ep of episodes) {
     if (!map.has(ep.title_id)) map.set(ep.title_id, new Map());
@@ -264,6 +264,8 @@ function ShowEpisodeGroup({ showTitle, episodes, posterUrl, compact, onToggleWat
   );
 }
 
+export const EPISODES_PER_PAGE = 5;
+
 function UnwatchedShowGroup({ showTitle, seasonNumber, episodes, posterUrl, onToggleWatched, onMarkSeasonWatched }: {
   showTitle: string;
   seasonNumber: number;
@@ -272,7 +274,10 @@ function UnwatchedShowGroup({ showTitle, seasonNumber, episodes, posterUrl, onTo
   onToggleWatched: (id: number, current: boolean) => void;
   onMarkSeasonWatched: (episodeIds: number[]) => void;
 }) {
+  const [showAllEpisodes, setShowAllEpisodes] = useState(false);
   const providers = getUniqueProviders(episodes[0]?.offers);
+  const visibleEpisodes = showAllEpisodes ? episodes : episodes.slice(0, EPISODES_PER_PAGE);
+  const hiddenCount = episodes.length - EPISODES_PER_PAGE;
 
   return (
     <div className="bg-gray-900 rounded-xl overflow-hidden border border-gray-800 hover:border-gray-700 transition-colors">
@@ -298,7 +303,7 @@ function UnwatchedShowGroup({ showTitle, seasonNumber, episodes, posterUrl, onTo
           </div>
           <p className="text-xs text-gray-500 mt-0.5">Season {seasonNumber}</p>
           <div className="mt-2 space-y-1">
-            {episodes.map((ep) => (
+            {visibleEpisodes.map((ep) => (
               <div key={ep.id} className="flex items-center gap-2 text-sm">
                 <WatchedIcon watched={!!ep.is_watched} onClick={() => onToggleWatched(ep.id, !!ep.is_watched)} />
                 <Link to={`/title/${ep.title_id}/season/${ep.season_number}/episode/${ep.episode_number}`} className="hover:text-indigo-400 transition-colors truncate">
@@ -308,6 +313,22 @@ function UnwatchedShowGroup({ showTitle, seasonNumber, episodes, posterUrl, onTo
               </div>
             ))}
           </div>
+          {!showAllEpisodes && hiddenCount > 0 && (
+            <button
+              onClick={() => setShowAllEpisodes(true)}
+              className="text-xs text-gray-400 hover:text-indigo-400 transition-colors mt-2 cursor-pointer"
+            >
+              Show all ({episodes.length} episodes)
+            </button>
+          )}
+          {showAllEpisodes && episodes.length > EPISODES_PER_PAGE && (
+            <button
+              onClick={() => setShowAllEpisodes(false)}
+              className="text-xs text-gray-400 hover:text-indigo-400 transition-colors mt-2 cursor-pointer"
+            >
+              Show less
+            </button>
+          )}
           {providers.length > 0 && (
             <div className="flex gap-1.5 mt-3">
               {providers.map((o) => (
@@ -323,11 +344,149 @@ function UnwatchedShowGroup({ showTitle, seasonNumber, episodes, posterUrl, onTo
   );
 }
 
+function UnwatchedShowCard({ titleId, seasonMap, expanded, onToggleExpand, onToggleWatched, onMarkSeasonWatched }: {
+  titleId: string;
+  seasonMap: Map<number, Episode[]>;
+  expanded: boolean;
+  onToggleExpand: () => void;
+  onToggleWatched: (id: number, current: boolean) => void;
+  onMarkSeasonWatched: (episodeIds: number[]) => void;
+}) {
+  const sortedSeasons = Array.from(seasonMap.entries()).sort(([a], [b]) => a - b);
+  const extraSeasons = sortedSeasons.length - 1;
+
+  if (expanded) {
+    return (
+      <div className="space-y-3">
+        {sortedSeasons.map(([seasonNum, eps]) => (
+          <UnwatchedShowGroup
+            key={`${titleId}-s${seasonNum}`}
+            showTitle={eps[0].show_title}
+            seasonNumber={seasonNum}
+            episodes={eps}
+            posterUrl={eps[0].poster_url}
+            onToggleWatched={onToggleWatched}
+            onMarkSeasonWatched={onMarkSeasonWatched}
+          />
+        ))}
+        {sortedSeasons.length > 1 && (
+          <button
+            onClick={onToggleExpand}
+            className="text-xs text-gray-400 hover:text-indigo-400 transition-colors cursor-pointer w-full text-center"
+          >
+            Collapse seasons
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  // Collapsed: show only earliest season with deck effect
+  const [seasonNum, eps] = sortedSeasons[0];
+
+  return (
+    <div className="relative">
+      {/* Shadow cards for deck effect */}
+      {extraSeasons >= 2 && (
+        <div className="absolute inset-0 translate-y-2 translate-x-2 scale-[0.94] bg-gray-900 rounded-xl border border-gray-800 opacity-30" />
+      )}
+      {extraSeasons >= 1 && (
+        <div className="absolute inset-0 translate-y-1 translate-x-1 scale-[0.97] bg-gray-900 rounded-xl border border-gray-800 opacity-60" />
+      )}
+      {/* Main card */}
+      <div className="relative z-10">
+        <UnwatchedShowGroup
+          showTitle={eps[0].show_title}
+          seasonNumber={seasonNum}
+          episodes={eps}
+          posterUrl={eps[0].poster_url}
+          onToggleWatched={onToggleWatched}
+          onMarkSeasonWatched={onMarkSeasonWatched}
+        />
+        {extraSeasons > 0 && (
+          <button
+            onClick={onToggleExpand}
+            className="w-full text-center text-xs text-gray-400 hover:text-indigo-400 transition-colors py-2 cursor-pointer"
+          >
+            +{extraSeasons} more season{extraSeasons > 1 ? "s" : ""}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function UnwatchedCarousel({ children }: { children: React.ReactNode }) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollButtons = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    updateScrollButtons();
+    el.addEventListener("scroll", updateScrollButtons, { passive: true });
+    const observer = new ResizeObserver(updateScrollButtons);
+    observer.observe(el);
+    return () => {
+      el.removeEventListener("scroll", updateScrollButtons);
+      observer.disconnect();
+    };
+  }, [updateScrollButtons]);
+
+  const scroll = (direction: "left" | "right") => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const cardWidth = 320 + 12; // w-80 (320px) + gap-3 (12px)
+    el.scrollBy({ left: direction === "left" ? -cardWidth : cardWidth, behavior: "smooth" });
+  };
+
+  return (
+    <div className="relative group">
+      {canScrollLeft && (
+        <button
+          onClick={() => scroll("left")}
+          className="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-3 z-20 bg-gray-800/90 hover:bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center shadow-lg cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+      )}
+      <div
+        ref={scrollRef}
+        className="flex gap-3 overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
+        style={{ scrollSnapType: "x mandatory" }}
+      >
+        {children}
+      </div>
+      {canScrollRight && (
+        <button
+          onClick={() => scroll("right")}
+          className="absolute right-0 top-1/2 -translate-y-1/2 translate-x-3 z-20 bg-gray-800/90 hover:bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center shadow-lg cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+}
+
 export default function HomePage() {
   const { user, loading: authLoading } = useAuth();
   const [today, setToday] = useState<Episode[]>([]);
   const [upcoming, setUpcoming] = useState<Episode[]>([]);
   const [unwatched, setUnwatched] = useState<Episode[]>([]);
+  const [expandedShows, setExpandedShows] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
@@ -442,21 +601,25 @@ export default function HomePage() {
       {unwatched.length > 0 && (
         <section>
           <h2 className="text-xl font-bold text-white mb-4">Unwatched</h2>
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {Array.from(unwatchedByShowAndSeason.entries()).map(([titleId, seasonMap]) =>
-              Array.from(seasonMap.entries()).map(([seasonNum, eps]) => (
-                <UnwatchedShowGroup
-                  key={`${titleId}-s${seasonNum}`}
-                  showTitle={eps[0].show_title}
-                  seasonNumber={seasonNum}
-                  episodes={eps}
-                  posterUrl={eps[0].poster_url}
+          <UnwatchedCarousel>
+            {Array.from(unwatchedByShowAndSeason.entries()).map(([titleId, seasonMap]) => (
+              <div key={titleId} className="w-80 flex-shrink-0" style={{ scrollSnapAlign: "start" }}>
+                <UnwatchedShowCard
+                  titleId={titleId}
+                  seasonMap={seasonMap}
+                  expanded={expandedShows.has(titleId)}
+                  onToggleExpand={() => setExpandedShows((prev) => {
+                    const next = new Set(prev);
+                    if (next.has(titleId)) next.delete(titleId);
+                    else next.add(titleId);
+                    return next;
+                  })}
                   onToggleWatched={toggleWatched}
                   onMarkSeasonWatched={markSeasonWatched}
                 />
-              ))
-            )}
-          </div>
+              </div>
+            ))}
+          </UnwatchedCarousel>
         </section>
       )}
 


### PR DESCRIPTION
## Summary
Transforms the unwatched episodes section from a grid layout to a horizontal carousel with a collapsible deck-of-cards UI for multi-season shows. Episodes within each season are now progressively revealed with a "Show all" button.

## Key Changes
- **Carousel Layout**: Replaced grid layout with a horizontally scrollable carousel (`UnwatchedCarousel`) featuring smooth scroll navigation with arrow buttons that appear on hover
- **Progressive Episode Reveal**: Added `EPISODES_PER_PAGE` constant (5 episodes) to limit initial display per season with "Show all" / "Show less" toggle buttons
- **Collapsible Season Cards**: New `UnwatchedShowCard` component displays multi-season shows in a collapsed state with a deck-of-cards visual effect (stacked shadow layers), expandable to show all seasons
- **Improved State Management**: Added `expandedShows` Set to track which shows have expanded season views
- **Exports for Testing**: Made `groupByShowAndSeason` and `EPISODES_PER_PAGE` exportable for unit testing
- **Comprehensive Test Suite**: Added `HomePage.test.ts` with 145 lines of tests covering grouping logic, progressive reveal behavior, and season ordering

## Implementation Details
- Carousel uses `useRef` and `ResizeObserver` to dynamically show/hide scroll buttons based on scroll position
- Deck effect achieved with absolute-positioned shadow cards at different scales and translations
- Season sorting ensures earliest season displays first in collapsed view
- Scroll snap alignment (`scroll-snap-align: start`) for smooth card-based scrolling
- Responsive design maintains w-80 card width with gap-3 spacing for consistent scroll calculations

https://claude.ai/code/session_01KPCwGrU8yrZSU8i1Mh3iAX