### PR TITLE
Add error handling for corrupted notifier config JSON

### DIFF
--- a/server/db/repository.test.ts
+++ b/server/db/repository.test.ts
@@ -36,8 +36,13 @@ import {
   getSettingsByPrefix,
   getOidcConfig,
   isOidcConfigured,
+  createNotifier,
+  getNotifiersByUser,
+  getNotifierById,
+  getDueNotifiers,
 } from "./repository";
 import { CONFIG } from "../config";
+import { getRawDb } from "./schema";
 
 beforeEach(() => {
   setupTestDb();
@@ -624,5 +629,60 @@ describe("getProviders", () => {
     expect(providers).toHaveLength(2);
     expect(providers[0].name).toBe("Disney Plus");
     expect(providers[1].name).toBe("Netflix");
+  });
+});
+
+// ─── Notifier JSON.parse error handling ─────────────────────────────────────
+
+describe("notifier config parsing", () => {
+  function createTestUser() {
+    return createUser("testuser", "hash123");
+  }
+
+  function corruptNotifierConfig(notifierId: string) {
+    const raw = getRawDb();
+    raw.prepare("UPDATE notifiers SET config = '{invalid json' WHERE id = ?").run(notifierId);
+  }
+
+  it("getNotifiersByUser returns empty config for corrupted JSON", () => {
+    const userId = createTestUser();
+    const id = createNotifier(userId, "email", "Test", { url: "http://example.com" }, "09:00", "UTC");
+    corruptNotifierConfig(id);
+
+    const notifiers = getNotifiersByUser(userId);
+    expect(notifiers).toHaveLength(1);
+    expect(notifiers[0].config).toEqual({});
+  });
+
+  it("getNotifierById returns empty config for corrupted JSON", () => {
+    const userId = createTestUser();
+    const id = createNotifier(userId, "email", "Test", { url: "http://example.com" }, "09:00", "UTC");
+    corruptNotifierConfig(id);
+
+    const notifier = getNotifierById(id, userId);
+    expect(notifier).not.toBeNull();
+    expect(notifier!.config).toEqual({});
+  });
+
+  it("getDueNotifiers returns empty config for corrupted JSON", () => {
+    const userId = createTestUser();
+    const id = createNotifier(userId, "email", "Test", { url: "http://example.com" }, "09:00", "UTC");
+    corruptNotifierConfig(id);
+
+    const timesByTimezone = new Map([
+      ["UTC", { time: "09:00", date: "2026-03-15" }],
+    ]);
+    const due = getDueNotifiers(timesByTimezone);
+    expect(due).toHaveLength(1);
+    expect(due[0].config).toEqual({});
+  });
+
+  it("getNotifiersByUser parses valid config correctly", () => {
+    const userId = createTestUser();
+    createNotifier(userId, "email", "Test", { url: "http://example.com" }, "09:00", "UTC");
+
+    const notifiers = getNotifiersByUser(userId);
+    expect(notifiers).toHaveLength(1);
+    expect(notifiers[0].config).toEqual({ url: "http://example.com" });
   });
 });

--- a/server/db/repository.ts
+++ b/server/db/repository.ts
@@ -1,6 +1,8 @@
 import { eq, and, or, like, sql, gte, lt, desc, asc, exists, notExists, count, inArray } from "drizzle-orm";
 import { logger } from "../logger";
 import { getDb } from "./schema";
+
+const log = logger.child({ module: "repository" });
 import {
   titles,
   providers,
@@ -1196,11 +1198,20 @@ export function getNotifiersByUser(userId: string) {
       .where(eq(notifiers.userId, userId))
       .orderBy(asc(notifiers.createdAt))
       .all()
-      .map((row) => ({
-        ...row,
-        config: JSON.parse(row.config),
-        enabled: Boolean(row.enabled),
-      }));
+      .map((row) => {
+        let config: Record<string, string>;
+        try {
+          config = JSON.parse(row.config);
+        } catch {
+          log.warn("Failed to parse notifier config", { id: row.id });
+          config = {};
+        }
+        return {
+          ...row,
+          config,
+          enabled: Boolean(row.enabled),
+        };
+      });
   });
 }
 
@@ -1226,9 +1237,16 @@ export function getNotifierById(id: string, userId: string) {
       .get();
 
     if (!row) return null;
+    let config: Record<string, string>;
+    try {
+      config = JSON.parse(row.config);
+    } catch {
+      log.warn("Failed to parse notifier config", { id: row.id });
+      config = {};
+    }
     return {
       ...row,
-      config: JSON.parse(row.config),
+      config,
       enabled: Boolean(row.enabled),
     };
   });
@@ -1264,11 +1282,20 @@ export function getDueNotifiers(
         if (!tzInfo) return false;
         return n.notify_time === tzInfo.time && n.last_sent_date !== tzInfo.date;
       })
-      .map((n) => ({
-        ...n,
-        config: JSON.parse(n.config),
-        todayDate: timesByTimezone.get(n.timezone)!.date,
-      }));
+      .map((n) => {
+        let config: Record<string, string>;
+        try {
+          config = JSON.parse(n.config);
+        } catch {
+          log.warn("Failed to parse notifier config", { id: n.id });
+          config = {};
+        }
+        return {
+          ...n,
+          config,
+          todayDate: timesByTimezone.get(n.timezone)!.date,
+        };
+      });
   });
 }
 


### PR DESCRIPTION
## Summary
This PR adds robust error handling for cases where notifier configuration JSON is corrupted or invalid in the database. Instead of crashing when parsing fails, the functions now gracefully fall back to an empty config object and log a warning.

## Key Changes
- Added try-catch blocks in three notifier retrieval functions to handle JSON parsing errors:
  - `getNotifiersByUser()` - Returns empty config when JSON parsing fails
  - `getNotifierById()` - Returns empty config when JSON parsing fails
  - `getDueNotifiers()` - Returns empty config when JSON parsing fails
- Added a child logger instance (`log`) to the repository module for better error tracking
- Added comprehensive test coverage in `repository.test.ts` to verify:
  - All three functions handle corrupted JSON gracefully
  - Valid JSON configs are still parsed correctly
  - Corrupted configs return empty objects instead of throwing errors

## Implementation Details
- When JSON parsing fails, a warning is logged with the notifier ID for debugging purposes
- The fallback behavior ensures the application continues to function even with corrupted data
- Tests use `getRawDb()` to directly corrupt notifier configs in the database to simulate real-world scenarios

https://claude.ai/code/session_017Ck9vqfVZmtj3yxNyiSmyH