### PR TITLE
Add TMDB fallback for missing titles in details endpoints

### DIFF
--- a/server/routes/details.test.ts
+++ b/server/routes/details.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterAll, mock } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "../types";
+import { CONFIG } from "../config";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { upsertTitles } from "../db/repository";
+import { makeParsedTitle } from "../test-utils/fixtures";
+
+// Ensure TMDB API key is set so fallback logic is exercised
+CONFIG.TMDB_API_KEY = "test-api-key";
+
+const mockFetchMovieDetails = mock(() => Promise.resolve({}));
+const mockFetchTvDetails = mock(() => Promise.resolve({}));
+const mockFetchMovieFullDetails = mock(() => Promise.resolve(null));
+const mockFetchShowFullDetails = mock(() => Promise.resolve(null));
+const mockFetchSeasonDetails = mock(() => Promise.resolve(null));
+const mockFetchEpisodeDetails = mock(() => Promise.resolve(null));
+
+const realClient = await import("../tmdb/client");
+
+mock.module("../tmdb/client", () => ({
+  ...realClient,
+  fetchMovieDetails: mockFetchMovieDetails,
+  fetchTvDetails: mockFetchTvDetails,
+  fetchMovieFullDetails: mockFetchMovieFullDetails,
+  fetchShowFullDetails: mockFetchShowFullDetails,
+  fetchSeasonDetails: mockFetchSeasonDetails,
+  fetchEpisodeDetails: mockFetchEpisodeDetails,
+}));
+
+const { makeTmdbMovieDetails, makeTmdbTvDetails } = await import("../test-utils/fixtures");
+const detailsApp = (await import("./details")).default;
+
+let app: Hono<AppEnv>;
+
+beforeEach(() => {
+  setupTestDb();
+
+  app = new Hono<AppEnv>();
+  app.route("/details", detailsApp);
+
+  mockFetchMovieDetails.mockClear();
+  mockFetchTvDetails.mockClear();
+  mockFetchMovieFullDetails.mockClear();
+  mockFetchShowFullDetails.mockClear();
+  mockFetchSeasonDetails.mockClear();
+  mockFetchEpisodeDetails.mockClear();
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+describe("GET /details/movie/:id", () => {
+  it("returns title from DB without TMDB fallback", async () => {
+    upsertTitles([makeParsedTitle({ id: "movie-123", title: "DB Movie", tmdbId: "123" })]);
+
+    const res = await app.request("/details/movie/movie-123");
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.title.title).toBe("DB Movie");
+    expect(mockFetchMovieDetails).not.toHaveBeenCalled();
+  });
+
+  it("fetches from TMDB and persists when title not in DB", async () => {
+    mockFetchMovieDetails.mockResolvedValueOnce(
+      makeTmdbMovieDetails({ id: 999, title: "TMDB Movie" })
+    );
+
+    const res = await app.request("/details/movie/movie-999");
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.title.title).toBe("TMDB Movie");
+    expect(body.title.id).toBe("movie-999");
+    expect(mockFetchMovieDetails).toHaveBeenCalledWith(999);
+  });
+
+  it("returns 404 when TMDB fallback fails", async () => {
+    mockFetchMovieDetails.mockRejectedValueOnce(new Error("TMDB API error"));
+
+    const res = await app.request("/details/movie/movie-999");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for invalid title ID format", async () => {
+    const res = await app.request("/details/movie/invalid-id");
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /details/show/:id", () => {
+  it("returns title from DB without TMDB fallback", async () => {
+    upsertTitles([makeParsedTitle({ id: "tv-456", objectType: "SHOW", title: "DB Show", tmdbId: "456" })]);
+
+    const res = await app.request("/details/show/tv-456");
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.title.title).toBe("DB Show");
+    expect(mockFetchTvDetails).not.toHaveBeenCalled();
+  });
+
+  it("fetches from TMDB and persists when show not in DB", async () => {
+    mockFetchTvDetails.mockResolvedValueOnce(
+      makeTmdbTvDetails({ id: 789, name: "TMDB Show" })
+    );
+
+    const res = await app.request("/details/show/tv-789");
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.title.title).toBe("TMDB Show");
+    expect(body.title.id).toBe("tv-789");
+    expect(mockFetchTvDetails).toHaveBeenCalledWith(789);
+  });
+
+  it("returns 404 when TMDB fallback fails", async () => {
+    mockFetchTvDetails.mockRejectedValueOnce(new Error("TMDB API error"));
+
+    const res = await app.request("/details/show/tv-789");
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /details/show/:id/season/:season", () => {
+  it("fetches show from TMDB when not in DB for season endpoint", async () => {
+    mockFetchTvDetails.mockResolvedValueOnce(
+      makeTmdbTvDetails({ id: 555, name: "Season Show" })
+    );
+
+    const res = await app.request("/details/show/tv-555/season/1");
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.title.title).toBe("Season Show");
+    expect(body.seasonNumber).toBe(1);
+    expect(mockFetchTvDetails).toHaveBeenCalledWith(555);
+  });
+});

--- a/server/routes/details.ts
+++ b/server/routes/details.ts
@@ -1,12 +1,15 @@
 import { Hono } from "hono";
-import { getTitleById } from "../db/repository";
+import { getTitleById, upsertTitles } from "../db/repository";
 import { CONFIG } from "../config";
 import {
+  fetchMovieDetails,
+  fetchTvDetails,
   fetchMovieFullDetails,
   fetchShowFullDetails,
   fetchSeasonDetails,
   fetchEpisodeDetails,
 } from "../tmdb/client";
+import { parseMovieDetails, parseTvDetails } from "../tmdb/parser";
 import type { AppEnv } from "../types";
 import { logger } from "../logger";
 
@@ -16,9 +19,42 @@ const app = new Hono<AppEnv>();
 
 const country = CONFIG.COUNTRY;
 
+function parseTitleId(titleId: string): { type: "MOVIE" | "SHOW"; tmdbId: number } | null {
+  const movieMatch = titleId.match(/^movie-(\d+)$/);
+  if (movieMatch) return { type: "MOVIE", tmdbId: parseInt(movieMatch[1], 10) };
+
+  const tvMatch = titleId.match(/^tv-(\d+)$/);
+  if (tvMatch) return { type: "SHOW", tmdbId: parseInt(tvMatch[1], 10) };
+
+  return null;
+}
+
+async function getOrFetchTitle(titleId: string, userId?: string) {
+  let title = getTitleById(titleId, userId);
+  if (title) return title;
+
+  const parsed = parseTitleId(titleId);
+  if (!parsed || !CONFIG.TMDB_API_KEY) return null;
+
+  try {
+    if (parsed.type === "MOVIE") {
+      const tmdbData = await fetchMovieDetails(parsed.tmdbId);
+      upsertTitles([parseMovieDetails(tmdbData)]);
+    } else {
+      const tmdbData = await fetchTvDetails(parsed.tmdbId);
+      upsertTitles([parseTvDetails(tmdbData)]);
+    }
+  } catch (e) {
+    log.error("TMDB fallback fetch failed", { titleId, err: e });
+    return null;
+  }
+
+  return getTitleById(titleId, userId);
+}
+
 app.get("/movie/:id", async (c) => {
   const user = c.get("user");
-  const title = getTitleById(c.req.param("id"), user?.id);
+  const title = await getOrFetchTitle(c.req.param("id"), user?.id);
   if (!title) return c.json({ error: "Title not found" }, 404);
 
   let tmdb = null;
@@ -39,7 +75,7 @@ app.get("/movie/:id", async (c) => {
 
 app.get("/show/:id", async (c) => {
   const user = c.get("user");
-  const title = getTitleById(c.req.param("id"), user?.id);
+  const title = await getOrFetchTitle(c.req.param("id"), user?.id);
   if (!title) return c.json({ error: "Title not found" }, 404);
 
   let tmdb = null;
@@ -60,7 +96,7 @@ app.get("/show/:id", async (c) => {
 
 app.get("/show/:id/season/:season", async (c) => {
   const user = c.get("user");
-  const title = getTitleById(c.req.param("id"), user?.id);
+  const title = await getOrFetchTitle(c.req.param("id"), user?.id);
   if (!title) return c.json({ error: "Title not found" }, 404);
 
   const seasonNumber = Number(c.req.param("season"));
@@ -84,7 +120,7 @@ app.get("/show/:id/season/:season", async (c) => {
 
 app.get("/show/:id/season/:season/episode/:episode", async (c) => {
   const user = c.get("user");
-  const title = getTitleById(c.req.param("id"), user?.id);
+  const title = await getOrFetchTitle(c.req.param("id"), user?.id);
   if (!title) return c.json({ error: "Title not found" }, 404);
 
   const seasonNumber = Number(c.req.param("season"));


### PR DESCRIPTION
## Summary
This PR adds automatic TMDB API fallback functionality to the details endpoints. When a title is not found in the database, the system now attempts to fetch it from TMDB, persist it locally, and return the enriched data to the user.

## Key Changes
- **New `getOrFetchTitle()` helper function**: Implements a two-tier lookup strategy that first checks the database, then falls back to TMDB API if the title is missing and an API key is configured
- **Title ID parsing**: Added `parseTitleId()` function to extract TMDB IDs from standardized title ID formats (`movie-{id}` and `tv-{id}`)
- **TMDB data persistence**: Successfully fetched titles from TMDB are automatically persisted to the database using `upsertTitles()` for future requests
- **Updated all detail endpoints**: Applied the new fallback logic to `/movie/:id`, `/show/:id`, `/show/:id/season/:season`, and `/show/:id/season/:season/episode/:episode` routes
- **Comprehensive test coverage**: Added 141 lines of test cases covering database hits, TMDB fallback scenarios, error handling, and invalid ID formats

## Implementation Details
- The fallback only triggers when a title is not found in the database AND a TMDB API key is configured
- Failed TMDB requests are logged but gracefully return 404 instead of propagating errors
- Invalid title ID formats (not matching `movie-*` or `tv-*` patterns) return 404 without attempting API calls
- The solution maintains backward compatibility with existing database-first behavior

https://claude.ai/code/session_01CbPyboobdVLV4fhEAbwLTC