### PR TITLE
Add web push notifications support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@sentry/bun": "^10.43.0",
         "drizzle-orm": "^0.45.1",
         "hono": "^4.4.0",
+        "web-push": "^3.6.7",
       },
       "devDependencies": {
         "@happy-dom/global-registrator": "^20.8.4",
@@ -17,6 +18,7 @@
         "@types/bun": "latest",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@types/web-push": "^3.6.4",
         "concurrently": "^9.2.1",
         "drizzle-kit": "^0.31.9",
         "happy-dom": "^20.8.4",
@@ -57,6 +59,8 @@
         "typescript-eslint": "^8.48.0",
         "vite": "^7.3.1",
         "vite-plugin-pwa": "^1.2.0",
+        "workbox-precaching": "^7.4.0",
+        "workbox-routing": "^7.4.0",
       },
     },
   },
@@ -651,6 +655,8 @@
 
     "@types/validate-npm-package-name": ["@types/validate-npm-package-name@4.0.2", "", {}, "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw=="],
 
+    "@types/web-push": ["@types/web-push@3.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ=="],
+
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
@@ -705,6 +711,8 @@
 
     "arraybuffer.prototype.slice": ["arraybuffer.prototype.slice@1.0.4", "", { "dependencies": { "array-buffer-byte-length": "^1.0.1", "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "is-array-buffer": "^3.0.4" } }, "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ=="],
 
+    "asn1.js": ["asn1.js@5.4.1", "", { "dependencies": { "bn.js": "^4.0.0", "inherits": "^2.0.1", "minimalistic-assert": "^1.0.0", "safer-buffer": "^2.1.0" } }, "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA=="],
+
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
     "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
@@ -725,6 +733,8 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.0", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA=="],
 
+    "bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
+
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
@@ -732,6 +742,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
@@ -854,6 +866,8 @@
     "drizzle-orm": ["drizzle-orm@0.45.1", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "eciesjs": ["eciesjs@0.4.18", "", { "dependencies": { "@ecies/ciphers": "^0.2.5", "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.7", "@noble/hashes": "^1.8.0" } }, "sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ=="],
 
@@ -1055,6 +1069,8 @@
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
+    "http_ece": ["http_ece@1.2.0", "", {}, "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA=="],
+
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
@@ -1197,6 +1213,10 @@
 
     "jsonpointer": ["jsonpointer@5.0.1", "", {}, "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="],
 
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
@@ -1272,6 +1292,8 @@
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
+
+    "minimalistic-assert": ["minimalistic-assert@1.0.1", "", {}, "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="],
 
     "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
@@ -1667,6 +1689,8 @@
 
     "vite-plugin-pwa": ["vite-plugin-pwa@1.2.0", "", { "dependencies": { "debug": "^4.3.6", "pretty-bytes": "^6.1.1", "tinyglobby": "^0.2.10", "workbox-build": "^7.4.0", "workbox-window": "^7.4.0" }, "peerDependencies": { "@vite-pwa/assets-generator": "^1.0.0", "vite": "^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@vite-pwa/assets-generator"] }, "sha512-a2xld+SJshT9Lgcv8Ji4+srFJL4k/1bVbd1x06JIkvecpQkwkvCncD1+gSzcdm3s+owWLpMJerG3aN5jupJEVw=="],
 
+    "web-push": ["web-push@3.6.7", "", { "dependencies": { "asn1.js": "^5.3.0", "http_ece": "1.2.0", "https-proxy-agent": "^7.0.0", "jws": "^4.0.0", "minimist": "^1.2.5" }, "bin": { "web-push": "src/cli.js" } }, "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A=="],
+
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
     "webidl-conversions": ["webidl-conversions@4.0.2", "", {}, "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="],
@@ -1816,6 +1840,8 @@
     "@types/pg/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
 
     "@types/tedious/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
+
+    "@types/web-push/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
 
     "@types/ws/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
 
@@ -1982,6 +2008,8 @@
     "@types/pg/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@types/tedious/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "@types/web-push/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@types/ws/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,8 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
     "vite": "^7.3.1",
-    "vite-plugin-pwa": "^1.2.0"
+    "vite-plugin-pwa": "^1.2.0",
+    "workbox-precaching": "^7.4.0",
+    "workbox-routing": "^7.4.0"
   }
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -257,6 +257,10 @@ export interface Notifier {
   updated_at: string;
 }
 
+export async function getVapidPublicKey(): Promise<{ publicKey: string }> {
+  return fetchJson("/notifiers/vapid-public-key");
+}
+
 export async function getNotifiers(): Promise<{ notifiers: Notifier[] }> {
   return fetchJson("/notifiers");
 }

--- a/frontend/src/lib/push.test.ts
+++ b/frontend/src/lib/push.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "bun:test";
+import { urlBase64ToUint8Array } from "./push";
+
+describe("urlBase64ToUint8Array", () => {
+  it("converts a base64url string to Uint8Array", () => {
+    // Known test vector: "AQAB" (base64url) = [1, 0, 1]
+    const result = urlBase64ToUint8Array("AQAB");
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result[0]).toBe(1);
+    expect(result[1]).toBe(0);
+    expect(result[2]).toBe(1);
+  });
+
+  it("handles base64url characters (- and _)", () => {
+    // "-" should become "+" and "_" should become "/"
+    const result = urlBase64ToUint8Array("A-B_");
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result.length).toBe(3);
+  });
+
+  it("adds padding as needed", () => {
+    // "AA" needs 2 padding chars
+    const result = urlBase64ToUint8Array("AA");
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result[0]).toBe(0);
+  });
+});

--- a/frontend/src/lib/push.ts
+++ b/frontend/src/lib/push.ts
@@ -1,0 +1,52 @@
+export function isPushSupported(): boolean {
+  return (
+    "serviceWorker" in navigator &&
+    "PushManager" in window &&
+    "Notification" in window
+  );
+}
+
+export function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const rawData = atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+  for (let i = 0; i < rawData.length; i++) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+}
+
+export async function subscribeToPush(
+  vapidPublicKey: string
+): Promise<{ endpoint: string; p256dh: string; auth: string }> {
+  const registration = await navigator.serviceWorker.ready;
+  const subscription = await registration.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
+  } as PushSubscriptionOptionsInit);
+
+  const json = subscription.toJSON();
+  if (!json.endpoint || !json.keys?.p256dh || !json.keys?.auth) {
+    throw new Error("Invalid push subscription");
+  }
+
+  return {
+    endpoint: json.endpoint,
+    p256dh: json.keys.p256dh,
+    auth: json.keys.auth,
+  };
+}
+
+export async function getExistingSubscription(): Promise<PushSubscription | null> {
+  if (!isPushSupported()) return null;
+  const registration = await navigator.serviceWorker.ready;
+  return registration.pushManager.getSubscription();
+}
+
+export async function unsubscribeFromPush(): Promise<void> {
+  const subscription = await getExistingSubscription();
+  if (subscription) {
+    await subscription.unsubscribe();
+  }
+}

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -3,6 +3,7 @@ import { useAuth } from "../context/AuthContext";
 import * as api from "../api";
 import type { JobsResponse, Notifier } from "../api";
 import type { AdminSettings } from "../types";
+import { isPushSupported, subscribeToPush, unsubscribeFromPush, getExistingSubscription } from "../lib/push";
 
 export default function ProfilePage() {
   const { user } = useAuth();
@@ -12,6 +13,7 @@ export default function ProfilePage() {
   return (
     <div className="max-w-2xl mx-auto space-y-8">
       <UserSection />
+      {isPushSupported() && <PushNotificationsSection />}
       <NotificationsSection />
       {user.is_admin && <BackgroundJobsSection />}
       {user.is_admin && <AdminSection />}
@@ -116,6 +118,175 @@ function UserSection() {
   );
 }
 
+function PushNotificationsSection() {
+  const [loading, setLoading] = useState(true);
+  const [enabling, setEnabling] = useState(false);
+  const [disabling, setDisabling] = useState(false);
+  const [pushNotifier, setPushNotifier] = useState<Notifier | null>(null);
+  const [hasSubscription, setHasSubscription] = useState(false);
+  const [permissionState, setPermissionState] = useState(Notification.permission);
+  const [msg, setMsg] = useState("");
+  const [err, setErr] = useState("");
+  const [testing, setTesting] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const [{ notifiers }, subscription] = await Promise.all([
+        api.getNotifiers(),
+        getExistingSubscription(),
+      ]);
+      const webpushNotifier = notifiers.find((n) => n.provider === "webpush") || null;
+      setPushNotifier(webpushNotifier);
+      setHasSubscription(!!subscription);
+      setPermissionState(Notification.permission);
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  async function handleEnable() {
+    setMsg("");
+    setErr("");
+    setEnabling(true);
+    try {
+      const permission = await Notification.requestPermission();
+      setPermissionState(permission);
+      if (permission !== "granted") {
+        setErr("Notification permission denied. Please enable it in your browser settings.");
+        return;
+      }
+
+      const { publicKey } = await api.getVapidPublicKey();
+      const subscription = await subscribeToPush(publicKey);
+
+      await api.createNotifier({
+        provider: "webpush",
+        name: "This Device",
+        config: subscription,
+        notify_time: "09:00",
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      });
+
+      setMsg("Push notifications enabled");
+      await refresh();
+    } catch (e: any) {
+      setErr(e.message);
+    } finally {
+      setEnabling(false);
+    }
+  }
+
+  async function handleDisable() {
+    setMsg("");
+    setErr("");
+    setDisabling(true);
+    try {
+      await unsubscribeFromPush();
+      if (pushNotifier) {
+        await api.deleteNotifier(pushNotifier.id);
+      }
+      setMsg("Push notifications disabled");
+      await refresh();
+    } catch (e: any) {
+      setErr(e.message);
+    } finally {
+      setDisabling(false);
+    }
+  }
+
+  async function handleTest() {
+    if (!pushNotifier) return;
+    setMsg("");
+    setErr("");
+    setTesting(true);
+    try {
+      const result = await api.testNotifier(pushNotifier.id);
+      if (result.success) {
+        setMsg(result.message);
+      } else {
+        setErr(result.message);
+      }
+    } catch (e: any) {
+      setErr(e.message);
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  if (loading) return <div className="text-gray-500">Loading push notification status...</div>;
+
+  const isEnabled = !!pushNotifier && pushNotifier.enabled && hasSubscription;
+  const isDenied = permissionState === "denied";
+
+  return (
+    <section>
+      <h2 className="text-xl font-bold text-white mb-4">Push Notifications</h2>
+
+      {msg && (
+        <div className="mb-4 p-3 rounded-lg bg-green-900/50 border border-green-700 text-green-200 text-sm">
+          {msg}
+        </div>
+      )}
+      {err && (
+        <div className="mb-4 p-3 rounded-lg bg-red-900/50 border border-red-700 text-red-200 text-sm">
+          {err}
+        </div>
+      )}
+
+      <div className="bg-gray-900 rounded-lg p-5">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-white font-medium">
+              {isEnabled ? "Push notifications are enabled" : "Get notified about new releases"}
+            </p>
+            <p className="text-sm text-gray-400 mt-1">
+              {isEnabled
+                ? "You'll receive notifications on this device"
+                : isDenied
+                  ? "Notifications are blocked. Enable them in your browser settings."
+                  : "Receive native push notifications for new episodes and movies"}
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            {isEnabled ? (
+              <>
+                <button
+                  onClick={handleTest}
+                  disabled={testing}
+                  className="px-3 py-1.5 text-sm bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg transition-colors cursor-pointer disabled:opacity-50"
+                >
+                  {testing ? "Sending..." : "Test"}
+                </button>
+                <button
+                  onClick={handleDisable}
+                  disabled={disabling}
+                  className="px-3 py-1.5 text-sm bg-red-900/50 hover:bg-red-800/50 text-red-300 rounded-lg transition-colors cursor-pointer disabled:opacity-50"
+                >
+                  {disabling ? "Disabling..." : "Disable"}
+                </button>
+              </>
+            ) : (
+              <button
+                onClick={handleEnable}
+                disabled={enabling || isDenied}
+                className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded-lg transition-colors cursor-pointer disabled:opacity-50"
+              >
+                {enabling ? "Enabling..." : "Enable"}
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 const TIMEZONE_OPTIONS = (() => {
   try {
     return Intl.supportedValuesOf("timeZone");
@@ -148,8 +319,9 @@ function NotificationsSection() {
   const refresh = useCallback(() => {
     Promise.all([api.getNotifiers(), api.getNotifierProviders()])
       .then(([n, p]) => {
-        setNotifiers(n.notifiers);
-        setProviders(p.providers);
+        // Hide webpush from manual notifier list — it's managed via PushNotificationsSection
+        setNotifiers(n.notifiers.filter((x) => x.provider !== "webpush"));
+        setProviders(p.providers.filter((x) => x !== "webpush"));
         setLoading(false);
       })
       .catch(() => setLoading(false));

--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -1,0 +1,75 @@
+/// <reference lib="webworker" />
+import { precacheAndRoute, cleanupOutdatedCaches } from "workbox-precaching";
+import { registerRoute, NavigationRoute } from "workbox-routing";
+
+declare let self: ServiceWorkerGlobalScope;
+
+// Precache all assets built by Vite
+precacheAndRoute(self.__WB_MANIFEST);
+cleanupOutdatedCaches();
+
+// Navigation fallback — serve index.html for all navigation requests except /api/
+const navigationRoute = new NavigationRoute(
+  async ({ request }) => {
+    const cache = await caches.open("workbox-precache-v2");
+    const cachedResponse = await cache.match("/index.html");
+    return cachedResponse || fetch(request);
+  },
+  { denylist: [/^\/api\//] }
+);
+registerRoute(navigationRoute);
+
+// Activate immediately
+self.skipWaiting();
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+// Push notification handler
+self.addEventListener("push", (event) => {
+  if (!event.data) return;
+
+  let payload: {
+    title: string;
+    body: string;
+    icon?: string;
+    badge?: string;
+    data?: { url?: string };
+  };
+
+  try {
+    payload = event.data.json();
+  } catch {
+    payload = { title: "Remindarr", body: event.data.text() };
+  }
+
+  event.waitUntil(
+    self.registration.showNotification(payload.title, {
+      body: payload.body,
+      icon: payload.icon || "/pwa-192x192.png",
+      badge: payload.badge || "/pwa-192x192.png",
+      data: payload.data,
+    })
+  );
+});
+
+// Notification click handler — open or focus the app
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+
+  const url = event.notification.data?.url || "/";
+
+  event.waitUntil(
+    self.clients.matchAll({ type: "window", includeUncontrolled: true }).then((clients) => {
+      // Focus existing window if available
+      for (const client of clients) {
+        if (client.url.includes(self.location.origin) && "focus" in client) {
+          client.navigate(url);
+          return client.focus();
+        }
+      }
+      // Open new window
+      return self.clients.openWindow(url);
+    })
+  );
+});

--- a/frontend/vite.config.test.ts
+++ b/frontend/vite.config.test.ts
@@ -6,17 +6,19 @@ describe("PWA configuration", () => {
     expect(pwaOptions.registerType).toBe("autoUpdate");
   });
 
-  it("enables clientsClaim for immediate SW control", () => {
-    expect(pwaOptions.workbox?.clientsClaim).toBe(true);
+  it("uses injectManifest strategy for custom service worker", () => {
+    expect(pwaOptions.strategies).toBe("injectManifest");
   });
 
-  it("enables cleanupOutdatedCaches to remove stale caches", () => {
-    expect(pwaOptions.workbox?.cleanupOutdatedCaches).toBe(true);
+  it("points to custom service worker source", () => {
+    expect(pwaOptions.srcDir).toBe("src");
+    expect(pwaOptions.filename).toBe("sw.ts");
   });
 
-  it("excludes /api/ routes from navigateFallback", () => {
-    const denylist = pwaOptions.workbox?.navigateFallbackDenylist;
-    expect(denylist).toBeDefined();
-    expect(denylist!.some((re) => re.test("/api/titles"))).toBe(true);
+  it("configures glob patterns for precaching", () => {
+    expect(pwaOptions.injectManifest?.globPatterns).toBeDefined();
+    expect(pwaOptions.injectManifest!.globPatterns!).toContain(
+      "**/*.{js,css,html,ico,png,svg,woff2}"
+    );
   });
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,14 +6,12 @@ import { VitePWA } from "vite-plugin-pwa";
 import type { VitePWAOptions } from "vite-plugin-pwa";
 
 export const pwaOptions: Partial<VitePWAOptions> = {
+  strategies: "injectManifest",
+  srcDir: "src",
+  filename: "sw.ts",
   registerType: "autoUpdate",
-  workbox: {
+  injectManifest: {
     globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
-    navigateFallback: "/index.html",
-    navigateFallbackDenylist: [/^\/api\//],
-    clientsClaim: true,
-    skipWaiting: true,
-    cleanupOutdatedCaches: true,
   },
   manifest: {
     name: "Remindarr",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "@sentry/bun": "^10.43.0",
     "drizzle-orm": "^0.45.1",
-    "hono": "^4.4.0"
+    "hono": "^4.4.0",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "@happy-dom/global-registrator": "^20.8.4",
@@ -30,6 +31,7 @@
     "@types/bun": "latest",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@types/web-push": "^3.6.4",
     "concurrently": "^9.2.1",
     "drizzle-kit": "^0.31.9",
     "happy-dom": "^20.8.4"

--- a/server/config.ts
+++ b/server/config.ts
@@ -38,6 +38,11 @@ export const CONFIG = {
   // CORS
   CORS_ORIGIN: process.env.CORS_ORIGIN || "",
 
+  // Web Push (VAPID)
+  VAPID_PUBLIC_KEY: process.env.VAPID_PUBLIC_KEY || "",
+  VAPID_PRIVATE_KEY: process.env.VAPID_PRIVATE_KEY || "",
+  VAPID_SUBJECT: process.env.VAPID_SUBJECT || "",
+
   // Sentry
   SENTRY_DSN: process.env.SENTRY_DSN || "",
 };

--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -67,6 +67,7 @@ export {
   createNotifier,
   updateNotifier,
   deleteNotifier,
+  disableNotifier,
   getNotifiersByUser,
   getNotifierById,
   getDueNotifiers,

--- a/server/db/repository/notifiers.ts
+++ b/server/db/repository/notifiers.ts
@@ -190,6 +190,16 @@ export function getDueNotifiers(
   });
 }
 
+export function disableNotifier(id: string) {
+  return traceDbQuery("disableNotifier", () => {
+    const db = getDb();
+    db.update(notifiers)
+      .set({ enabled: 0, updatedAt: sql`datetime('now')` })
+      .where(eq(notifiers.id, id))
+      .run();
+  });
+}
+
 export function markNotifierSent(id: string, date: string) {
   return traceDbQuery("markNotifierSent", () => {
     const db = getDb();

--- a/server/jobs/notifications.ts
+++ b/server/jobs/notifications.ts
@@ -8,9 +8,11 @@ import {
   getDistinctNotifierTimezones,
   getEnabledNotifierSchedules,
   markNotifierSent,
+  disableNotifier,
 } from "../db/repository";
 import { getProvider } from "../notifications/registry";
 import { buildNotificationContent } from "../notifications/content";
+import { SubscriptionExpiredError } from "../notifications/webpush";
 
 function getCurrentTimeInTimezone(tz: string): { time: string; date: string } {
   const now = new Date();
@@ -156,6 +158,11 @@ export function registerNotificationJobs() {
           markNotifierSent(notifier.id, notifier.todayDate);
           log.info("Sent notification", { provider: notifier.provider, userId: notifier.user_id });
         } catch (err) {
+          if (err instanceof SubscriptionExpiredError) {
+            log.warn("Push subscription expired, disabling notifier", { notifierId: notifier.id });
+            disableNotifier(notifier.id);
+            continue;
+          }
           const message = err instanceof Error ? err.message : String(err);
           log.error("Failed to send notification", { provider: notifier.provider, notifierId: notifier.id, error: message });
         }

--- a/server/notifications/registry.ts
+++ b/server/notifications/registry.ts
@@ -1,8 +1,10 @@
 import { DiscordProvider } from "./discord";
+import { WebPushProvider } from "./webpush";
 import type { NotificationProvider } from "./types";
 
 const providers = new Map<string, NotificationProvider>();
 providers.set("discord", new DiscordProvider());
+providers.set("webpush", new WebPushProvider());
 
 export function getProvider(name: string): NotificationProvider | undefined {
   return providers.get(name);

--- a/server/notifications/vapid.test.ts
+++ b/server/notifications/vapid.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { CONFIG } from "../config";
+
+CONFIG.DB_PATH = ":memory:";
+
+import { getVapidKeys, getVapidPublicKey } from "./vapid";
+import { getSetting, setSetting, deleteSetting } from "../db/repository";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+
+describe("vapid", () => {
+  const originalPublic = CONFIG.VAPID_PUBLIC_KEY;
+  const originalPrivate = CONFIG.VAPID_PRIVATE_KEY;
+  const originalSubject = CONFIG.VAPID_SUBJECT;
+
+  beforeEach(() => {
+    setupTestDb();
+    CONFIG.VAPID_PUBLIC_KEY = "";
+    CONFIG.VAPID_PRIVATE_KEY = "";
+    CONFIG.VAPID_SUBJECT = "";
+  });
+
+  afterEach(() => {
+    teardownTestDb();
+    CONFIG.VAPID_PUBLIC_KEY = originalPublic;
+    CONFIG.VAPID_PRIVATE_KEY = originalPrivate;
+    CONFIG.VAPID_SUBJECT = originalSubject;
+  });
+
+  it("uses env vars when provided", () => {
+    CONFIG.VAPID_PUBLIC_KEY = "env-public";
+    CONFIG.VAPID_PRIVATE_KEY = "env-private";
+    CONFIG.VAPID_SUBJECT = "mailto:test@example.com";
+
+    const keys = getVapidKeys();
+    expect(keys.publicKey).toBe("env-public");
+    expect(keys.privateKey).toBe("env-private");
+    expect(keys.subject).toBe("mailto:test@example.com");
+  });
+
+  it("uses settings table when env vars not set", () => {
+    setSetting("vapid_public_key", "db-public");
+    setSetting("vapid_private_key", "db-private");
+    setSetting("vapid_subject", "mailto:db@example.com");
+
+    const keys = getVapidKeys();
+    expect(keys.publicKey).toBe("db-public");
+    expect(keys.privateKey).toBe("db-private");
+    expect(keys.subject).toBe("mailto:db@example.com");
+  });
+
+  it("auto-generates and persists keys when neither env nor DB has them", () => {
+    const keys = getVapidKeys();
+    expect(keys.publicKey).toBeTruthy();
+    expect(keys.privateKey).toBeTruthy();
+    expect(keys.subject).toBe("mailto:noreply@remindarr.local");
+
+    // Check persisted
+    expect(getSetting("vapid_public_key")).toBe(keys.publicKey);
+    expect(getSetting("vapid_private_key")).toBe(keys.privateKey);
+  });
+
+  it("env vars take precedence over DB settings", () => {
+    setSetting("vapid_public_key", "db-public");
+    setSetting("vapid_private_key", "db-private");
+    CONFIG.VAPID_PUBLIC_KEY = "env-public";
+    CONFIG.VAPID_PRIVATE_KEY = "env-private";
+
+    const keys = getVapidKeys();
+    expect(keys.publicKey).toBe("env-public");
+    expect(keys.privateKey).toBe("env-private");
+  });
+
+  it("getVapidPublicKey returns only the public key", () => {
+    const keys = getVapidKeys();
+    expect(getVapidPublicKey()).toBe(keys.publicKey);
+  });
+});

--- a/server/notifications/vapid.ts
+++ b/server/notifications/vapid.ts
@@ -1,0 +1,49 @@
+import webpush from "web-push";
+import { CONFIG } from "../config";
+import { getSetting, setSetting } from "../db/repository";
+import { logger } from "../logger";
+
+const log = logger.child({ module: "vapid" });
+
+interface VapidKeys {
+  publicKey: string;
+  privateKey: string;
+  subject: string;
+}
+
+export function getVapidKeys(): VapidKeys {
+  // Priority: env vars > settings table > auto-generate
+  let publicKey = CONFIG.VAPID_PUBLIC_KEY;
+  let privateKey = CONFIG.VAPID_PRIVATE_KEY;
+  let subject = CONFIG.VAPID_SUBJECT;
+
+  if (!publicKey || !privateKey) {
+    // Try settings table
+    publicKey = getSetting("vapid_public_key") || "";
+    privateKey = getSetting("vapid_private_key") || "";
+    subject = subject || getSetting("vapid_subject") || "";
+  }
+
+  if (!publicKey || !privateKey) {
+    // Auto-generate and persist
+    log.info("Generating new VAPID keys");
+    const keys = webpush.generateVAPIDKeys();
+    publicKey = keys.publicKey;
+    privateKey = keys.privateKey;
+    setSetting("vapid_public_key", publicKey);
+    setSetting("vapid_private_key", privateKey);
+  }
+
+  if (!subject) {
+    subject = "mailto:noreply@remindarr.local";
+    if (!CONFIG.VAPID_SUBJECT && !getSetting("vapid_subject")) {
+      setSetting("vapid_subject", subject);
+    }
+  }
+
+  return { publicKey, privateKey, subject };
+}
+
+export function getVapidPublicKey(): string {
+  return getVapidKeys().publicKey;
+}

--- a/server/notifications/webpush.test.ts
+++ b/server/notifications/webpush.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn, mock } from "bun:test";
+import { WebPushProvider, SubscriptionExpiredError } from "./webpush";
+import type { NotificationContent } from "./types";
+
+// Mock web-push module
+mock.module("web-push", () => ({
+  default: {
+    setVapidDetails: () => {},
+    sendNotification: async () => ({ statusCode: 201 }),
+  },
+}));
+
+// Mock vapid module
+mock.module("./vapid", () => ({
+  getVapidKeys: () => ({
+    publicKey: "test-public-key",
+    privateKey: "test-private-key",
+    subject: "mailto:test@example.com",
+  }),
+}));
+
+const provider = new WebPushProvider();
+
+const sampleContent: NotificationContent = {
+  date: "2026-03-15",
+  episodes: [
+    {
+      showTitle: "Breaking Bad",
+      seasonNumber: 1,
+      episodeNumber: 3,
+      episodeName: "...And the Bag's in the River",
+      posterUrl: "/abc123.jpg",
+      offers: [{ providerName: "Netflix", providerIconUrl: null }],
+    },
+  ],
+  movies: [
+    {
+      title: "The Matrix",
+      releaseYear: 1999,
+      posterUrl: "/matrix.jpg",
+      offers: [{ providerName: "HBO Max", providerIconUrl: null }],
+    },
+  ],
+};
+
+const validConfig = {
+  endpoint: "https://push.example.com/abc123",
+  p256dh: "test-p256dh-key",
+  auth: "test-auth-key",
+};
+
+describe("WebPushProvider.validateConfig", () => {
+  it("accepts valid config", () => {
+    const result = provider.validateConfig(validConfig);
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects missing endpoint", () => {
+    const result = provider.validateConfig({ p256dh: "x", auth: "y" });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("endpoint");
+  });
+
+  it("rejects missing p256dh", () => {
+    const result = provider.validateConfig({ endpoint: "x", auth: "y" });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("p256dh");
+  });
+
+  it("rejects missing auth", () => {
+    const result = provider.validateConfig({ endpoint: "x", p256dh: "y" });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("auth");
+  });
+});
+
+describe("WebPushProvider.send", () => {
+  it("sends push notification with correct payload", async () => {
+    const webpush = await import("web-push");
+    let sentPayload: string | undefined;
+    const sendSpy = spyOn(webpush.default, "sendNotification").mockImplementation(
+      async (_sub: any, payload: any) => {
+        sentPayload = payload;
+        return { statusCode: 201 } as any;
+      }
+    );
+
+    await provider.send(validConfig, sampleContent);
+
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(sentPayload!);
+    expect(parsed.title).toContain("2 new releases");
+    expect(parsed.body).toContain("Breaking Bad");
+    expect(parsed.body).toContain("The Matrix");
+    expect(parsed.icon).toBe("/pwa-192x192.png");
+
+    sendSpy.mockRestore();
+  });
+
+  it("skips sending when content is empty", async () => {
+    const webpush = await import("web-push");
+    const sendSpy = spyOn(webpush.default, "sendNotification");
+
+    await provider.send(validConfig, { date: "2026-03-15", episodes: [], movies: [] });
+
+    expect(sendSpy).not.toHaveBeenCalled();
+    sendSpy.mockRestore();
+  });
+
+  it("throws SubscriptionExpiredError on 410", async () => {
+    const webpush = await import("web-push");
+    const sendSpy = spyOn(webpush.default, "sendNotification").mockImplementation(async () => {
+      const err: any = new Error("Gone");
+      err.statusCode = 410;
+      throw err;
+    });
+
+    await expect(provider.send(validConfig, sampleContent)).rejects.toThrow(
+      SubscriptionExpiredError
+    );
+
+    sendSpy.mockRestore();
+  });
+
+  it("throws generic error on other failures", async () => {
+    const webpush = await import("web-push");
+    const sendSpy = spyOn(webpush.default, "sendNotification").mockImplementation(async () => {
+      const err: any = new Error("Server Error");
+      err.statusCode = 500;
+      err.body = "Internal Server Error";
+      throw err;
+    });
+
+    await expect(provider.send(validConfig, sampleContent)).rejects.toThrow("Web push failed");
+
+    sendSpy.mockRestore();
+  });
+});

--- a/server/notifications/webpush.ts
+++ b/server/notifications/webpush.ts
@@ -1,0 +1,97 @@
+import webpush from "web-push";
+import { logger } from "../logger";
+import { getVapidKeys } from "./vapid";
+import type { NotificationContent, NotificationProvider } from "./types";
+
+const log = logger.child({ module: "webpush" });
+
+export class SubscriptionExpiredError extends Error {
+  constructor(endpoint: string) {
+    super(`Push subscription expired: ${endpoint.slice(0, 60)}`);
+    this.name = "SubscriptionExpiredError";
+  }
+}
+
+export class WebPushProvider implements NotificationProvider {
+  readonly name = "webpush";
+
+  validateConfig(
+    config: Record<string, string>
+  ): { valid: boolean; error?: string } {
+    if (!config.endpoint) {
+      return { valid: false, error: "Push subscription endpoint is required" };
+    }
+    if (!config.p256dh) {
+      return { valid: false, error: "Push subscription p256dh key is required" };
+    }
+    if (!config.auth) {
+      return { valid: false, error: "Push subscription auth key is required" };
+    }
+    return { valid: true };
+  }
+
+  async send(
+    config: Record<string, string>,
+    content: NotificationContent
+  ): Promise<void> {
+    const { episodes, movies } = content;
+    if (episodes.length === 0 && movies.length === 0) return;
+
+    const vapid = getVapidKeys();
+    webpush.setVapidDetails(vapid.subject, vapid.publicKey, vapid.privateKey);
+
+    const payload = this.buildPayload(content);
+    const subscription: webpush.PushSubscription = {
+      endpoint: config.endpoint,
+      keys: {
+        p256dh: config.p256dh,
+        auth: config.auth,
+      },
+    };
+
+    try {
+      await webpush.sendNotification(subscription, JSON.stringify(payload));
+    } catch (err: any) {
+      if (err.statusCode === 410 || err.statusCode === 404) {
+        throw new SubscriptionExpiredError(config.endpoint);
+      }
+      throw new Error(
+        `Web push failed (${err.statusCode || "unknown"}): ${err.body || err.message}`
+      );
+    }
+  }
+
+  private buildPayload(content: NotificationContent) {
+    const { episodes, movies, date } = content;
+    const totalCount = episodes.length + movies.length;
+
+    const lines: string[] = [];
+    // Group episodes by show
+    const showMap = new Map<string, typeof episodes>();
+    for (const ep of episodes) {
+      const existing = showMap.get(ep.showTitle) || [];
+      existing.push(ep);
+      showMap.set(ep.showTitle, existing);
+    }
+
+    for (const [showTitle, eps] of showMap) {
+      const codes = eps.map(
+        (ep) =>
+          `S${String(ep.seasonNumber).padStart(2, "0")}E${String(ep.episodeNumber).padStart(2, "0")}`
+      );
+      lines.push(`${showTitle} ${codes.join(", ")}`);
+    }
+
+    for (const movie of movies) {
+      lines.push(movie.releaseYear ? `${movie.title} (${movie.releaseYear})` : movie.title);
+    }
+
+    return {
+      title: `Remindarr — ${totalCount} new release${totalCount !== 1 ? "s" : ""}`,
+      body: lines.join("\n"),
+      icon: "/pwa-192x192.png",
+      badge: "/pwa-192x192.png",
+      data: { url: "/" },
+    };
+  }
+}

--- a/server/routes/notifiers.ts
+++ b/server/routes/notifiers.ts
@@ -10,6 +10,7 @@ import {
 import { getProvider, getAvailableProviders } from "../notifications/registry";
 import { buildNotificationContent } from "../notifications/content";
 import { refreshNotificationSchedule } from "../jobs/notifications";
+import { getVapidPublicKey } from "../notifications/vapid";
 
 const app = new Hono<AppEnv>();
 
@@ -40,6 +41,16 @@ app.get("/", (c) => {
 // GET /providers — available provider types
 app.get("/providers", (c) => {
   return c.json({ providers: getAvailableProviders() });
+});
+
+// GET /vapid-public-key — VAPID public key for push subscriptions
+app.get("/vapid-public-key", (c) => {
+  try {
+    const publicKey = getVapidPublicKey();
+    return c.json({ publicKey });
+  } catch {
+    return c.json({ error: "VAPID keys not configured" }, 500);
+  }
 });
 
 // POST / — create notifier


### PR DESCRIPTION
## Summary
This PR adds native web push notification support to Remindarr, allowing users to receive browser push notifications for new releases on their devices.

## Key Changes

### Frontend
- **New Push Notifications UI**: Added `PushNotificationsSection` component in ProfilePage for managing push subscriptions with enable/disable/test functionality
- **Service Worker**: Implemented custom service worker (`sw.ts`) using Workbox to handle push events, notification display, and click handling
- **Push Utilities**: Created `push.ts` library with functions for checking push support, subscribing/unsubscribing, and managing subscriptions
- **API Integration**: Added `getVapidPublicKey()` endpoint call to retrieve the server's VAPID public key
- **PWA Configuration**: Switched from Workbox auto-generation to `injectManifest` strategy to support custom service worker with push event handling
- **Dependencies**: Added `workbox-precaching` and `workbox-routing` for service worker functionality

### Backend
- **WebPush Provider**: Implemented `WebPushProvider` class that validates push subscriptions and sends notifications with formatted payloads
- **VAPID Key Management**: Created `vapid.ts` module to handle VAPID key generation, persistence, and retrieval with priority: env vars > database > auto-generate
- **Configuration**: Added `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, and `VAPID_SUBJECT` environment variables
- **Notifier Management**: Added `disableNotifier()` function to disable notifiers when subscriptions expire
- **Error Handling**: Implemented `SubscriptionExpiredError` to handle expired push subscriptions (410/404 responses)
- **Notification Scheduling**: Updated notification job to catch and handle expired subscriptions by disabling them
- **API Endpoint**: Added `GET /notifiers/vapid-public-key` endpoint for clients to retrieve the public key
- **UI Filtering**: Hidden webpush provider from manual notifier list in NotificationsSection since it's managed separately
- **Dependencies**: Added `web-push` library for server-side push notification delivery
- **Tests**: Added comprehensive test suites for WebPushProvider and VAPID key management

## Implementation Details
- Push subscriptions are stored as notifier configurations with endpoint, p256dh, and auth keys
- Notifications are formatted with episode/movie information grouped by show title
- Service worker automatically handles notification clicks by opening/focusing the app
- Expired subscriptions are automatically disabled to prevent repeated failures
- VAPID keys are auto-generated on first use and persisted in the database for consistency

https://claude.ai/code/session_01Uuni9xUNQTdvX41pFNPqD2