### PR TITLE
Fix Docker build by copying frontend package.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN bun run build
 FROM oven/bun:1 AS server-build
 WORKDIR /app
 COPY package.json bun.lock ./
+COPY frontend/package.json ./frontend/
 RUN bun install --frozen-lockfile --production
 COPY server/ ./server/
 COPY tsconfig.json ./


### PR DESCRIPTION
## Summary
Fixed a Docker build issue where the frontend's `package.json` was not being copied into the server build stage, causing dependency resolution failures.

## Key Changes
- Added `COPY frontend/package.json ./frontend/` to the server-build stage in the Dockerfile
- This ensures the frontend package configuration is available during the `bun install` step, allowing proper resolution of workspace dependencies

## Implementation Details
The server build stage now copies the frontend's `package.json` before running `bun install --frozen-lockfile --production`. This is necessary for monorepo setups where the root `bun.lock` file may reference dependencies defined in the frontend workspace, and bun needs access to all workspace package.json files to properly resolve the lockfile.

https://claude.ai/code/session_01UEtj2caDaL1tZbYMG4C7J5