### PR TITLE
Remove password from logs, display in console instead

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -39,7 +39,8 @@ if (getUserCount() === 0) {
   const hash = await Bun.password.hash(password);
   const adminId = createUser("admin", hash, "Admin", "local", undefined, true);
   migrateTrackedData(adminId);
-  logger.info("Admin account created", { username: "admin", password });
+  logger.info("Admin account created", { username: "admin" });
+  console.log(`\n  Default admin password: ${password}\n  Change it after first login.\n`);
 }
 
 const app = new Hono<AppEnv>();


### PR DESCRIPTION
## Summary
Improved security by removing the admin password from server logs and displaying it directly in the console output during initial setup.

## Key Changes
- Removed `password` field from the logger info call when admin account is created
- Added console output to display the default admin password and a reminder to change it after first login
- Password is now only visible in the console during server startup, not persisted in logs

## Implementation Details
The password is still generated and used for account creation, but is no longer included in structured logging output. Instead, it's printed directly to the console with helpful context about changing it after the first login. This reduces the risk of sensitive credentials being exposed through log aggregation systems while still making the initial password accessible to administrators during setup.

https://claude.ai/code/session_01CBXKaeg8M6wNJ391juz7Lo