### PR TITLE
Add client-side filtering for browse categories

### DIFF
--- a/frontend/src/components/CategoryBrowse.test.ts
+++ b/frontend/src/components/CategoryBrowse.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "bun:test";
+import {
+  filterBrowseTitles,
+  extractBrowseGenres,
+  extractBrowseProviders,
+  extractBrowseLanguages,
+} from "./CategoryBrowse";
+import type { Title } from "../types";
+
+function makeTitle(overrides: Partial<Title> & { id: string }): Title {
+  return {
+    object_type: "MOVIE",
+    title: "Test Title",
+    original_title: null,
+    release_year: 2025,
+    release_date: "2025-01-01",
+    runtime_minutes: 120,
+    short_description: "A test movie",
+    genres: [],
+    imdb_id: null,
+    tmdb_id: null,
+    poster_url: null,
+    age_certification: null,
+    original_language: "en",
+    tmdb_url: null,
+    imdb_score: null,
+    imdb_votes: null,
+    tmdb_score: null,
+    is_tracked: false,
+    offers: [],
+    ...overrides,
+  };
+}
+
+function makeOffer(providerName: string, technicalName: string) {
+  return {
+    id: 1,
+    title_id: "test",
+    provider_id: 1,
+    monetization_type: "FLATRATE",
+    presentation_type: "HD",
+    price_value: null,
+    price_currency: null,
+    url: "https://example.com",
+    available_to: null,
+    provider_name: providerName,
+    provider_technical_name: technicalName,
+    provider_icon_url: "https://example.com/icon.png",
+  };
+}
+
+describe("filterBrowseTitles", () => {
+  const titles: Title[] = [
+    makeTitle({ id: "1", genres: ["Action", "Drama"], original_language: "en", offers: [makeOffer("Netflix", "netflix")] }),
+    makeTitle({ id: "2", genres: ["Comedy"], original_language: "fr", offers: [makeOffer("Disney Plus", "disney_plus")] }),
+    makeTitle({ id: "3", genres: ["Action", "Comedy"], original_language: "en", offers: [makeOffer("Netflix", "netflix"), makeOffer("Disney Plus", "disney_plus")] }),
+  ];
+
+  it("returns all titles when no filters are active", () => {
+    const result = filterBrowseTitles(titles, { genre: "", provider: "", language: "" });
+    expect(result.length).toBe(3);
+  });
+
+  it("filters by genre", () => {
+    const result = filterBrowseTitles(titles, { genre: "Action", provider: "", language: "" });
+    expect(result.length).toBe(2);
+    expect(result.map((t) => t.id)).toEqual(["1", "3"]);
+  });
+
+  it("filters by provider", () => {
+    const result = filterBrowseTitles(titles, { genre: "", provider: "disney_plus", language: "" });
+    expect(result.length).toBe(2);
+    expect(result.map((t) => t.id)).toEqual(["2", "3"]);
+  });
+
+  it("filters by language", () => {
+    const result = filterBrowseTitles(titles, { genre: "", provider: "", language: "fr" });
+    expect(result.length).toBe(1);
+    expect(result[0].id).toBe("2");
+  });
+
+  it("combines filters with AND logic", () => {
+    const result = filterBrowseTitles(titles, { genre: "Action", provider: "netflix", language: "en" });
+    expect(result.length).toBe(2);
+    expect(result.map((t) => t.id)).toEqual(["1", "3"]);
+  });
+
+  it("returns empty array when no titles match", () => {
+    const result = filterBrowseTitles(titles, { genre: "Horror", provider: "", language: "" });
+    expect(result.length).toBe(0);
+  });
+
+  it("handles empty titles array", () => {
+    const result = filterBrowseTitles([], { genre: "Action", provider: "", language: "" });
+    expect(result.length).toBe(0);
+  });
+});
+
+describe("extractBrowseGenres", () => {
+  it("extracts unique sorted genres from titles", () => {
+    const titles = [
+      makeTitle({ id: "1", genres: ["Drama", "Action"] }),
+      makeTitle({ id: "2", genres: ["Comedy", "Action"] }),
+    ];
+    const genres = extractBrowseGenres(titles);
+    expect(genres).toEqual(["Action", "Comedy", "Drama"]);
+  });
+
+  it("returns empty array for titles with no genres", () => {
+    const titles = [makeTitle({ id: "1", genres: [] })];
+    expect(extractBrowseGenres(titles)).toEqual([]);
+  });
+
+  it("returns empty array for empty titles", () => {
+    expect(extractBrowseGenres([])).toEqual([]);
+  });
+});
+
+describe("extractBrowseProviders", () => {
+  it("extracts unique providers sorted by name", () => {
+    const titles = [
+      makeTitle({ id: "1", offers: [makeOffer("Netflix", "netflix"), makeOffer("Disney Plus", "disney_plus")] }),
+      makeTitle({ id: "2", offers: [makeOffer("Netflix", "netflix")] }),
+    ];
+    const providers = extractBrowseProviders(titles);
+    expect(providers.length).toBe(2);
+    expect(providers[0].name).toBe("Disney Plus");
+    expect(providers[1].name).toBe("Netflix");
+  });
+
+  it("returns empty array for titles with no offers", () => {
+    const titles = [makeTitle({ id: "1", offers: [] })];
+    expect(extractBrowseProviders(titles)).toEqual([]);
+  });
+});
+
+describe("extractBrowseLanguages", () => {
+  it("extracts unique sorted languages", () => {
+    const titles = [
+      makeTitle({ id: "1", original_language: "en" }),
+      makeTitle({ id: "2", original_language: "fr" }),
+      makeTitle({ id: "3", original_language: "en" }),
+    ];
+    const languages = extractBrowseLanguages(titles);
+    expect(languages).toEqual(["en", "fr"]);
+  });
+
+  it("excludes null languages", () => {
+    const titles = [
+      makeTitle({ id: "1", original_language: null }),
+      makeTitle({ id: "2", original_language: "en" }),
+    ];
+    const languages = extractBrowseLanguages(titles);
+    expect(languages).toEqual(["en"]);
+  });
+
+  it("returns empty array for empty titles", () => {
+    expect(extractBrowseLanguages([])).toEqual([]);
+  });
+});

--- a/frontend/src/components/CategoryBrowse.tsx
+++ b/frontend/src/components/CategoryBrowse.tsx
@@ -1,20 +1,67 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import * as api from "../api";
-import type { Title } from "../types";
+import type { Title, Provider } from "../types";
 import { normalizeSearchTitle } from "../types";
 import TitleList from "./TitleList";
 import FilterBar from "./FilterBar";
 import type { BrowseCategory } from "./CategoryBar";
+
+export function filterBrowseTitles(
+  titles: Title[],
+  filters: { genre: string; provider: string; language: string }
+): Title[] {
+  return titles.filter((t) => {
+    if (filters.genre && !t.genres.includes(filters.genre)) return false;
+    if (filters.provider && !t.offers.some((o) => o.provider_technical_name === filters.provider))
+      return false;
+    if (filters.language && t.original_language !== filters.language) return false;
+    return true;
+  });
+}
+
+export function extractBrowseGenres(titles: Title[]): string[] {
+  const set = new Set<string>();
+  titles.forEach((t) => t.genres.forEach((g) => set.add(g)));
+  return Array.from(set).sort();
+}
+
+export function extractBrowseProviders(titles: Title[]): Provider[] {
+  const map = new Map<string, Provider>();
+  titles.forEach((t) =>
+    t.offers.forEach((o) => {
+      if (!map.has(o.provider_technical_name)) {
+        map.set(o.provider_technical_name, {
+          id: o.provider_id,
+          name: o.provider_name,
+          technical_name: o.provider_technical_name,
+          icon_url: o.provider_icon_url,
+        });
+      }
+    })
+  );
+  return Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function extractBrowseLanguages(titles: Title[]): string[] {
+  const set = new Set<string>();
+  titles.forEach((t) => {
+    if (t.original_language) set.add(t.original_language);
+  });
+  return Array.from(set).sort();
+}
 
 interface Props {
   category: Exclude<BrowseCategory, "new_releases">;
 }
 
 export default function CategoryBrowse({ category }: Props) {
-  const [titles, setTitles] = useState<Title[]>([]);
+  const [rawTitles, setRawTitles] = useState<Title[]>([]);
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [type, setType] = useState("");
+  const [genre, setGenre] = useState("");
+  const [provider, setProvider] = useState("");
+  const [language, setLanguage] = useState("");
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [error, setError] = useState("");
@@ -34,9 +81,12 @@ export default function CategoryBrowse({ category }: Props) {
       });
       const normalized = res.titles.map(normalizeSearchTitle);
       if (append) {
-        setTitles((prev) => [...prev, ...normalized]);
+        setRawTitles((prev) => [...prev, ...normalized]);
       } else {
-        setTitles(normalized);
+        setRawTitles(normalized);
+        setGenre("");
+        setProvider("");
+        setLanguage("");
       }
       setTotalPages(res.totalPages);
       setPage(pageNum);
@@ -71,12 +121,29 @@ export default function CategoryBrowse({ category }: Props) {
     return () => observer.disconnect();
   }, [page, totalPages, loadingMore, fetchTitles]);
 
+  const availableGenres = useMemo(() => extractBrowseGenres(rawTitles), [rawTitles]);
+  const availableProviders = useMemo(() => extractBrowseProviders(rawTitles), [rawTitles]);
+  const availableLanguages = useMemo(() => extractBrowseLanguages(rawTitles), [rawTitles]);
+  const titles = useMemo(
+    () => filterBrowseTitles(rawTitles, { genre, provider, language }),
+    [rawTitles, genre, provider, language]
+  );
+
   return (
     <div className="space-y-4">
       <FilterBar
         type={type}
         onTypeChange={setType}
         showDaysFilter={false}
+        genre={genre}
+        onGenreChange={setGenre}
+        genres={availableGenres}
+        provider={provider}
+        onProviderChange={setProvider}
+        providers={availableProviders}
+        language={language}
+        onLanguageChange={setLanguage}
+        languages={availableLanguages}
       />
 
       {error && (

--- a/server/routes/browse.test.ts
+++ b/server/routes/browse.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterAll, mock } from "bun:test";
 import { Hono } from "hono";
 import type { TmdbDiscoverMovieResult, TmdbDiscoverTvResult } from "../tmdb/types";
 import type { AppEnv } from "../types";
+import { CONFIG } from "../config";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
 import { upsertTitles, trackTitle, createUser } from "../db/repository";
 import { makeParsedTitle } from "../test-utils/fixtures";
@@ -197,6 +198,34 @@ describe("GET /browse", () => {
     const body = await res.json();
 
     expect(body.titles[0].isTracked).toBe(false);
+  });
+
+  it("returns genres and offers in response for client-side filtering", async () => {
+    const movie = makeTmdbDiscoverMovie({ id: 900 });
+    mockFetchPopularMovies.mockResolvedValueOnce({
+      results: [movie], total_pages: 1, total_results: 1, page: 1,
+    });
+    mockFetchMovieDetails.mockResolvedValueOnce(makeTmdbMovieDetails({
+      id: 900,
+      genres: [{ id: 28, name: "Action" }, { id: 35, name: "Comedy" }],
+      "watch/providers": {
+        id: 900,
+        results: {
+          [CONFIG.COUNTRY]: {
+            link: "https://tmdb.org",
+            flatrate: [{ logo_path: "/nf.jpg", provider_id: 8, provider_name: "Netflix", display_priority: 1 }],
+          },
+        },
+      },
+    }));
+
+    const res = await app.request("/browse?category=popular&type=MOVIE");
+    const body = await res.json();
+
+    expect(body.titles).toHaveLength(1);
+    expect(body.titles[0].genres).toEqual(["Action", "Comedy"]);
+    expect(body.titles[0].offers.length).toBeGreaterThan(0);
+    expect(body.titles[0].offers[0].providerName).toBe("Netflix");
   });
 
   it("returns isTracked=true for tracked titles when user is authenticated", async () => {


### PR DESCRIPTION
## Summary
This PR adds client-side filtering capabilities to the category browse feature, allowing users to filter titles by genre, provider, and language. The filtering logic is extracted into testable utility functions and integrated with the existing FilterBar component.

## Key Changes
- **New utility functions** in `CategoryBrowse.tsx`:
  - `filterBrowseTitles()`: Filters titles based on genre, provider, and language with AND logic
  - `extractBrowseGenres()`: Extracts and sorts unique genres from titles
  - `extractBrowseProviders()`: Extracts and sorts unique providers from titles
  - `extractBrowseLanguages()`: Extracts and sorts unique languages from titles

- **Component updates**:
  - Separated raw titles state (`rawTitles`) from filtered titles state (`titles`)
  - Added filter state management for genre, provider, and language
  - Used `useMemo` to efficiently compute available filter options and filtered results
  - Reset filters when category/type changes
  - Extended FilterBar props to include genre, provider, and language filters with their available options

- **Test coverage**:
  - Added comprehensive test suite (`CategoryBrowse.test.ts`) with 14 tests covering all utility functions
  - Added integration test in `browse.test.ts` verifying genres and offers are returned in API response for client-side filtering

## Implementation Details
- Filters use AND logic: all active filters must match for a title to be included
- Provider filtering uses `provider_technical_name` for consistency
- Language filtering handles null values gracefully
- All extracted options are sorted alphabetically for consistent UI presentation
- Memoization prevents unnecessary recalculations when raw titles haven't changed

https://claude.ai/code/session_01FrgPNezWnoAwK6Js3db8zU