### PR TITLE
Add health check endpoint for uptime monitoring

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -21,6 +21,7 @@ import jobsRoutes from "./routes/jobs";
 import browseRoutes from "./routes/browse";
 import detailsRoutes from "./routes/details";
 import notifierRoutes from "./routes/notifiers";
+import healthRoutes from "./routes/health";
 import type { AppEnv } from "./types";
 import * as Sentry from "@sentry/node";
 import { logger, requestLogger } from "./logger";
@@ -57,6 +58,9 @@ app.use("/api/*", cors());
 
 // Request logging
 app.use("/api/*", requestLogger());
+
+// Health check (public — used by Sentry uptime monitoring)
+app.route("/api/health", healthRoutes);
 
 // Auth routes (public)
 app.route("/api/auth", authRoutes);

--- a/server/routes/health.test.ts
+++ b/server/routes/health.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import healthApp from "./health";
+
+let app: Hono;
+
+beforeEach(() => {
+  setupTestDb();
+  app = new Hono();
+  app.route("/health", healthApp);
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+describe("GET /health", () => {
+  it("returns ok status", async () => {
+    const res = await app.request("/health");
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+  });
+});

--- a/server/routes/health.ts
+++ b/server/routes/health.ts
@@ -1,0 +1,16 @@
+import { Hono } from "hono";
+import { getDb } from "../db/schema";
+
+const app = new Hono();
+
+app.get("/", (c) => {
+  try {
+    const db = getDb();
+    db.run(/* sql */ `SELECT 1`);
+    return c.json({ status: "ok" });
+  } catch {
+    return c.json({ status: "error" }, 503);
+  }
+});
+
+export default app;


### PR DESCRIPTION
## Summary
This PR adds a new health check endpoint that can be used by monitoring services like Sentry to verify the application is running and the database is accessible.

## Key Changes
- **New health check route** (`server/routes/health.ts`): Implements a GET endpoint that returns `{ status: "ok" }` with a 200 status code if the database is accessible, or `{ status: "error" }` with a 503 status code if there's an error
- **Health check tests** (`server/routes/health.test.ts`): Adds test coverage for the health endpoint to verify it returns the expected response
- **Route registration** (`server/index.ts`): Registers the health check route at `/api/health` as a public endpoint (before auth routes) with a comment noting it's used by Sentry uptime monitoring

## Implementation Details
- The health check performs a simple `SELECT 1` query against the database to verify connectivity
- The endpoint is intentionally placed before authentication routes to allow external monitoring services to access it without credentials
- Error handling is implemented to gracefully return a 503 status if the database is unavailable

https://claude.ai/code/session_01NddJMtUR4ufYYCofpCr6We