### PR TITLE
Exclude test-utils directory from TypeScript compilation

### DIFF
--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -31,5 +31,5 @@
     "noUncheckedSideEffectImports": true
   },
   "include": ["src"],
-  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test-utils"]
 }


### PR DESCRIPTION
## Summary
Updated the TypeScript configuration to exclude the `src/test-utils` directory from compilation, alongside existing test file exclusions.

## Changes
- Added `src/test-utils` to the `exclude` array in `frontend/tsconfig.app.json`

## Details
This change prevents TypeScript from compiling test utility files as part of the application build. The `test-utils` directory likely contains helper functions and utilities used exclusively in testing environments and should not be included in the production application bundle.

https://claude.ai/code/session_01YZicdR2wEQycJJcWFfVMPm