### PR TITLE
Fix expired push subscriptions: auto-recover instead of showing confusing error

### DIFF
--- a/frontend/src/pages/ProfilePage.test.tsx
+++ b/frontend/src/pages/ProfilePage.test.tsx
@@ -1,0 +1,208 @@
+import { describe, it, expect, mock, afterEach, beforeEach } from "bun:test";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+// Mock browser Notification API
+Object.defineProperty(globalThis, "Notification", {
+  value: { permission: "granted", requestPermission: () => Promise.resolve("granted" as NotificationPermission) },
+  writable: true,
+  configurable: true,
+});
+
+// Track calls to push helpers
+const mockUnsubscribeFromPush = mock(() => Promise.resolve());
+const mockGetExistingSubscription = mock(() => Promise.resolve(null as PushSubscription | null));
+let mockIsPushSupported = true;
+
+mock.module("../lib/push", () => ({
+  isPushSupported: () => mockIsPushSupported,
+  subscribeToPush: mock(() => Promise.resolve({ endpoint: "https://fcm.example.com/new", p256dh: "key", auth: "auth" })),
+  unsubscribeFromPush: mockUnsubscribeFromPush,
+  getExistingSubscription: mockGetExistingSubscription,
+}));
+
+// Mock API
+const mockGetNotifiers = mock(() => Promise.resolve({ notifiers: [] as any[] }));
+const mockDeleteNotifier = mock(() => Promise.resolve());
+const mockTestNotifier = mock(() => Promise.resolve({ success: true, message: "Test notification sent" }));
+
+mock.module("../api", () => ({
+  getNotifiers: mockGetNotifiers,
+  getNotifierProviders: mock(() => Promise.resolve({ providers: ["discord"] })),
+  getVapidPublicKey: mock(() => Promise.resolve({ publicKey: "test-key" })),
+  createNotifier: mock(() => Promise.resolve({ notifier: {} })),
+  updateNotifier: mock(() => Promise.resolve({ notifier: {} })),
+  deleteNotifier: mockDeleteNotifier,
+  testNotifier: mockTestNotifier,
+  getJobs: mock(() => Promise.resolve({ crons: [], stats: {}, recentJobs: [] })),
+  getAdminSettings: mock(() => Promise.resolve({ oidc_configured: false, oidc: { issuer_url: { value: "", source: "unset" }, client_id: { value: "", source: "unset" }, client_secret: { value: "", source: "unset" }, redirect_uri: { value: "", source: "unset" } } })),
+  changePassword: mock(() => Promise.resolve()),
+}));
+
+// Mock AuthContext
+mock.module("../context/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: "u1", username: "testuser", display_name: "Test User", auth_provider: "local", is_admin: false },
+    loading: false,
+  }),
+}));
+
+// Import after mocks
+const { default: ProfilePage } = await import("./ProfilePage");
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}
+
+afterEach(() => {
+  cleanup();
+  mockGetNotifiers.mockReset();
+  mockDeleteNotifier.mockReset();
+  mockTestNotifier.mockReset();
+  mockUnsubscribeFromPush.mockReset();
+  mockGetExistingSubscription.mockReset();
+  mockIsPushSupported = true;
+});
+
+beforeEach(() => {
+  // Default: no notifiers, no subscription
+  mockGetNotifiers.mockImplementation(() => Promise.resolve({ notifiers: [] }));
+  mockDeleteNotifier.mockImplementation(() => Promise.resolve());
+  mockUnsubscribeFromPush.mockImplementation(() => Promise.resolve());
+  mockGetExistingSubscription.mockImplementation(() => Promise.resolve(null));
+  mockTestNotifier.mockImplementation(() => Promise.resolve({ success: true, message: "Test notification sent" }));
+});
+
+const FAKE_SUBSCRIPTION = { endpoint: "https://fcm.example.com/send/abc" } as PushSubscription;
+
+function makeWebpushNotifier(overrides: Record<string, any> = {}) {
+  return {
+    id: "n1",
+    user_id: "u1",
+    provider: "webpush",
+    name: "Webpush",
+    config: { endpoint: "https://fcm.example.com/send/abc", p256dh: "key", auth: "auth" },
+    notify_time: "09:00",
+    timezone: "UTC",
+    enabled: true,
+    last_sent_date: null,
+    created_at: "2026-01-01",
+    updated_at: "2026-01-01",
+    ...overrides,
+  };
+}
+
+describe("PushNotificationsSection", () => {
+  it("auto-cleans up disabled webpush notifier on page load", async () => {
+    // Notifier exists but is disabled (background job disabled it)
+    mockGetNotifiers.mockImplementation(() =>
+      Promise.resolve({ notifiers: [makeWebpushNotifier({ enabled: false })] })
+    );
+    mockGetExistingSubscription.mockImplementation(() => Promise.resolve(FAKE_SUBSCRIPTION));
+
+    render(<ProfilePage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText(/subscription expired/i)).toBeDefined();
+    });
+
+    // Should have cleaned up
+    expect(mockUnsubscribeFromPush).toHaveBeenCalled();
+    expect(mockDeleteNotifier).toHaveBeenCalledWith("n1");
+
+    // Should show Enable button (not enabled state)
+    expect(screen.getByText("Enable")).toBeDefined();
+  });
+
+  it("auto-cleans up stale DB notifier when browser has no subscription", async () => {
+    // Notifier exists in DB but no browser subscription
+    mockGetNotifiers.mockImplementation(() =>
+      Promise.resolve({ notifiers: [makeWebpushNotifier({ enabled: true })] })
+    );
+    mockGetExistingSubscription.mockImplementation(() => Promise.resolve(null));
+
+    render(<ProfilePage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(mockDeleteNotifier).toHaveBeenCalledWith("n1");
+    });
+
+    // Should show Enable button
+    expect(screen.getByText("Enable")).toBeDefined();
+  });
+
+  it("auto-recovers when test reveals expired subscription", async () => {
+    // Push is enabled and active
+    mockGetNotifiers.mockImplementation(() =>
+      Promise.resolve({ notifiers: [makeWebpushNotifier()] })
+    );
+    mockGetExistingSubscription.mockImplementation(() => Promise.resolve(FAKE_SUBSCRIPTION));
+
+    // Test will return expired
+    mockTestNotifier.mockImplementation(() =>
+      Promise.resolve({ success: false, message: "Push subscription expired: https://fcm.example.com/send/abc" })
+    );
+
+    render(<ProfilePage />, { wrapper: Wrapper });
+
+    // Wait for initial load
+    await waitFor(() => {
+      expect(screen.getByText("Test")).toBeDefined();
+    });
+
+    // Click test button
+    fireEvent.click(screen.getByText("Test"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/subscription expired/i)).toBeDefined();
+    });
+
+    // Should have cleaned up
+    expect(mockUnsubscribeFromPush).toHaveBeenCalled();
+    expect(mockDeleteNotifier).toHaveBeenCalledWith("n1");
+
+    // Should now show Enable button
+    expect(screen.getByText("Enable")).toBeDefined();
+  });
+
+  it("shows normal error for non-expired test failures", async () => {
+    mockGetNotifiers.mockImplementation(() =>
+      Promise.resolve({ notifiers: [makeWebpushNotifier()] })
+    );
+    mockGetExistingSubscription.mockImplementation(() => Promise.resolve(FAKE_SUBSCRIPTION));
+    mockTestNotifier.mockImplementation(() =>
+      Promise.resolve({ success: false, message: "Web push failed (500): Internal error" })
+    );
+
+    render(<ProfilePage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Test")).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByText("Test"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Web push failed/)).toBeDefined();
+    });
+
+    // Should NOT have cleaned up
+    expect(mockDeleteNotifier).not.toHaveBeenCalled();
+  });
+
+  it("renders normally when push is enabled and healthy", async () => {
+    mockGetNotifiers.mockImplementation(() =>
+      Promise.resolve({ notifiers: [makeWebpushNotifier()] })
+    );
+    mockGetExistingSubscription.mockImplementation(() => Promise.resolve(FAKE_SUBSCRIPTION));
+
+    render(<ProfilePage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Push notifications are enabled")).toBeDefined();
+    });
+
+    expect(screen.getByText("Test")).toBeDefined();
+    expect(screen.getByText("Disable")).toBeDefined();
+  });
+});

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -136,8 +136,24 @@ function PushNotificationsSection() {
         getExistingSubscription(),
       ]);
       const webpushNotifier = notifiers.find((n) => n.provider === "webpush") || null;
-      setPushNotifier(webpushNotifier);
-      setHasSubscription(!!subscription);
+
+      // Auto-cleanup stale states
+      if (webpushNotifier && !webpushNotifier.enabled) {
+        // Background job disabled it (expired subscription) — clean up
+        try { await unsubscribeFromPush(); } catch { /* ignore */ }
+        try { await api.deleteNotifier(webpushNotifier.id); } catch { /* ignore */ }
+        setPushNotifier(null);
+        setHasSubscription(false);
+        setErr("Push subscription expired. Please re-enable push notifications.");
+      } else if (webpushNotifier && !subscription) {
+        // DB record exists but browser has no subscription — stale
+        try { await api.deleteNotifier(webpushNotifier.id); } catch { /* ignore */ }
+        setPushNotifier(null);
+        setHasSubscription(false);
+      } else {
+        setPushNotifier(webpushNotifier);
+        setHasSubscription(!!subscription);
+      }
       setPermissionState(Notification.permission);
     } catch {
       // ignore
@@ -208,6 +224,13 @@ function PushNotificationsSection() {
       const result = await api.testNotifier(pushNotifier.id);
       if (result.success) {
         setMsg(result.message);
+      } else if (result.message.toLowerCase().includes("subscription expired")) {
+        // Auto-cleanup expired subscription
+        try { await unsubscribeFromPush(); } catch { /* ignore */ }
+        try { await api.deleteNotifier(pushNotifier.id); } catch { /* ignore */ }
+        setPushNotifier(null);
+        setHasSubscription(false);
+        setErr("Push subscription expired. Please re-enable push notifications.");
       } else {
         setErr(result.message);
       }


### PR DESCRIPTION
When a push subscription expires (FCM returns 410/404), the app now
automatically cleans up the stale subscription and prompts re-enable,
instead of showing a raw error while still claiming notifications are enabled.

- On page load: detect disabled notifier (expired by background job) or
  missing browser subscription, auto-cleanup DB record and browser state
- On test failure: detect "subscription expired" message, auto-cleanup
  and show user-friendly re-enable prompt
- Add comprehensive tests for all recovery scenarios

https://claude.ai/code/session_01FxaSrFsgur4bkgy3gCX7za