### PR TITLE
Refactor Dockerfile frontend build stage for monorepo structure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 # Stage 1: Build frontend
 FROM oven/bun:1.3.9 AS frontend-build
-WORKDIR /app/frontend
-COPY frontend/package.json frontend/bun.lock ./
-RUN bun install --frozen-lockfile
-COPY frontend/ ./
-RUN bun run build
+WORKDIR /app
+COPY package.json bun.lock ./
+COPY frontend/package.json frontend/bun.lock ./frontend/
+RUN cd frontend && bun install --frozen-lockfile
+COPY frontend/ ./frontend/
+RUN cd frontend && bun run build
 
 # Stage 2: Build server
 FROM oven/bun:1.3.9 AS server-build


### PR DESCRIPTION
## Summary
Updated the Dockerfile frontend build stage to support a monorepo structure by adjusting the working directory and copy operations to properly handle root-level configuration files alongside frontend-specific files.

## Key Changes
- Changed initial `WORKDIR` from `/app/frontend` to `/app` to establish the monorepo root
- Updated `COPY` commands to explicitly copy root-level `package.json` and `bun.lock` files
- Separated frontend-specific file copies into a dedicated step with explicit `./frontend/` destination
- Modified build commands to use `cd frontend &&` prefix to execute within the frontend directory context

## Implementation Details
This refactoring allows the Docker build to access both root-level and frontend-specific configuration files, which is necessary for monorepo setups where shared dependencies or configuration may exist at the project root. The explicit directory navigation ensures build commands execute in the correct context while maintaining proper file organization in the container.

https://claude.ai/code/session_017EUy2kAGPzonpaph7S5xqD