### PR TITLE
Move OIDC state store from memory to SQLite database

### DIFF
--- a/server/auth/oidc.test.ts
+++ b/server/auth/oidc.test.ts
@@ -3,8 +3,8 @@ import { CONFIG } from "../config";
 CONFIG.DB_PATH = ":memory:";
 
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
-import { exchangeCode, clearDiscoveryCache, getDiscovery } from "./oidc";
-import { setSetting } from "../db/repository";
+import { exchangeCode, clearDiscoveryCache, getDiscovery, generateState, validateState } from "./oidc";
+import { setSetting, createOidcState, consumeOidcState, cleanExpiredOidcStates } from "../db/repository";
 
 // Helper to create a fake JWT with given payload
 function fakeJwt(payload: Record<string, unknown>): string {
@@ -187,5 +187,64 @@ describe("exchangeCode", () => {
 
     expect(result.sub).toBe("user-no-jwt");
     expect(result.claims.groups).toEqual(["admin"]);
+  });
+});
+
+describe("OIDC state store", () => {
+  it("generates and validates a state token", () => {
+    const state = generateState();
+    expect(typeof state).toBe("string");
+    expect(state.length).toBeGreaterThan(0);
+    expect(validateState(state)).toBe(true);
+  });
+
+  it("rejects an unknown state token", () => {
+    expect(validateState("nonexistent")).toBe(false);
+  });
+
+  it("consumes state on validation (single use)", () => {
+    const state = generateState();
+    expect(validateState(state)).toBe(true);
+    expect(validateState(state)).toBe(false);
+  });
+
+  it("rejects expired state tokens", () => {
+    // Directly insert a state with old timestamp
+    const oldState = "expired-state";
+    createOidcState(oldState);
+    // Manually update created_at to 11 minutes ago
+    const { getDb } = require("../db/schema");
+    const db = getDb();
+    const elevenMinutesAgo = Date.now() - 11 * 60 * 1000;
+    db.run(
+      require("drizzle-orm").sql`UPDATE oidc_states SET created_at = ${elevenMinutesAgo} WHERE state = ${oldState}`
+    );
+
+    expect(consumeOidcState(oldState)).toBe(false);
+  });
+
+  it("cleans up expired states", () => {
+    const { getDb } = require("../db/schema");
+    const db = getDb();
+    const elevenMinutesAgo = Date.now() - 11 * 60 * 1000;
+
+    // Insert some expired states directly
+    createOidcState("expired-1");
+    createOidcState("expired-2");
+    db.run(
+      require("drizzle-orm").sql`UPDATE oidc_states SET created_at = ${elevenMinutesAgo}`
+    );
+
+    // Insert a fresh state
+    createOidcState("fresh-1");
+
+    cleanExpiredOidcStates();
+
+    // Expired states should be gone
+    expect(consumeOidcState("expired-1")).toBe(false);
+    expect(consumeOidcState("expired-2")).toBe(false);
+
+    // Fresh state should still be valid
+    expect(consumeOidcState("fresh-1")).toBe(true);
   });
 });

--- a/server/auth/oidc.ts
+++ b/server/auth/oidc.ts
@@ -1,4 +1,4 @@
-import { getOidcConfig } from "../db/repository";
+import { getOidcConfig, createOidcState, consumeOidcState, cleanExpiredOidcStates } from "../db/repository";
 import { traceHttp } from "../tracing";
 
 interface OidcDiscovery {
@@ -32,25 +32,20 @@ export function clearDiscoveryCache() {
   cachedDiscovery = null;
 }
 
-// Simple in-memory state store for OIDC authorization flow
-const stateStore = new Map<string, number>();
+// SQLite-backed state store for OIDC authorization flow
+// Supports multi-instance deployments and avoids memory leak risks
 
 export function generateState(): string {
-  // Clean up old states (older than 10 minutes)
-  const now = Date.now();
-  for (const [key, ts] of stateStore) {
-    if (now - ts > 10 * 60 * 1000) stateStore.delete(key);
-  }
+  // Clean up expired states
+  cleanExpiredOidcStates();
 
   const state = crypto.randomUUID();
-  stateStore.set(state, now);
+  createOidcState(state);
   return state;
 }
 
 export function validateState(state: string): boolean {
-  if (!stateStore.has(state)) return false;
-  stateStore.delete(state);
-  return true;
+  return consumeOidcState(state);
 }
 
 /** Exchange authorization code for tokens and extract user info from id_token */

--- a/server/db/repository.ts
+++ b/server/db/repository.ts
@@ -13,6 +13,7 @@ import {
   tracked,
   watchedEpisodes,
   notifiers,
+  oidcStates,
 } from "./schema";
 import type { ParsedTitle } from "../tmdb/parser";
 import { extractProviders } from "../tmdb/parser";
@@ -1108,6 +1109,39 @@ export function isOidcConfigured(): boolean {
   return traceDbQuery("isOidcConfigured", () => {
     const { issuerUrl, clientId, clientSecret } = getOidcConfig();
     return Boolean(issuerUrl && clientId && clientSecret);
+  });
+}
+
+// ─── OIDC State Store ────────────────────────────────────────────────────────
+
+const OIDC_STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+export function createOidcState(state: string): void {
+  traceDbQuery("createOidcState", () => {
+    const db = getDb();
+    db.insert(oidcStates).values({ state, createdAt: Date.now() }).run();
+  });
+}
+
+export function consumeOidcState(state: string): boolean {
+  return traceDbQuery("consumeOidcState", () => {
+    const db = getDb();
+    const row = db
+      .select()
+      .from(oidcStates)
+      .where(eq(oidcStates.state, state))
+      .get();
+    if (!row) return false;
+    db.delete(oidcStates).where(eq(oidcStates.state, state)).run();
+    return Date.now() - row.createdAt < OIDC_STATE_TTL_MS;
+  });
+}
+
+export function cleanExpiredOidcStates(): void {
+  traceDbQuery("cleanExpiredOidcStates", () => {
+    const db = getDb();
+    const cutoff = Date.now() - OIDC_STATE_TTL_MS;
+    db.delete(oidcStates).where(lt(oidcStates.createdAt, cutoff)).run();
   });
 }
 

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -194,6 +194,11 @@ export const notifiers = sqliteTable(
   ]
 );
 
+export const oidcStates = sqliteTable("oidc_states", {
+  state: text("state").primaryKey(),
+  createdAt: integer("created_at").notNull(),
+});
+
 export const schemaVersion = sqliteTable("schema_version", {
   version: integer("version").primaryKey(),
 });
@@ -253,7 +258,7 @@ export const notifiersRelations = relations(notifiers, ({ one }) => ({
 // ─── Database Instance ──────────────────────────────────────────────────────
 
 const schemaExports = {
-  titles, providers, offers, scores, episodes, users, sessions, settings, tracked, watchedEpisodes, notifiers, schemaVersion,
+  titles, providers, offers, scores, episodes, users, sessions, settings, tracked, watchedEpisodes, notifiers, oidcStates, schemaVersion,
   titlesRelations, providersRelations, offersRelations, scoresRelations, episodesRelations,
   usersRelations, sessionsRelations, trackedRelations, watchedEpisodesRelations, notifiersRelations,
 };
@@ -415,6 +420,13 @@ function initSchema(db: Database) {
   `);
 
   db.run(`
+    CREATE TABLE IF NOT EXISTS oidc_states (
+      state TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL
+    )
+  `);
+
+  db.run(`
     CREATE TABLE IF NOT EXISTS schema_version (
       version INTEGER PRIMARY KEY
     )
@@ -566,6 +578,17 @@ function migrateSchema(db: Database) {
       log.info("Added original_language column to titles table", { version: 6 });
     }
     setSchemaVersion(db, 6);
+  }
+  // Migration v7: Add oidc_states table
+  if (getSchemaVersion(db) < 7) {
+    db.run(`
+      CREATE TABLE IF NOT EXISTS oidc_states (
+        state TEXT PRIMARY KEY,
+        created_at INTEGER NOT NULL
+      )
+    `);
+    log.info("Created oidc_states table", { version: 7 });
+    setSchemaVersion(db, 7);
   }
 }
 


### PR DESCRIPTION
## Summary
Migrates the OIDC authorization state store from an in-memory Map to a SQLite-backed database table. This enables support for multi-instance deployments and eliminates potential memory leak risks from the in-memory implementation.

## Key Changes
- **Database Schema**: Added new `oidc_states` table with `state` (primary key) and `created_at` columns
  - Includes schema migration (v7) to create the table for existing databases
  - Table definition added to both `initSchema()` and `migrateSchema()` functions

- **Repository Functions**: Implemented three new database functions in `repository.ts`:
  - `createOidcState(state)`: Stores a new state token with current timestamp
  - `consumeOidcState(state)`: Retrieves and deletes a state token, returning validity based on TTL
  - `cleanExpiredOidcStates()`: Removes states older than 10 minutes

- **OIDC Module**: Refactored `oidc.ts` to use database-backed state management:
  - `generateState()`: Now calls `createOidcState()` and `cleanExpiredOidcStates()`
  - `validateState()`: Simplified to call `consumeOidcState()`
  - Removed in-memory `stateStore` Map entirely

- **Tests**: Added comprehensive test suite covering:
  - State generation and validation
  - Single-use enforcement (state consumed after first validation)
  - Expiration handling (states older than 10 minutes rejected)
  - Cleanup of expired states while preserving fresh ones

## Implementation Details
- State TTL is set to 10 minutes (`OIDC_STATE_TTL_MS`)
- States are single-use: `consumeOidcState()` deletes the state after retrieval
- Expired state cleanup is performed on each `generateState()` call
- All database operations are traced via `traceDbQuery()` for observability

https://claude.ai/code/session_016JoeT31B8QTVRsCdi43x59