### PR TITLE
Replace manual "Load More" button with Intersection Observer

### DIFF
--- a/frontend/src/components/CategoryBrowse.tsx
+++ b/frontend/src/components/CategoryBrowse.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import * as api from "../api";
 import type { Title } from "../types";
 import { normalizeSearchTitle } from "../types";
@@ -52,11 +52,24 @@ export default function CategoryBrowse({ category }: Props) {
     fetchTitles(1, false);
   }, [fetchTitles]);
 
-  function handleLoadMore() {
-    if (page < totalPages) {
-      fetchTitles(page + 1, true);
-    }
-  }
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && page < totalPages && !loadingMore) {
+          fetchTitles(page + 1, true);
+        }
+      },
+      { rootMargin: "200px" }
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [page, totalPages, loadingMore, fetchTitles]);
 
   return (
     <div className="space-y-4">
@@ -78,14 +91,10 @@ export default function CategoryBrowse({ category }: Props) {
         <>
           <TitleList titles={titles} emptyMessage="No titles found." />
           {page < totalPages && (
-            <div className="text-center py-4">
-              <button
-                onClick={handleLoadMore}
-                disabled={loadingMore}
-                className="px-6 py-2 bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors cursor-pointer"
-              >
-                {loadingMore ? "Loading..." : "Load More"}
-              </button>
+            <div ref={sentinelRef} className="text-center py-4">
+              {loadingMore && (
+                <div className="text-gray-500 text-sm">Loading...</div>
+              )}
             </div>
           )}
         </>


### PR DESCRIPTION
## Summary
Replaced the manual "Load More" button with an automatic infinite scroll implementation using the Intersection Observer API. This provides a more seamless user experience by automatically loading additional titles as the user scrolls near the bottom of the list.

## Key Changes
- Removed the `handleLoadMore()` function and its associated button UI
- Added `useRef` hook to create a sentinel element that triggers loading when visible
- Implemented `IntersectionObserver` in a new `useEffect` hook to detect when the user scrolls near the bottom of the list (200px margin)
- The observer automatically fetches the next page when the sentinel becomes visible and there are more pages to load
- Replaced the "Load More" button with a simple loading indicator text that only displays while fetching

## Implementation Details
- The sentinel div is positioned at the bottom of the results and acts as a trigger point
- The `rootMargin: "200px"` setting ensures loading begins before the user reaches the absolute bottom, providing a smoother experience
- The observer properly cleans up on unmount and updates when `page`, `totalPages`, `loadingMore`, or `fetchTitles` change
- Loading state is still respected to prevent duplicate requests while a fetch is in progress

https://claude.ai/code/session_014U2m5hTSAmDaSGQh7qrnCy