### PR TITLE
Batch fetch offers for multiple titles to improve performance

### DIFF
--- a/server/db/repository.test.ts
+++ b/server/db/repository.test.ts
@@ -6,6 +6,7 @@ import {
   getTitleById,
   getRecentTitles,
   getOffersForTitle,
+  getOffersForTitles,
   searchLocalTitles,
   trackTitle,
   untrackTitle,
@@ -106,6 +107,38 @@ describe("upsertTitles", () => {
     expect(offers[0].provider_name).toBe("Netflix");
   });
 
+  it("batch-fetches offers for multiple titles", () => {
+    upsertTitles([
+      makeParsedTitle({
+        id: "movie-1",
+        title: "Movie One",
+        offers: [makeParsedOffer({ titleId: "movie-1", providerId: 8, providerName: "Netflix" })],
+      }),
+      makeParsedTitle({
+        id: "movie-2",
+        title: "Movie Two",
+        offers: [makeParsedOffer({ titleId: "movie-2", providerId: 337, providerName: "Disney Plus" })],
+      }),
+      makeParsedTitle({
+        id: "movie-3",
+        title: "Movie Three",
+        offers: [],
+      }),
+    ]);
+
+    const offerMap = getOffersForTitles(["movie-1", "movie-2", "movie-3"]);
+    expect(offerMap.get("movie-1")).toHaveLength(1);
+    expect(offerMap.get("movie-1")![0].provider_name).toBe("Netflix");
+    expect(offerMap.get("movie-2")).toHaveLength(1);
+    expect(offerMap.get("movie-2")![0].provider_name).toBe("Disney Plus");
+    expect(offerMap.get("movie-3")).toBeUndefined();
+  });
+
+  it("returns empty map for empty titleIds", () => {
+    const offerMap = getOffersForTitles([]);
+    expect(offerMap.size).toBe(0);
+  });
+
   it("upserts scores", () => {
     upsertTitles([makeParsedTitle({ scores: { imdbScore: 8.0, imdbVotes: 5000, tmdbScore: 7.5 } })]);
     const result = getTitleById("movie-123");
@@ -161,6 +194,29 @@ describe("getRecentTitles", () => {
     const results = getRecentTitles({ daysBack: 0 });
     expect(results).toHaveLength(2);
     expect(results[0].title).toBe("New");
+  });
+
+  it("includes offers via batch fetch", () => {
+    upsertTitles([
+      makeParsedTitle({
+        id: "movie-1",
+        releaseDate: "2025-01-01",
+        offers: [makeParsedOffer({ titleId: "movie-1", providerId: 8, providerName: "Netflix" })],
+      }),
+      makeParsedTitle({
+        id: "movie-2",
+        title: "No Offers",
+        releaseDate: "2025-01-02",
+        offers: [],
+      }),
+    ]);
+    const results = getRecentTitles({ daysBack: 0 });
+    expect(results).toHaveLength(2);
+    const withOffers = results.find((r) => r.id === "movie-1")!;
+    const withoutOffers = results.find((r) => r.id === "movie-2")!;
+    expect(withOffers.offers).toHaveLength(1);
+    expect(withOffers.offers[0].provider_name).toBe("Netflix");
+    expect(withoutOffers.offers).toEqual([]);
   });
 
   it("filters by objectType", () => {

--- a/server/db/repository.ts
+++ b/server/db/repository.ts
@@ -284,11 +284,12 @@ export function getRecentTitles(filters: TitleFilters = {}, userId?: string) {
       .offset(offset)
       .all();
 
+    const offersByTitle = getOffersForTitles(rows.map((r) => r.id));
     return rows.map((row) => ({
       ...row,
       genres: row.genres ? JSON.parse(row.genres) : [],
       is_tracked: Boolean(row.is_tracked),
-      offers: getOffersForTitle(row.id),
+      offers: offersByTitle.get(row.id) ?? [],
     }));
   });
 }
@@ -315,6 +316,33 @@ export function getOffersForTitle(titleId: string) {
       .innerJoin(providers, eq(offers.providerId, providers.id))
       .where(eq(offers.titleId, titleId))
       .all();
+  });
+}
+
+export function getOffersForTitles(titleIds: string[]) {
+  return traceDbQuery("getOffersForTitles", () => {
+    if (titleIds.length === 0) return new Map<string, ReturnType<typeof getOffersForTitle>>();
+    const db = getDb();
+    const allOffers = db
+      .select({
+        id: offers.id,
+        title_id: offers.titleId,
+        provider_id: offers.providerId,
+        monetization_type: offers.monetizationType,
+        presentation_type: offers.presentationType,
+        price_value: offers.priceValue,
+        price_currency: offers.priceCurrency,
+        url: offers.url,
+        available_to: offers.availableTo,
+        provider_name: providers.name,
+        provider_technical_name: providers.technicalName,
+        provider_icon_url: providers.iconUrl,
+      })
+      .from(offers)
+      .innerJoin(providers, eq(offers.providerId, providers.id))
+      .where(inArray(offers.titleId, titleIds))
+      .all();
+    return Map.groupBy(allOffers, (o) => o.title_id);
   });
 }
 
@@ -389,11 +417,12 @@ export function getTrackedTitles(userId: string) {
       .orderBy(desc(tracked.trackedAt))
       .all();
 
+    const offersByTitle = getOffersForTitles(rows.map((r) => r.id));
     return rows.map((row) => ({
       ...row,
       genres: row.genres ? JSON.parse(row.genres) : [],
       is_tracked: true,
-      offers: getOffersForTitle(row.id),
+      offers: offersByTitle.get(row.id) ?? [],
     }));
   });
 }
@@ -438,11 +467,12 @@ export function searchLocalTitles(query: string, limit = 50, userId?: string) {
       .limit(limit)
       .all();
 
+    const offersByTitle = getOffersForTitles(rows.map((r) => r.id));
     return rows.map((row) => ({
       ...row,
       genres: row.genres ? JSON.parse(row.genres) : [],
       is_tracked: Boolean(row.is_tracked),
-      offers: getOffersForTitle(row.id),
+      offers: offersByTitle.get(row.id) ?? [],
     }));
   });
 }
@@ -545,11 +575,12 @@ export function getTitlesByMonth(filters: MonthFilters, userId?: string) {
     .orderBy(asc(titles.releaseDate))
     .all();
 
+  const offersByTitle = getOffersForTitles(rows.map((r) => r.id));
   return rows.map((row) => ({
     ...row,
     genres: row.genres ? JSON.parse(row.genres) : [],
     is_tracked: Boolean(row.is_tracked),
-    offers: getOffersForTitle(row.id),
+    offers: offersByTitle.get(row.id) ?? [],
   }));
   });
 }
@@ -688,10 +719,11 @@ export function getEpisodesByMonth(filters: MonthFilters, userId?: string) {
       .orderBy(asc(episodes.airDate), asc(titles.title))
       .all();
 
+    const offersByTitle = getOffersForTitles([...new Set(rows.map((r) => r.title_id))]);
     return rows.map((row) => ({
       ...row,
       is_watched: !!row.is_watched,
-      offers: getOffersForTitle(row.title_id),
+      offers: offersByTitle.get(row.title_id) ?? [],
     }));
   });
 }
@@ -730,10 +762,11 @@ export function getEpisodesByDateRange(startDate: string, endDate: string, userI
       .orderBy(asc(episodes.airDate), asc(titles.title))
       .all();
 
+    const offersByTitle = getOffersForTitles([...new Set(rows.map((r) => r.title_id))]);
     return rows.map((row) => ({
       ...row,
       is_watched: !!row.is_watched,
-      offers: getOffersForTitle(row.title_id),
+      offers: offersByTitle.get(row.title_id) ?? [],
     }));
   });
 }
@@ -783,10 +816,11 @@ export function getUnwatchedEpisodes(userId: string) {
       .orderBy(asc(titles.title), asc(episodes.seasonNumber), asc(episodes.episodeNumber))
       .all();
 
+    const offersByTitle = getOffersForTitles([...new Set(rows.map((r) => r.title_id))]);
     return rows.map((row) => ({
       ...row,
       is_watched: false,
-      offers: getOffersForTitle(row.title_id),
+      offers: offersByTitle.get(row.title_id) ?? [],
     }));
   });
 }
@@ -1317,9 +1351,10 @@ export function getTrackedMoviesByReleaseDate(date: string, userId: string) {
       .where(and(eq(titles.releaseDate, date), eq(titles.objectType, "MOVIE")))
       .all();
 
+    const offersByTitle = getOffersForTitles(rows.map((r) => r.id));
     return rows.map((row) => ({
       ...row,
-      offers: getOffersForTitle(row.id),
+      offers: offersByTitle.get(row.id) ?? [],
     }));
   });
 }


### PR DESCRIPTION
## Summary
This PR introduces a new `getOffersForTitles()` function that batch-fetches offers for multiple titles in a single database query, replacing individual per-title queries throughout the codebase. This optimization reduces N+1 query problems and improves performance when retrieving lists of titles.

## Key Changes
- **New function `getOffersForTitles()`**: Accepts an array of title IDs and returns a `Map<titleId, offers[]>` with all offers fetched in a single query, including provider details via a join
- **Updated 8 query functions** to use batch fetching instead of individual queries:
  - `getRecentTitles()`
  - `getTrackedTitles()`
  - `searchLocalTitles()`
  - `getTitlesByMonth()`
  - `getEpisodesByMonth()`
  - `getEpisodesByDateRange()`
  - `getUnwatchedEpisodes()`
  - `getTrackedMoviesByReleaseDate()`
- **Added comprehensive tests** for the new batch function, including edge cases (empty input, titles with/without offers)
- **Added integration test** for `getRecentTitles()` to verify offers are properly included via batch fetch

## Implementation Details
- The batch function uses `Map.groupBy()` to organize results by title ID, making lookups O(1)
- Handles empty title ID arrays gracefully by returning an empty Map
- Uses `new Set()` to deduplicate title IDs in episode-related functions where the same title may appear multiple times
- Maintains backward compatibility by returning empty arrays for titles with no offers

https://claude.ai/code/session_01UrhGRvVF4W4fV7PrfgpR2s