### PR TITLE
Add Reels page for full-screen episode browsing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { Routes, Route, NavLink, Link, useLocation } from "react-router";
-import { Menu, X } from "lucide-react";
+import { Menu, X, Clapperboard } from "lucide-react";
 import { useAuth } from "./context/AuthContext";
 import HomePage from "./pages/HomePage";
 import BrowsePage from "./pages/BrowsePage";
@@ -12,6 +12,7 @@ import TitleDetailPage from "./pages/TitleDetailPage";
 import SeasonDetailPage from "./pages/SeasonDetailPage";
 import EpisodeDetailPage from "./pages/EpisodeDetailPage";
 import PersonPage from "./pages/PersonPage";
+import ReelsPage from "./pages/ReelsPage";
 import RequireAuth from "./components/RequireAuth";
 import { navLinkClass } from "./nav-utils";
 
@@ -57,6 +58,12 @@ export default function App() {
                   className={({ isActive }) => navLinkClass(isActive)}
                 >
                   Calendar
+                </NavLink>
+                <NavLink
+                  to="/reels"
+                  className={({ isActive }) => navLinkClass(isActive)}
+                >
+                  Reels
                 </NavLink>
               </>
             )}
@@ -126,6 +133,13 @@ export default function App() {
                 >
                   Calendar
                 </NavLink>
+                <NavLink
+                  to="/reels"
+                  className={({ isActive }) => navLinkClass(isActive, true)}
+                >
+                  <Clapperboard size={16} className="inline mr-1" />
+                  Reels
+                </NavLink>
               </>
             )}
             <div className="border-t border-gray-800 my-2" />
@@ -162,6 +176,7 @@ export default function App() {
           <Route path="/login" element={<LoginPage />} />
           <Route path="/tracked" element={<RequireAuth><TrackedPage /></RequireAuth>} />
           <Route path="/calendar" element={<RequireAuth><CalendarPage /></RequireAuth>} />
+          <Route path="/reels" element={<RequireAuth><ReelsPage /></RequireAuth>} />
           <Route path="/profile" element={<RequireAuth><ProfilePage /></RequireAuth>} />
           <Route path="/title/:id" element={<TitleDetailPage />} />
           <Route path="/title/:id/season/:season" element={<SeasonDetailPage />} />

--- a/frontend/src/components/ReelsCard.tsx
+++ b/frontend/src/components/ReelsCard.tsx
@@ -1,0 +1,124 @@
+import { CheckCircle, Check } from "lucide-react";
+import type { Episode, Offer } from "../types";
+
+function formatEpisodeCode(ep: Episode): string {
+  const s = String(ep.season_number).padStart(2, "0");
+  const e = String(ep.episode_number).padStart(2, "0");
+  return `S${s}E${e}`;
+}
+
+function getUniqueProviders(offers?: Offer[]) {
+  if (!offers?.length) return [];
+  const map = new Map<number, Offer>();
+  for (const o of offers) {
+    if (o.monetization_type === "FLATRATE" || o.monetization_type === "FREE" || o.monetization_type === "ADS") {
+      if (!map.has(o.provider_id)) map.set(o.provider_id, o);
+    }
+  }
+  return Array.from(map.values());
+}
+
+export function getBackgroundImageUrl(episode: Episode): string | null {
+  if (episode.still_path) {
+    return `https://image.tmdb.org/t/p/w1280${episode.still_path}`;
+  }
+  if (episode.poster_url) {
+    return episode.poster_url;
+  }
+  return null;
+}
+
+interface ReelsCardProps {
+  episode: Episode;
+  caughtUp: boolean;
+  onMarkWatched: () => void;
+  index: number;
+  total: number;
+}
+
+export default function ReelsCard({ episode, caughtUp, onMarkWatched, index, total }: ReelsCardProps) {
+  const bgUrl = getBackgroundImageUrl(episode);
+  const providers = getUniqueProviders(episode.offers);
+
+  return (
+    <div className="snap-start h-dvh w-full relative flex-shrink-0 overflow-hidden">
+      {/* Background image */}
+      {bgUrl ? (
+        <img
+          src={bgUrl}
+          alt=""
+          className="absolute inset-0 w-full h-full object-cover"
+          loading="lazy"
+        />
+      ) : (
+        <div className="absolute inset-0 bg-gradient-to-b from-gray-800 to-gray-950" />
+      )}
+
+      {/* Gradient overlay */}
+      <div className="absolute inset-0 bg-gradient-to-b from-black/30 via-transparent to-black/90" />
+
+      {/* Position indicator */}
+      <div className="absolute top-4 right-4 z-10 bg-black/50 px-3 py-1 rounded-full text-xs text-white/80">
+        {index + 1} / {total}
+      </div>
+
+      {/* Bottom content */}
+      <div className="absolute bottom-0 left-0 right-0 p-6 pb-10 z-10">
+        {caughtUp ? (
+          <div className="text-center py-8">
+            <div className="inline-flex items-center gap-2 bg-green-500/20 text-green-400 px-4 py-2 rounded-full text-lg font-semibold mb-2">
+              <Check size={20} />
+              All caught up!
+            </div>
+            <p className="text-gray-400 text-sm">{episode.show_title}</p>
+          </div>
+        ) : (
+          <>
+            {/* Show title */}
+            <h2 className="text-2xl font-bold text-white mb-1 drop-shadow-lg">
+              {episode.show_title}
+            </h2>
+
+            {/* Episode code + name */}
+            <p className="text-base text-white/90 font-medium mb-2 drop-shadow">
+              {formatEpisodeCode(episode)}
+              {episode.name && ` · ${episode.name}`}
+            </p>
+
+            {/* Overview */}
+            {episode.overview && (
+              <p className="text-sm text-white/70 line-clamp-3 mb-4 drop-shadow">
+                {episode.overview}
+              </p>
+            )}
+
+            {/* Provider icons */}
+            {providers.length > 0 && (
+              <div className="flex gap-2 mb-4">
+                {providers.map((p) => (
+                  <img
+                    key={p.provider_id}
+                    src={p.provider_icon_url}
+                    alt={p.provider_name}
+                    title={p.provider_name}
+                    className="w-8 h-8 rounded-lg"
+                    loading="lazy"
+                  />
+                ))}
+              </div>
+            )}
+
+            {/* Mark as watched button */}
+            <button
+              onClick={onMarkWatched}
+              className="flex items-center gap-2 bg-indigo-600 hover:bg-indigo-500 active:bg-indigo-700 text-white px-6 py-3 rounded-xl text-base font-semibold transition-colors cursor-pointer w-full justify-center"
+            >
+              <CheckCircle size={20} />
+              Mark as Watched
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { Link } from "react-router";
+import { Maximize2 } from "lucide-react";
 import { useAuth } from "../context/AuthContext";
 import * as api from "../api";
 import type { Episode, Offer } from "../types";
@@ -600,7 +601,17 @@ export default function HomePage() {
       {/* Unwatched Episodes */}
       {unwatched.length > 0 && (
         <section>
-          <h2 className="text-xl font-bold text-white mb-4">Unwatched</h2>
+          <div className="flex items-center gap-3 mb-4">
+            <h2 className="text-xl font-bold text-white">Unwatched</h2>
+            <Link
+              to="/reels"
+              className="flex items-center gap-1 text-xs text-gray-400 hover:text-indigo-400 transition-colors"
+              title="Full-screen reels view"
+            >
+              <Maximize2 size={14} />
+              Reels
+            </Link>
+          </div>
           <UnwatchedCarousel>
             {Array.from(unwatchedByShowAndSeason.entries()).map(([titleId, seasonMap]) => (
               <div key={titleId} className="w-80 flex-shrink-0" style={{ scrollSnapAlign: "start" }}>

--- a/frontend/src/pages/ReelsPage.test.ts
+++ b/frontend/src/pages/ReelsPage.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "bun:test";
+import { getFirstUnwatchedPerShow } from "./ReelsPage";
+import type { Episode } from "../types";
+
+function makeEpisode(
+  overrides: Partial<Episode> & { id: number; title_id: string; season_number: number; episode_number: number }
+): Episode {
+  return {
+    name: `Episode ${overrides.episode_number}`,
+    overview: null,
+    air_date: "2025-01-01",
+    still_path: null,
+    show_title: overrides.title_id === "show-1" ? "Show One" : "Show Two",
+    poster_url: null,
+    ...overrides,
+  };
+}
+
+describe("getFirstUnwatchedPerShow", () => {
+  it("returns empty array for empty input", () => {
+    expect(getFirstUnwatchedPerShow([])).toEqual([]);
+  });
+
+  it("groups episodes by show and sorts by season then episode", () => {
+    const episodes: Episode[] = [
+      makeEpisode({ id: 3, title_id: "show-1", season_number: 2, episode_number: 1 }),
+      makeEpisode({ id: 1, title_id: "show-1", season_number: 1, episode_number: 1 }),
+      makeEpisode({ id: 2, title_id: "show-1", season_number: 1, episode_number: 2 }),
+      makeEpisode({ id: 4, title_id: "show-2", season_number: 1, episode_number: 1 }),
+    ];
+
+    const cards = getFirstUnwatchedPerShow(episodes);
+
+    expect(cards.length).toBe(2);
+
+    const show1 = cards.find((c) => c.titleId === "show-1")!;
+    expect(show1.episodes.length).toBe(3);
+    expect(show1.episodes[0].id).toBe(1); // S01E01
+    expect(show1.episodes[1].id).toBe(2); // S01E02
+    expect(show1.episodes[2].id).toBe(3); // S02E01
+    expect(show1.currentIndex).toBe(0);
+    expect(show1.caughtUp).toBe(false);
+
+    const show2 = cards.find((c) => c.titleId === "show-2")!;
+    expect(show2.episodes.length).toBe(1);
+  });
+
+  it("handles single episode", () => {
+    const episodes: Episode[] = [
+      makeEpisode({ id: 1, title_id: "show-1", season_number: 3, episode_number: 5 }),
+    ];
+
+    const cards = getFirstUnwatchedPerShow(episodes);
+    expect(cards.length).toBe(1);
+    expect(cards[0].titleId).toBe("show-1");
+    expect(cards[0].episodes.length).toBe(1);
+    expect(cards[0].episodes[0].season_number).toBe(3);
+    expect(cards[0].episodes[0].episode_number).toBe(5);
+  });
+
+  it("uses show_title and poster_url from first sorted episode", () => {
+    const episodes: Episode[] = [
+      makeEpisode({ id: 2, title_id: "show-1", season_number: 2, episode_number: 1, show_title: "Show One", poster_url: "/poster2.jpg" }),
+      makeEpisode({ id: 1, title_id: "show-1", season_number: 1, episode_number: 1, show_title: "Show One", poster_url: "/poster1.jpg" }),
+    ];
+
+    const cards = getFirstUnwatchedPerShow(episodes);
+    expect(cards[0].showTitle).toBe("Show One");
+    expect(cards[0].posterUrl).toBe("/poster1.jpg");
+  });
+
+  it("sorts episodes correctly across multiple seasons", () => {
+    const episodes: Episode[] = [
+      makeEpisode({ id: 5, title_id: "show-1", season_number: 3, episode_number: 2 }),
+      makeEpisode({ id: 4, title_id: "show-1", season_number: 3, episode_number: 1 }),
+      makeEpisode({ id: 2, title_id: "show-1", season_number: 1, episode_number: 3 }),
+      makeEpisode({ id: 1, title_id: "show-1", season_number: 1, episode_number: 1 }),
+      makeEpisode({ id: 3, title_id: "show-1", season_number: 2, episode_number: 1 }),
+    ];
+
+    const cards = getFirstUnwatchedPerShow(episodes);
+    const ids = cards[0].episodes.map((e) => e.id);
+    expect(ids).toEqual([1, 2, 3, 4, 5]);
+  });
+});
+
+describe("ShowCard advancement logic", () => {
+  it("advancing currentIndex past all episodes means caught up", () => {
+    const episodes: Episode[] = [
+      makeEpisode({ id: 1, title_id: "show-1", season_number: 1, episode_number: 1 }),
+      makeEpisode({ id: 2, title_id: "show-1", season_number: 1, episode_number: 2 }),
+    ];
+
+    const cards = getFirstUnwatchedPerShow(episodes);
+    const card = cards[0];
+
+    // Simulate marking episodes watched
+    const afterFirst = { ...card, currentIndex: card.currentIndex + 1 };
+    expect(afterFirst.currentIndex).toBe(1);
+    expect(afterFirst.currentIndex < afterFirst.episodes.length).toBe(true);
+
+    const afterSecond = afterFirst.currentIndex + 1;
+    expect(afterSecond >= card.episodes.length).toBe(true); // caught up
+  });
+
+  it("single episode show becomes caught up after one mark", () => {
+    const episodes: Episode[] = [
+      makeEpisode({ id: 1, title_id: "show-1", season_number: 1, episode_number: 1 }),
+    ];
+
+    const cards = getFirstUnwatchedPerShow(episodes);
+    const nextIndex = cards[0].currentIndex + 1;
+    expect(nextIndex >= cards[0].episodes.length).toBe(true);
+  });
+});

--- a/frontend/src/pages/ReelsPage.tsx
+++ b/frontend/src/pages/ReelsPage.tsx
@@ -1,0 +1,209 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useNavigate, Link } from "react-router";
+import { X } from "lucide-react";
+import * as api from "../api";
+import type { Episode } from "../types";
+import ReelsCard from "../components/ReelsCard";
+
+interface ShowCard {
+  titleId: string;
+  showTitle: string;
+  posterUrl: string | null;
+  episodes: Episode[];
+  currentIndex: number;
+  caughtUp: boolean;
+}
+
+export function getFirstUnwatchedPerShow(episodes: Episode[]): ShowCard[] {
+  const grouped = new Map<string, Episode[]>();
+  for (const ep of episodes) {
+    if (!grouped.has(ep.title_id)) grouped.set(ep.title_id, []);
+    grouped.get(ep.title_id)!.push(ep);
+  }
+
+  const cards: ShowCard[] = [];
+  for (const [titleId, eps] of grouped) {
+    const sorted = [...eps].sort((a, b) => {
+      if (a.season_number !== b.season_number) return a.season_number - b.season_number;
+      return a.episode_number - b.episode_number;
+    });
+    cards.push({
+      titleId,
+      showTitle: sorted[0].show_title,
+      posterUrl: sorted[0].poster_url,
+      episodes: sorted,
+      currentIndex: 0,
+      caughtUp: false,
+    });
+  }
+
+  return cards;
+}
+
+export default function ReelsPage() {
+  const navigate = useNavigate();
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const [cards, setCards] = useState<ShowCard[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await api.getUpcomingEpisodes();
+        setCards(getFirstUnwatchedPerShow(data.unwatched));
+      } catch (err: any) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  // Loop: when sentinel at bottom becomes visible, scroll back to top
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    const container = scrollRef.current;
+    if (!sentinel || !container || cards.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          container.scrollTo({ top: 0, behavior: "smooth" });
+        }
+      },
+      { root: container, threshold: 0.5 }
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [cards.length]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container) return;
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (!container) return;
+      const cardHeight = window.innerHeight;
+      if (e.key === "ArrowDown" || e.key === "j") {
+        e.preventDefault();
+        container.scrollBy({ top: cardHeight, behavior: "smooth" });
+      } else if (e.key === "ArrowUp" || e.key === "k") {
+        e.preventDefault();
+        container.scrollBy({ top: -cardHeight, behavior: "smooth" });
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  const markWatched = useCallback(async (titleId: string) => {
+    setCards((prev) => {
+      return prev.map((card) => {
+        if (card.titleId !== titleId || card.caughtUp) return card;
+        const episode = card.episodes[card.currentIndex];
+        if (!episode) return card;
+
+        const nextIndex = card.currentIndex + 1;
+        if (nextIndex >= card.episodes.length) {
+          return { ...card, caughtUp: true };
+        }
+        return { ...card, currentIndex: nextIndex };
+      });
+    });
+
+    // Find the episode to mark
+    const card = cards.find((c) => c.titleId === titleId);
+    if (!card || card.caughtUp) return;
+    const episode = card.episodes[card.currentIndex];
+    if (!episode) return;
+
+    try {
+      await api.watchEpisode(episode.id);
+    } catch (err) {
+      // Revert on failure
+      setCards((prev) =>
+        prev.map((c) => {
+          if (c.titleId !== titleId) return c;
+          if (c.caughtUp) {
+            return { ...c, caughtUp: false, currentIndex: c.episodes.length - 1 };
+          }
+          return { ...c, currentIndex: Math.max(0, c.currentIndex - 1) };
+        })
+      );
+      console.error("Failed to mark watched:", err);
+    }
+  }, [cards]);
+
+  if (loading) {
+    return (
+      <div className="fixed inset-0 z-[100] bg-black flex items-center justify-center">
+        <p className="text-gray-500">Loading...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="fixed inset-0 z-[100] bg-black flex items-center justify-center p-6">
+        <div className="text-center">
+          <p className="text-red-400 mb-4">{error}</p>
+          <button onClick={() => navigate(-1)} className="text-indigo-400 hover:text-indigo-300 cursor-pointer">
+            Go back
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (cards.length === 0) {
+    return (
+      <div className="fixed inset-0 z-[100] bg-black flex items-center justify-center p-6">
+        <div className="text-center">
+          <p className="text-gray-400 text-lg mb-2">No unwatched episodes</p>
+          <p className="text-gray-600 text-sm mb-6">You're all caught up!</p>
+          <Link to="/" className="text-indigo-400 hover:text-indigo-300">
+            Back to Home
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={scrollRef}
+      className="fixed inset-0 z-[100] bg-black overflow-y-scroll snap-y snap-mandatory [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
+    >
+      {/* Close button */}
+      <button
+        onClick={() => navigate(-1)}
+        className="fixed top-4 left-4 z-[110] bg-black/50 hover:bg-black/70 text-white p-2 rounded-full transition-colors cursor-pointer"
+        aria-label="Close"
+      >
+        <X size={24} />
+      </button>
+
+      {/* Cards */}
+      {cards.map((card, i) => (
+        <ReelsCard
+          key={card.titleId}
+          episode={card.episodes[card.caughtUp ? card.episodes.length - 1 : card.currentIndex]}
+          caughtUp={card.caughtUp}
+          onMarkWatched={() => markWatched(card.titleId)}
+          index={i}
+          total={cards.length}
+        />
+      ))}
+
+      {/* Sentinel for loop detection */}
+      <div ref={sentinelRef} className="snap-start h-dvh w-full flex items-center justify-center">
+        <p className="text-gray-600 text-sm">Scrolling back to start...</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Introduces a new full-screen "Reels" page that displays unwatched episodes in a vertical scrolling interface similar to social media reels. Users can browse through episodes, mark them as watched, and navigate using keyboard shortcuts or mouse scrolling.

## Key Changes
- **New ReelsPage component** (`frontend/src/pages/ReelsPage.tsx`):
  - Displays unwatched episodes grouped by show with vertical snap scrolling
  - Implements infinite loop behavior (scrolls back to top when reaching the end)
  - Supports keyboard navigation (arrow keys and vim-style j/k keys)
  - Tracks watched episodes and advances to the next unwatched episode per show
  - Includes loading, error, and "all caught up" states

- **New ReelsCard component** (`frontend/src/components/ReelsCard.tsx`):
  - Full-screen card displaying episode details (title, season/episode number, overview)
  - Shows streaming provider icons for available services
  - "Mark as Watched" button with visual feedback
  - "All caught up" state when user has watched all episodes for a show
  - Displays position indicator (e.g., "3 / 10")

- **Updated App.tsx**:
  - Added `/reels` route with authentication requirement
  - Added "Reels" navigation link in both desktop and mobile menus
  - Imported Clapperboard icon for the reels navigation item

- **Updated HomePage.tsx**:
  - Added "Reels" link next to "Unwatched" section header
  - Allows quick access to full-screen reels view from the home page

- **Test suite** (`frontend/src/pages/ReelsPage.test.ts`):
  - Comprehensive tests for `getFirstUnwatchedPerShow` function
  - Tests episode grouping, sorting, and state advancement logic

## Notable Implementation Details
- Episodes are grouped by show and sorted by season/episode number
- State management handles optimistic updates with rollback on API failure
- Intersection Observer API used for infinite scroll loop detection
- Snap scrolling ensures full-screen card alignment
- Keyboard shortcuts (↑/↓, j/k) for hands-free navigation
- Lazy loading for images to optimize performance

https://claude.ai/code/session_014MyURg7QPoh43r9i42qnxM