### PR TITLE
Remove custom notifier names, auto-generate from provider

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -271,7 +271,6 @@ export async function getNotifierProviders(): Promise<{ providers: string[] }> {
 
 export async function createNotifier(data: {
   provider: string;
-  name: string;
   config: Record<string, string>;
   notify_time: string;
   timezone: string;
@@ -285,7 +284,6 @@ export async function createNotifier(data: {
 export async function updateNotifier(
   id: string,
   data: Partial<{
-    name: string;
     config: Record<string, string>;
     notify_time: string;
     timezone: string;

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -167,7 +167,6 @@ function PushNotificationsSection() {
 
       await api.createNotifier({
         provider: "webpush",
-        name: "This Device",
         config: subscription,
         notify_time: "09:00",
         timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -310,7 +309,6 @@ function NotificationsSection() {
 
   // Form fields
   const [formProvider, setFormProvider] = useState("discord");
-  const [formName, setFormName] = useState("");
   const [formWebhookUrl, setFormWebhookUrl] = useState("");
   const [formTime, setFormTime] = useState("09:00");
   const [formTimezone, setFormTimezone] = useState(USER_TIMEZONE);
@@ -333,7 +331,6 @@ function NotificationsSection() {
 
   function resetForm() {
     setFormProvider("discord");
-    setFormName("");
     setFormWebhookUrl("");
     setFormTime("09:00");
     setFormTimezone(USER_TIMEZONE);
@@ -344,7 +341,6 @@ function NotificationsSection() {
   function startEdit(n: Notifier) {
     setEditingId(n.id);
     setFormProvider(n.provider);
-    setFormName(n.name);
     setFormWebhookUrl(n.config.webhookUrl || "");
     setFormTime(n.notify_time);
     setFormTimezone(n.timezone);
@@ -367,7 +363,6 @@ function NotificationsSection() {
     try {
       if (editingId) {
         await api.updateNotifier(editingId, {
-          name: formName,
           config,
           notify_time: formTime,
           timezone: formTimezone,
@@ -376,7 +371,6 @@ function NotificationsSection() {
       } else {
         await api.createNotifier({
           provider: formProvider,
-          name: formName,
           config,
           notify_time: formTime,
           timezone: formTimezone,
@@ -463,10 +457,7 @@ function NotificationsSection() {
             >
               <div className="flex items-center justify-between mb-2">
                 <div className="flex items-center gap-2">
-                  <span className="text-white font-medium">{n.name}</span>
-                  <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-indigo-900/50 text-indigo-300 capitalize">
-                    {n.provider}
-                  </span>
+                  <span className="text-white font-medium capitalize">{n.provider}</span>
                   <span
                     className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${
                       n.enabled
@@ -541,18 +532,6 @@ function NotificationsSection() {
                 </option>
               ))}
             </select>
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-300 mb-1">Name</label>
-            <input
-              type="text"
-              value={formName}
-              onChange={(e) => setFormName(e.target.value)}
-              placeholder="My Discord"
-              className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
-              required
-            />
           </div>
 
           {formProvider === "discord" && (

--- a/server/routes/notifiers.test.ts
+++ b/server/routes/notifiers.test.ts
@@ -37,7 +37,6 @@ function jsonHeaders() {
 
 const validNotifier = {
   provider: "discord",
-  name: "My Discord",
   config: {
     webhookUrl: "https://discord.com/api/webhooks/123456789/abcdefghijklmnop",
   },
@@ -79,7 +78,7 @@ describe("POST /notifiers", () => {
     });
     expect(res.status).toBe(201);
     const body = await res.json();
-    expect(body.notifier.name).toBe("My Discord");
+    expect(body.notifier.name).toBe("Discord");
     expect(body.notifier.provider).toBe("discord");
     expect(body.notifier.notify_time).toBe("09:00");
     expect(body.notifier.timezone).toBe("UTC");
@@ -144,11 +143,10 @@ describe("PUT /notifiers/:id", () => {
     const res = await app.request(`/notifiers/${notifier.id}`, {
       method: "PUT",
       headers: jsonHeaders(),
-      body: JSON.stringify({ name: "Updated Discord", notify_time: "18:00" }),
+      body: JSON.stringify({ notify_time: "18:00" }),
     });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.notifier.name).toBe("Updated Discord");
     expect(body.notifier.notify_time).toBe("18:00");
   });
 
@@ -156,7 +154,7 @@ describe("PUT /notifiers/:id", () => {
     const res = await app.request("/notifiers/nonexistent", {
       method: "PUT",
       headers: jsonHeaders(),
-      body: JSON.stringify({ name: "Test" }),
+      body: JSON.stringify({ notify_time: "10:00" }),
     });
     expect(res.status).toBe(404);
   });
@@ -212,7 +210,7 @@ describe("ownership enforcement", () => {
     const updateRes = await app.request(`/notifiers/${notifier.id}`, {
       method: "PUT",
       headers: { ...user2Headers, "Content-Type": "application/json" },
-      body: JSON.stringify({ name: "Hacked" }),
+      body: JSON.stringify({ notify_time: "10:00" }),
     });
     expect(updateRes.status).toBe(404);
 

--- a/server/routes/notifiers.ts
+++ b/server/routes/notifiers.ts
@@ -58,11 +58,13 @@ app.post("/", async (c) => {
   const user = c.get("user")!;
   const body = await c.req.json();
 
-  const { provider, name, config, notify_time, timezone } = body;
+  const { provider, config, notify_time, timezone } = body;
 
-  if (!provider || !name || !config) {
-    return c.json({ error: "provider, name, and config are required" }, 400);
+  if (!provider || !config) {
+    return c.json({ error: "provider and config are required" }, 400);
   }
+
+  const name = provider.charAt(0).toUpperCase() + provider.slice(1);
 
   const providerImpl = getProvider(provider);
   if (!providerImpl) {
@@ -124,7 +126,6 @@ app.put("/:id", async (c) => {
   }
 
   updateNotifier(id, user.id, {
-    name: body.name,
     config: body.config,
     notifyTime: body.notify_time,
     timezone: body.timezone,


### PR DESCRIPTION
## Summary
This PR removes the ability for users to set custom names for notifiers and instead auto-generates notifier names based on their provider type (e.g., "Discord", "Webpush"). This simplifies the notifier management UI and API while maintaining clear provider identification.

## Key Changes
- **Frontend**: Removed the "Name" input field from the notifier creation/editing form in ProfilePage
- **Frontend**: Updated notifier display to show only the capitalized provider name instead of custom name + provider badge
- **Backend**: Modified POST `/notifiers` endpoint to auto-generate notifier name from provider (capitalized)
- **Backend**: Removed `name` field from PUT `/notifiers/:id` update payload - name is now immutable
- **API Types**: Updated `createNotifier()` and `updateNotifier()` function signatures to remove the `name` parameter
- **Tests**: Updated test expectations to verify auto-generated names and removed name-related test cases

## Implementation Details
- The notifier name is now automatically generated server-side using `provider.charAt(0).toUpperCase() + provider.slice(1)`
- This ensures consistency and prevents duplicate/confusing custom names
- The UI now displays provider information more cleanly with a single capitalized label instead of separate name and provider badge
- Both web push and webhook-based notifiers follow the same naming convention

https://claude.ai/code/session_0164mpnuAaw1YTH74VfQEQjb