### PR TITLE
Change default browse category from new releases to popular

### DIFF
--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -16,7 +16,7 @@ const CATEGORY_LABELS: Record<BrowseCategory, string> = {
 };
 
 export default function BrowsePage() {
-  const [category, setCategory] = useState<BrowseCategory>("new_releases");
+  const [category, setCategory] = useState<BrowseCategory>("popular");
   const [searchResults, setSearchResults] = useState<Title[] | null>(null);
   const [searchLoading, setSearchLoading] = useState(false);
   const [searchError, setSearchError] = useState("");


### PR DESCRIPTION
## Summary
Updated the default browse category on the BrowsePage from "new_releases" to "popular" to better align with user engagement preferences.

## Changes
- Changed the initial state of the `category` useState hook from `"new_releases"` to `"popular"` in BrowsePage component

## Details
This change affects the default view users see when landing on the browse page. Instead of showing newly released titles first, the page will now default to displaying popular titles, which may provide a better user experience by highlighting trending or well-received content.

https://claude.ai/code/session_01CdJTTJpEuNT6pQGW9ASXny