### PR TITLE
Add mobile responsive navigation with hamburger menu

### DIFF
--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "bun:test";
+import { navLinkClass } from "./nav-utils";
+
+describe("navLinkClass", () => {
+  it("returns desktop active classes", () => {
+    const result = navLinkClass(true);
+    expect(result).toContain("px-4 py-2");
+    expect(result).toContain("bg-indigo-600 text-white");
+    expect(result).not.toContain("block w-full");
+  });
+
+  it("returns desktop inactive classes", () => {
+    const result = navLinkClass(false);
+    expect(result).toContain("px-4 py-2");
+    expect(result).toContain("text-gray-400 hover:text-white hover:bg-gray-800");
+    expect(result).not.toContain("bg-indigo-600");
+  });
+
+  it("returns mobile active classes", () => {
+    const result = navLinkClass(true, true);
+    expect(result).toContain("block w-full px-3 py-2.5");
+    expect(result).toContain("bg-indigo-600 text-white");
+    expect(result).not.toContain("px-4 py-2");
+  });
+
+  it("returns mobile inactive classes", () => {
+    const result = navLinkClass(false, true);
+    expect(result).toContain("block w-full px-3 py-2.5");
+    expect(result).toContain("text-gray-400 hover:text-white hover:bg-gray-800");
+    expect(result).not.toContain("bg-indigo-600");
+  });
+
+  it("always includes common classes", () => {
+    for (const isActive of [true, false]) {
+      for (const mobile of [true, false]) {
+        const result = navLinkClass(isActive, mobile);
+        expect(result).toContain("rounded-lg");
+        expect(result).toContain("text-sm");
+        expect(result).toContain("font-medium");
+        expect(result).toContain("transition-colors");
+      }
+    }
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,6 @@
-import { Routes, Route, NavLink, Link } from "react-router";
+import { useState, useEffect } from "react";
+import { Routes, Route, NavLink, Link, useLocation } from "react-router";
+import { Menu, X } from "lucide-react";
 import { useAuth } from "./context/AuthContext";
 import HomePage from "./pages/HomePage";
 import BrowsePage from "./pages/BrowsePage";
@@ -10,38 +12,34 @@ import TitleDetailPage from "./pages/TitleDetailPage";
 import SeasonDetailPage from "./pages/SeasonDetailPage";
 import EpisodeDetailPage from "./pages/EpisodeDetailPage";
 import RequireAuth from "./components/RequireAuth";
+import { navLinkClass } from "./nav-utils";
 
 export default function App() {
   const { user, loading, logout } = useAuth();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const location = useLocation();
+
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [location.pathname]);
 
   return (
     <div className="min-h-screen bg-gray-950 text-gray-100">
       <nav className="bg-gray-900 border-b border-gray-800 sticky top-0 z-50">
         <div className="max-w-7xl mx-auto px-4 flex items-center justify-between h-14">
           <Link to="/" className="text-lg font-bold text-white tracking-tight hover:text-indigo-400 transition-colors">Remindarr</Link>
-          <div className="flex gap-1">
+          {/* Desktop nav links */}
+          <div className="hidden sm:flex gap-1">
             <NavLink
               to="/"
               end
-              className={({ isActive }) =>
-                `px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-                  isActive
-                    ? "bg-indigo-600 text-white"
-                    : "text-gray-400 hover:text-white hover:bg-gray-800"
-                }`
-              }
+              className={({ isActive }) => navLinkClass(isActive)}
             >
               Home
             </NavLink>
             <NavLink
               to="/browse"
-              className={({ isActive }) =>
-                `px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-                  isActive
-                    ? "bg-indigo-600 text-white"
-                    : "text-gray-400 hover:text-white hover:bg-gray-800"
-                }`
-              }
+              className={({ isActive }) => navLinkClass(isActive)}
             >
               Browse
             </NavLink>
@@ -49,32 +47,21 @@ export default function App() {
               <>
                 <NavLink
                   to="/tracked"
-                  className={({ isActive }) =>
-                    `px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-                      isActive
-                        ? "bg-indigo-600 text-white"
-                        : "text-gray-400 hover:text-white hover:bg-gray-800"
-                    }`
-                  }
+                  className={({ isActive }) => navLinkClass(isActive)}
                 >
                   Tracked
                 </NavLink>
                 <NavLink
                   to="/calendar"
-                  className={({ isActive }) =>
-                    `px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-                      isActive
-                        ? "bg-indigo-600 text-white"
-                        : "text-gray-400 hover:text-white hover:bg-gray-800"
-                    }`
-                  }
+                  className={({ isActive }) => navLinkClass(isActive)}
                 >
                   Calendar
                 </NavLink>
               </>
             )}
           </div>
-          <div className="flex items-center gap-3">
+          {/* Desktop user section */}
+          <div className="hidden sm:flex items-center gap-3">
             {loading ? null : user ? (
               <>
                 <Link
@@ -99,7 +86,73 @@ export default function App() {
               </NavLink>
             )}
           </div>
+          {/* Mobile hamburger button */}
+          <button
+            onClick={() => setMenuOpen((prev) => !prev)}
+            className="sm:hidden p-2 text-gray-400 hover:text-white transition-colors cursor-pointer"
+            aria-label={menuOpen ? "Close menu" : "Open menu"}
+          >
+            {menuOpen ? <X size={22} /> : <Menu size={22} />}
+          </button>
         </div>
+        {/* Mobile dropdown menu */}
+        {menuOpen && (
+          <div className="sm:hidden border-t border-gray-800 bg-gray-900 px-4 py-3 space-y-1">
+            <NavLink
+              to="/"
+              end
+              className={({ isActive }) => navLinkClass(isActive, true)}
+            >
+              Home
+            </NavLink>
+            <NavLink
+              to="/browse"
+              className={({ isActive }) => navLinkClass(isActive, true)}
+            >
+              Browse
+            </NavLink>
+            {user && (
+              <>
+                <NavLink
+                  to="/tracked"
+                  className={({ isActive }) => navLinkClass(isActive, true)}
+                >
+                  Tracked
+                </NavLink>
+                <NavLink
+                  to="/calendar"
+                  className={({ isActive }) => navLinkClass(isActive, true)}
+                >
+                  Calendar
+                </NavLink>
+              </>
+            )}
+            <div className="border-t border-gray-800 my-2" />
+            {loading ? null : user ? (
+              <>
+                <Link
+                  to="/profile"
+                  className="block w-full px-3 py-2.5 text-sm text-gray-400 hover:text-white transition-colors"
+                >
+                  {user.display_name || user.username}
+                </Link>
+                <button
+                  onClick={logout}
+                  className="block w-full text-left px-3 py-2.5 text-sm text-gray-500 hover:text-white transition-colors cursor-pointer"
+                >
+                  Logout
+                </button>
+              </>
+            ) : (
+              <NavLink
+                to="/login"
+                className="block w-full px-3 py-2.5 text-sm text-gray-400 hover:text-white transition-colors"
+              >
+                Sign In
+              </NavLink>
+            )}
+          </div>
+        )}
       </nav>
       <main className="max-w-7xl mx-auto px-4 py-6">
         <Routes>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -124,6 +124,6 @@
     @apply bg-background text-foreground;
     }
   html {
-    @apply font-sans;
+    @apply font-sans overflow-x-hidden;
     }
 }

--- a/frontend/src/nav-utils.ts
+++ b/frontend/src/nav-utils.ts
@@ -1,0 +1,5 @@
+export function navLinkClass(isActive: boolean, mobile = false): string {
+  return `${mobile ? "block w-full px-3 py-2.5" : "px-4 py-2"} rounded-lg text-sm font-medium transition-colors ${
+    isActive ? "bg-indigo-600 text-white" : "text-gray-400 hover:text-white hover:bg-gray-800"
+  }`;
+}


### PR DESCRIPTION
## Summary
This PR adds mobile responsiveness to the navigation bar by implementing a hamburger menu for smaller screens while maintaining the desktop layout on larger viewports.

## Key Changes
- **Mobile Navigation**: Added a hamburger menu button that toggles a dropdown menu on screens smaller than `sm` breakpoint
- **Responsive Layout**: Desktop navigation links and user section are hidden on mobile (`hidden sm:flex`) and replaced with a hamburger button
- **Menu State Management**: Implemented `menuOpen` state that automatically closes when the route changes
- **Code Extraction**: Extracted repeated nav link styling into a reusable `navLinkClass()` utility function to reduce duplication
- **Mobile Menu Styling**: Mobile dropdown menu includes all navigation links and user actions with appropriate spacing and separators
- **Icons**: Added Menu and X icons from lucide-react for the hamburger button
- **CSS Fix**: Added `overflow-x-hidden` to prevent horizontal scrolling on mobile

## Implementation Details
- The mobile menu automatically closes when navigating to a different route via the `useLocation()` hook
- The `navLinkClass()` utility function supports both desktop and mobile variants with different padding and layout styles
- Mobile menu items use `block w-full` for full-width clickable areas
- Added comprehensive unit tests for the `navLinkClass()` utility function covering all combinations of active/inactive and desktop/mobile states

https://claude.ai/code/session_0119yZJQMtLuC6vG8HQWM7Tn