### PR TITLE
Auto-scroll to today's date on calendar initial load

### DIFF
--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -98,6 +98,7 @@ function AgendaCalendar() {
   const bottomRef = useRef<HTMLDivElement>(null);
   const topRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const todayRef = useRef<HTMLDivElement>(null);
   const monthOptions = useMemo(() => getMonthOptions(), []);
 
   // Track which months we've loaded to avoid duplicates
@@ -154,6 +155,15 @@ function AgendaCalendar() {
       setInitialLoading(false);
     });
   }, [typeFilter, loadMonth]);
+
+  // Scroll to today after initial load
+  useEffect(() => {
+    if (!initialLoading && todayRef.current) {
+      requestAnimationFrame(() => {
+        todayRef.current?.scrollIntoView({ block: "start" });
+      });
+    }
+  }, [initialLoading]);
 
   // Load more months at bottom
   const loadNextMonth = useCallback(async () => {
@@ -341,7 +351,7 @@ function AgendaCalendar() {
                 });
 
                 return (
-                  <div key={dateKey}>
+                  <div key={dateKey} ref={isDateToday ? todayRef : undefined}>
                     {/* Date header */}
                     <div className={`sticky top-0 z-10 px-3 py-2 text-sm font-medium ${
                       isDateToday


### PR DESCRIPTION
## Summary
Added automatic scroll-to-today functionality to the agenda calendar. When the calendar finishes its initial load, it now automatically scrolls to display today's date at the top of the viewport.

## Key Changes
- Added `todayRef` ref to track the DOM element containing today's date
- Implemented `useEffect` hook that triggers after initial loading completes to scroll today's date into view
- Used `requestAnimationFrame` to ensure scroll happens after DOM rendering is complete
- Attached the ref to the date container div when `isDateToday` is true

## Implementation Details
- The scroll behavior uses `scrollIntoView({ block: "start" })` to position today's date at the top of the container
- The effect only runs once after `initialLoading` becomes false, preventing unnecessary scroll operations
- `requestAnimationFrame` is used to defer the scroll action, ensuring the DOM is fully rendered before scrolling

https://claude.ai/code/session_01DBYkqR5i842SGKtZCXzsdU