### PR TITLE
Make CORS configuration explicit and configurable via env var

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -34,6 +34,9 @@ export const CONFIG = {
   OIDC_ADMIN_CLAIM: process.env.OIDC_ADMIN_CLAIM || "",
   OIDC_ADMIN_VALUE: process.env.OIDC_ADMIN_VALUE || "",
 
+  // CORS
+  CORS_ORIGIN: process.env.CORS_ORIGIN || "",
+
   // Sentry
   SENTRY_DSN: process.env.SENTRY_DSN || "",
 };

--- a/server/cors.test.ts
+++ b/server/cors.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "bun:test";
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+
+function createApp(corsOrigin: string) {
+  const app = new Hono();
+  if (corsOrigin) {
+    const origins = corsOrigin
+      .split(",")
+      .map((o) => o.trim())
+      .filter(Boolean);
+    app.use(
+      "/api/*",
+      cors({
+        origin: origins,
+        credentials: true,
+      }),
+    );
+  }
+  app.get("/api/test", (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe("CORS configuration", () => {
+  it("sends no CORS headers when CORS_ORIGIN is empty", async () => {
+    const app = createApp("");
+    const res = await app.request("/api/test", {
+      headers: { Origin: "https://evil.example.com" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+  });
+
+  it("allows a matching origin", async () => {
+    const app = createApp("https://myapp.example.com");
+    const res = await app.request("/api/test", {
+      headers: { Origin: "https://myapp.example.com" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://myapp.example.com",
+    );
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+  });
+
+  it("rejects a non-matching origin", async () => {
+    const app = createApp("https://myapp.example.com");
+    const res = await app.request("/api/test", {
+      headers: { Origin: "https://evil.example.com" },
+    });
+    expect(res.status).toBe(200);
+    // Hono cors returns empty string for non-matching origins
+    const acao = res.headers.get("Access-Control-Allow-Origin");
+    expect(!acao || acao === "").toBe(true);
+  });
+
+  it("supports comma-separated multiple origins", async () => {
+    const app = createApp(
+      "https://app1.example.com, https://app2.example.com",
+    );
+
+    const res1 = await app.request("/api/test", {
+      headers: { Origin: "https://app1.example.com" },
+    });
+    expect(res1.headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://app1.example.com",
+    );
+
+    const res2 = await app.request("/api/test", {
+      headers: { Origin: "https://app2.example.com" },
+    });
+    expect(res2.headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://app2.example.com",
+    );
+
+    const res3 = await app.request("/api/test", {
+      headers: { Origin: "https://other.example.com" },
+    });
+    const acao = res3.headers.get("Access-Control-Allow-Origin");
+    expect(!acao || acao === "").toBe(true);
+  });
+
+  it("handles preflight OPTIONS requests with allowed origin", async () => {
+    const app = createApp("https://myapp.example.com");
+    const res = await app.request("/api/test", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://myapp.example.com",
+        "Access-Control-Request-Method": "POST",
+      },
+    });
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://myapp.example.com",
+    );
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -54,8 +54,18 @@ app.onError((err, c) => {
   return c.json({ error: "Internal server error" }, 500);
 });
 
-// CORS for dev
-app.use("/api/*", cors());
+// CORS — restricted to explicit origins via CORS_ORIGIN env var (comma-separated).
+// When not set, no CORS headers are sent (same-origin policy applies).
+if (CONFIG.CORS_ORIGIN) {
+  const origins = CONFIG.CORS_ORIGIN.split(",").map((o) => o.trim()).filter(Boolean);
+  app.use(
+    "/api/*",
+    cors({
+      origin: origins,
+      credentials: true,
+    }),
+  );
+}
 
 // Request logging
 app.use("/api/*", requestLogger());


### PR DESCRIPTION
## Summary
Replace the permissive default CORS configuration with an explicit, environment-variable-driven approach that restricts cross-origin requests to explicitly allowed origins.

## Key Changes
- **Added `CORS_ORIGIN` environment variable** to `server/config.ts` for configuring allowed origins (comma-separated list)
- **Updated CORS middleware** in `server/index.ts` to:
  - Only enable CORS when `CORS_ORIGIN` is explicitly set
  - Parse comma-separated origins and trim whitespace
  - Enable credentials support for authenticated requests
  - Default to same-origin policy when not configured
- **Added comprehensive test suite** (`server/cors.test.ts`) covering:
  - No CORS headers when origin is not configured
  - Matching origin acceptance with proper headers
  - Non-matching origin rejection
  - Multiple comma-separated origins support
  - Preflight OPTIONS request handling

## Implementation Details
- When `CORS_ORIGIN` is empty/unset, no CORS middleware is applied, enforcing browser same-origin policy
- Origins are parsed from a comma-separated string with automatic trimming to handle formatting variations
- Credentials are enabled to support authentication tokens in cross-origin requests
- Tests use Hono's built-in test utilities and Bun's test runner

https://claude.ai/code/session_01EfF6FhiRTgbs1g4AGvYyhz