### PR TITLE
Add isTracked field to search and browse results

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -74,6 +74,7 @@ export interface SearchTitle {
     imdbVotes: number | null;
     tmdbScore: number | null;
   };
+  isTracked?: boolean;
 }
 
 export interface SearchOffer {
@@ -314,7 +315,7 @@ export function normalizeSearchTitle(t: SearchTitle): Title {
     imdb_score: t.scores.imdbScore,
     imdb_votes: t.scores.imdbVotes,
     tmdb_score: t.scores.tmdbScore,
-    is_tracked: false,
+    is_tracked: t.isTracked ?? false,
     offers: t.offers.map((o, i) => ({
       id: i,
       title_id: t.id,

--- a/server/db/repository.test.ts
+++ b/server/db/repository.test.ts
@@ -10,6 +10,7 @@ import {
   trackTitle,
   untrackTitle,
   getTrackedTitles,
+  getTrackedTitleIds,
   getProviders,
   upsertEpisodes,
   deleteEpisodesForTitle,
@@ -222,6 +223,27 @@ describe("tracking", () => {
 
     const tracked = getTrackedTitles(userId);
     expect(tracked[0].notes).toBe("updated note");
+  });
+
+  it("getTrackedTitleIds returns set of tracked title IDs", () => {
+    upsertTitles([makeParsedTitle({ id: "movie-1" }), makeParsedTitle({ id: "movie-2" })]);
+    const userId = createUser("testuser", "hash");
+
+    trackTitle("movie-1", userId);
+    trackTitle("movie-2", userId);
+
+    const ids = getTrackedTitleIds(userId);
+    expect(ids).toBeInstanceOf(Set);
+    expect(ids.size).toBe(2);
+    expect(ids.has("movie-1")).toBe(true);
+    expect(ids.has("movie-2")).toBe(true);
+    expect(ids.has("movie-999")).toBe(false);
+  });
+
+  it("getTrackedTitleIds returns empty set for user with no tracked titles", () => {
+    const userId = createUser("testuser", "hash");
+    const ids = getTrackedTitleIds(userId);
+    expect(ids.size).toBe(0);
   });
 });
 

--- a/server/db/repository.ts
+++ b/server/db/repository.ts
@@ -298,6 +298,16 @@ export function untrackTitle(titleId: string, userId: string) {
     .run();
 }
 
+export function getTrackedTitleIds(userId: string): Set<string> {
+  const db = getDb();
+  const rows = db
+    .select({ titleId: tracked.titleId })
+    .from(tracked)
+    .where(eq(tracked.userId, userId))
+    .all();
+  return new Set(rows.map((r) => r.titleId));
+}
+
 export function getTrackedTitles(userId: string) {
   const db = getDb();
   const rows = db

--- a/server/routes/browse.test.ts
+++ b/server/routes/browse.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { Hono } from "hono";
+import type { AppEnv } from "../types";
 
 const mockFetchPopularMovies = mock(() => Promise.resolve({ results: [], total_pages: 1, total_results: 0, page: 1 }));
 const mockFetchPopularTv = mock(() => Promise.resolve({ results: [], total_pages: 1, total_results: 0, page: 1 }));
@@ -11,6 +12,7 @@ const mockFetchMovieDetails = mock(() => Promise.resolve({}));
 const mockFetchTvDetails = mock(() => Promise.resolve({}));
 const mockGetMovieGenres = mock(() => Promise.resolve(new Map([[28, "Action"]])));
 const mockGetTvGenres = mock(() => Promise.resolve(new Map([[18, "Drama"]])));
+const mockGetTrackedTitleIds = mock(() => new Set<string>());
 
 mock.module("../tmdb/client", () => ({
   fetchPopularMovies: mockFetchPopularMovies,
@@ -23,15 +25,20 @@ mock.module("../tmdb/client", () => ({
   fetchTvDetails: mockFetchTvDetails,
   getMovieGenres: mockGetMovieGenres,
   getTvGenres: mockGetTvGenres,
+  searchMulti: mock(() => Promise.resolve({ results: [], total_pages: 1, total_results: 0, page: 1 })),
+}));
+
+mock.module("../db/repository", () => ({
+  getTrackedTitleIds: mockGetTrackedTitleIds,
 }));
 
 const { makeTmdbDiscoverMovie, makeTmdbDiscoverTv, makeTmdbMovieDetails, makeTmdbTvDetails } = await import("../test-utils/fixtures");
 const browseApp = (await import("./browse")).default;
 
-let app: Hono;
+let app: Hono<AppEnv>;
 
 beforeEach(() => {
-  app = new Hono();
+  app = new Hono<AppEnv>();
   app.route("/browse", browseApp);
 
   mockFetchPopularMovies.mockClear();
@@ -42,6 +49,7 @@ beforeEach(() => {
   mockFetchTopRatedTv.mockClear();
   mockFetchMovieDetails.mockClear();
   mockFetchTvDetails.mockClear();
+  mockGetTrackedTitleIds.mockClear();
 });
 
 describe("GET /browse", () => {
@@ -169,5 +177,41 @@ describe("GET /browse", () => {
     const body = await res.json();
     expect(body.titles).toHaveLength(1);
     expect(body.titles[0].title).toBe("Discover Movie");
+  });
+
+  it("returns isTracked=false when no user is authenticated", async () => {
+    const movie = makeTmdbDiscoverMovie();
+    mockFetchPopularMovies.mockResolvedValueOnce({
+      results: [movie], total_pages: 1, total_results: 1, page: 1,
+    });
+    mockFetchMovieDetails.mockResolvedValueOnce(makeTmdbMovieDetails({ id: movie.id }));
+
+    const res = await app.request("/browse?category=popular&type=MOVIE");
+    const body = await res.json();
+
+    expect(body.titles[0].isTracked).toBe(false);
+    expect(mockGetTrackedTitleIds).not.toHaveBeenCalled();
+  });
+
+  it("returns isTracked=true for tracked titles when user is authenticated", async () => {
+    const movie = makeTmdbDiscoverMovie({ id: 555 });
+    mockFetchPopularMovies.mockResolvedValueOnce({
+      results: [movie], total_pages: 1, total_results: 1, page: 1,
+    });
+    mockFetchMovieDetails.mockResolvedValueOnce(makeTmdbMovieDetails({ id: 555 }));
+    mockGetTrackedTitleIds.mockReturnValueOnce(new Set(["movie-555"]));
+
+    const authedApp = new Hono<AppEnv>();
+    authedApp.use("/browse/*", async (c, next) => {
+      c.set("user", { id: "user-1", username: "testuser", isAdmin: false });
+      await next();
+    });
+    authedApp.route("/browse", browseApp);
+
+    const res = await authedApp.request("/browse?category=popular&type=MOVIE");
+    const body = await res.json();
+
+    expect(body.titles[0].isTracked).toBe(true);
+    expect(mockGetTrackedTitleIds).toHaveBeenCalledWith("user-1");
   });
 });

--- a/server/routes/browse.ts
+++ b/server/routes/browse.ts
@@ -18,6 +18,7 @@ import {
   parseTvDetails,
   type ParsedTitle,
 } from "../tmdb/parser";
+import { getTrackedTitleIds } from "../db/repository";
 
 const VALID_CATEGORIES = ["popular", "upcoming", "top_rated"] as const;
 type Category = (typeof VALID_CATEGORIES)[number];
@@ -87,7 +88,14 @@ app.get("/", async (c) => {
       })
     );
 
-    return c.json({ titles, page, totalPages });
+    const user = c.get("user");
+    const trackedIds = user ? getTrackedTitleIds(user.id) : new Set<string>();
+    const titlesWithTracked = titles.map((t) => ({
+      ...t,
+      isTracked: trackedIds.has(t.id),
+    }));
+
+    return c.json({ titles: titlesWithTracked, page, totalPages });
   } catch (err: any) {
     return c.json({ error: err.message }, 500);
   }

--- a/server/routes/search.test.ts
+++ b/server/routes/search.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "../types";
+
+const mockSearchMulti = mock(() => Promise.resolve({ results: [], total_pages: 1, total_results: 0, page: 1 }));
+const mockFetchMovieDetails = mock(() => Promise.resolve({}));
+const mockFetchTvDetails = mock(() => Promise.resolve({}));
+const mockGetMovieGenres = mock(() => Promise.resolve(new Map([[28, "Action"]])));
+const mockGetTvGenres = mock(() => Promise.resolve(new Map([[18, "Drama"]])));
+const mockGetTrackedTitleIds = mock(() => new Set<string>());
+
+mock.module("../tmdb/client", () => ({
+  searchMulti: mockSearchMulti,
+  fetchMovieDetails: mockFetchMovieDetails,
+  fetchTvDetails: mockFetchTvDetails,
+  getMovieGenres: mockGetMovieGenres,
+  getTvGenres: mockGetTvGenres,
+  fetchPopularMovies: mock(() => Promise.resolve({ results: [], total_pages: 1, total_results: 0, page: 1 })),
+  fetchPopularTv: mock(() => Promise.resolve({ results: [], total_pages: 1, total_results: 0, page: 1 })),
+  fetchUpcomingMovies: mock(() => Promise.resolve({ results: [], total_pages: 1, total_results: 0, page: 1 })),
+  fetchOnTheAirTv: mock(() => Promise.resolve({ results: [], total_pages: 1, total_results: 0, page: 1 })),
+  fetchTopRatedMovies: mock(() => Promise.resolve({ results: [], total_pages: 1, total_results: 0, page: 1 })),
+  fetchTopRatedTv: mock(() => Promise.resolve({ results: [], total_pages: 1, total_results: 0, page: 1 })),
+}));
+
+mock.module("../db/repository", () => ({
+  getTrackedTitleIds: mockGetTrackedTitleIds,
+}));
+
+const { makeTmdbSearchMultiMovie, makeTmdbMovieDetails } = await import("../test-utils/fixtures");
+const searchApp = (await import("./search")).default;
+
+let app: Hono<AppEnv>;
+
+beforeEach(() => {
+  app = new Hono<AppEnv>();
+  app.route("/search", searchApp);
+
+  mockSearchMulti.mockClear();
+  mockFetchMovieDetails.mockClear();
+  mockFetchTvDetails.mockClear();
+  mockGetTrackedTitleIds.mockClear();
+});
+
+describe("GET /search", () => {
+  it("returns 400 when query is missing", async () => {
+    const res = await app.request("/search");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("required");
+  });
+
+  it("returns search results with isTracked=false when no user", async () => {
+    const movie = makeTmdbSearchMultiMovie({ id: 42 });
+    mockSearchMulti.mockResolvedValueOnce({
+      results: [movie], total_pages: 1, total_results: 1, page: 1,
+    });
+    mockFetchMovieDetails.mockResolvedValueOnce(makeTmdbMovieDetails({ id: 42 }));
+
+    const res = await app.request("/search?q=test");
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.titles).toHaveLength(1);
+    expect(body.titles[0].isTracked).toBe(false);
+    expect(mockGetTrackedTitleIds).not.toHaveBeenCalled();
+  });
+
+  it("returns isTracked=true for tracked titles when user is authenticated", async () => {
+    const movie = makeTmdbSearchMultiMovie({ id: 42 });
+    mockSearchMulti.mockResolvedValueOnce({
+      results: [movie], total_pages: 1, total_results: 1, page: 1,
+    });
+    mockFetchMovieDetails.mockResolvedValueOnce(makeTmdbMovieDetails({ id: 42 }));
+    mockGetTrackedTitleIds.mockReturnValueOnce(new Set(["movie-42"]));
+
+    const authedApp = new Hono<AppEnv>();
+    authedApp.use("/search/*", async (c, next) => {
+      c.set("user", { id: "user-1", username: "testuser", isAdmin: false });
+      await next();
+    });
+    authedApp.route("/search", searchApp);
+
+    const res = await authedApp.request("/search?q=test");
+    const body = await res.json();
+
+    expect(body.titles[0].isTracked).toBe(true);
+    expect(mockGetTrackedTitleIds).toHaveBeenCalledWith("user-1");
+  });
+});

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { searchMulti, fetchMovieDetails, fetchTvDetails, getMovieGenres, getTvGenres } from "../tmdb/client";
 import { parseSearchResult, parseMovieDetails, parseTvDetails, type ParsedTitle } from "../tmdb/parser";
+import { getTrackedTitleIds } from "../db/repository";
 
 const app = new Hono();
 
@@ -41,7 +42,14 @@ app.get("/", async (c) => {
       })
     );
 
-    return c.json({ titles, count: titles.length });
+    const user = c.get("user");
+    const trackedIds = user ? getTrackedTitleIds(user.id) : new Set<string>();
+    const titlesWithTracked = titles.map((t) => ({
+      ...t,
+      isTracked: trackedIds.has(t.id),
+    }));
+
+    return c.json({ titles: titlesWithTracked, count: titlesWithTracked.length });
   } catch (err: any) {
     return c.json({ error: err.message }, 500);
   }


### PR DESCRIPTION
## Summary
This PR adds the ability to display whether titles are tracked by the authenticated user in search and browse results. When a user is logged in, the API now returns an `isTracked` boolean field for each title, allowing the frontend to visually indicate which titles the user is already tracking.

## Key Changes
- **New database function**: Added `getTrackedTitleIds()` to efficiently retrieve a set of all tracked title IDs for a user
- **Search route**: Updated `/search` endpoint to include `isTracked` field based on user's tracked titles
- **Browse route**: Updated `/browse` endpoint to include `isTracked` field based on user's tracked titles
- **Frontend types**: Added optional `isTracked` field to `SearchTitle` interface and updated `normalizeSearchTitle()` to use the value from the API response
- **Test coverage**: Added comprehensive tests for both authenticated and unauthenticated scenarios in search and browse routes, plus tests for the new `getTrackedTitleIds()` function

## Implementation Details
- The `isTracked` field defaults to `false` when no user is authenticated (no database query is made)
- When a user is authenticated, `getTrackedTitleIds()` is called once per request and the result is used to enrich all titles in the response
- The implementation uses a `Set` for O(1) lookup performance when checking if a title is tracked
- Both routes follow the same pattern for consistency

https://claude.ai/code/session_01K2YFsj855JfN6rLreJ3qsK