### PR TITLE
Add type safety to admin settings API functions

### DIFF
--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -15,7 +15,7 @@ const mockFetch = mock(async (url: string, options?: RequestInit) => {
 
 globalThis.fetch = mockFetch as any;
 
-const { browseTitles } = await import("./api");
+const { browseTitles, getAdminSettings, updateAdminSettings } = await import("./api");
 
 beforeEach(() => {
   lastFetchUrl = "";
@@ -45,5 +45,59 @@ describe("browseTitles", () => {
   it("omits type param when not provided", async () => {
     await browseTitles({ category: "popular" });
     expect(lastFetchUrl).not.toContain("type=");
+  });
+});
+
+describe("getAdminSettings", () => {
+  it("calls /api/admin/settings", async () => {
+    const mockSettings = {
+      oidc: {
+        issuer_url: { value: "https://example.com", source: "db" },
+        client_id: { value: "my-client", source: "db" },
+        client_secret: { value: "********", source: "db" },
+        redirect_uri: { value: "", source: "unset" },
+        admin_claim: { value: "", source: "unset" },
+        admin_value: { value: "", source: "unset" },
+      },
+      oidc_configured: true,
+    };
+    mockFetch.mockImplementationOnce(async (url: string, options?: RequestInit) => {
+      lastFetchUrl = url;
+      lastFetchOptions = options;
+      return new Response(JSON.stringify(mockSettings), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    const result = await getAdminSettings();
+    expect(lastFetchUrl).toBe("/api/admin/settings");
+    expect(result.oidc_configured).toBe(true);
+    expect(result.oidc.issuer_url.value).toBe("https://example.com");
+    expect(result.oidc.issuer_url.source).toBe("db");
+  });
+});
+
+describe("updateAdminSettings", () => {
+  it("calls PUT /api/admin/settings with body", async () => {
+    const mockResponse = { success: true, oidc_configured: true };
+    mockFetch.mockImplementationOnce(async (url: string, options?: RequestInit) => {
+      lastFetchUrl = url;
+      lastFetchOptions = options;
+      return new Response(JSON.stringify(mockResponse), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    const result = await updateAdminSettings({
+      oidc_issuer_url: "https://example.com",
+      oidc_client_id: "my-client",
+    });
+    expect(lastFetchUrl).toBe("/api/admin/settings");
+    expect(lastFetchOptions?.method).toBe("PUT");
+    const body = JSON.parse(lastFetchOptions?.body as string);
+    expect(body.oidc_issuer_url).toBe("https://example.com");
+    expect(body.oidc_client_id).toBe("my-client");
+    expect(result.success).toBe(true);
+    expect(result.oidc_configured).toBe(true);
   });
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -8,6 +8,9 @@ import type {
   SeasonDetailsResponse,
   EpisodeDetailsResponse,
   PersonDetailsResponse,
+  AdminSettings,
+  AdminSettingsUpdateRequest,
+  AdminSettingsUpdateResponse,
 } from "./types";
 
 const BASE = "/api";
@@ -193,11 +196,11 @@ export async function changePassword(currentPassword: string, newPassword: strin
 
 // ─── Admin ───────────────────────────────────────────────────────────────────
 
-export async function getAdminSettings(): Promise<any> {
+export async function getAdminSettings(): Promise<AdminSettings> {
   return fetchJson("/admin/settings");
 }
 
-export async function updateAdminSettings(settings: Record<string, string>): Promise<any> {
+export async function updateAdminSettings(settings: AdminSettingsUpdateRequest): Promise<AdminSettingsUpdateResponse> {
   return fetchJson("/admin/settings", {
     method: "PUT",
     body: JSON.stringify(settings),

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -2,21 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useAuth } from "../context/AuthContext";
 import * as api from "../api";
 import type { JobsResponse, Notifier } from "../api";
-
-interface OidcField {
-  value: string;
-  source: "env" | "db" | "unset";
-}
-
-interface AdminSettings {
-  oidc: {
-    issuer_url: OidcField;
-    client_id: OidcField;
-    client_secret: OidcField;
-    redirect_uri: OidcField;
-  };
-  oidc_configured: boolean;
-}
+import type { AdminSettings } from "../types";
 
 export default function ProfilePage() {
   const { user } = useAuth();

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -347,6 +347,39 @@ export interface PersonDetailsResponse {
   };
 }
 
+// ─── Admin Settings Types ────────────────────────────────────────────────────
+
+export interface OidcSettingField {
+  value: string;
+  source: "env" | "db" | "unset";
+}
+
+export interface AdminSettings {
+  oidc: {
+    issuer_url: OidcSettingField;
+    client_id: OidcSettingField;
+    client_secret: OidcSettingField;
+    redirect_uri: OidcSettingField;
+    admin_claim: OidcSettingField;
+    admin_value: OidcSettingField;
+  };
+  oidc_configured: boolean;
+}
+
+export interface AdminSettingsUpdateRequest {
+  oidc_issuer_url?: string;
+  oidc_client_id?: string;
+  oidc_client_secret?: string;
+  oidc_redirect_uri?: string;
+  oidc_admin_claim?: string;
+  oidc_admin_value?: string;
+}
+
+export interface AdminSettingsUpdateResponse {
+  success: boolean;
+  oidc_configured: boolean;
+}
+
 // Normalize search results to same shape as DB titles
 export function normalizeSearchTitle(t: SearchTitle): Title {
   return {


### PR DESCRIPTION
## Summary
This PR improves type safety for admin settings management by extracting type definitions from the ProfilePage component into a centralized types module and applying proper TypeScript types to the admin API functions.

## Key Changes
- **Extracted admin settings types** to `types.ts`:
  - `OidcSettingField`: Represents a single OIDC configuration field with value and source
  - `AdminSettings`: Complete admin settings response structure
  - `AdminSettingsUpdateRequest`: Request payload for updating settings
  - `AdminSettingsUpdateResponse`: Response structure for update operations

- **Updated API functions** in `api.ts`:
  - `getAdminSettings()`: Now returns `Promise<AdminSettings>` instead of `Promise<any>`
  - `updateAdminSettings()`: Now accepts `AdminSettingsUpdateRequest` and returns `Promise<AdminSettingsUpdateResponse>` instead of generic types

- **Refactored ProfilePage component**:
  - Removed duplicate type definitions (`OidcField`, `AdminSettings`)
  - Now imports `AdminSettings` from centralized types module

- **Added comprehensive test coverage** in `api.test.ts`:
  - Tests for `getAdminSettings()` endpoint and response structure
  - Tests for `updateAdminSettings()` with PUT method verification and request body validation

## Implementation Details
The OIDC settings structure supports tracking configuration sources (environment variables, database, or unset), allowing the UI to display where each setting originates. The update request uses simplified field names (e.g., `oidc_issuer_url`) while the response maintains the nested structure with source information.

https://claude.ai/code/session_014PUKnxGN9WHJzyuu6kg7Za