### PR TITLE
Add request timeout handling to TMDB API client

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -18,6 +18,7 @@ export const CONFIG = {
   TMDB_API_KEY: process.env.TMDB_API_KEY || "",
   TMDB_BASE_URL: "https://api.themoviedb.org/3",
   TMDB_IMAGE_BASE_URL: "https://image.tmdb.org/t/p",
+  TMDB_API_TIMEOUT_MS: Number(process.env.TMDB_API_TIMEOUT_MS) || 15000,
   EPISODE_SYNC_DELAY_MS: 500,
   SYNC_TITLES_CRON: process.env.SYNC_TITLES_CRON || "0 3 * * *",
   SYNC_EPISODES_CRON: process.env.SYNC_EPISODES_CRON || "30 3 * * *",

--- a/server/tmdb/client.test.ts
+++ b/server/tmdb/client.test.ts
@@ -1,0 +1,97 @@
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+
+// Mock tracing to just call the function directly
+mock.module("../tracing", () => ({
+  traceHttp: (_method: string, _url: string, fn: () => Promise<unknown>) => fn(),
+}));
+
+// Mock config with a short timeout for testing
+mock.module("../config", () => ({
+  CONFIG: {
+    TMDB_BASE_URL: "https://api.themoviedb.org/3",
+    TMDB_API_KEY: "test-key",
+    TMDB_API_TIMEOUT_MS: 100,
+    COUNTRY: "US",
+    LANGUAGE: "en",
+    TMDB_IMAGE_BASE_URL: "https://image.tmdb.org/t/p",
+  },
+}));
+
+// Import after mocks are set up
+const { searchMulti } = await import("./client");
+
+describe("tmdbRequest timeout", () => {
+  beforeEach(() => {
+    // Reset global fetch mock between tests
+    globalThis.fetch = globalThis.fetch;
+  });
+
+  test("aborts request when timeout is exceeded", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      // Wait longer than the 100ms timeout
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      // If signal wasn't aborted, return a response
+      if (init?.signal?.aborted) {
+        throw new DOMException("The operation was aborted.", "AbortError");
+      }
+      return new Response(JSON.stringify({ results: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    try {
+      await expect(searchMulti("test")).rejects.toThrow();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("passes abort signal to fetch", async () => {
+    let receivedSignal: AbortSignal | undefined;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      receivedSignal = init?.signal ?? undefined;
+      return new Response(JSON.stringify({ results: [], total_pages: 1, total_results: 0, page: 1 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    try {
+      await searchMulti("test");
+      expect(receivedSignal).toBeDefined();
+      expect(receivedSignal).toBeInstanceOf(AbortSignal);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("completes successfully when response is fast", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      return new Response(
+        JSON.stringify({ results: [{ id: 1 }], total_pages: 1, total_results: 1, page: 1 }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }) as unknown as typeof fetch;
+
+    try {
+      const result = await searchMulti("test");
+      expect(result.results).toHaveLength(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("throws on non-ok response", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      return new Response("Not Found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    try {
+      await expect(searchMulti("test")).rejects.toThrow("TMDB API error 404: Not Found");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/server/tmdb/client.ts
+++ b/server/tmdb/client.ts
@@ -28,17 +28,24 @@ async function tmdbRequest<T>(path: string, params?: Record<string, string>): Pr
     }
   }
   return traceHttp("GET", url.toString(), async () => {
-    const res = await fetch(url.toString(), {
-      headers: {
-        Authorization: `Bearer ${CONFIG.TMDB_API_KEY}`,
-        "Content-Type": "application/json",
-      },
-    });
-    if (!res.ok) {
-      const body = await res.text();
-      throw new Error(`TMDB API error ${res.status}: ${body}`);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), CONFIG.TMDB_API_TIMEOUT_MS);
+    try {
+      const res = await fetch(url.toString(), {
+        headers: {
+          Authorization: `Bearer ${CONFIG.TMDB_API_KEY}`,
+          "Content-Type": "application/json",
+        },
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        const body = await res.text();
+        throw new Error(`TMDB API error ${res.status}: ${body}`);
+      }
+      return res.json() as Promise<T>;
+    } finally {
+      clearTimeout(timeout);
     }
-    return res.json() as Promise<T>;
   });
 }
 


### PR DESCRIPTION
## Summary
This PR adds configurable timeout handling to TMDB API requests to prevent indefinite hangs and improve reliability.

## Key Changes
- **Added timeout configuration**: New `TMDB_API_TIMEOUT_MS` config option (defaults to 15 seconds) to control request timeout duration
- **Implemented AbortController**: Modified `tmdbRequest()` to use `AbortController` with a timeout that aborts requests exceeding the configured duration
- **Proper cleanup**: Added try/finally block to ensure timeout is cleared regardless of success or failure
- **Comprehensive test coverage**: Added 4 test cases covering:
  - Request abortion when timeout is exceeded
  - Abort signal is properly passed to fetch
  - Successful completion when response is fast
  - Error handling for non-ok responses

## Implementation Details
- The timeout is set via `setTimeout()` which triggers `controller.abort()` if the request takes too long
- The abort signal is passed to the fetch `RequestInit` options
- Timeout cleanup is guaranteed via finally block to prevent memory leaks
- Tests use Bun's test framework with mocked config and tracing modules for isolation

https://claude.ai/code/session_01CrXE6fYi8268kf9rJSxMPc