### PR TITLE
Add provider ID filtering and populate filter dropdowns from TMDB

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -58,7 +58,15 @@ export async function browseTitles(params: {
   genre?: string;
   provider?: string;
   language?: string;
-}): Promise<{ titles: SearchTitle[]; page: number; totalPages: number; availableGenres: string[] }> {
+}): Promise<{
+  titles: SearchTitle[];
+  page: number;
+  totalPages: number;
+  totalResults: number;
+  availableGenres: string[];
+  availableProviders: { id: number; name: string; iconUrl: string }[];
+  availableLanguages: { code: string; name: string }[];
+}> {
   const qs = new URLSearchParams();
   qs.set("category", params.category);
   if (params.type) qs.set("type", params.type);

--- a/frontend/src/components/CategoryBrowse.tsx
+++ b/frontend/src/components/CategoryBrowse.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import * as api from "../api";
-import type { Title, Provider } from "../types";
+import type { Title } from "../types";
 import { normalizeSearchTitle } from "../types";
 import TitleList from "./TitleList";
 import FilterBar from "./FilterBar";
@@ -79,11 +79,11 @@ export default function CategoryBrowse({
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [error, setError] = useState("");
+  const [totalResults, setTotalResults] = useState(0);
   const [availableGenres, setAvailableGenres] = useState<string[]>([]);
 
-  // Track providers/languages from loaded titles for dropdowns
-  const availableProviders = useMemo(() => extractBrowseProviders(titles), [titles]);
-  const availableLanguages = useMemo(() => extractBrowseLanguages(titles), [titles]);
+  const [availableProviders, setAvailableProviders] = useState<{ id: number; name: string; iconUrl: string }[]>([]);
+  const [availableLanguages, setAvailableLanguages] = useState<{ code: string; name: string }[]>([]);
 
   const fetchTitles = useCallback(async (pageNum: number, append: boolean) => {
     if (append) {
@@ -110,7 +110,16 @@ export default function CategoryBrowse({
       if (res.availableGenres) {
         setAvailableGenres(res.availableGenres);
       }
+      if (res.availableProviders) {
+        setAvailableProviders(res.availableProviders);
+      }
+      if (res.availableLanguages) {
+        setAvailableLanguages(res.availableLanguages);
+      }
       setTotalPages(res.totalPages);
+      if (!append) {
+        setTotalResults(res.totalResults);
+      }
       setPage(pageNum);
     } catch (err: any) {
       setError(err.message);
@@ -170,6 +179,9 @@ export default function CategoryBrowse({
         <div className="text-center py-12 text-gray-500">Loading...</div>
       ) : (
         <>
+          {totalResults > 0 && (
+            <p className="text-sm text-gray-500">{totalResults} result{totalResults !== 1 ? "s" : ""}</p>
+          )}
           <TitleList titles={titles} emptyMessage="No titles found." />
           {page < totalPages && (
             <div ref={sentinelRef} className="text-center py-4">

--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -1,4 +1,12 @@
-import type { Provider } from "../types";
+interface ProviderOption {
+  id: number;
+  name: string;
+}
+
+interface LanguageOption {
+  code: string;
+  name: string;
+}
 
 interface Props {
   type: string;
@@ -11,10 +19,10 @@ interface Props {
   genres?: string[];
   provider?: string;
   onProviderChange?: (provider: string) => void;
-  providers?: Provider[];
+  providers?: ProviderOption[];
   language?: string;
   onLanguageChange?: (language: string) => void;
-  languages?: string[];
+  languages?: string[] | LanguageOption[];
 }
 
 const TYPES = [
@@ -114,7 +122,7 @@ export default function FilterBar({
         >
           <option value="">All Platforms</option>
           {providers.map((p) => (
-            <option key={p.technical_name} value={p.technical_name}>
+            <option key={p.id} value={String(p.id)}>
               {p.name}
             </option>
           ))}
@@ -127,11 +135,17 @@ export default function FilterBar({
           className={selectClass}
         >
           <option value="">All Languages</option>
-          {languages.map((l) => (
-            <option key={l} value={l}>
-              {languageLabel(l)}
-            </option>
-          ))}
+          {languages.map((l) =>
+            typeof l === "string" ? (
+              <option key={l} value={l}>
+                {languageLabel(l)}
+              </option>
+            ) : (
+              <option key={l.code} value={l.code}>
+                {l.name}
+              </option>
+            )
+          )}
         </select>
       )}
     </div>

--- a/server/db/repository.ts
+++ b/server/db/repository.ts
@@ -203,20 +203,27 @@ export function getRecentTitles(filters: TitleFilters = {}, userId?: string) {
     conditions.push(eq(titles.objectType, objectType));
   }
   if (provider) {
-    conditions.push(
-      exists(
-        db
-          .select({ one: sql`1` })
-          .from(offers)
-          .innerJoin(providers, eq(offers.providerId, providers.id))
-          .where(
-            and(
-              eq(offers.titleId, titles.id),
-              eq(providers.technicalName, provider)
-            )
-          )
-      )
-    );
+    const providerId = Number(provider);
+    if (!isNaN(providerId)) {
+      conditions.push(
+        exists(
+          db
+            .select({ one: sql`1` })
+            .from(offers)
+            .where(and(eq(offers.titleId, titles.id), eq(offers.providerId, providerId)))
+        )
+      );
+    } else {
+      conditions.push(
+        exists(
+          db
+            .select({ one: sql`1` })
+            .from(offers)
+            .innerJoin(providers, eq(offers.providerId, providers.id))
+            .where(and(eq(offers.titleId, titles.id), eq(providers.technicalName, provider)))
+        )
+      );
+    }
   }
   if (genre) {
     conditions.push(like(titles.genres, `%"${genre}"%`));
@@ -455,20 +462,27 @@ export function getTitlesByMonth(filters: MonthFilters, userId?: string) {
     conditions.push(eq(titles.objectType, objectType));
   }
   if (provider) {
-    conditions.push(
-      exists(
-        db
-          .select({ one: sql`1` })
-          .from(offers)
-          .innerJoin(providers, eq(offers.providerId, providers.id))
-          .where(
-            and(
-              eq(offers.titleId, titles.id),
-              eq(providers.technicalName, provider)
-            )
-          )
-      )
-    );
+    const providerId = Number(provider);
+    if (!isNaN(providerId)) {
+      conditions.push(
+        exists(
+          db
+            .select({ one: sql`1` })
+            .from(offers)
+            .where(and(eq(offers.titleId, titles.id), eq(offers.providerId, providerId)))
+        )
+      );
+    } else {
+      conditions.push(
+        exists(
+          db
+            .select({ one: sql`1` })
+            .from(offers)
+            .innerJoin(providers, eq(offers.providerId, providers.id))
+            .where(and(eq(offers.titleId, titles.id), eq(providers.technicalName, provider)))
+        )
+      );
+    }
   }
 
   const rows = db

--- a/server/routes/browse.test.ts
+++ b/server/routes/browse.test.ts
@@ -13,6 +13,19 @@ const mockFetchMovieDetails = mock(() => Promise.resolve({}));
 const mockFetchTvDetails = mock(() => Promise.resolve({}));
 const mockGetMovieGenres = mock(() => Promise.resolve(new Map([[28, "Action"], [878, "Science Fiction"]])));
 const mockGetTvGenres = mock(() => Promise.resolve(new Map([[18, "Drama"], [10765, "Sci-Fi & Fantasy"]])));
+const mockGetMovieWatchProviders = mock(() => Promise.resolve([
+  { id: 8, name: "Netflix", iconUrl: "https://image.tmdb.org/t/p/w92/nf.jpg" },
+  { id: 337, name: "Disney Plus", iconUrl: "https://image.tmdb.org/t/p/w92/dp.jpg" },
+]));
+const mockGetTvWatchProviders = mock(() => Promise.resolve([
+  { id: 8, name: "Netflix", iconUrl: "https://image.tmdb.org/t/p/w92/nf.jpg" },
+  { id: 1899, name: "Max", iconUrl: "https://image.tmdb.org/t/p/w92/max.jpg" },
+]));
+const mockGetLanguages = mock(() => Promise.resolve([
+  { code: "en", name: "English" },
+  { code: "ja", name: "Japanese" },
+  { code: "fr", name: "French" },
+]));
 
 const realClient = await import("../tmdb/client");
 
@@ -24,6 +37,9 @@ mock.module("../tmdb/client", () => ({
   fetchTvDetails: mockFetchTvDetails,
   getMovieGenres: mockGetMovieGenres,
   getTvGenres: mockGetTvGenres,
+  getMovieWatchProviders: mockGetMovieWatchProviders,
+  getTvWatchProviders: mockGetTvWatchProviders,
+  getLanguages: mockGetLanguages,
   searchMulti: mock(() => Promise.resolve({ results: [], total_pages: 1, total_results: 0, page: 1 })),
 }));
 
@@ -42,6 +58,9 @@ beforeEach(() => {
   mockDiscoverTv.mockClear();
   mockFetchMovieDetails.mockClear();
   mockFetchTvDetails.mockClear();
+  mockGetMovieWatchProviders.mockClear();
+  mockGetTvWatchProviders.mockClear();
+  mockGetLanguages.mockClear();
 });
 
 afterAll(() => {
@@ -75,6 +94,7 @@ describe("GET /browse", () => {
     expect(body.titles).toHaveLength(1);
     expect(body.page).toBe(1);
     expect(body.totalPages).toBe(5);
+    expect(body.totalResults).toBe(100);
     expect(mockDiscoverMovies).toHaveBeenCalledTimes(1);
     const callArgs = (mockDiscoverMovies.mock.calls[0] as unknown[])[0] as Record<string, unknown>;
     expect(callArgs.sortBy).toBe("popularity.desc");
@@ -117,6 +137,7 @@ describe("GET /browse", () => {
     const body = await res.json();
     expect(body.titles).toHaveLength(2);
     expect(body.totalPages).toBe(3); // max of 2 and 3
+    expect(body.totalResults).toBe(100); // 40 + 60
     expect(mockDiscoverMovies).toHaveBeenCalled();
     expect(mockDiscoverTv).toHaveBeenCalled();
   });
@@ -246,6 +267,24 @@ describe("GET /browse", () => {
     expect(body.availableGenres).toContain("Drama");
     expect(body.availableGenres).toContain("Science Fiction");
     expect(body.availableGenres).toContain("Sci-Fi & Fantasy");
+  });
+
+  it("returns availableProviders and availableLanguages from TMDB", async () => {
+    mockDiscoverMovies.mockResolvedValueOnce({
+      results: [], total_pages: 1, total_results: 0, page: 1,
+    });
+
+    const res = await app.request("/browse?category=popular&type=MOVIE");
+    const body = await res.json();
+
+    expect(body.availableProviders).toBeDefined();
+    expect(body.availableProviders.length).toBeGreaterThan(0);
+    expect(body.availableProviders.find((p: any) => p.name === "Netflix")).toBeDefined();
+    expect(body.availableProviders.find((p: any) => p.name === "Max")).toBeDefined();
+
+    expect(body.availableLanguages).toBeDefined();
+    expect(body.availableLanguages.length).toBeGreaterThan(0);
+    expect(body.availableLanguages.find((l: any) => l.code === "en")).toBeDefined();
   });
 
   it("returns isTracked=true for tracked titles when user is authenticated", async () => {

--- a/server/routes/browse.ts
+++ b/server/routes/browse.ts
@@ -6,6 +6,9 @@ import {
   fetchTvDetails,
   getMovieGenres,
   getTvGenres,
+  getMovieWatchProviders,
+  getTvWatchProviders,
+  getLanguages,
   type DiscoverFilters,
 } from "../tmdb/client";
 import {
@@ -103,7 +106,13 @@ app.get("/", async (c) => {
   }
 
   try {
-    const [movieGenreMap, tvGenreMap] = await Promise.all([getMovieGenres(), getTvGenres()]);
+    const [movieGenreMap, tvGenreMap, movieProviders, tvProviders, tmdbLanguages] = await Promise.all([
+      getMovieGenres(),
+      getTvGenres(),
+      getMovieWatchProviders(),
+      getTvWatchProviders(),
+      getLanguages(),
+    ]);
     const allGenres = new Map([...movieGenreMap, ...tvGenreMap]);
 
     // Build discover filters
@@ -119,15 +128,18 @@ app.get("/", async (c) => {
 
     let basicTitles: ParsedTitle[] = [];
     let totalPages = 1;
+    let totalResults = 0;
 
     if (type === "MOVIE") {
       const res = await fetchMoviesByCategory(category as Category, discoverOpts);
       basicTitles = res.results.map((m) => parseDiscoverMovie(m, allGenres));
       totalPages = Math.min(res.total_pages, 500);
+      totalResults = res.total_results;
     } else if (type === "SHOW") {
       const res = await fetchTvByCategory(category as Category, discoverOpts);
       basicTitles = res.results.map((t) => parseDiscoverTv(t, allGenres));
       totalPages = Math.min(res.total_pages, 500);
+      totalResults = res.total_results;
     } else {
       const [movieRes, tvRes] = await Promise.all([
         fetchMoviesByCategory(category as Category, discoverOpts),
@@ -137,6 +149,7 @@ app.get("/", async (c) => {
       const tvShows = tvRes.results.map((t) => parseDiscoverTv(t, allGenres));
       basicTitles = [...movies, ...tvShows];
       totalPages = Math.min(Math.max(movieRes.total_pages, tvRes.total_pages), 500);
+      totalResults = movieRes.total_results + tvRes.total_results;
     }
 
     // Fetch full details with watch providers for each result
@@ -162,10 +175,19 @@ app.get("/", async (c) => {
       isTracked: trackedIds.has(t.id),
     }));
 
-    // Build available genres from TMDB genre maps for dropdown population
+    // Build available filter options from TMDB data for dropdown population
     const availableGenres = Array.from(new Set([...movieGenreMap.values(), ...tvGenreMap.values()])).sort();
 
-    return c.json({ titles: titlesWithTracked, page, totalPages, availableGenres });
+    // Deduplicate providers by ID and sort by name
+    const providerMap = new Map<number, { id: number; name: string; iconUrl: string }>();
+    for (const p of [...movieProviders, ...tvProviders]) {
+      if (!providerMap.has(p.id)) providerMap.set(p.id, p);
+    }
+    const availableProviders = Array.from(providerMap.values()).sort((a, b) => a.name.localeCompare(b.name));
+
+    const availableLanguages = tmdbLanguages;
+
+    return c.json({ titles: titlesWithTracked, page, totalPages, totalResults, availableGenres, availableProviders, availableLanguages });
   } catch (err: any) {
     return c.json({ error: err.message }, 500);
   }

--- a/server/tmdb/client.ts
+++ b/server/tmdb/client.ts
@@ -10,6 +10,8 @@ import type {
   TmdbSearchMultiResult,
   TmdbFindResponse,
   TmdbGenreListResponse,
+  TmdbWatchProviderListResponse,
+  TmdbLanguage,
   TmdbMovieFullDetails,
   TmdbShowFullDetails,
   TmdbSeasonDetails,
@@ -246,4 +248,51 @@ export async function getTvGenres(): Promise<Map<number, string>> {
   });
   tvGenreCache = new Map(data.genres.map((g) => [g.id, g.name]));
   return tvGenreCache;
+}
+
+// ─── Watch provider lists (for filter dropdowns) ────────────────────────────
+
+let movieProviderCache: { id: number; name: string; iconUrl: string }[] | null = null;
+let tvProviderCache: { id: number; name: string; iconUrl: string }[] | null = null;
+
+export async function getMovieWatchProviders(): Promise<{ id: number; name: string; iconUrl: string }[]> {
+  if (movieProviderCache) return movieProviderCache;
+  const data = await tmdbRequest<TmdbWatchProviderListResponse>("/watch/providers/movie", {
+    watch_region: CONFIG.COUNTRY,
+    language: tmdbLanguage(),
+  });
+  movieProviderCache = data.results.map((p) => ({
+    id: p.provider_id,
+    name: p.provider_name,
+    iconUrl: `${CONFIG.TMDB_IMAGE_BASE_URL}/w92${p.logo_path}`,
+  }));
+  return movieProviderCache;
+}
+
+export async function getTvWatchProviders(): Promise<{ id: number; name: string; iconUrl: string }[]> {
+  if (tvProviderCache) return tvProviderCache;
+  const data = await tmdbRequest<TmdbWatchProviderListResponse>("/watch/providers/tv", {
+    watch_region: CONFIG.COUNTRY,
+    language: tmdbLanguage(),
+  });
+  tvProviderCache = data.results.map((p) => ({
+    id: p.provider_id,
+    name: p.provider_name,
+    iconUrl: `${CONFIG.TMDB_IMAGE_BASE_URL}/w92${p.logo_path}`,
+  }));
+  return tvProviderCache;
+}
+
+// ─── Language list ──────────────────────────────────────────────────────────
+
+let languageCache: { code: string; name: string }[] | null = null;
+
+export async function getLanguages(): Promise<{ code: string; name: string }[]> {
+  if (languageCache) return languageCache;
+  const data = await tmdbRequest<TmdbLanguage[]>("/configuration/languages");
+  languageCache = data
+    .map((l) => ({ code: l.iso_639_1, name: l.english_name }))
+    .filter((l) => l.name && l.name !== "No Language")
+    .sort((a, b) => a.name.localeCompare(b.name));
+  return languageCache;
 }

--- a/server/tmdb/types.ts
+++ b/server/tmdb/types.ts
@@ -166,6 +166,28 @@ export interface TmdbGenreListResponse {
   genres: TmdbGenre[];
 }
 
+// ─── Watch provider list ────────────────────────────────────────────────────
+
+export interface TmdbWatchProviderListEntry {
+  provider_id: number;
+  provider_name: string;
+  logo_path: string;
+  display_priority: number;
+  display_priorities: Record<string, number>;
+}
+
+export interface TmdbWatchProviderListResponse {
+  results: TmdbWatchProviderListEntry[];
+}
+
+// ─── Language list ──────────────────────────────────────────────────────────
+
+export interface TmdbLanguage {
+  iso_639_1: string;
+  english_name: string;
+  name: string;
+}
+
 // ─── Full Detail Types (for detail pages with credits, release dates) ───────
 
 export interface TmdbCastMember {


### PR DESCRIPTION
## Summary
This PR enhances the browse functionality by adding support for filtering by provider ID (in addition to provider name) and populating filter dropdowns (providers and languages) directly from TMDB data instead of extracting them from loaded titles.

## Key Changes

- **Provider filtering by ID**: Modified `getRecentTitles()` and `getTitlesByMonth()` in the repository to accept provider as either a numeric ID or a technical name, optimizing queries when an ID is available by avoiding the join with the providers table.

- **TMDB data fetching**: Added three new functions to `tmdb/client.ts`:
  - `getMovieWatchProviders()` - fetches available movie streaming providers
  - `getTvWatchProviders()` - fetches available TV streaming providers
  - `getLanguages()` - fetches available languages with caching

- **API response enhancement**: Updated `/browse` endpoint to return `totalResults`, `availableProviders`, and `availableLanguages` in the response, populated from TMDB data rather than derived from loaded titles.

- **Frontend updates**:
  - Modified `FilterBar.tsx` to accept provider objects with `id` and `name` properties, using provider ID as the select value
  - Updated `CategoryBrowse.tsx` to receive and display filter options from the API response
  - Added display of total results count on the browse page
  - Removed client-side extraction of providers/languages from titles

- **Type definitions**: Added `TmdbWatchProviderListResponse` and `TmdbLanguage` interfaces to support the new TMDB endpoints.

## Notable Implementation Details

- Provider filtering intelligently checks if the input is a numeric ID using `Number()` and `isNaN()` to determine the query path
- Watch providers are deduplicated by ID across movie and TV results and sorted alphabetically
- Languages are filtered to exclude "No Language" entries and sorted by English name
- All new TMDB data is cached to avoid redundant API calls
- The browse endpoint now returns comprehensive filter options upfront, improving UX by showing all available filters regardless of current results

https://claude.ai/code/session_01V77RLWXaCopjFZiwXJtBbh