### PR TITLE
Extract filter loading logic into reusable loadFilters function

### DIFF
--- a/frontend/src/components/NewReleases.test.ts
+++ b/frontend/src/components/NewReleases.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+const mockProviders = [
+  { id: 1, name: "Netflix", technical_name: "netflix", icon_url: "" },
+];
+
+beforeEach(() => {
+  mock.restore();
+});
+
+describe("loadFilters", () => {
+  it("returns all filter data when all API calls succeed", async () => {
+    mock.module("../api", () => ({
+      getGenres: () => Promise.resolve({ genres: ["Action", "Drama"] }),
+      getProviders: () => Promise.resolve({ providers: mockProviders }),
+      getLanguages: () => Promise.resolve({ languages: ["en", "fr"] }),
+    }));
+
+    const { loadFilters } = await import("./loadFilters");
+    const result = await loadFilters();
+
+    expect(result.genres).toEqual(["Action", "Drama"]);
+    expect(result.providers).toEqual(mockProviders);
+    expect(result.languages).toEqual(["en", "fr"]);
+  });
+
+  it("returns empty genres when getGenres fails", async () => {
+    mock.module("../api", () => ({
+      getGenres: () => Promise.reject(new Error("Network error")),
+      getProviders: () => Promise.resolve({ providers: mockProviders }),
+      getLanguages: () => Promise.resolve({ languages: ["en"] }),
+    }));
+
+    const { loadFilters } = await import("./loadFilters");
+    const result = await loadFilters();
+
+    expect(result.genres).toEqual([]);
+    expect(result.providers).toEqual(mockProviders);
+    expect(result.languages).toEqual(["en"]);
+  });
+
+  it("returns empty providers when getProviders fails", async () => {
+    mock.module("../api", () => ({
+      getGenres: () => Promise.resolve({ genres: ["Action"] }),
+      getProviders: () => Promise.reject(new Error("Server error")),
+      getLanguages: () => Promise.resolve({ languages: ["en"] }),
+    }));
+
+    const { loadFilters } = await import("./loadFilters");
+    const result = await loadFilters();
+
+    expect(result.genres).toEqual(["Action"]);
+    expect(result.providers).toEqual([]);
+    expect(result.languages).toEqual(["en"]);
+  });
+
+  it("returns empty languages when getLanguages fails", async () => {
+    mock.module("../api", () => ({
+      getGenres: () => Promise.resolve({ genres: ["Action"] }),
+      getProviders: () => Promise.resolve({ providers: mockProviders }),
+      getLanguages: () => Promise.reject(new Error("Timeout")),
+    }));
+
+    const { loadFilters } = await import("./loadFilters");
+    const result = await loadFilters();
+
+    expect(result.genres).toEqual(["Action"]);
+    expect(result.providers).toEqual(mockProviders);
+    expect(result.languages).toEqual([]);
+  });
+
+  it("returns all empty arrays when all API calls fail", async () => {
+    mock.module("../api", () => ({
+      getGenres: () => Promise.reject(new Error("fail")),
+      getProviders: () => Promise.reject(new Error("fail")),
+      getLanguages: () => Promise.reject(new Error("fail")),
+    }));
+
+    const { loadFilters } = await import("./loadFilters");
+    const result = await loadFilters();
+
+    expect(result.genres).toEqual([]);
+    expect(result.providers).toEqual([]);
+    expect(result.languages).toEqual([]);
+  });
+});

--- a/frontend/src/components/NewReleases.tsx
+++ b/frontend/src/components/NewReleases.tsx
@@ -3,6 +3,7 @@ import * as api from "../api";
 import type { Title, Provider } from "../types";
 import TitleList from "./TitleList";
 import FilterBar from "./FilterBar";
+import { loadFilters } from "./loadFilters";
 
 interface Props {
   type: string[];
@@ -45,13 +46,11 @@ export default function NewReleases({
   const [languages, setLanguages] = useState<string[]>([]);
 
   useEffect(() => {
-    Promise.all([api.getGenres(), api.getProviders(), api.getLanguages()]).then(
-      ([g, p, l]) => {
-        setGenres(g.genres);
-        setProviders(p.providers);
-        setLanguages(l.languages);
-      }
-    );
+    loadFilters().then(({ genres, providers, languages }) => {
+      setGenres(genres);
+      setProviders(providers);
+      setLanguages(languages);
+    });
   }, []);
 
   const fetchTitles = useCallback(async () => {

--- a/frontend/src/components/loadFilters.ts
+++ b/frontend/src/components/loadFilters.ts
@@ -1,0 +1,28 @@
+import * as api from "../api";
+import type { Provider } from "../types";
+
+export async function loadFilters(): Promise<{
+  genres: string[];
+  providers: Provider[];
+  languages: string[];
+}> {
+  const [genresResult, providersResult, languagesResult] =
+    await Promise.allSettled([
+      api.getGenres(),
+      api.getProviders(),
+      api.getLanguages(),
+    ]);
+
+  return {
+    genres:
+      genresResult.status === "fulfilled" ? genresResult.value.genres : [],
+    providers:
+      providersResult.status === "fulfilled"
+        ? providersResult.value.providers
+        : [],
+    languages:
+      languagesResult.status === "fulfilled"
+        ? languagesResult.value.languages
+        : [],
+  };
+}


### PR DESCRIPTION
## Summary
Refactored the filter loading logic in the NewReleases component into a separate, testable `loadFilters` function that handles API calls with graceful error handling.

## Key Changes
- Created new `loadFilters.ts` module that encapsulates the logic for fetching genres, providers, and languages from the API
- Implemented error resilience using `Promise.allSettled()` to ensure partial failures don't prevent the component from rendering (returns empty arrays for failed requests)
- Updated `NewReleases.tsx` to use the new `loadFilters()` function instead of directly calling individual API methods
- Added comprehensive test suite (`NewReleases.test.ts`) covering success cases and all failure scenarios

## Implementation Details
- The `loadFilters()` function returns an object with `genres`, `providers`, and `languages` arrays
- Uses `Promise.allSettled()` instead of `Promise.all()` to handle individual API failures gracefully
- Each failed API call defaults to an empty array rather than rejecting the entire operation
- Tests verify both successful data loading and resilience to individual API failures

https://claude.ai/code/session_01G7DmVJyHDp8PvCqKHBAzqa