### PR TITLE
Add error handling and retry for pagination in CategoryBrowse

### DIFF
--- a/frontend/src/components/CategoryBrowse.tsx
+++ b/frontend/src/components/CategoryBrowse.tsx
@@ -199,7 +199,18 @@ export default function CategoryBrowse({
             <p className="text-sm text-gray-500">{totalResults} result{totalResults !== 1 ? "s" : ""}</p>
           )}
           <TitleList titles={hideTracked ? titles.filter((t) => !t.is_tracked) : titles} emptyMessage="No titles found." />
-          {page < totalPages && (
+          {error && (
+            <div className="text-center py-4 text-red-400">
+              <p>{error}</p>
+              <button
+                onClick={() => fetchTitles(page + 1, true)}
+                className="mt-2 text-sm underline hover:text-red-300"
+              >
+                Retry
+              </button>
+            </div>
+          )}
+          {!error && page < totalPages && (
             <div ref={sentinelRef} className="text-center py-4">
               {loadingMore && (
                 <div className="text-gray-500 text-sm">Loading...</div>


### PR DESCRIPTION
## Summary
Added error handling and retry functionality to the pagination feature in CategoryBrowse component. When a pagination request fails, users now see an error message with a retry button instead of silently failing or showing the load-more sentinel.

## Key Changes
- Display error message when pagination fails, with a red-styled error container
- Add "Retry" button that allows users to attempt loading the next page again
- Prevent the load-more sentinel from appearing when an error is present
- Only show pagination controls when there's no error and more pages are available

## Implementation Details
- Error state is checked before rendering the infinite scroll sentinel
- Retry button calls `fetchTitles(page + 1, true)` to attempt loading the next page
- Error message and retry button are styled consistently with the component's design (red-400 text with hover effects)
- The conditional logic ensures error UI and loading UI don't appear simultaneously

https://claude.ai/code/session_01KmypvzviwxDQ4FbxM8c9KW