### PR TITLE
Add person detail page with filmography and biography

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import ProfilePage from "./pages/ProfilePage";
 import TitleDetailPage from "./pages/TitleDetailPage";
 import SeasonDetailPage from "./pages/SeasonDetailPage";
 import EpisodeDetailPage from "./pages/EpisodeDetailPage";
+import PersonPage from "./pages/PersonPage";
 import RequireAuth from "./components/RequireAuth";
 import { navLinkClass } from "./nav-utils";
 
@@ -165,6 +166,7 @@ export default function App() {
           <Route path="/title/:id" element={<TitleDetailPage />} />
           <Route path="/title/:id/season/:season" element={<SeasonDetailPage />} />
           <Route path="/title/:id/season/:season/episode/:episode" element={<EpisodeDetailPage />} />
+          <Route path="/person/:personId" element={<PersonPage />} />
         </Routes>
       </main>
     </div>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -7,6 +7,7 @@ import type {
   ShowDetailsResponse,
   SeasonDetailsResponse,
   EpisodeDetailsResponse,
+  PersonDetailsResponse,
 } from "./types";
 
 const BASE = "/api";
@@ -165,6 +166,10 @@ export async function getSeasonDetails(titleId: string, season: number): Promise
 
 export async function getEpisodeDetails(titleId: string, season: number, episode: number): Promise<EpisodeDetailsResponse> {
   return fetchJson(`/details/show/${encodeURIComponent(titleId)}/season/${season}/episode/${episode}`);
+}
+
+export async function getPersonDetails(personId: number): Promise<PersonDetailsResponse> {
+  return fetchJson(`/details/person/${personId}`);
 }
 
 // ─── Auth ────────────────────────────────────────────────────────────────────

--- a/frontend/src/components/PersonCard.test.ts
+++ b/frontend/src/components/PersonCard.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from "bun:test";
+
+// PersonCard is a React component - we test its interface contract here
+// since we can't render components without a DOM
+describe("PersonCard props interface", () => {
+  it("requires id, name, role, and profilePath", async () => {
+    // Verify the module exports a default function
+    const mod = await import("./PersonCard");
+    expect(typeof mod.default).toBe("function");
+  });
+});

--- a/frontend/src/components/PersonCard.tsx
+++ b/frontend/src/components/PersonCard.tsx
@@ -1,0 +1,28 @@
+import { Link } from "react-router";
+
+const TMDB_IMG = "https://image.tmdb.org/t/p";
+
+interface PersonCardProps {
+  id: number;
+  name: string;
+  role: string;
+  profilePath: string | null;
+}
+
+export default function PersonCard({ id, name, role, profilePath }: PersonCardProps) {
+  return (
+    <Link to={`/person/${id}`} className="flex-shrink-0 w-28 text-center group">
+      <div className="w-20 h-20 mx-auto rounded-full overflow-hidden bg-gray-800 mb-2 group-hover:ring-2 group-hover:ring-indigo-500 transition-all">
+        {profilePath ? (
+          <img src={`${TMDB_IMG}/w185${profilePath}`} alt={name} className="w-full h-full object-cover" loading="lazy" />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-gray-600 text-2xl">
+            {name.charAt(0)}
+          </div>
+        )}
+      </div>
+      <p className="text-sm font-medium text-white truncate group-hover:text-indigo-400 transition-colors">{name}</p>
+      <p className="text-xs text-gray-400 truncate">{role}</p>
+    </Link>
+  );
+}

--- a/frontend/src/pages/EpisodeDetailPage.tsx
+++ b/frontend/src/pages/EpisodeDetailPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { useParams, Link } from "react-router";
 import * as api from "../api";
 import type { EpisodeDetailsResponse, CastMember, CrewMember } from "../types";
+import PersonCard from "../components/PersonCard";
 
 const TMDB_IMG = "https://image.tmdb.org/t/p";
 
@@ -154,17 +155,7 @@ export default function EpisodeDetailPage() {
           <h2 className="text-lg font-semibold text-white">Cast</h2>
           <div className="flex gap-4 overflow-x-auto pb-2">
             {allCast.slice(0, 20).map((c) => (
-              <div key={c.id} className="flex-shrink-0 w-28 text-center">
-                <div className="w-20 h-20 mx-auto rounded-full overflow-hidden bg-gray-800 mb-2">
-                  {c.profile_path ? (
-                    <img src={`${TMDB_IMG}/w185${c.profile_path}`} alt={c.name} className="w-full h-full object-cover" loading="lazy" />
-                  ) : (
-                    <div className="w-full h-full flex items-center justify-center text-gray-600 text-2xl">{c.name.charAt(0)}</div>
-                  )}
-                </div>
-                <p className="text-sm font-medium text-white truncate">{c.name}</p>
-                <p className="text-xs text-gray-400 truncate">{c.character}</p>
-              </div>
+              <PersonCard key={c.id} id={c.id} name={c.name} role={c.character} profilePath={c.profile_path} />
             ))}
           </div>
         </section>

--- a/frontend/src/pages/PersonPage.test.ts
+++ b/frontend/src/pages/PersonPage.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "bun:test";
+import type { PersonCastCredit, PersonCrewCredit } from "../types";
+
+describe("PersonPage", () => {
+  it("exports as default", async () => {
+    const mod = await import("./PersonPage");
+    expect(typeof mod.default).toBe("function");
+  });
+});
+
+describe("PersonCastCredit type", () => {
+  it("supports movie credits", () => {
+    const credit: PersonCastCredit = {
+      id: 550,
+      media_type: "movie",
+      title: "Fight Club",
+      character: "Tyler Durden",
+      release_date: "1999-10-15",
+      poster_path: "/poster.jpg",
+      vote_average: 8.4,
+      vote_count: 25000,
+      popularity: 60.5,
+    };
+    expect(credit.media_type).toBe("movie");
+    expect(credit.title).toBe("Fight Club");
+  });
+
+  it("supports tv credits", () => {
+    const credit: PersonCastCredit = {
+      id: 1396,
+      media_type: "tv",
+      name: "Breaking Bad",
+      character: "Walter White",
+      first_air_date: "2008-01-20",
+      poster_path: "/poster.jpg",
+      vote_average: 8.9,
+      vote_count: 12000,
+      popularity: 80.2,
+    };
+    expect(credit.media_type).toBe("tv");
+    expect(credit.name).toBe("Breaking Bad");
+  });
+});
+
+describe("PersonCrewCredit type", () => {
+  it("supports crew credits with job and department", () => {
+    const credit: PersonCrewCredit = {
+      id: 550,
+      media_type: "movie",
+      title: "Fight Club",
+      job: "Director",
+      department: "Directing",
+      release_date: "1999-10-15",
+      poster_path: "/poster.jpg",
+      vote_average: 8.4,
+      vote_count: 25000,
+      popularity: 60.5,
+    };
+    expect(credit.job).toBe("Director");
+    expect(credit.department).toBe("Directing");
+  });
+});

--- a/frontend/src/pages/PersonPage.tsx
+++ b/frontend/src/pages/PersonPage.tsx
@@ -1,0 +1,226 @@
+import { useState, useEffect } from "react";
+import { useParams, Link } from "react-router";
+import * as api from "../api";
+import type { PersonDetailsResponse, PersonCastCredit, PersonCrewCredit } from "../types";
+
+const TMDB_IMG = "https://image.tmdb.org/t/p";
+const BIO_TRUNCATE_LENGTH = 600;
+
+function formatDate(dateStr: string | null | undefined): string {
+  if (!dateStr) return "—";
+  const d = new Date(dateStr + "T00:00:00");
+  return d.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
+}
+
+function getYear(dateStr?: string): string {
+  if (!dateStr) return "";
+  return dateStr.substring(0, 4);
+}
+
+function creditTitle(credit: PersonCastCredit | PersonCrewCredit): string {
+  return credit.title || credit.name || "Untitled";
+}
+
+function creditTitleId(credit: PersonCastCredit | PersonCrewCredit): string {
+  return credit.media_type === "movie" ? `movie-${credit.id}` : `tv-${credit.id}`;
+}
+
+function deduplicateCast(credits: PersonCastCredit[]): PersonCastCredit[] {
+  const seen = new Set<number>();
+  return credits.filter((c) => {
+    if (seen.has(c.id)) return false;
+    seen.add(c.id);
+    return true;
+  });
+}
+
+function deduplicateCrew(credits: PersonCrewCredit[]): PersonCrewCredit[] {
+  const seen = new Set<string>();
+  return credits.filter((c) => {
+    const key = `${c.id}-${c.job}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function CreditCard({ credit, subtitle }: { credit: PersonCastCredit | PersonCrewCredit; subtitle: string }) {
+  return (
+    <Link
+      to={`/title/${creditTitleId(credit)}`}
+      className="flex-shrink-0 w-32 sm:w-36 group"
+    >
+      <div className="aspect-[2/3] rounded-lg overflow-hidden bg-gray-800 mb-2">
+        {credit.poster_path ? (
+          <img
+            src={`${TMDB_IMG}/w342${credit.poster_path}`}
+            alt={creditTitle(credit)}
+            className="w-full h-full object-cover group-hover:scale-105 transition-transform"
+            loading="lazy"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-gray-600 text-sm px-2 text-center">
+            {creditTitle(credit)}
+          </div>
+        )}
+      </div>
+      <p className="text-sm font-medium text-white truncate group-hover:text-indigo-400 transition-colors">
+        {creditTitle(credit)}
+      </p>
+      <p className="text-xs text-gray-400 truncate">{subtitle}</p>
+      {getYear(credit.release_date || credit.first_air_date) && (
+        <p className="text-xs text-gray-500">{getYear(credit.release_date || credit.first_air_date)}</p>
+      )}
+    </Link>
+  );
+}
+
+export default function PersonPage() {
+  const { personId } = useParams<{ personId: string }>();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<PersonDetailsResponse | null>(null);
+  const [bioExpanded, setBioExpanded] = useState(false);
+
+  useEffect(() => {
+    if (!personId) return;
+    let cancelled = false;
+
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const resp = await api.getPersonDetails(Number(personId));
+        if (!cancelled) setData(resp);
+      } catch (e: any) {
+        if (!cancelled) setError(e.message || "Failed to load person details");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    load();
+    return () => { cancelled = true; };
+  }, [personId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="text-gray-400">Loading...</div>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="text-red-400">{error || "Person not found"}</div>
+      </div>
+    );
+  }
+
+  const { person } = data;
+  const biography = person.biography || "";
+  const showBioToggle = biography.length > BIO_TRUNCATE_LENGTH;
+  const displayBio = bioExpanded || !showBioToggle ? biography : biography.slice(0, BIO_TRUNCATE_LENGTH) + "...";
+
+  const castCredits = deduplicateCast(
+    [...person.combined_credits.cast].sort((a, b) => b.popularity - a.popularity)
+  );
+  const crewCredits = deduplicateCrew(
+    [...person.combined_credits.crew].sort((a, b) => b.popularity - a.popularity)
+  );
+
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row gap-6">
+        <div className="flex-shrink-0">
+          <div className="w-40 h-40 sm:w-48 sm:h-48 rounded-2xl overflow-hidden bg-gray-800">
+            {person.profile_path ? (
+              <img
+                src={`${TMDB_IMG}/w300${person.profile_path}`}
+                alt={person.name}
+                className="w-full h-full object-cover"
+              />
+            ) : (
+              <div className="w-full h-full flex items-center justify-center text-gray-600 text-5xl">
+                {person.name.charAt(0)}
+              </div>
+            )}
+          </div>
+        </div>
+        <div className="flex-1 space-y-3">
+          <h1 className="text-2xl sm:text-3xl font-bold text-white">{person.name}</h1>
+          <div className="flex flex-wrap gap-2 text-sm">
+            {person.known_for_department && (
+              <span className="bg-indigo-500/20 text-indigo-300 px-2 py-0.5 rounded">
+                {person.known_for_department}
+              </span>
+            )}
+          </div>
+          <div className="flex flex-wrap gap-x-6 gap-y-1 text-sm text-gray-400">
+            {person.birthday && (
+              <div>
+                <span className="text-gray-500">Born: </span>
+                <span>{formatDate(person.birthday)}</span>
+              </div>
+            )}
+            {person.deathday && (
+              <div>
+                <span className="text-gray-500">Died: </span>
+                <span>{formatDate(person.deathday)}</span>
+              </div>
+            )}
+            {person.place_of_birth && (
+              <div>
+                <span className="text-gray-500">From: </span>
+                <span>{person.place_of_birth}</span>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Biography */}
+      {biography && (
+        <section className="space-y-2">
+          <h2 className="text-lg font-semibold text-white">Biography</h2>
+          <p className="text-gray-300 leading-relaxed whitespace-pre-line">{displayBio}</p>
+          {showBioToggle && (
+            <button
+              onClick={() => setBioExpanded(!bioExpanded)}
+              className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors cursor-pointer"
+            >
+              {bioExpanded ? "Show less" : "Show more"}
+            </button>
+          )}
+        </section>
+      )}
+
+      {/* Acting Credits */}
+      {castCredits.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold text-white">Acting ({castCredits.length})</h2>
+          <div className="flex gap-4 overflow-x-auto pb-2">
+            {castCredits.map((c) => (
+              <CreditCard key={`cast-${c.id}-${c.character}`} credit={c} subtitle={c.character} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Crew Credits */}
+      {crewCredits.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold text-white">Crew ({crewCredits.length})</h2>
+          <div className="flex gap-4 overflow-x-auto pb-2">
+            {crewCredits.map((c) => (
+              <CreditCard key={`crew-${c.id}-${c.job}`} credit={c} subtitle={c.job} />
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/SeasonDetailPage.tsx
+++ b/frontend/src/pages/SeasonDetailPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { useParams, Link } from "react-router";
 import * as api from "../api";
 import type { SeasonDetailsResponse } from "../types";
+import PersonCard from "../components/PersonCard";
 
 const TMDB_IMG = "https://image.tmdb.org/t/p";
 
@@ -171,17 +172,7 @@ export default function SeasonDetailPage() {
           <h2 className="text-lg font-semibold text-white">Season Cast</h2>
           <div className="flex gap-4 overflow-x-auto pb-2">
             {tmdb.credits.cast.slice(0, 15).map((c) => (
-              <div key={c.id} className="flex-shrink-0 w-28 text-center">
-                <div className="w-20 h-20 mx-auto rounded-full overflow-hidden bg-gray-800 mb-2">
-                  {c.profile_path ? (
-                    <img src={`${TMDB_IMG}/w185${c.profile_path}`} alt={c.name} className="w-full h-full object-cover" loading="lazy" />
-                  ) : (
-                    <div className="w-full h-full flex items-center justify-center text-gray-600 text-2xl">{c.name.charAt(0)}</div>
-                  )}
-                </div>
-                <p className="text-sm font-medium text-white truncate">{c.name}</p>
-                <p className="text-xs text-gray-400 truncate">{c.character}</p>
-              </div>
+              <PersonCard key={c.id} id={c.id} name={c.name} role={c.character} profilePath={c.profile_path} />
             ))}
           </div>
         </section>

--- a/frontend/src/pages/TitleDetailPage.tsx
+++ b/frontend/src/pages/TitleDetailPage.tsx
@@ -12,6 +12,7 @@ import type {
   SeasonSummary,
 } from "../types";
 import TrackButton from "../components/TrackButton";
+import PersonCard from "../components/PersonCard";
 
 const TMDB_IMG = "https://image.tmdb.org/t/p";
 
@@ -52,24 +53,6 @@ function RatingBadge({ label, score, max = 10 }: { label: string; score: number 
       <span className="text-xl font-bold text-white">
         {score.toFixed(1)}<span className="text-sm text-gray-500">/{max}</span>
       </span>
-    </div>
-  );
-}
-
-function PersonCard({ name, role, profilePath }: { name: string; role: string; profilePath: string | null }) {
-  return (
-    <div className="flex-shrink-0 w-28 text-center">
-      <div className="w-20 h-20 mx-auto rounded-full overflow-hidden bg-gray-800 mb-2">
-        {profilePath ? (
-          <img src={`${TMDB_IMG}/w185${profilePath}`} alt={name} className="w-full h-full object-cover" loading="lazy" />
-        ) : (
-          <div className="w-full h-full flex items-center justify-center text-gray-600 text-2xl">
-            {name.charAt(0)}
-          </div>
-        )}
-      </div>
-      <p className="text-sm font-medium text-white truncate">{name}</p>
-      <p className="text-xs text-gray-400 truncate">{role}</p>
     </div>
   );
 }
@@ -346,7 +329,7 @@ function MovieDetail({ data }: { data: MovieDetailsResponse }) {
         <Section title="Cast">
           <div className="flex gap-4 overflow-x-auto pb-2">
             {cast.map((c: CastMember) => (
-              <PersonCard key={c.id} name={c.name} role={c.character} profilePath={c.profile_path} />
+              <PersonCard key={c.id} id={c.id} name={c.name} role={c.character} profilePath={c.profile_path} />
             ))}
           </div>
         </Section>
@@ -609,7 +592,7 @@ function ShowDetail({ data }: { data: ShowDetailsResponse }) {
         <Section title="Created By">
           <div className="flex gap-4">
             {creators.map((c) => (
-              <PersonCard key={c.id} name={c.name} role="Creator" profilePath={c.profile_path} />
+              <PersonCard key={c.id} id={c.id} name={c.name} role="Creator" profilePath={c.profile_path} />
             ))}
           </div>
         </Section>
@@ -619,7 +602,7 @@ function ShowDetail({ data }: { data: ShowDetailsResponse }) {
         <Section title="Cast">
           <div className="flex gap-4 overflow-x-auto pb-2">
             {cast.map((c: CastMember) => (
-              <PersonCard key={c.id} name={c.name} role={c.character} profilePath={c.profile_path} />
+              <PersonCard key={c.id} id={c.id} name={c.name} role={c.character} profilePath={c.profile_path} />
             ))}
           </div>
         </Section>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -297,6 +297,56 @@ export interface EpisodeDetailsResponse {
   country: string;
 }
 
+// ─── Person Types ────────────────────────────────────────────────────────────
+
+export interface PersonCastCredit {
+  id: number;
+  media_type: "movie" | "tv";
+  title?: string;
+  name?: string;
+  character: string;
+  release_date?: string;
+  first_air_date?: string;
+  poster_path: string | null;
+  vote_average: number;
+  vote_count: number;
+  popularity: number;
+}
+
+export interface PersonCrewCredit {
+  id: number;
+  media_type: "movie" | "tv";
+  title?: string;
+  name?: string;
+  job: string;
+  department: string;
+  release_date?: string;
+  first_air_date?: string;
+  poster_path: string | null;
+  vote_average: number;
+  vote_count: number;
+  popularity: number;
+}
+
+export interface PersonDetailsResponse {
+  person: {
+    id: number;
+    name: string;
+    biography: string;
+    birthday: string | null;
+    deathday: string | null;
+    place_of_birth: string | null;
+    known_for_department: string;
+    profile_path: string | null;
+    also_known_as: string[];
+    popularity: number;
+    combined_credits: {
+      cast: PersonCastCredit[];
+      crew: PersonCrewCredit[];
+    };
+  };
+}
+
 // Normalize search results to same shape as DB titles
 export function normalizeSearchTitle(t: SearchTitle): Title {
   return {

--- a/server/routes/details.test.ts
+++ b/server/routes/details.test.ts
@@ -15,6 +15,7 @@ const mockFetchMovieFullDetails = mock(() => Promise.resolve(null));
 const mockFetchShowFullDetails = mock(() => Promise.resolve(null));
 const mockFetchSeasonDetails = mock(() => Promise.resolve(null));
 const mockFetchEpisodeDetails = mock(() => Promise.resolve(null));
+const mockFetchPersonDetails = mock(() => Promise.resolve(null as any));
 
 const realClient = await import("../tmdb/client");
 
@@ -26,6 +27,7 @@ mock.module("../tmdb/client", () => ({
   fetchShowFullDetails: mockFetchShowFullDetails,
   fetchSeasonDetails: mockFetchSeasonDetails,
   fetchEpisodeDetails: mockFetchEpisodeDetails,
+  fetchPersonDetails: mockFetchPersonDetails,
 }));
 
 const { makeTmdbMovieDetails, makeTmdbTvDetails } = await import("../test-utils/fixtures");
@@ -45,6 +47,7 @@ beforeEach(() => {
   mockFetchShowFullDetails.mockClear();
   mockFetchSeasonDetails.mockClear();
   mockFetchEpisodeDetails.mockClear();
+  mockFetchPersonDetails.mockClear();
 });
 
 afterAll(() => {
@@ -137,5 +140,41 @@ describe("GET /details/show/:id/season/:season", () => {
     expect(body.title.title).toBe("Season Show");
     expect(body.seasonNumber).toBe(1);
     expect(mockFetchTvDetails).toHaveBeenCalledWith(555);
+  });
+});
+
+describe("GET /details/person/:personId", () => {
+  it("returns person details from TMDB", async () => {
+    mockFetchPersonDetails.mockResolvedValueOnce({
+      id: 123,
+      name: "Test Actor",
+      biography: "A test biography",
+      birthday: "1990-01-15",
+      deathday: null,
+      place_of_birth: "Test City",
+      known_for_department: "Acting",
+      profile_path: "/test.jpg",
+      also_known_as: [],
+      popularity: 50,
+      combined_credits: { cast: [], crew: [] },
+    });
+
+    const res = await app.request("/details/person/123");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.person.name).toBe("Test Actor");
+    expect(body.person.biography).toBe("A test biography");
+    expect(mockFetchPersonDetails).toHaveBeenCalledWith(123);
+  });
+
+  it("returns 400 for invalid person ID", async () => {
+    const res = await app.request("/details/person/abc");
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when TMDB fetch fails", async () => {
+    mockFetchPersonDetails.mockRejectedValueOnce(new Error("Not found"));
+    const res = await app.request("/details/person/999");
+    expect(res.status).toBe(404);
   });
 });

--- a/server/routes/details.ts
+++ b/server/routes/details.ts
@@ -8,6 +8,7 @@ import {
   fetchShowFullDetails,
   fetchSeasonDetails,
   fetchEpisodeDetails,
+  fetchPersonDetails,
 } from "../tmdb/client";
 import { parseMovieDetails, parseTvDetails } from "../tmdb/parser";
 import type { AppEnv } from "../types";
@@ -142,6 +143,25 @@ app.get("/show/:id/season/:season/episode/:episode", async (c) => {
     episodeNumber,
     country,
   });
+});
+
+app.get("/person/:personId", async (c) => {
+  const personId = Number(c.req.param("personId"));
+  if (!personId || isNaN(personId)) {
+    return c.json({ error: "Invalid person ID" }, 400);
+  }
+
+  if (!CONFIG.TMDB_API_KEY) {
+    return c.json({ error: "TMDB not configured" }, 503);
+  }
+
+  try {
+    const person = await fetchPersonDetails(personId);
+    return c.json({ person });
+  } catch (e) {
+    log.error("TMDB person fetch failed", { personId, err: e });
+    return c.json({ error: "Person not found" }, 404);
+  }
 });
 
 export default app;

--- a/server/tmdb/client.ts
+++ b/server/tmdb/client.ts
@@ -14,6 +14,7 @@ import type {
   TmdbShowFullDetails,
   TmdbSeasonDetails,
   TmdbEpisodeDetails,
+  TmdbPersonDetails,
 } from "./types";
 
 async function tmdbRequest<T>(path: string, params?: Record<string, string>): Promise<T> {
@@ -97,6 +98,15 @@ export async function fetchEpisodeDetails(
   return tmdbRequest<TmdbEpisodeDetails>(`/tv/${tmdbId}/season/${seasonNumber}/episode/${episodeNumber}`, {
     language: tmdbLanguage(),
     append_to_response: "credits",
+  });
+}
+
+// ─── Person endpoints ────────────────────────────────────────────────────────
+
+export async function fetchPersonDetails(personId: number): Promise<TmdbPersonDetails> {
+  return tmdbRequest<TmdbPersonDetails>(`/person/${personId}`, {
+    language: tmdbLanguage(),
+    append_to_response: "combined_credits",
   });
 }
 

--- a/server/tmdb/types.ts
+++ b/server/tmdb/types.ts
@@ -339,3 +339,53 @@ export interface TmdbEpisodeDetails {
   crew: TmdbCrewMember[];
   credits: TmdbCredits;
 }
+
+// ─── Person Types ────────────────────────────────────────────────────────────
+
+export interface TmdbPersonCastCredit {
+  id: number;
+  media_type: "movie" | "tv";
+  title?: string;
+  name?: string;
+  character: string;
+  release_date?: string;
+  first_air_date?: string;
+  poster_path: string | null;
+  vote_average: number;
+  vote_count: number;
+  popularity: number;
+}
+
+export interface TmdbPersonCrewCredit {
+  id: number;
+  media_type: "movie" | "tv";
+  title?: string;
+  name?: string;
+  job: string;
+  department: string;
+  release_date?: string;
+  first_air_date?: string;
+  poster_path: string | null;
+  vote_average: number;
+  vote_count: number;
+  popularity: number;
+}
+
+export interface TmdbPersonCombinedCredits {
+  cast: TmdbPersonCastCredit[];
+  crew: TmdbPersonCrewCredit[];
+}
+
+export interface TmdbPersonDetails {
+  id: number;
+  name: string;
+  biography: string;
+  birthday: string | null;
+  deathday: string | null;
+  place_of_birth: string | null;
+  known_for_department: string;
+  profile_path: string | null;
+  also_known_as: string[];
+  popularity: number;
+  combined_credits: TmdbPersonCombinedCredits;
+}


### PR DESCRIPTION
## Summary
This PR adds a comprehensive person detail page that displays actor and crew member information from TMDB, including their biography, filmography (both acting and crew credits), and personal details.

## Key Changes

**Frontend:**
- Added `PersonPage.tsx` - New page component displaying person details with:
  - Profile image, name, birth/death dates, and place of birth
  - Expandable biography section (truncated at 600 characters)
  - Acting credits carousel sorted by popularity with deduplication
  - Crew credits carousel sorted by popularity with deduplication
  - Clickable credit cards linking to title detail pages
- Created `PersonCard.tsx` - Reusable component for displaying person cards with profile image and role
  - Extracted from inline implementations in `TitleDetailPage`, `EpisodeDetailPage`, and `SeasonDetailPage`
  - Now links to person detail page when clicked
- Updated `TitleDetailPage`, `EpisodeDetailPage`, and `SeasonDetailPage` to use the new `PersonCard` component
- Added route `/person/:personId` in `App.tsx`
- Added `getPersonDetails()` API function in `api.ts`

**Backend:**
- Added `/details/person/:personId` endpoint in `server/routes/details.ts`
  - Validates person ID format
  - Fetches person details from TMDB with combined credits
  - Returns 400 for invalid IDs, 404 when person not found
- Added `fetchPersonDetails()` function in `server/tmdb/client.ts`
  - Requests person data with `combined_credits` append parameter

**Types:**
- Added `PersonCastCredit` and `PersonCrewCredit` interfaces in `frontend/src/types.ts`
- Added `PersonDetailsResponse` interface for API response shape
- Added corresponding TMDB types in `server/tmdb/types.ts`

**Tests:**
- Added `PersonPage.test.ts` with type validation tests
- Added `PersonCard.test.ts` with interface contract tests
- Updated `server/routes/details.test.ts` with person endpoint tests

## Implementation Details
- Credits are deduplicated (cast by ID, crew by ID+job combination) and sorted by popularity
- Biography text is truncated with a "Show more/less" toggle for long biographies
- Person cards use circular profile images with fallback initials
- Credit cards display poster images with fallback title text and hover effects
- Responsive design with mobile-friendly layouts

https://claude.ai/code/session_016D6f2voRPxXULhdwBej5QG