### PR TITLE
fix: remove setupHonoErrorHandler to prevent sentryErrorMiddleware Error: undefined

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -46,13 +46,11 @@ if (getUserCount() === 0) {
 
 const app = new Hono<AppEnv>();
 
-// Sentry error handler (captures exceptions + creates request spans)
-Sentry.setupHonoErrorHandler(app);
-
 app.onError((err, c) => {
   if (err instanceof HTTPException) {
     return err.getResponse();
   }
+  Sentry.captureException(err);
   return c.json({ error: "Internal server error" }, 500);
 });
 


### PR DESCRIPTION
Fixes #95

The `sentryErrorMiddleware` in `@sentry/node@10.43.0` fires on all responses (not just errors) and calls `captureException(context.error)` without a null check. When `context.error` is undefined on successful requests, this produces a synthetic "Error: undefined" Sentry event.

Removes `setupHonoErrorHandler` and instead calls `Sentry.captureException(err)` directly in `app.onError` for non-HTTPException errors.

Generated with [Claude Code](https://claude.ai/code)