### PR TITLE
Add clear filters functionality to browse page

### DIFF
--- a/frontend/src/components/CategoryBrowse.tsx
+++ b/frontend/src/components/CategoryBrowse.tsx
@@ -67,6 +67,7 @@ interface Props {
   onProviderChange: (provider: string[]) => void;
   language: string[];
   onLanguageChange: (language: string[]) => void;
+  onClearFilters?: () => void;
 }
 
 export default function CategoryBrowse({
@@ -79,6 +80,7 @@ export default function CategoryBrowse({
   onProviderChange,
   language,
   onLanguageChange,
+  onClearFilters,
 }: Props) {
   const [titles, setTitles] = useState<Title[]>([]);
   const [loading, setLoading] = useState(false);
@@ -174,6 +176,7 @@ export default function CategoryBrowse({
         language={language}
         onLanguageChange={onLanguageChange}
         languages={availableLanguages}
+        onClearFilters={onClearFilters}
       />
 
       {error && (

--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -25,6 +25,7 @@ interface Props {
   language?: string[];
   onLanguageChange?: (language: string[]) => void;
   languages?: string[] | LanguageOption[];
+  onClearFilters?: () => void;
 }
 
 const TYPES = [
@@ -73,7 +74,14 @@ export default function FilterBar({
   language,
   onLanguageChange,
   languages,
+  onClearFilters,
 }: Props) {
+  const hasActiveFilters =
+    type.length > 0 ||
+    (daysBack !== undefined && daysBack !== 30 && showDaysFilter) ||
+    (genre && genre.length > 0) ||
+    (provider && provider.length > 0) ||
+    (language && language.length > 0);
   return (
     <div className="flex flex-wrap gap-4 items-center">
       <div className="flex gap-1 bg-gray-800 rounded-lg p-1">
@@ -145,6 +153,14 @@ export default function FilterBar({
           selected={language || []}
           onChange={onLanguageChange}
         />
+      )}
+      {onClearFilters && hasActiveFilters && (
+        <button
+          onClick={onClearFilters}
+          className="px-3 py-1.5 rounded-md text-xs font-medium text-gray-400 hover:text-white transition-colors cursor-pointer"
+        >
+          Clear filters
+        </button>
       )}
     </div>
   );

--- a/frontend/src/components/NewReleases.tsx
+++ b/frontend/src/components/NewReleases.tsx
@@ -15,6 +15,7 @@ interface Props {
   onProviderChange: (provider: string[]) => void;
   language: string[];
   onLanguageChange: (language: string[]) => void;
+  onClearFilters?: () => void;
 }
 
 export default function NewReleases({
@@ -28,6 +29,7 @@ export default function NewReleases({
   onProviderChange,
   language,
   onLanguageChange,
+  onClearFilters,
 }: Props) {
   const [titles, setTitles] = useState<Title[]>([]);
   const [loading, setLoading] = useState(false);
@@ -101,6 +103,7 @@ export default function NewReleases({
           language={language}
           onLanguageChange={onLanguageChange}
           languages={languages}
+          onClearFilters={onClearFilters}
         />
         <button
           onClick={handleSync}

--- a/frontend/src/pages/BrowsePage.test.ts
+++ b/frontend/src/pages/BrowsePage.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "bun:test";
+import { buildCategoryParams, FILTER_KEYS } from "./BrowsePage";
+
+describe("buildCategoryParams", () => {
+  it("preserves filter params when switching category", () => {
+    const prev = new URLSearchParams("category=popular&type=MOVIE&genre=Action&provider=8&language=en");
+    const result = buildCategoryParams(prev, "upcoming");
+
+    expect(result.get("category")).toBe("upcoming");
+    expect(result.get("type")).toBe("MOVIE");
+    expect(result.get("genre")).toBe("Action");
+    expect(result.get("provider")).toBe("8");
+    expect(result.get("language")).toBe("en");
+  });
+
+  it("deletes category param when switching to popular (default)", () => {
+    const prev = new URLSearchParams("category=upcoming&type=SHOW");
+    const result = buildCategoryParams(prev, "popular");
+
+    expect(result.has("category")).toBe(false);
+    expect(result.get("type")).toBe("SHOW");
+  });
+
+  it("sets category param for non-popular categories", () => {
+    const prev = new URLSearchParams();
+    const result = buildCategoryParams(prev, "top_rated");
+
+    expect(result.get("category")).toBe("top_rated");
+  });
+
+  it("preserves daysBack when switching categories", () => {
+    const prev = new URLSearchParams("category=new_releases&daysBack=7&type=MOVIE");
+    const result = buildCategoryParams(prev, "popular");
+
+    expect(result.has("category")).toBe(false);
+    expect(result.get("daysBack")).toBe("7");
+    expect(result.get("type")).toBe("MOVIE");
+  });
+});
+
+describe("FILTER_KEYS", () => {
+  it("contains all expected filter keys", () => {
+    expect(FILTER_KEYS).toEqual(["type", "genre", "provider", "language", "daysBack"]);
+  });
+});

--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -73,6 +73,18 @@ function useQueryParamArray(
   return [value, setValue];
 }
 
+export const FILTER_KEYS = ["type", "genre", "provider", "language", "daysBack"] as const;
+
+export function buildCategoryParams(prev: URLSearchParams, cat: BrowseCategory): URLSearchParams {
+  const next = new URLSearchParams(prev);
+  if (cat === "popular") {
+    next.delete("category");
+  } else {
+    next.set("category", cat);
+  }
+  return next;
+}
+
 export default function BrowsePage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [searchResults, setSearchResults] = useState<Title[] | null>(null);
@@ -86,27 +98,23 @@ export default function BrowsePage() {
 
   const setCategory = useCallback(
     (cat: BrowseCategory) => {
-      setSearchParams(
-        (prev) => {
-          const next = new URLSearchParams(prev);
-          if (cat === "popular") {
-            next.delete("category");
-          } else {
-            next.set("category", cat);
-          }
-          // Clear filters when switching categories
-          next.delete("type");
-          next.delete("genre");
-          next.delete("provider");
-          next.delete("language");
-          next.delete("daysBack");
-          return next;
-        },
-        { replace: true }
-      );
+      setSearchParams((prev) => buildCategoryParams(prev, cat), { replace: true });
     },
     [setSearchParams]
   );
+
+  const clearFilters = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        for (const key of FILTER_KEYS) {
+          next.delete(key);
+        }
+        return next;
+      },
+      { replace: true }
+    );
+  }, [setSearchParams]);
 
   const [type, setType] = useQueryParamArray(searchParams, setSearchParams, "type");
   const [genre, setGenre] = useQueryParamArray(searchParams, setSearchParams, "genre");
@@ -192,6 +200,7 @@ export default function BrowsePage() {
               onProviderChange={setProvider}
               language={language}
               onLanguageChange={setLanguage}
+              onClearFilters={clearFilters}
             />
           ) : (
             <CategoryBrowse
@@ -205,6 +214,7 @@ export default function BrowsePage() {
               onProviderChange={setProvider}
               language={language}
               onLanguageChange={setLanguage}
+              onClearFilters={clearFilters}
             />
           )}
         </div>


### PR DESCRIPTION
## Summary
This PR adds a "Clear filters" button to the FilterBar component that allows users to reset all active filters while maintaining their current category selection.

## Key Changes
- **Extracted filter management logic**: Created `buildCategoryParams()` helper function to handle category switching while preserving filters, and defined `FILTER_KEYS` constant to centralize filter key definitions
- **Added clearFilters callback**: Implemented `clearFilters()` callback in BrowsePage that removes all filter parameters from URL while preserving the category
- **Updated FilterBar component**: 
  - Added `onClearFilters` prop and `hasActiveFilters` state to determine when to show the clear button
  - Displays "Clear filters" button only when filters are active
  - Button has subtle styling with hover effects
- **Propagated callback**: Passed `onClearFilters` through component hierarchy (BrowsePage → NewReleases/CategoryBrowse → FilterBar)
- **Added comprehensive tests**: Created test suite for `buildCategoryParams()` and `FILTER_KEYS` to ensure filter preservation and category switching work correctly

## Notable Implementation Details
- The `buildCategoryParams()` function preserves all filter parameters when switching categories, only modifying the category parameter itself
- The "popular" category is treated as the default state and removes the category parameter from the URL
- The clear filters button only appears when at least one filter is active, keeping the UI clean when no filtering is applied
- Filter keys are centralized in `FILTER_KEYS` constant to ensure consistency across clearing and other filter operations

https://claude.ai/code/session_01VvBRS42Xvohy3WUzryrXvz