### PR TITLE
Replace fetchUpcomingMovies with discoverMovies for flexible date ranges

### DIFF
--- a/server/routes/browse.test.ts
+++ b/server/routes/browse.test.ts
@@ -8,7 +8,7 @@ import { makeParsedTitle } from "../test-utils/fixtures";
 
 const mockFetchPopularMovies = mock(() => Promise.resolve({ results: [] as TmdbDiscoverMovieResult[], total_pages: 1, total_results: 0, page: 1 }));
 const mockFetchPopularTv = mock(() => Promise.resolve({ results: [] as TmdbDiscoverTvResult[], total_pages: 1, total_results: 0, page: 1 }));
-const mockFetchUpcomingMovies = mock(() => Promise.resolve({ results: [] as TmdbDiscoverMovieResult[], total_pages: 1, total_results: 0, page: 1 }));
+const mockDiscoverMovies = mock(() => Promise.resolve({ results: [] as TmdbDiscoverMovieResult[], total_pages: 1, total_results: 0, page: 1 }));
 const mockFetchOnTheAirTv = mock(() => Promise.resolve({ results: [] as TmdbDiscoverTvResult[], total_pages: 1, total_results: 0, page: 1 }));
 const mockFetchTopRatedMovies = mock(() => Promise.resolve({ results: [] as TmdbDiscoverMovieResult[], total_pages: 1, total_results: 0, page: 1 }));
 const mockFetchTopRatedTv = mock(() => Promise.resolve({ results: [] as TmdbDiscoverTvResult[], total_pages: 1, total_results: 0, page: 1 }));
@@ -23,7 +23,7 @@ mock.module("../tmdb/client", () => ({
   ...realClient,
   fetchPopularMovies: mockFetchPopularMovies,
   fetchPopularTv: mockFetchPopularTv,
-  fetchUpcomingMovies: mockFetchUpcomingMovies,
+  discoverMovies: mockDiscoverMovies,
   fetchOnTheAirTv: mockFetchOnTheAirTv,
   fetchTopRatedMovies: mockFetchTopRatedMovies,
   fetchTopRatedTv: mockFetchTopRatedTv,
@@ -47,7 +47,7 @@ beforeEach(() => {
 
   mockFetchPopularMovies.mockClear();
   mockFetchPopularTv.mockClear();
-  mockFetchUpcomingMovies.mockClear();
+  mockDiscoverMovies.mockClear();
   mockFetchOnTheAirTv.mockClear();
   mockFetchTopRatedMovies.mockClear();
   mockFetchTopRatedTv.mockClear();
@@ -128,14 +128,19 @@ describe("GET /browse", () => {
     expect(mockFetchPopularTv).toHaveBeenCalled();
   });
 
-  it("uses upcoming fetchers for upcoming category", async () => {
-    mockFetchUpcomingMovies.mockResolvedValueOnce({
+  it("uses discover endpoint for upcoming movies with date range", async () => {
+    mockDiscoverMovies.mockResolvedValueOnce({
       results: [], total_pages: 1, total_results: 0, page: 1,
     });
 
     const res = await app.request("/browse?category=upcoming&type=MOVIE");
     expect(res.status).toBe(200);
-    expect(mockFetchUpcomingMovies).toHaveBeenCalled();
+    expect(mockDiscoverMovies).toHaveBeenCalledTimes(1);
+    const callArgs = (mockDiscoverMovies.mock.calls[0] as unknown[])[0] as Record<string, unknown>;
+    expect(callArgs.releaseDateGte).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(callArgs.releaseDateLte).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(callArgs.sortBy).toBe("release_date.asc");
+    expect(callArgs.page).toBe(1);
   });
 
   it("uses on_the_air for upcoming TV shows", async () => {

--- a/server/routes/browse.ts
+++ b/server/routes/browse.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import {
   fetchPopularMovies,
   fetchPopularTv,
-  fetchUpcomingMovies,
+  discoverMovies,
   fetchOnTheAirTv,
   fetchTopRatedMovies,
   fetchTopRatedTv,
@@ -24,9 +24,25 @@ import type { AppEnv } from "../types";
 const VALID_CATEGORIES = ["popular", "upcoming", "top_rated"] as const;
 type Category = (typeof VALID_CATEGORIES)[number];
 
+function formatDate(date: Date): string {
+  return date.toISOString().split("T")[0];
+}
+
+function fetchUpcomingMoviesDiscover(page: number) {
+  const today = new Date();
+  const sixMonthsLater = new Date(today);
+  sixMonthsLater.setMonth(sixMonthsLater.getMonth() + 6);
+  return discoverMovies({
+    releaseDateGte: formatDate(today),
+    releaseDateLte: formatDate(sixMonthsLater),
+    sortBy: "release_date.asc",
+    page,
+  });
+}
+
 const movieFetchers: Record<Category, (page: number) => ReturnType<typeof fetchPopularMovies>> = {
   popular: fetchPopularMovies,
-  upcoming: fetchUpcomingMovies,
+  upcoming: fetchUpcomingMoviesDiscover,
   top_rated: fetchTopRatedMovies,
 };
 

--- a/server/tmdb/client.ts
+++ b/server/tmdb/client.ts
@@ -106,11 +106,12 @@ export async function discoverMovies(options: {
   releaseDateGte?: string;
   releaseDateLte?: string;
   page?: number;
+  sortBy?: string;
 }): Promise<TmdbDiscoverResponse<TmdbDiscoverMovieResult>> {
   const params: Record<string, string> = {
     language: tmdbLanguage(),
     region: CONFIG.COUNTRY,
-    sort_by: "release_date.desc",
+    sort_by: options.sortBy || "release_date.desc",
     page: String(options.page || 1),
     "vote_count.gte": "0",
     watch_region: CONFIG.COUNTRY,


### PR DESCRIPTION
## Summary
Refactored the upcoming movies fetching logic to use the `discoverMovies` endpoint instead of the dedicated `fetchUpcomingMovies` function. This change enables more flexible control over the date range for upcoming movies.

## Key Changes
- Replaced `fetchUpcomingMovies` import with `discoverMovies` in browse routes
- Created `fetchUpcomingMoviesDiscover` wrapper function that:
  - Calculates a 6-month date range from today
  - Formats dates in ISO 8601 format (YYYY-MM-DD)
  - Calls `discoverMovies` with `release_date.asc` sorting
- Updated `discoverMovies` to accept optional `sortBy` parameter (defaults to `release_date.desc`)
- Updated all test mocks and assertions to reflect the new implementation

## Implementation Details
- Added `formatDate` utility function to convert Date objects to ISO 8601 string format
- The upcoming movies query now explicitly filters for movies releasing within the next 6 months, providing better control over the date range compared to the previous implementation
- The `sortBy` parameter in `discoverMovies` is optional and maintains backward compatibility with existing callers

https://claude.ai/code/session_018ffCdpow6N1RVGo3FLR4M8