### PR TITLE
Add rate limiting middleware to API endpoints

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -7,6 +7,7 @@ import { CONFIG } from "./config";
 import { getDb, migrateTrackedData } from "./db/schema";
 import { getUserCount, createUser, deleteExpiredSessions } from "./db/repository";
 import { optionalAuth, requireAuth, requireAdmin } from "./middleware/auth";
+import { rateLimiter } from "./middleware/rate-limit";
 import syncRoutes from "./routes/sync";
 import titlesRoutes from "./routes/titles";
 import searchRoutes from "./routes/search";
@@ -71,6 +72,9 @@ app.use("/api/titles/*", optionalAuth);
 app.use("/api/titles", optionalAuth);
 app.route("/api/titles", titlesRoutes);
 
+// Rate limit search: 30 requests per minute
+app.use("/api/search/*", rateLimiter({ limit: 30, windowMs: 60_000 }));
+app.use("/api/search", rateLimiter({ limit: 30, windowMs: 60_000 }));
 app.use("/api/search/*", optionalAuth);
 app.use("/api/search", optionalAuth);
 app.route("/api/search", searchRoutes);
@@ -115,6 +119,8 @@ app.use("/api/details", optionalAuth);
 app.route("/api/details", detailsRoutes);
 
 // Sync (public — typically triggered by cron)
+app.use("/api/sync/*", rateLimiter({ limit: 5, windowMs: 60_000 }));
+app.use("/api/sync", rateLimiter({ limit: 5, windowMs: 60_000 }));
 app.route("/api/sync", syncRoutes);
 
 // Episodes (optionalAuth for upcoming, sync is public)

--- a/server/middleware/rate-limit.test.ts
+++ b/server/middleware/rate-limit.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "bun:test";
+import { Hono } from "hono";
+import { rateLimiter } from "./rate-limit";
+import type { AppEnv } from "../types";
+
+function createApp(limit: number, windowMs: number) {
+  const app = new Hono<AppEnv>();
+  app.use("/test/*", rateLimiter({ limit, windowMs }));
+  app.get("/test/hello", (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe("rateLimiter", () => {
+  it("allows requests under the limit", async () => {
+    const app = createApp(3, 60_000);
+
+    for (let i = 0; i < 3; i++) {
+      const res = await app.request("/test/hello");
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("returns 429 when limit is exceeded", async () => {
+    const app = createApp(2, 60_000);
+
+    await app.request("/test/hello");
+    await app.request("/test/hello");
+
+    const res = await app.request("/test/hello");
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe("Too many requests");
+    expect(res.headers.get("Retry-After")).toBe("60");
+  });
+
+  it("uses x-forwarded-for to differentiate clients", async () => {
+    const app = createApp(1, 60_000);
+
+    const res1 = await app.request("/test/hello", {
+      headers: { "x-forwarded-for": "1.1.1.1" },
+    });
+    expect(res1.status).toBe(200);
+
+    const res2 = await app.request("/test/hello", {
+      headers: { "x-forwarded-for": "2.2.2.2" },
+    });
+    expect(res2.status).toBe(200);
+
+    // First client is now rate limited
+    const res3 = await app.request("/test/hello", {
+      headers: { "x-forwarded-for": "1.1.1.1" },
+    });
+    expect(res3.status).toBe(429);
+  });
+
+  it("refills tokens over time", async () => {
+    const app = new Hono<AppEnv>();
+    // Use a very short window so tokens refill quickly
+    app.use("/test/*", rateLimiter({ limit: 1, windowMs: 50 }));
+    app.get("/test/hello", (c) => c.json({ ok: true }));
+
+    const res1 = await app.request("/test/hello");
+    expect(res1.status).toBe(200);
+
+    const res2 = await app.request("/test/hello");
+    expect(res2.status).toBe(429);
+
+    // Wait for tokens to refill
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    const res3 = await app.request("/test/hello");
+    expect(res3.status).toBe(200);
+  });
+
+  it("supports custom keyGenerator", async () => {
+    const app = new Hono<AppEnv>();
+    app.use(
+      "/test/*",
+      rateLimiter({
+        limit: 1,
+        windowMs: 60_000,
+        keyGenerator: () => "same-key",
+      })
+    );
+    app.get("/test/hello", (c) => c.json({ ok: true }));
+
+    const res1 = await app.request("/test/hello", {
+      headers: { "x-forwarded-for": "1.1.1.1" },
+    });
+    expect(res1.status).toBe(200);
+
+    // Different IP but same key → rate limited
+    const res2 = await app.request("/test/hello", {
+      headers: { "x-forwarded-for": "2.2.2.2" },
+    });
+    expect(res2.status).toBe(429);
+  });
+});

--- a/server/middleware/rate-limit.ts
+++ b/server/middleware/rate-limit.ts
@@ -1,0 +1,73 @@
+import { createMiddleware } from "hono/factory";
+import type { AppEnv } from "../types";
+import { logger } from "../logger";
+
+const log = logger.child({ module: "rate-limit" });
+
+interface TokenBucket {
+  tokens: number;
+  lastRefill: number;
+}
+
+interface RateLimitOptions {
+  /** Maximum number of requests allowed in the window */
+  limit: number;
+  /** Window duration in milliseconds */
+  windowMs: number;
+  /** Function to derive a key from the request (defaults to x-forwarded-for or "anonymous") */
+  keyGenerator?: (c: { req: { header: (name: string) => string | undefined } }) => string;
+}
+
+/**
+ * In-memory token bucket rate limiter.
+ * Each call creates an independent store, so different routes can have different limits.
+ */
+export function rateLimiter(options: RateLimitOptions) {
+  const { limit, windowMs } = options;
+  const keyGenerator =
+    options.keyGenerator ??
+    ((c) => c.req.header("x-forwarded-for") ?? "anonymous");
+
+  const buckets = new Map<string, TokenBucket>();
+
+  // Periodically clean up stale buckets to prevent memory leaks
+  const cleanupInterval = setInterval(() => {
+    const now = Date.now();
+    for (const [key, bucket] of buckets) {
+      if (now - bucket.lastRefill > windowMs * 2) {
+        buckets.delete(key);
+      }
+    }
+  }, windowMs * 2);
+
+  // Allow the timer to not block process exit
+  if (cleanupInterval.unref) {
+    cleanupInterval.unref();
+  }
+
+  return createMiddleware<AppEnv>(async (c, next) => {
+    const key = keyGenerator(c);
+    const now = Date.now();
+
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = { tokens: limit, lastRefill: now };
+      buckets.set(key, bucket);
+    }
+
+    // Refill tokens based on elapsed time
+    const elapsed = now - bucket.lastRefill;
+    const tokensToAdd = (elapsed / windowMs) * limit;
+    bucket.tokens = Math.min(limit, bucket.tokens + tokensToAdd);
+    bucket.lastRefill = now;
+
+    if (bucket.tokens < 1) {
+      log.warn("Rate limit exceeded", { key, path: c.req.path });
+      c.header("Retry-After", String(Math.ceil(windowMs / 1000)));
+      return c.json({ error: "Too many requests" }, 429);
+    }
+
+    bucket.tokens -= 1;
+    await next();
+  });
+}


### PR DESCRIPTION
## Summary
Implements a token bucket-based rate limiter middleware to protect API endpoints from abuse. The rate limiter is applied to search and sync endpoints with configurable request limits per time window.

## Key Changes
- **New rate limiter middleware** (`server/middleware/rate-limit.ts`):
  - Token bucket algorithm implementation with automatic token refill over time
  - Configurable request limits and time windows
  - Client differentiation via `x-forwarded-for` header (with fallback to "anonymous")
  - Support for custom key generation functions
  - Automatic cleanup of stale buckets to prevent memory leaks
  - Returns 429 status with `Retry-After` header when limit exceeded

- **Comprehensive test suite** (`server/middleware/rate-limit.test.ts`):
  - Tests for requests under/over limits
  - Client differentiation via IP headers
  - Token refill behavior over time
  - Custom key generator support

- **Applied rate limiting to API endpoints** (`server/index.ts`):
  - Search endpoints: 30 requests per minute
  - Sync endpoints: 5 requests per minute

## Implementation Details
- Uses in-memory Map for token bucket storage (independent per middleware instance)
- Cleanup interval set to 2x the window duration to prevent unbounded memory growth
- Timer is marked as non-blocking (`unref()`) to not prevent process exit
- Rate limiting applied before authentication middleware to fail fast on abuse
- Graceful error responses with appropriate HTTP status codes and headers

https://claude.ai/code/session_012SzDQy7cN7wK3GchrQvwUn