### PR TITLE
Pin Bun runtime to version 1.3.9 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build frontend
-FROM oven/bun:1 AS frontend-build
+FROM oven/bun:1.3.9 AS frontend-build
 WORKDIR /app/frontend
 COPY frontend/package.json frontend/bun.lock ./
 RUN bun install --frozen-lockfile
@@ -7,7 +7,7 @@ COPY frontend/ ./
 RUN bun run build
 
 # Stage 2: Build server
-FROM oven/bun:1 AS server-build
+FROM oven/bun:1.3.9 AS server-build
 WORKDIR /app
 COPY package.json bun.lock ./
 COPY frontend/package.json ./frontend/
@@ -16,7 +16,7 @@ COPY server/ ./server/
 COPY tsconfig.json ./
 
 # Stage 3: Production
-FROM oven/bun:1-slim
+FROM oven/bun:1.3.9-slim
 WORKDIR /app
 COPY --from=server-build /app/ ./
 COPY --from=frontend-build /app/frontend/dist ./frontend/dist


### PR DESCRIPTION
## Summary
This PR pins the Bun runtime to a specific version (1.3.9) across all Docker build stages, replacing the previously used floating `1` tag.

## Changes
- Updated frontend build stage from `oven/bun:1` to `oven/bun:1.3.9`
- Updated server build stage from `oven/bun:1` to `oven/bun:1.3.9`
- Updated production stage from `oven/bun:1-slim` to `oven/bun:1.3.9-slim`

## Details
By pinning to a specific version, this ensures consistent and reproducible builds across different environments and deployment times. This prevents unexpected breaking changes or behavioral differences that could occur when using the floating `1` tag, which may receive minor and patch version updates.

https://claude.ai/code/session_0133WbYHh6SaR1XC7iYt3yL9