### PR TITLE
Add external links component for movies, shows, and people

### DIFF
--- a/frontend/src/components/ExternalLinks.test.tsx
+++ b/frontend/src/components/ExternalLinks.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { render, screen, cleanup } from "@testing-library/react";
+import ExternalLinks from "./ExternalLinks";
+
+afterEach(cleanup);
+
+describe("ExternalLinks", () => {
+  it("always renders TMDB link", () => {
+    render(<ExternalLinks tmdbId={123} type="movie" />);
+    const link = screen.getByTestId("external-link-tmdb");
+    expect(link).toBeTruthy();
+    expect(link.getAttribute("href")).toBe("https://www.themoviedb.org/movie/123");
+  });
+
+  it("renders all links when all IDs are present", () => {
+    const externalIds = {
+      imdb_id: "tt1234567",
+      facebook_id: "TestMovie",
+      instagram_id: "testmovie",
+      twitter_id: "testmovie",
+    };
+    render(<ExternalLinks externalIds={externalIds} tmdbId={456} type="movie" />);
+
+    expect(screen.getByTestId("external-link-tmdb").getAttribute("href")).toBe(
+      "https://www.themoviedb.org/movie/456",
+    );
+    expect(screen.getByTestId("external-link-imdb").getAttribute("href")).toBe(
+      "https://www.imdb.com/title/tt1234567",
+    );
+    expect(screen.getByTestId("external-link-instagram").getAttribute("href")).toBe(
+      "https://www.instagram.com/testmovie",
+    );
+    expect(screen.getByTestId("external-link-x").getAttribute("href")).toBe(
+      "https://x.com/testmovie",
+    );
+    expect(screen.getByTestId("external-link-facebook").getAttribute("href")).toBe(
+      "https://www.facebook.com/TestMovie",
+    );
+  });
+
+  it("hides links with null IDs", () => {
+    const externalIds = {
+      imdb_id: null,
+      facebook_id: null,
+      instagram_id: null,
+      twitter_id: null,
+    };
+    render(<ExternalLinks externalIds={externalIds} tmdbId={789} type="tv" />);
+
+    expect(screen.getByTestId("external-link-tmdb")).toBeTruthy();
+    expect(screen.queryByTestId("external-link-imdb")).toBeNull();
+    expect(screen.queryByTestId("external-link-instagram")).toBeNull();
+    expect(screen.queryByTestId("external-link-x")).toBeNull();
+    expect(screen.queryByTestId("external-link-facebook")).toBeNull();
+  });
+
+  it("uses /name/ path for person IMDB links", () => {
+    const externalIds = { imdb_id: "nm1234567" };
+    render(<ExternalLinks externalIds={externalIds} tmdbId={42} type="person" />);
+
+    expect(screen.getByTestId("external-link-imdb").getAttribute("href")).toBe(
+      "https://www.imdb.com/name/nm1234567",
+    );
+    expect(screen.getByTestId("external-link-tmdb").getAttribute("href")).toBe(
+      "https://www.themoviedb.org/person/42",
+    );
+  });
+
+  it("uses /title/ path for movie IMDB links", () => {
+    const externalIds = { imdb_id: "tt9999999" };
+    render(<ExternalLinks externalIds={externalIds} tmdbId={100} type="movie" />);
+
+    expect(screen.getByTestId("external-link-imdb").getAttribute("href")).toBe(
+      "https://www.imdb.com/title/tt9999999",
+    );
+  });
+
+  it("uses /tv/ path for TV show TMDB links", () => {
+    render(<ExternalLinks tmdbId={200} type="tv" />);
+
+    expect(screen.getByTestId("external-link-tmdb").getAttribute("href")).toBe(
+      "https://www.themoviedb.org/tv/200",
+    );
+  });
+
+  it("opens links in new tab", () => {
+    const externalIds = { imdb_id: "tt0000001" };
+    render(<ExternalLinks externalIds={externalIds} tmdbId={1} type="movie" />);
+
+    const links = screen.getAllByRole("link");
+    for (const link of links) {
+      expect(link.getAttribute("target")).toBe("_blank");
+      expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+    }
+  });
+
+  it("renders with no externalIds prop", () => {
+    render(<ExternalLinks tmdbId={999} type="movie" />);
+    // Should only show TMDB link
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(1);
+    expect(links[0].getAttribute("href")).toBe("https://www.themoviedb.org/movie/999");
+  });
+});

--- a/frontend/src/components/ExternalLinks.tsx
+++ b/frontend/src/components/ExternalLinks.tsx
@@ -1,0 +1,120 @@
+import type { ExternalIds } from "../types";
+
+interface ExternalLinksProps {
+  externalIds?: ExternalIds | null;
+  tmdbId: number;
+  type: "movie" | "tv" | "person";
+}
+
+const TMDB_BASE = "https://www.themoviedb.org";
+
+function buildLinks(
+  externalIds: ExternalIds | null | undefined,
+  tmdbId: number,
+  type: "movie" | "tv" | "person",
+) {
+  const links: { label: string; url: string; icon: React.ReactNode }[] = [];
+
+  links.push({
+    label: "TMDB",
+    url: `${TMDB_BASE}/${type}/${tmdbId}`,
+    icon: <TmdbIcon />,
+  });
+
+  if (externalIds?.imdb_id) {
+    const imdbPath = type === "person" ? "name" : "title";
+    links.push({
+      label: "IMDB",
+      url: `https://www.imdb.com/${imdbPath}/${externalIds.imdb_id}`,
+      icon: <ImdbIcon />,
+    });
+  }
+
+  if (externalIds?.instagram_id) {
+    links.push({
+      label: "Instagram",
+      url: `https://www.instagram.com/${externalIds.instagram_id}`,
+      icon: <InstagramIcon />,
+    });
+  }
+
+  if (externalIds?.twitter_id) {
+    links.push({
+      label: "X",
+      url: `https://x.com/${externalIds.twitter_id}`,
+      icon: <XIcon />,
+    });
+  }
+
+  if (externalIds?.facebook_id) {
+    links.push({
+      label: "Facebook",
+      url: `https://www.facebook.com/${externalIds.facebook_id}`,
+      icon: <FacebookIcon />,
+    });
+  }
+
+  return links;
+}
+
+export default function ExternalLinks({ externalIds, tmdbId, type }: ExternalLinksProps) {
+  const links = buildLinks(externalIds, tmdbId, type);
+
+  return (
+    <div className="flex items-center gap-3 flex-wrap">
+      {links.map((link) => (
+        <a
+          key={link.label}
+          href={link.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          title={link.label}
+          className="text-gray-400 hover:text-white transition-colors"
+          data-testid={`external-link-${link.label.toLowerCase()}`}
+        >
+          {link.icon}
+        </a>
+      ))}
+    </div>
+  );
+}
+
+function TmdbIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5">
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 14H9V8h2v8zm5 0h-2V8h2v8z" />
+    </svg>
+  );
+}
+
+function ImdbIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5">
+      <path d="M2 4v16h20V4H2zm3 12H4V8h1v8zm5.5 0H9.3l-.5-3.5-.5 3.5H7V8h1.2l.5 3.5L9.2 8h1.3v8zm4.5 0h-1.5V8H14c.8 0 1.4.2 1.8.6.4.4.7 1 .7 1.8v3.2c0 .8-.2 1.4-.7 1.8-.4.4-1 .6-1.8.6zm4 0h-1.5V8H19c1.1 0 2 .7 2 1.6v1.8c0 .9-.4 1.5-1 1.7l1.2 2.9h-1.6L18.5 13H18v3zm-4-6.8v5.6c.6 0 .8-.3.8-.8v-4c0-.5-.2-.8-.8-.8zm4 0v2.3h.5c.3 0 .5-.2.5-.5v-1.3c0-.3-.2-.5-.5-.5H18z" />
+    </svg>
+  );
+}
+
+function InstagramIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5">
+      <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zM12 0C8.741 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.052.014 8.333 0 8.741 0 12c0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98C8.333 23.986 8.741 24 12 24c3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98C15.668.014 15.259 0 12 0zm0 5.838a6.162 6.162 0 100 12.324 6.162 6.162 0 000-12.324zM12 16a4 4 0 110-8 4 4 0 010 8zm6.406-11.845a1.44 1.44 0 100 2.881 1.44 1.44 0 000-2.881z" />
+    </svg>
+  );
+}
+
+function XIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5">
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}
+
+function FacebookIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5">
+      <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
+    </svg>
+  );
+}

--- a/frontend/src/pages/PersonPage.tsx
+++ b/frontend/src/pages/PersonPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { useParams, Link } from "react-router";
 import * as api from "../api";
 import type { PersonDetailsResponse, PersonCastCredit, PersonCrewCredit } from "../types";
+import ExternalLinks from "../components/ExternalLinks";
 
 const TMDB_IMG = "https://image.tmdb.org/t/p";
 const BIO_TRUNCATE_LENGTH = 600;
@@ -180,6 +181,11 @@ export default function PersonPage() {
               </div>
             )}
           </div>
+          <ExternalLinks
+            externalIds={person.external_ids}
+            tmdbId={person.id}
+            type="person"
+          />
         </div>
       </div>
 

--- a/frontend/src/pages/TitleDetailPage.tsx
+++ b/frontend/src/pages/TitleDetailPage.tsx
@@ -13,6 +13,7 @@ import type {
 } from "../types";
 import TrackButton from "../components/TrackButton";
 import PersonCard from "../components/PersonCard";
+import ExternalLinks from "../components/ExternalLinks";
 
 const TMDB_IMG = "https://image.tmdb.org/t/p";
 
@@ -423,6 +424,17 @@ function MovieDetail({ data }: { data: MovieDetailsResponse }) {
         </Section>
       )}
 
+      {/* External Links */}
+      {tmdb && (
+        <Section title="Links">
+          <ExternalLinks
+            externalIds={tmdb.external_ids ?? { imdb_id: tmdb.imdb_id }}
+            tmdbId={tmdb.id}
+            type="movie"
+          />
+        </Section>
+      )}
+
       {/* Additional Info */}
       {tmdb && (
         <Section title="Details">
@@ -696,6 +708,17 @@ function ShowDetail({ data }: { data: ShowDetailsResponse }) {
               </a>
             ))}
           </div>
+        </Section>
+      )}
+
+      {/* External Links */}
+      {tmdb && (
+        <Section title="Links">
+          <ExternalLinks
+            externalIds={tmdb.external_ids}
+            tmdbId={tmdb.id}
+            type="tv"
+          />
         </Section>
       )}
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,3 +1,10 @@
+export interface ExternalIds {
+  imdb_id?: string | null;
+  facebook_id?: string | null;
+  instagram_id?: string | null;
+  twitter_id?: string | null;
+}
+
 export interface Offer {
   id: number;
   title_id: string;
@@ -208,6 +215,7 @@ export interface MovieDetailsResponse {
     credits: { cast: CastMember[]; crew: CrewMember[] };
     release_dates: { results: ReleaseDatesResult[] };
     "watch/providers": { results: Record<string, WatchProviderCountry> };
+    external_ids?: ExternalIds;
   } | null;
   country: string;
 }
@@ -242,6 +250,7 @@ export interface ShowDetailsResponse {
     credits: { cast: CastMember[]; crew: CrewMember[] };
     content_ratings: { results: { iso_3166_1: string; rating: string }[] };
     "watch/providers": { results: Record<string, WatchProviderCountry> };
+    external_ids?: ExternalIds;
   } | null;
   country: string;
 }
@@ -344,6 +353,7 @@ export interface PersonDetailsResponse {
       cast: PersonCastCredit[];
       crew: PersonCrewCredit[];
     };
+    external_ids?: ExternalIds;
   };
 }
 

--- a/server/tmdb/client.test.ts
+++ b/server/tmdb/client.test.ts
@@ -151,19 +151,19 @@ describe("fetchMovieFullDetails", () => {
     await fetchMovieFullDetails("55");
     const url = new URL((fetchSpy.mock.calls[0] as [string])[0]);
     expect(url.pathname).toBe("/3/movie/55");
-    expect(url.searchParams.get("append_to_response")).toBe("credits,release_dates,watch/providers");
+    expect(url.searchParams.get("append_to_response")).toBe("credits,release_dates,watch/providers,external_ids");
   });
 });
 
 // ─── fetchShowFullDetails ───────────────────────────────────────────────────
 
 describe("fetchShowFullDetails", () => {
-  it("appends credits, content_ratings, watch/providers", async () => {
+  it("appends credits, content_ratings, watch/providers, external_ids", async () => {
     fetchSpy.mockResolvedValueOnce(jsonResponse({ id: 1 }));
     await fetchShowFullDetails("77");
     const url = new URL((fetchSpy.mock.calls[0] as [string])[0]);
     expect(url.pathname).toBe("/3/tv/77");
-    expect(url.searchParams.get("append_to_response")).toBe("credits,content_ratings,watch/providers");
+    expect(url.searchParams.get("append_to_response")).toBe("credits,content_ratings,watch/providers,external_ids");
   });
 });
 
@@ -201,7 +201,7 @@ describe("fetchPersonDetails", () => {
     expect(result.name).toBe("Actor Name");
     const url = new URL((fetchSpy.mock.calls[0] as [string])[0]);
     expect(url.pathname).toBe("/3/person/200");
-    expect(url.searchParams.get("append_to_response")).toBe("combined_credits");
+    expect(url.searchParams.get("append_to_response")).toBe("combined_credits,external_ids");
   });
 });
 

--- a/server/tmdb/client.ts
+++ b/server/tmdb/client.ts
@@ -84,14 +84,14 @@ export async function fetchTvDetails(tmdbId: number): Promise<TmdbTvDetails> {
 export async function fetchMovieFullDetails(tmdbId: string): Promise<TmdbMovieFullDetails> {
   return tmdbRequest<TmdbMovieFullDetails>(`/movie/${tmdbId}`, {
     language: tmdbLanguage(),
-    append_to_response: "credits,release_dates,watch/providers",
+    append_to_response: "credits,release_dates,watch/providers,external_ids",
   });
 }
 
 export async function fetchShowFullDetails(tmdbId: string): Promise<TmdbShowFullDetails> {
   return tmdbRequest<TmdbShowFullDetails>(`/tv/${tmdbId}`, {
     language: tmdbLanguage(),
-    append_to_response: "credits,content_ratings,watch/providers",
+    append_to_response: "credits,content_ratings,watch/providers,external_ids",
   });
 }
 
@@ -118,7 +118,7 @@ export async function fetchEpisodeDetails(
 export async function fetchPersonDetails(personId: number): Promise<TmdbPersonDetails> {
   return tmdbRequest<TmdbPersonDetails>(`/person/${personId}`, {
     language: tmdbLanguage(),
-    append_to_response: "combined_credits",
+    append_to_response: "combined_credits,external_ids",
   });
 }
 

--- a/server/tmdb/types.ts
+++ b/server/tmdb/types.ts
@@ -35,6 +35,9 @@ export interface TmdbGenre {
 export interface TmdbExternalIds {
   imdb_id: string | null;
   tvdb_id?: number | null;
+  facebook_id?: string | null;
+  instagram_id?: string | null;
+  twitter_id?: string | null;
 }
 
 export interface TmdbWatchProviderEntry {
@@ -295,6 +298,7 @@ export interface TmdbMovieFullDetails {
   credits: TmdbCredits;
   release_dates: { results: TmdbReleaseDatesResult[] };
   "watch/providers": { results: Record<string, TmdbWatchProviderCountry> };
+  external_ids?: TmdbExternalIds;
 }
 
 export interface TmdbShowFullDetails {
@@ -327,6 +331,7 @@ export interface TmdbShowFullDetails {
   credits: TmdbCredits;
   content_ratings: { results: TmdbContentRatingResult[] };
   "watch/providers": { results: Record<string, TmdbWatchProviderCountry> };
+  external_ids?: TmdbExternalIds;
 }
 
 export interface TmdbSeasonDetails {
@@ -410,4 +415,5 @@ export interface TmdbPersonDetails {
   also_known_as: string[];
   popularity: number;
   combined_credits: TmdbPersonCombinedCredits;
+  external_ids?: TmdbExternalIds;
 }


### PR DESCRIPTION
## Summary
This PR adds a new `ExternalLinks` component that displays links to external platforms (TMDB, IMDb, Instagram, X/Twitter, Facebook) for movies, TV shows, and people. The component is integrated into the detail pages and uses external ID data from TMDB API responses.

## Key Changes
- **New Component**: Created `ExternalLinks.tsx` with support for rendering links to TMDB, IMDb, Instagram, X, and Facebook
  - Dynamically builds links based on available external IDs
  - Handles different URL paths for different content types (e.g., `/name/` vs `/title/` for IMDb)
  - Includes SVG icons for each platform with hover effects
  
- **Type Definitions**: Added `ExternalIds` interface to `types.ts` to standardize external ID structure across the application

- **API Integration**: Updated TMDB client requests to include `external_ids` in the `append_to_response` parameter for:
  - Movie full details
  - Show full details
  - Person details

- **Page Integration**: Integrated `ExternalLinks` component into:
  - `TitleDetailPage.tsx` (both movie and show detail sections)
  - `PersonPage.tsx`

- **Type Updates**: Extended TMDB type definitions to include `facebook_id`, `instagram_id`, and `twitter_id` fields in `TmdbExternalIds`

- **Testing**: Added comprehensive test suite (`ExternalLinks.test.tsx`) covering:
  - Always-present TMDB link
  - Conditional rendering of optional external links
  - Correct URL generation for different content types
  - Link security attributes (target="_blank", rel="noopener noreferrer")

## Implementation Details
- The component gracefully handles missing external IDs by only rendering available links
- Links open in new tabs with proper security attributes to prevent window.opener access
- Each link includes a title attribute and data-testid for accessibility and testing
- SVG icons are inline and styled with Tailwind CSS for consistent sizing and hover effects

https://claude.ai/code/session_01Xzhfy9Tf1mjmeStze7eo9J