### PR TITLE
Fix ISO 8601 timestamp handling in formatDate across detail pages

### DIFF
--- a/frontend/src/pages/EpisodeDetailPage.tsx
+++ b/frontend/src/pages/EpisodeDetailPage.tsx
@@ -8,7 +8,8 @@ const TMDB_IMG = "https://image.tmdb.org/t/p";
 
 function formatDate(dateStr: string | null | undefined): string {
   if (!dateStr) return "—";
-  const d = new Date(dateStr + "T00:00:00");
+  const d = new Date(dateStr.includes("T") ? dateStr : dateStr + "T00:00:00");
+  if (isNaN(d.getTime())) return "—";
   return d.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
 }
 

--- a/frontend/src/pages/PersonPage.tsx
+++ b/frontend/src/pages/PersonPage.tsx
@@ -8,7 +8,8 @@ const BIO_TRUNCATE_LENGTH = 600;
 
 function formatDate(dateStr: string | null | undefined): string {
   if (!dateStr) return "—";
-  const d = new Date(dateStr + "T00:00:00");
+  const d = new Date(dateStr.includes("T") ? dateStr : dateStr + "T00:00:00");
+  if (isNaN(d.getTime())) return "—";
   return d.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
 }
 

--- a/frontend/src/pages/SeasonDetailPage.tsx
+++ b/frontend/src/pages/SeasonDetailPage.tsx
@@ -8,7 +8,8 @@ const TMDB_IMG = "https://image.tmdb.org/t/p";
 
 function formatDate(dateStr: string | null | undefined): string {
   if (!dateStr) return "—";
-  const d = new Date(dateStr + "T00:00:00");
+  const d = new Date(dateStr.includes("T") ? dateStr : dateStr + "T00:00:00");
+  if (isNaN(d.getTime())) return "—";
   return d.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
 }
 

--- a/frontend/src/pages/TitleDetailPage.tsx
+++ b/frontend/src/pages/TitleDetailPage.tsx
@@ -27,7 +27,8 @@ const RELEASE_TYPE_LABELS: Record<number, string> = {
 
 function formatDate(dateStr: string | null | undefined): string {
   if (!dateStr) return "—";
-  const d = new Date(dateStr + "T00:00:00");
+  const d = new Date(dateStr.includes("T") ? dateStr : dateStr + "T00:00:00");
+  if (isNaN(d.getTime())) return "—";
   return d.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
 }
 

--- a/frontend/src/pages/formatDate.test.ts
+++ b/frontend/src/pages/formatDate.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "bun:test";
+
+/**
+ * Tests for the formatDate function used across detail pages.
+ * The function is inlined in each page file, so we replicate it here
+ * to verify the fix for ISO 8601 timestamp handling.
+ */
+function formatDate(dateStr: string | null | undefined): string {
+  if (!dateStr) return "—";
+  const d = new Date(dateStr.includes("T") ? dateStr : dateStr + "T00:00:00");
+  if (isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
+}
+
+describe("formatDate", () => {
+  it("formats YYYY-MM-DD date strings", () => {
+    const result = formatDate("2024-11-01");
+    expect(result).toBe("Nov 1, 2024");
+  });
+
+  it("formats full ISO 8601 timestamps from TMDB release_dates", () => {
+    const result = formatDate("2024-11-01T00:00:00.000Z");
+    expect(result).toInclude("2024");
+    expect(result).toInclude("Nov");
+  });
+
+  it("returns dash for null", () => {
+    expect(formatDate(null)).toBe("—");
+  });
+
+  it("returns dash for undefined", () => {
+    expect(formatDate(undefined)).toBe("—");
+  });
+
+  it("returns dash for empty string", () => {
+    expect(formatDate("")).toBe("—");
+  });
+
+  it("returns dash for malformed date string", () => {
+    expect(formatDate("not-a-date")).toBe("—");
+  });
+});


### PR DESCRIPTION
## Summary
Fixed the `formatDate` function to properly handle both YYYY-MM-DD date strings and full ISO 8601 timestamps (with time components) returned by the TMDB API. Previously, the function would incorrectly append "T00:00:00" to timestamps that already contained time information, causing parsing issues.

## Key Changes
- Updated `formatDate` in 4 detail page files (EpisodeDetailPage, PersonPage, SeasonDetailPage, TitleDetailPage) to:
  - Check if the input string already contains a "T" character before appending the time component
  - Add validation to return "—" for malformed dates that fail to parse
- Added comprehensive test suite (`formatDate.test.ts`) to verify the fix handles:
  - YYYY-MM-DD format strings
  - Full ISO 8601 timestamps with timezone information
  - Null, undefined, and empty string inputs
  - Malformed date strings

## Implementation Details
The fix uses a simple conditional check (`dateStr.includes("T")`) to determine whether the input is already a full ISO 8601 timestamp or just a date string. This allows the function to handle both formats correctly without double-processing the time component. The added `isNaN()` validation ensures graceful fallback to "—" for any unparseable input.

https://claude.ai/code/session_01YDTRdBWwEay1kzeroMfjn1