### PR TITLE
Add Sentry error tracking for failed jobs and graceful shutdown

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -132,8 +132,9 @@ registerSyncJobs();
 registerNotificationJobs();
 startWorker();
 
-process.on("SIGTERM", () => {
+process.on("SIGTERM", async () => {
   stopWorker();
+  await Sentry.flush(2000);
   process.exit(0);
 });
 

--- a/server/jobs/worker.test.ts
+++ b/server/jobs/worker.test.ts
@@ -10,9 +10,12 @@ const withMonitorSpy = spyOn(Sentry, "withMonitor").mockImplementation(
   }) as typeof Sentry.withMonitor
 );
 
+const captureExceptionSpy = spyOn(Sentry, "captureException").mockReturnValue("test-event-id");
+
 beforeEach(() => {
   setupTestDb();
   withMonitorSpy.mockClear();
+  captureExceptionSpy.mockClear();
 });
 
 afterAll(() => {
@@ -77,8 +80,9 @@ describe("worker Sentry monitoring", () => {
       }) as typeof Sentry.withMonitor
     );
 
+    const jobError = new Error("job failed");
     registerHandler("failing-job", async () => {
-      throw new Error("job failed");
+      throw jobError;
     });
     enqueueJob("failing-job");
 
@@ -89,5 +93,6 @@ describe("worker Sentry monitoring", () => {
       expect.any(Function),
       undefined
     );
+    expect(captureExceptionSpy).toHaveBeenCalledWith(jobError);
   });
 });

--- a/server/jobs/worker.ts
+++ b/server/jobs/worker.ts
@@ -52,6 +52,7 @@ export async function processJobs() {
       completeJob(job.id);
       log.info("Completed job", { name, jobId: job.id });
     } catch (err) {
+      Sentry.captureException(err);
       const message = err instanceof Error ? err.message : String(err);
       failJob(job.id, message);
       log.error("Failed job", { name, jobId: job.id, attempt: job.attempts, maxAttempts: job.max_attempts, error: message });


### PR DESCRIPTION
## Summary
This PR enhances error tracking and observability by capturing job failures in Sentry and ensuring proper Sentry event flushing during graceful shutdown.

## Key Changes
- **Job error tracking**: Added `Sentry.captureException()` call in the job worker's error handler to report failed jobs to Sentry
- **Graceful shutdown**: Modified the SIGTERM signal handler to flush pending Sentry events (2 second timeout) before process exit
- **Test coverage**: Updated worker tests to verify that job exceptions are properly captured by Sentry, including a new assertion that `captureException` is called with the thrown error

## Implementation Details
- The `processJobs()` function now captures exceptions immediately when a job fails, before logging and marking the job as failed
- The SIGTERM handler is now async to allow awaiting the Sentry flush operation, ensuring no events are lost during shutdown
- Test setup includes a spy on `Sentry.captureException` that is cleared between test runs for proper isolation

https://claude.ai/code/session_01Ssx6BuWkwLLLGFurYrvDbn