### PR TITLE
Add genre and language filtering for titles

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -31,6 +31,8 @@ export async function getTitles(params: {
   daysBack?: number;
   type?: string;
   provider?: string;
+  genre?: string;
+  language?: string;
   limit?: number;
   offset?: number;
 } = {}): Promise<{ titles: Title[]; count: number }> {
@@ -38,6 +40,8 @@ export async function getTitles(params: {
   if (params.daysBack) qs.set("daysBack", String(params.daysBack));
   if (params.type) qs.set("type", params.type);
   if (params.provider) qs.set("provider", params.provider);
+  if (params.genre) qs.set("genre", params.genre);
+  if (params.language) qs.set("language", params.language);
   if (params.limit) qs.set("limit", String(params.limit));
   if (params.offset) qs.set("offset", String(params.offset));
   return fetchJson(`/titles?${qs}`);
@@ -92,6 +96,14 @@ export async function resolveImdb(url: string): Promise<{ success: boolean; titl
 
 export async function getProviders(): Promise<{ providers: Provider[] }> {
   return fetchJson("/titles/providers");
+}
+
+export async function getGenres(): Promise<{ genres: string[] }> {
+  return fetchJson("/titles/genres");
+}
+
+export async function getLanguages(): Promise<{ languages: string[] }> {
+  return fetchJson("/titles/languages");
 }
 
 export async function getCalendarTitles(params: {

--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -1,9 +1,20 @@
+import type { Provider } from "../types";
+
 interface Props {
   type: string;
   onTypeChange: (type: string) => void;
   daysBack?: number;
   onDaysBackChange?: (days: number) => void;
   showDaysFilter?: boolean;
+  genre?: string;
+  onGenreChange?: (genre: string) => void;
+  genres?: string[];
+  provider?: string;
+  onProviderChange?: (provider: string) => void;
+  providers?: Provider[];
+  language?: string;
+  onLanguageChange?: (language: string) => void;
+  languages?: string[];
 }
 
 const TYPES = [
@@ -19,7 +30,34 @@ const DAYS = [
   { value: 90, label: "90d" },
 ];
 
-export default function FilterBar({ type, onTypeChange, daysBack, onDaysBackChange, showDaysFilter = true }: Props) {
+const selectClass =
+  "bg-gray-800 text-gray-300 text-xs rounded-lg px-3 py-1.5 border-0 outline-none cursor-pointer appearance-none hover:text-white focus:ring-1 focus:ring-gray-600";
+
+function languageLabel(code: string): string {
+  try {
+    const names = new Intl.DisplayNames(["en"], { type: "language" });
+    return names.of(code) || code;
+  } catch {
+    return code;
+  }
+}
+
+export default function FilterBar({
+  type,
+  onTypeChange,
+  daysBack,
+  onDaysBackChange,
+  showDaysFilter = true,
+  genre,
+  onGenreChange,
+  genres,
+  provider,
+  onProviderChange,
+  providers,
+  language,
+  onLanguageChange,
+  languages,
+}: Props) {
   return (
     <div className="flex flex-wrap gap-4 items-center">
       <div className="flex gap-1 bg-gray-800 rounded-lg p-1">
@@ -53,6 +91,48 @@ export default function FilterBar({ type, onTypeChange, daysBack, onDaysBackChan
             </button>
           ))}
         </div>
+      )}
+      {genres && genres.length > 0 && onGenreChange && (
+        <select
+          value={genre || ""}
+          onChange={(e) => onGenreChange(e.target.value)}
+          className={selectClass}
+        >
+          <option value="">All Genres</option>
+          {genres.map((g) => (
+            <option key={g} value={g}>
+              {g}
+            </option>
+          ))}
+        </select>
+      )}
+      {providers && providers.length > 0 && onProviderChange && (
+        <select
+          value={provider || ""}
+          onChange={(e) => onProviderChange(e.target.value)}
+          className={selectClass}
+        >
+          <option value="">All Platforms</option>
+          {providers.map((p) => (
+            <option key={p.technical_name} value={p.technical_name}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      )}
+      {languages && languages.length > 0 && onLanguageChange && (
+        <select
+          value={language || ""}
+          onChange={(e) => onLanguageChange(e.target.value)}
+          className={selectClass}
+        >
+          <option value="">All Languages</option>
+          {languages.map((l) => (
+            <option key={l} value={l}>
+              {languageLabel(l)}
+            </option>
+          ))}
+        </select>
       )}
     </div>
   );

--- a/frontend/src/components/NewReleases.tsx
+++ b/frontend/src/components/NewReleases.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import * as api from "../api";
-import type { Title } from "../types";
+import type { Title, Provider } from "../types";
 import TitleList from "./TitleList";
 import FilterBar from "./FilterBar";
 
@@ -10,20 +10,43 @@ export default function NewReleases() {
   const [syncing, setSyncing] = useState(false);
   const [type, setType] = useState("");
   const [daysBack, setDaysBack] = useState(30);
+  const [genre, setGenre] = useState("");
+  const [provider, setProvider] = useState("");
+  const [language, setLanguage] = useState("");
   const [error, setError] = useState("");
+
+  const [genres, setGenres] = useState<string[]>([]);
+  const [providers, setProviders] = useState<Provider[]>([]);
+  const [languages, setLanguages] = useState<string[]>([]);
+
+  useEffect(() => {
+    Promise.all([api.getGenres(), api.getProviders(), api.getLanguages()]).then(
+      ([g, p, l]) => {
+        setGenres(g.genres);
+        setProviders(p.providers);
+        setLanguages(l.languages);
+      }
+    );
+  }, []);
 
   const fetchTitles = useCallback(async () => {
     setLoading(true);
     setError("");
     try {
-      const res = await api.getTitles({ daysBack, type: type || undefined });
+      const res = await api.getTitles({
+        daysBack,
+        type: type || undefined,
+        genre: genre || undefined,
+        provider: provider || undefined,
+        language: language || undefined,
+      });
       setTitles(res.titles);
     } catch (err: any) {
       setError(err.message);
     } finally {
       setLoading(false);
     }
-  }, [daysBack, type]);
+  }, [daysBack, type, genre, provider, language]);
 
   useEffect(() => {
     fetchTitles();
@@ -50,6 +73,15 @@ export default function NewReleases() {
           onTypeChange={setType}
           daysBack={daysBack}
           onDaysBackChange={setDaysBack}
+          genre={genre}
+          onGenreChange={setGenre}
+          genres={genres}
+          provider={provider}
+          onProviderChange={setProvider}
+          providers={providers}
+          language={language}
+          onLanguageChange={setLanguage}
+          languages={languages}
         />
         <button
           onClick={handleSync}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -27,6 +27,7 @@ export interface Title {
   tmdb_id: string | null;
   poster_url: string | null;
   age_certification: string | null;
+  original_language: string | null;
   tmdb_url: string | null;
   imdb_score: number | null;
   imdb_votes: number | null;
@@ -67,6 +68,7 @@ export interface SearchTitle {
   tmdbId: string | null;
   posterUrl: string | null;
   ageCertification: string | null;
+  originalLanguage: string | null;
   tmdbUrl: string | null;
   offers: SearchOffer[];
   scores: {
@@ -310,6 +312,7 @@ export function normalizeSearchTitle(t: SearchTitle): Title {
     tmdb_id: t.tmdbId,
     poster_url: t.posterUrl,
     age_certification: t.ageCertification,
+    original_language: t.originalLanguage,
     tmdb_url: t.tmdbUrl,
     imdb_score: t.scores.imdbScore,
     imdb_votes: t.scores.imdbVotes,

--- a/server/db/repository.test.ts
+++ b/server/db/repository.test.ts
@@ -11,6 +11,8 @@ import {
   untrackTitle,
   getTrackedTitles,
   getProviders,
+  getGenres,
+  getLanguages,
   upsertEpisodes,
   deleteEpisodesForTitle,
   watchEpisode,
@@ -76,6 +78,18 @@ describe("upsertTitles", () => {
     upsertTitles([makeParsedTitle({ originalTitle: null })]);
     const result = getTitleById("movie-123");
     expect(result!.original_title).toBeNull();
+  });
+
+  it("stores and retrieves original_language", () => {
+    upsertTitles([makeParsedTitle({ originalLanguage: "ja" })]);
+    const result = getTitleById("movie-123");
+    expect(result!.original_language).toBe("ja");
+  });
+
+  it("stores null original_language when not provided", () => {
+    upsertTitles([makeParsedTitle({ originalLanguage: null })]);
+    const result = getTitleById("movie-123");
+    expect(result!.original_language).toBeNull();
   });
 
   it("upserts providers and offers", () => {
@@ -167,6 +181,73 @@ describe("getRecentTitles", () => {
     const results = getRecentTitles({ daysBack: 0, limit: 1, offset: 1 });
     expect(results).toHaveLength(1);
     expect(results[0].id).toBe("movie-2");
+  });
+
+  it("filters by genre", () => {
+    upsertTitles([
+      makeParsedTitle({ id: "movie-1", genres: ["Action", "Drama"], releaseDate: "2025-01-01" }),
+      makeParsedTitle({ id: "movie-2", title: "Comedy Film", genres: ["Comedy"], releaseDate: "2025-01-02" }),
+    ]);
+    const results = getRecentTitles({ daysBack: 0, genre: "Comedy" });
+    expect(results).toHaveLength(1);
+    expect(results[0].title).toBe("Comedy Film");
+  });
+
+  it("filters by language", () => {
+    upsertTitles([
+      makeParsedTitle({ id: "movie-1", originalLanguage: "en", releaseDate: "2025-01-01" }),
+      makeParsedTitle({ id: "movie-2", title: "Japanese Movie", originalLanguage: "ja", releaseDate: "2025-01-02" }),
+    ]);
+    const results = getRecentTitles({ daysBack: 0, language: "ja" });
+    expect(results).toHaveLength(1);
+    expect(results[0].title).toBe("Japanese Movie");
+  });
+
+  it("combines genre and language filters", () => {
+    upsertTitles([
+      makeParsedTitle({ id: "movie-1", genres: ["Action"], originalLanguage: "en", releaseDate: "2025-01-01" }),
+      makeParsedTitle({ id: "movie-2", title: "Korean Action", genres: ["Action"], originalLanguage: "ko", releaseDate: "2025-01-02" }),
+      makeParsedTitle({ id: "movie-3", title: "Korean Drama", genres: ["Drama"], originalLanguage: "ko", releaseDate: "2025-01-03" }),
+    ]);
+    const results = getRecentTitles({ daysBack: 0, genre: "Action", language: "ko" });
+    expect(results).toHaveLength(1);
+    expect(results[0].title).toBe("Korean Action");
+  });
+});
+
+describe("getGenres", () => {
+  it("returns distinct genres sorted alphabetically", () => {
+    upsertTitles([
+      makeParsedTitle({ id: "movie-1", genres: ["Drama", "Action"] }),
+      makeParsedTitle({ id: "movie-2", genres: ["Comedy", "Action"] }),
+    ]);
+    const genres = getGenres();
+    expect(genres).toEqual(["Action", "Comedy", "Drama"]);
+  });
+
+  it("returns empty array when no titles exist", () => {
+    expect(getGenres()).toEqual([]);
+  });
+});
+
+describe("getLanguages", () => {
+  it("returns distinct languages sorted", () => {
+    upsertTitles([
+      makeParsedTitle({ id: "movie-1", originalLanguage: "ja" }),
+      makeParsedTitle({ id: "movie-2", originalLanguage: "en" }),
+      makeParsedTitle({ id: "movie-3", originalLanguage: "en" }),
+    ]);
+    const languages = getLanguages();
+    expect(languages).toEqual(["en", "ja"]);
+  });
+
+  it("excludes null languages", () => {
+    upsertTitles([
+      makeParsedTitle({ id: "movie-1", originalLanguage: null }),
+      makeParsedTitle({ id: "movie-2", originalLanguage: "en" }),
+    ]);
+    const languages = getLanguages();
+    expect(languages).toEqual(["en"]);
   });
 });
 

--- a/server/db/repository.ts
+++ b/server/db/repository.ts
@@ -61,6 +61,7 @@ export function upsertTitles(parsedTitles: ParsedTitle[]) {
           runtimeMinutes: t.runtimeMinutes,
           shortDescription: t.shortDescription,
           genres: JSON.stringify(t.genres),
+          originalLanguage: t.originalLanguage,
           imdbId: t.imdbId,
           tmdbId: t.tmdbId,
           posterUrl: t.posterUrl,
@@ -78,6 +79,7 @@ export function upsertTitles(parsedTitles: ParsedTitle[]) {
             runtimeMinutes: sql`excluded.runtime_minutes`,
             shortDescription: sql`excluded.short_description`,
             genres: sql`excluded.genres`,
+            originalLanguage: sql`excluded.original_language`,
             imdbId: sql`excluded.imdb_id`,
             tmdbId: sql`excluded.tmdb_id`,
             posterUrl: sql`excluded.poster_url`,
@@ -152,6 +154,7 @@ export function getTitleById(titleId: string, userId?: string) {
       tmdb_id: titles.tmdbId,
       poster_url: titles.posterUrl,
       age_certification: titles.ageCertification,
+      original_language: titles.originalLanguage,
       tmdb_url: titles.tmdbUrl,
       updated_at: titles.updatedAt,
       imdb_score: scores.imdbScore,
@@ -180,13 +183,15 @@ export interface TitleFilters {
   daysBack?: number;
   objectType?: string;
   provider?: string;
+  genre?: string;
+  language?: string;
   limit?: number;
   offset?: number;
 }
 
 export function getRecentTitles(filters: TitleFilters = {}, userId?: string) {
   const db = getDb();
-  const { daysBack = 30, objectType, provider, limit = 100, offset = 0 } = filters;
+  const { daysBack = 30, objectType, provider, genre, language, limit = 100, offset = 0 } = filters;
 
   const conditions: ReturnType<typeof eq>[] = [];
 
@@ -212,6 +217,12 @@ export function getRecentTitles(filters: TitleFilters = {}, userId?: string) {
       )
     );
   }
+  if (genre) {
+    conditions.push(like(titles.genres, `%"${genre}"%`));
+  }
+  if (language) {
+    conditions.push(eq(titles.originalLanguage, language));
+  }
 
   const trackedSubquery = userId
     ? sql<number>`(SELECT EXISTS(SELECT 1 FROM tracked tr WHERE tr.title_id = ${titles.id} AND tr.user_id = ${userId}))`
@@ -232,6 +243,7 @@ export function getRecentTitles(filters: TitleFilters = {}, userId?: string) {
       tmdb_id: titles.tmdbId,
       poster_url: titles.posterUrl,
       age_certification: titles.ageCertification,
+      original_language: titles.originalLanguage,
       tmdb_url: titles.tmdbUrl,
       updated_at: titles.updatedAt,
       imdb_score: scores.imdbScore,
@@ -315,6 +327,7 @@ export function getTrackedTitles(userId: string) {
       tmdb_id: titles.tmdbId,
       poster_url: titles.posterUrl,
       age_certification: titles.ageCertification,
+      original_language: titles.originalLanguage,
       tmdb_url: titles.tmdbUrl,
       updated_at: titles.updatedAt,
       imdb_score: scores.imdbScore,
@@ -363,6 +376,7 @@ export function searchLocalTitles(query: string, limit = 50, userId?: string) {
       tmdb_id: titles.tmdbId,
       poster_url: titles.posterUrl,
       age_certification: titles.ageCertification,
+      original_language: titles.originalLanguage,
       tmdb_url: titles.tmdbUrl,
       updated_at: titles.updatedAt,
       imdb_score: scores.imdbScore,
@@ -461,6 +475,7 @@ export function getTitlesByMonth(filters: MonthFilters, userId?: string) {
       tmdb_id: titles.tmdbId,
       poster_url: titles.posterUrl,
       age_certification: titles.ageCertification,
+      original_language: titles.originalLanguage,
       tmdb_url: titles.tmdbUrl,
       updated_at: titles.updatedAt,
       imdb_score: scores.imdbScore,
@@ -494,6 +509,28 @@ export function getProviders() {
     .from(providers)
     .orderBy(asc(providers.name))
     .all();
+}
+
+export function getGenres(): string[] {
+  const raw = getRawDb();
+  const rows = raw.prepare(
+    "SELECT DISTINCT genres FROM titles WHERE genres IS NOT NULL AND genres != '[]'"
+  ).all() as { genres: string }[];
+
+  const genreSet = new Set<string>();
+  for (const row of rows) {
+    const parsed = JSON.parse(row.genres) as string[];
+    for (const g of parsed) genreSet.add(g);
+  }
+  return Array.from(genreSet).sort();
+}
+
+export function getLanguages(): string[] {
+  const raw = getRawDb();
+  const rows = raw.prepare(
+    "SELECT DISTINCT original_language FROM titles WHERE original_language IS NOT NULL ORDER BY original_language"
+  ).all() as { original_language: string }[];
+  return rows.map((r) => r.original_language);
 }
 
 // ─── Episodes ────────────────────────────────────────────────────────────────

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -30,6 +30,7 @@ export const titles = sqliteTable(
     tmdbId: text("tmdb_id"),
     posterUrl: text("poster_url"),
     ageCertification: text("age_certification"),
+    originalLanguage: text("original_language"),
     tmdbUrl: text("tmdb_url"),
     updatedAt: text("updated_at").default(sql`(datetime('now'))`),
   },
@@ -302,6 +303,7 @@ function initSchema(db: Database) {
       tmdb_id TEXT,
       poster_url TEXT,
       age_certification TEXT,
+      original_language TEXT,
       tmdb_url TEXT,
       updated_at TEXT DEFAULT (datetime('now'))
     )
@@ -549,6 +551,18 @@ function migrateSchema(db: Database) {
     db.run("CREATE INDEX IF NOT EXISTS idx_notifiers_enabled_time ON notifiers(enabled, notify_time)");
     console.log("[Migration v5] Created notifiers table.");
     setSchemaVersion(db, 5);
+  }
+
+  // Migration v6: Add original_language column to titles
+  if (getSchemaVersion(db) < 6) {
+    const titlesInfo = db.prepare(
+      "SELECT sql FROM sqlite_master WHERE type='table' AND name='titles'"
+    ).get() as any;
+    if (titlesInfo && !titlesInfo.sql.includes("original_language")) {
+      db.run("ALTER TABLE titles ADD COLUMN original_language TEXT");
+      console.log("[Migration v6] Added original_language column to titles table.");
+    }
+    setSchemaVersion(db, 6);
   }
 }
 

--- a/server/routes/titles.test.ts
+++ b/server/routes/titles.test.ts
@@ -52,6 +52,61 @@ describe("GET /titles", () => {
     expect(body.titles).toHaveLength(0);
     expect(body.count).toBe(0);
   });
+
+  it("filters by genre", async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    upsertTitles([
+      makeParsedTitle({ id: "movie-1", genres: ["Action"], releaseDate: today }),
+      makeParsedTitle({ id: "movie-2", title: "Comedy Film", genres: ["Comedy"], releaseDate: today }),
+    ]);
+
+    const res = await app.request("/titles?daysBack=9999&genre=Comedy");
+    const body = await res.json();
+    expect(body.titles).toHaveLength(1);
+    expect(body.titles[0].title).toBe("Comedy Film");
+  });
+
+  it("filters by language", async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    upsertTitles([
+      makeParsedTitle({ id: "movie-1", originalLanguage: "en", releaseDate: today }),
+      makeParsedTitle({ id: "movie-2", title: "Japanese Movie", originalLanguage: "ja", releaseDate: today }),
+    ]);
+
+    const res = await app.request("/titles?daysBack=9999&language=ja");
+    const body = await res.json();
+    expect(body.titles).toHaveLength(1);
+    expect(body.titles[0].title).toBe("Japanese Movie");
+  });
+});
+
+describe("GET /titles/genres", () => {
+  it("returns available genres", async () => {
+    upsertTitles([
+      makeParsedTitle({ genres: ["Action", "Drama"] }),
+    ]);
+
+    const res = await app.request("/titles/genres");
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.genres).toContain("Action");
+    expect(body.genres).toContain("Drama");
+  });
+});
+
+describe("GET /titles/languages", () => {
+  it("returns available languages", async () => {
+    upsertTitles([
+      makeParsedTitle({ originalLanguage: "en" }),
+    ]);
+
+    const res = await app.request("/titles/languages");
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.languages).toContain("en");
+  });
 });
 
 describe("GET /titles/providers", () => {

--- a/server/routes/titles.ts
+++ b/server/routes/titles.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { getRecentTitles, getProviders } from "../db/repository";
+import { getRecentTitles, getProviders, getGenres, getLanguages } from "../db/repository";
 import type { AppEnv } from "../types";
 
 const app = new Hono<AppEnv>();
@@ -9,16 +9,28 @@ app.get("/", (c) => {
   const daysBack = Number(c.req.query("daysBack")) || 30;
   const objectType = c.req.query("type");
   const provider = c.req.query("provider");
+  const genre = c.req.query("genre");
+  const language = c.req.query("language");
   const limit = Number(c.req.query("limit")) || 100;
   const offset = Number(c.req.query("offset")) || 0;
 
-  const titles = getRecentTitles({ daysBack, objectType, provider, limit, offset }, user?.id);
+  const titles = getRecentTitles({ daysBack, objectType, provider, genre, language, limit, offset }, user?.id);
   return c.json({ titles, count: titles.length });
 });
 
 app.get("/providers", (c) => {
   const providers = getProviders();
   return c.json({ providers });
+});
+
+app.get("/genres", (c) => {
+  const genres = getGenres();
+  return c.json({ genres });
+});
+
+app.get("/languages", (c) => {
+  const languages = getLanguages();
+  return c.json({ languages });
 });
 
 export default app;

--- a/server/test-utils/fixtures.ts
+++ b/server/test-utils/fixtures.ts
@@ -12,6 +12,7 @@ export function makeParsedTitle(overrides?: Partial<ParsedTitle>): ParsedTitle {
     runtimeMinutes: 120,
     shortDescription: "A test movie",
     genres: ["Action", "Drama"],
+    originalLanguage: "en",
     imdbId: "tt1234567",
     tmdbId: "123",
     posterUrl: "https://image.tmdb.org/t/p/w342/test.jpg",

--- a/server/tmdb/parser.test.ts
+++ b/server/tmdb/parser.test.ts
@@ -63,6 +63,12 @@ describe("parseMovieDetails", () => {
     expect(result.originalTitle).toBe("Film Original");
   });
 
+  it("parses original_language", () => {
+    const movie = makeTmdbMovieDetails({ original_language: "ja" });
+    const result = parseMovieDetails(movie);
+    expect(result.originalLanguage).toBe("ja");
+  });
+
   it("parses watch providers for configured country", () => {
     const movie = makeTmdbMovieDetails({
       "watch/providers": {
@@ -115,6 +121,12 @@ describe("parseTvDetails", () => {
     const result = parseTvDetails(tv);
     expect(result.originalTitle).toBe("Original Show Name");
   });
+
+  it("parses original_language", () => {
+    const tv = makeTmdbTvDetails({ original_language: "ko" });
+    const result = parseTvDetails(tv);
+    expect(result.originalLanguage).toBe("ko");
+  });
 });
 
 describe("parseDiscoverMovie", () => {
@@ -144,6 +156,13 @@ describe("parseDiscoverMovie", () => {
     const result = parseDiscoverMovie(movie, genreMap);
     expect(result.originalTitle).toBe("Pelicula");
   });
+
+  it("parses original_language", () => {
+    const genreMap = new Map([[28, "Action"]]);
+    const movie = makeTmdbDiscoverMovie({ original_language: "fr" });
+    const result = parseDiscoverMovie(movie, genreMap);
+    expect(result.originalLanguage).toBe("fr");
+  });
 });
 
 describe("parseDiscoverTv", () => {
@@ -163,6 +182,13 @@ describe("parseDiscoverTv", () => {
     const tv = makeTmdbDiscoverTv({ original_name: "Serie Original" });
     const result = parseDiscoverTv(tv, genreMap);
     expect(result.originalTitle).toBe("Serie Original");
+  });
+
+  it("parses original_language", () => {
+    const genreMap = new Map([[18, "Drama"]]);
+    const tv = makeTmdbDiscoverTv({ original_language: "es" });
+    const result = parseDiscoverTv(tv, genreMap);
+    expect(result.originalLanguage).toBe("es");
   });
 });
 

--- a/server/tmdb/parser.ts
+++ b/server/tmdb/parser.ts
@@ -21,6 +21,7 @@ export interface ParsedTitle {
   runtimeMinutes: number | null;
   shortDescription: string | null;
   genres: string[];
+  originalLanguage: string | null;
   imdbId: string | null;
   tmdbId: string | null;
   posterUrl: string | null;
@@ -143,6 +144,7 @@ export function parseMovieDetails(movie: TmdbMovieDetails): ParsedTitle {
     runtimeMinutes: movie.runtime,
     shortDescription: movie.overview,
     genres: movie.genres.map((g) => g.name),
+    originalLanguage: movie.original_language || null,
     imdbId: movie.external_ids?.imdb_id || null,
     tmdbId: String(movie.id),
     posterUrl: posterUrl(movie.poster_path),
@@ -172,6 +174,7 @@ export function parseTvDetails(tv: TmdbTvDetails): ParsedTitle {
     runtimeMinutes: runtime,
     shortDescription: tv.overview,
     genres: tv.genres.map((g) => g.name),
+    originalLanguage: tv.original_language || null,
     imdbId: tv.external_ids?.imdb_id || null,
     tmdbId: String(tv.id),
     posterUrl: posterUrl(tv.poster_path),
@@ -203,6 +206,7 @@ export function parseDiscoverMovie(
     runtimeMinutes: null,
     shortDescription: movie.overview,
     genres: movie.genre_ids.map((gid) => genreMap.get(gid) || "").filter(Boolean),
+    originalLanguage: movie.original_language || null,
     imdbId: null,
     tmdbId: String(movie.id),
     posterUrl: posterUrl(movie.poster_path),
@@ -232,6 +236,7 @@ export function parseDiscoverTv(
     runtimeMinutes: null,
     shortDescription: tv.overview,
     genres: tv.genre_ids.map((gid) => genreMap.get(gid) || "").filter(Boolean),
+    originalLanguage: tv.original_language || null,
     imdbId: null,
     tmdbId: String(tv.id),
     posterUrl: posterUrl(tv.poster_path),
@@ -264,6 +269,7 @@ export function parseSearchResult(
       runtimeMinutes: null,
       shortDescription: result.overview || null,
       genres: (result.genre_ids || []).map((gid) => genreMap.get(gid) || "").filter(Boolean),
+      originalLanguage: null,
       imdbId: null,
       tmdbId: String(result.id),
       posterUrl: posterUrl(result.poster_path || null),
@@ -290,6 +296,7 @@ export function parseSearchResult(
     runtimeMinutes: null,
     shortDescription: result.overview || null,
     genres: (result.genre_ids || []).map((gid) => genreMap.get(gid) || "").filter(Boolean),
+    originalLanguage: null,
     imdbId: null,
     tmdbId: String(result.id),
     posterUrl: posterUrl(result.poster_path || null),


### PR DESCRIPTION
## Summary
This PR adds genre and language filtering capabilities to the title discovery system, allowing users to filter new releases by genre and original language in addition to existing filters.

## Key Changes

**Frontend:**
- Extended `FilterBar` component with genre, language, and provider filter dropdowns
- Added `languageLabel()` utility function to display language codes as human-readable names using `Intl.DisplayNames`
- Updated `NewReleases` component to fetch and manage genre/language filter options
- Modified API calls to include genre and language query parameters

**Backend:**
- Added `original_language` column to the titles table with database migration (v6)
- Implemented `getGenres()` and `getLanguages()` repository functions to retrieve distinct values from the database
- Extended `getRecentTitles()` to support genre and language filtering
- Added new API endpoints: `GET /titles/genres` and `GET /titles/languages`
- Updated TMDB parser to extract `original_language` from movie and TV show details

**Database:**
- Added `original_language` text column to titles schema
- Implemented migration to safely add the column to existing databases
- Updated all title query functions to include the new field in results

**Testing:**
- Added comprehensive test coverage for genre and language filtering
- Added tests for the new `getGenres()` and `getLanguages()` functions
- Added tests for the new API endpoints
- Updated test fixtures to include `originalLanguage` field

## Implementation Details
- Genre filtering uses JSON pattern matching (`LIKE`) on the stored genres array
- Language filtering uses exact match on the `original_language` column
- Filters can be combined with existing type and provider filters
- Language names are displayed using the browser's `Intl.DisplayNames` API for localization

https://claude.ai/code/session_015EuzDGgXYd2P9kVuioY9Pj