### PR TITLE
Add view mode toggle between grid and agenda calendar layouts

### DIFF
--- a/frontend/src/pages/CalendarPage.test.tsx
+++ b/frontend/src/pages/CalendarPage.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, mock, afterEach, beforeEach } from "bun:test";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import type { ReactNode } from "react";
+
+// Mock useIsMobile hook
+let mockIsMobile = false;
+mock.module("../hooks/useIsMobile", () => ({
+  useIsMobile: () => mockIsMobile,
+}));
+
+// Mock API calls
+mock.module("../api", () => ({
+  getCalendarTitles: mock(() =>
+    Promise.resolve({ titles: [], episodes: [], count: 0 })
+  ),
+  watchEpisode: mock(() => Promise.resolve()),
+  unwatchEpisode: mock(() => Promise.resolve()),
+  watchEpisodesBulk: mock(() => Promise.resolve()),
+}));
+
+// Must import after mocks
+const { default: CalendarPage } = await import("./CalendarPage");
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  mockIsMobile = false;
+});
+
+describe("CalendarPage", () => {
+  it("renders grid view by default on desktop", () => {
+    render(<CalendarPage />, { wrapper: Wrapper });
+
+    // Grid view has weekday headers
+    expect(screen.getByText("Mon")).toBeDefined();
+    expect(screen.getByText("Tue")).toBeDefined();
+    expect(screen.getByText("Wed")).toBeDefined();
+  });
+
+  it("renders view toggle buttons on desktop", () => {
+    render(<CalendarPage />, { wrapper: Wrapper });
+
+    expect(screen.getByTitle("Grid view")).toBeDefined();
+    expect(screen.getByTitle("Agenda view")).toBeDefined();
+  });
+
+  it("switches to agenda view when agenda toggle is clicked", async () => {
+    render(<CalendarPage />, { wrapper: Wrapper });
+
+    // Verify we're in grid mode (weekday headers visible)
+    expect(screen.getByText("Mon")).toBeDefined();
+
+    // Click agenda toggle
+    fireEvent.click(screen.getByTitle("Agenda view"));
+
+    // Grid weekday headers should be gone, month picker (select) should be visible
+    expect(screen.queryByText("Mon")).toBeNull();
+    // Agenda mode shows a select dropdown for month jumping
+    const selects = screen.getAllByRole("combobox");
+    expect(selects.length).toBeGreaterThan(0);
+  });
+
+  it("switches back to grid view from agenda view", () => {
+    render(<CalendarPage />, { wrapper: Wrapper });
+
+    // Switch to agenda
+    fireEvent.click(screen.getByTitle("Agenda view"));
+    expect(screen.queryByText("Mon")).toBeNull();
+
+    // Switch back to grid
+    fireEvent.click(screen.getByTitle("Grid view"));
+    expect(screen.getByText("Mon")).toBeDefined();
+  });
+
+  it("renders agenda view on mobile without toggle", () => {
+    mockIsMobile = true;
+    render(<CalendarPage />, { wrapper: Wrapper });
+
+    // No toggle buttons on mobile
+    expect(screen.queryByTitle("Grid view")).toBeNull();
+    expect(screen.queryByTitle("Agenda view")).toBeNull();
+  });
+});

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { Link } from "react-router";
-import { ChevronLeftIcon, ChevronRightIcon, CheckCircleIcon, CircleIcon } from "lucide-react";
+import { ChevronLeftIcon, ChevronRightIcon, CheckCircleIcon, CircleIcon, LayoutGridIcon, ListIcon } from "lucide-react";
 import { getCalendarTitles, watchEpisode, unwatchEpisode, watchEpisodesBulk } from "../api";
 import { useIsMobile } from "../hooks/useIsMobile";
 import TitleList from "../components/TitleList";
@@ -72,14 +72,50 @@ function getMonthOptions(): { label: string; value: string }[] {
   return options;
 }
 
+type ViewMode = "grid" | "agenda";
+
+function ViewToggle({ viewMode, onViewModeChange }: { viewMode: ViewMode; onViewModeChange: (mode: ViewMode) => void }) {
+  return (
+    <div className="flex items-center bg-gray-800 rounded-lg p-0.5">
+      <button
+        onClick={() => onViewModeChange("grid")}
+        className={`p-1.5 rounded-md transition-colors cursor-pointer ${
+          viewMode === "grid"
+            ? "bg-indigo-600 text-white"
+            : "text-gray-400 hover:text-white"
+        }`}
+        title="Grid view"
+      >
+        <LayoutGridIcon className="size-4" />
+      </button>
+      <button
+        onClick={() => onViewModeChange("agenda")}
+        className={`p-1.5 rounded-md transition-colors cursor-pointer ${
+          viewMode === "agenda"
+            ? "bg-indigo-600 text-white"
+            : "text-gray-400 hover:text-white"
+        }`}
+        title="Agenda view"
+      >
+        <ListIcon className="size-4" />
+      </button>
+    </div>
+  );
+}
+
 export default function CalendarPage() {
   const isMobile = useIsMobile();
+  const [viewMode, setViewMode] = useState<ViewMode>("grid");
 
   if (isMobile) {
     return <AgendaCalendar />;
   }
 
-  return <GridCalendar />;
+  if (viewMode === "agenda") {
+    return <AgendaCalendar viewMode={viewMode} onViewModeChange={setViewMode} />;
+  }
+
+  return <GridCalendar viewMode={viewMode} onViewModeChange={setViewMode} />;
 }
 
 // ─── Mobile Agenda View ──────────────────────────────────────────────────────
@@ -90,7 +126,7 @@ interface AgendaMonth {
   episodes: Episode[];
 }
 
-function AgendaCalendar() {
+function AgendaCalendar({ viewMode, onViewModeChange }: { viewMode?: ViewMode; onViewModeChange?: (mode: ViewMode) => void } = {}) {
   const [typeFilter, setTypeFilter] = useState("");
   const [months, setMonths] = useState<AgendaMonth[]>([]);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -303,17 +339,22 @@ function AgendaCalendar() {
     <div ref={containerRef} className="space-y-4">
       {/* Header: month picker + type filter */}
       <div className="flex flex-col gap-3">
-        <select
-          value={formatMonth(new Date())}
-          onChange={(e) => jumpToMonth(e.target.value)}
-          className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-        >
-          {monthOptions.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
+        <div className="flex items-center gap-3">
+          <select
+            value={formatMonth(new Date())}
+            onChange={(e) => jumpToMonth(e.target.value)}
+            className={`px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 ${viewMode ? "flex-1" : "w-full"}`}
+          >
+            {monthOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          {viewMode && onViewModeChange && (
+            <ViewToggle viewMode={viewMode} onViewModeChange={onViewModeChange} />
+          )}
+        </div>
         <div className="flex items-center gap-2">
           {typeFilters.map((f) => (
             <button
@@ -473,7 +514,7 @@ function AgendaCalendar() {
 
 // ─── Desktop Grid Calendar ──────────────────────────────────────────────────
 
-function GridCalendar() {
+function GridCalendar({ viewMode, onViewModeChange }: { viewMode: ViewMode; onViewModeChange: (mode: ViewMode) => void }) {
   const [currentMonth, setCurrentMonth] = useState(new Date());
   const [typeFilter, setTypeFilter] = useState("");
   const [titles, setTitles] = useState<Title[]>([]);
@@ -640,6 +681,7 @@ function GridCalendar() {
               {f.label}
             </button>
           ))}
+          <ViewToggle viewMode={viewMode} onViewModeChange={onViewModeChange} />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
This PR adds a view mode toggle to the CalendarPage, allowing desktop users to switch between grid and agenda calendar layouts. Previously, the agenda view was only available on mobile devices. The grid view remains the default for desktop users.

## Key Changes
- **New ViewToggle component**: Created a reusable toggle button component with grid and agenda view options, styled with Lucide React icons (LayoutGridIcon and ListIcon)
- **View mode state management**: Added `viewMode` state to CalendarPage to track the current view ("grid" or "agenda")
- **Desktop view switching**: Desktop users can now toggle between GridCalendar and AgendaCalendar views using the new toggle buttons
- **Updated component signatures**: Modified GridCalendar and AgendaCalendar to accept optional `viewMode` and `onViewModeChange` props to support the toggle functionality
- **Mobile behavior unchanged**: Mobile devices continue to render the agenda view exclusively without toggle buttons
- **UI layout adjustments**: Updated AgendaCalendar's header layout to accommodate the toggle button alongside the month picker when in desktop mode
- **Comprehensive test coverage**: Added CalendarPage.test.tsx with tests covering:
  - Default grid view rendering on desktop
  - View toggle button visibility
  - Switching between grid and agenda views
  - Mobile-specific behavior (no toggle buttons)

## Implementation Details
- The ViewToggle component uses conditional styling to highlight the active view mode with an indigo background
- The toggle is only rendered on desktop; mobile users see the agenda view by default without any toggle UI
- Both calendar views maintain their existing functionality while gaining the ability to be switched between

https://claude.ai/code/session_01NWemp2VAgjqnqHSKNfZ3jp