### PR TITLE
Fix stale closure in markWatched callback during rapid swiping

### DIFF
--- a/frontend/src/pages/ReelsPage.tsx
+++ b/frontend/src/pages/ReelsPage.tsx
@@ -45,6 +45,8 @@ export default function ReelsPage() {
   const scrollRef = useRef<HTMLDivElement>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
   const [cards, setCards] = useState<ShowCard[]>([]);
+  const cardsRef = useRef<ShowCard[]>([]);
+  cardsRef.current = cards;
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
@@ -102,25 +104,25 @@ export default function ReelsPage() {
   }, []);
 
   const markWatched = useCallback(async (titleId: string) => {
-    setCards((prev) => {
-      return prev.map((card) => {
-        if (card.titleId !== titleId || card.caughtUp) return card;
-        const episode = card.episodes[card.currentIndex];
-        if (!episode) return card;
-
-        const nextIndex = card.currentIndex + 1;
-        if (nextIndex >= card.episodes.length) {
-          return { ...card, caughtUp: true };
-        }
-        return { ...card, currentIndex: nextIndex };
-      });
-    });
-
-    // Find the episode to mark
-    const card = cards.find((c) => c.titleId === titleId);
+    // Read from ref to avoid stale closure when rapid swiping/tapping
+    const card = cardsRef.current.find((c) => c.titleId === titleId);
     if (!card || card.caughtUp) return;
     const episode = card.episodes[card.currentIndex];
     if (!episode) return;
+
+    setCards((prev) => {
+      return prev.map((c) => {
+        if (c.titleId !== titleId || c.caughtUp) return c;
+        const ep = c.episodes[c.currentIndex];
+        if (!ep) return c;
+
+        const nextIndex = c.currentIndex + 1;
+        if (nextIndex >= c.episodes.length) {
+          return { ...c, caughtUp: true };
+        }
+        return { ...c, currentIndex: nextIndex };
+      });
+    });
 
     try {
       await api.watchEpisode(episode.id);
@@ -137,7 +139,7 @@ export default function ReelsPage() {
       );
       console.error("Failed to mark watched:", err);
     }
-  }, [cards]);
+  }, []);
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary
Fixed a stale closure bug in the `markWatched` callback that could cause incorrect behavior when users rapidly swipe or tap through reels. The callback now uses a ref to access the current cards state instead of relying on the stale `cards` dependency.

## Key Changes
- Added `cardsRef` to maintain a current reference to the cards state
- Moved card lookup logic before the `setCards` call to read from the ref instead of the stale closure
- Removed `cards` from the dependency array of `markWatched`, replacing it with an empty array since the ref eliminates the need for it
- Refactored variable names in the state update function for consistency (`card` → `c`, `episode` → `ep`)

## Implementation Details
The issue occurred because `markWatched` was dependent on the `cards` state, but during rapid user interactions, the callback could capture stale card data. By using a ref pattern, the callback now always reads the current cards state at execution time rather than at definition time, ensuring the correct episode is marked as watched even during rapid swiping/tapping sequences.

https://claude.ai/code/session_01D4hjY8NTcoDsNDtnnk2nvE