### PR TITLE
Add push subscription verification and cleanup on enable

### DIFF
--- a/frontend/src/lib/push.test.ts
+++ b/frontend/src/lib/push.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "bun:test";
-import { urlBase64ToUint8Array } from "./push";
+import { describe, it, expect, mock } from "bun:test";
+import { urlBase64ToUint8Array, subscribeToPush } from "./push";
 
 describe("urlBase64ToUint8Array", () => {
   it("converts a base64url string to Uint8Array", () => {
@@ -23,5 +23,90 @@ describe("urlBase64ToUint8Array", () => {
     const result = urlBase64ToUint8Array("AA");
     expect(result).toBeInstanceOf(Uint8Array);
     expect(result[0]).toBe(0);
+  });
+});
+
+function setupServiceWorkerMock(opts: {
+  existingSubscription?: { unsubscribe: () => Promise<boolean> } | null;
+  newSubscription?: { toJSON: () => Record<string, any> };
+}) {
+  const mockSubscribe = mock(() => Promise.resolve(opts.newSubscription));
+  const mockGetSubscription = mock(() => Promise.resolve(opts.existingSubscription ?? null));
+
+  Object.defineProperty(navigator, "serviceWorker", {
+    value: {
+      ready: Promise.resolve({
+        pushManager: {
+          getSubscription: mockGetSubscription,
+          subscribe: mockSubscribe,
+        },
+      }),
+    },
+    configurable: true,
+  });
+
+  return { mockSubscribe, mockGetSubscription };
+}
+
+const VALID_SUBSCRIPTION = {
+  toJSON: () => ({
+    endpoint: "https://fcm.example.com/send/fresh",
+    keys: { p256dh: "newp256dh", auth: "newauth" },
+  }),
+};
+
+describe("subscribeToPush", () => {
+  it("unsubscribes existing subscription before creating new one", async () => {
+    const mockUnsubscribe = mock(() => Promise.resolve(true));
+    const { mockSubscribe, mockGetSubscription } = setupServiceWorkerMock({
+      existingSubscription: { unsubscribe: mockUnsubscribe },
+      newSubscription: VALID_SUBSCRIPTION,
+    });
+
+    const result = await subscribeToPush("test-vapid-key");
+
+    expect(mockGetSubscription).toHaveBeenCalled();
+    expect(mockUnsubscribe).toHaveBeenCalled();
+    expect(mockSubscribe).toHaveBeenCalled();
+    expect(result.endpoint).toBe("https://fcm.example.com/send/fresh");
+    expect(result.p256dh).toBe("newp256dh");
+    expect(result.auth).toBe("newauth");
+  });
+
+  it("proceeds even if existing unsubscribe fails", async () => {
+    const mockUnsubscribe = mock(() => Promise.reject(new Error("unsubscribe failed")));
+    const { mockSubscribe } = setupServiceWorkerMock({
+      existingSubscription: { unsubscribe: mockUnsubscribe },
+      newSubscription: VALID_SUBSCRIPTION,
+    });
+
+    const result = await subscribeToPush("test-vapid-key");
+
+    expect(mockUnsubscribe).toHaveBeenCalled();
+    expect(mockSubscribe).toHaveBeenCalled();
+    expect(result.endpoint).toBe("https://fcm.example.com/send/fresh");
+  });
+
+  it("works when no existing subscription", async () => {
+    const { mockSubscribe, mockGetSubscription } = setupServiceWorkerMock({
+      existingSubscription: null,
+      newSubscription: VALID_SUBSCRIPTION,
+    });
+
+    const result = await subscribeToPush("test-vapid-key");
+
+    expect(mockGetSubscription).toHaveBeenCalled();
+    expect(mockSubscribe).toHaveBeenCalled();
+    expect(result.endpoint).toBe("https://fcm.example.com/send/fresh");
+  });
+
+  it("throws when subscription has missing keys", async () => {
+    setupServiceWorkerMock({
+      newSubscription: {
+        toJSON: () => ({ endpoint: "https://fcm.example.com/send/x", keys: {} }),
+      },
+    });
+
+    await expect(subscribeToPush("test-vapid-key")).rejects.toThrow("Invalid push subscription");
   });
 });

--- a/frontend/src/lib/push.ts
+++ b/frontend/src/lib/push.ts
@@ -21,6 +21,19 @@ export async function subscribeToPush(
   vapidPublicKey: string
 ): Promise<{ endpoint: string; p256dh: string; auth: string }> {
   const registration = await navigator.serviceWorker.ready;
+
+  // Force-clear any existing subscription to guarantee a fresh endpoint.
+  // Without this, pushManager.subscribe() with the same applicationServerKey
+  // returns the same (potentially expired) subscription.
+  const existing = await registration.pushManager.getSubscription();
+  if (existing) {
+    try {
+      await existing.unsubscribe();
+    } catch {
+      // Best effort — proceed to subscribe anyway
+    }
+  }
+
   const subscription = await registration.pushManager.subscribe({
     userVisibleOnly: true,
     applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),

--- a/frontend/src/pages/ProfilePage.test.tsx
+++ b/frontend/src/pages/ProfilePage.test.tsx
@@ -30,7 +30,7 @@ mock.module("../api", () => ({
   getNotifiers: mockGetNotifiers,
   getNotifierProviders: mock(() => Promise.resolve({ providers: ["discord"] })),
   getVapidPublicKey: mock(() => Promise.resolve({ publicKey: "test-key" })),
-  createNotifier: mock(() => Promise.resolve({ notifier: {} })),
+  createNotifier: mock(() => Promise.resolve({ notifier: { id: "n-new" } })),
   updateNotifier: mock(() => Promise.resolve({ notifier: {} })),
   deleteNotifier: mockDeleteNotifier,
   testNotifier: mockTestNotifier,
@@ -188,6 +188,33 @@ describe("PushNotificationsSection", () => {
 
     // Should NOT have cleaned up
     expect(mockDeleteNotifier).not.toHaveBeenCalled();
+  });
+
+  it("cleans up when fresh subscription fails verification after enable", async () => {
+    // Start with no notifiers (user sees Enable button)
+    mockGetNotifiers.mockImplementation(() => Promise.resolve({ notifiers: [] }));
+    mockGetExistingSubscription.mockImplementation(() => Promise.resolve(null));
+
+    // Test notification will report expired subscription
+    mockTestNotifier.mockImplementation(() =>
+      Promise.resolve({ success: false, message: "Push subscription expired: https://fcm.example.com/send/new" })
+    );
+
+    render(<ProfilePage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Enable")).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByText("Enable"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Could not establish/)).toBeDefined();
+    });
+
+    // Should have cleaned up the just-created notifier
+    expect(mockDeleteNotifier).toHaveBeenCalledWith("n-new");
+    expect(mockUnsubscribeFromPush).toHaveBeenCalled();
   });
 
   it("renders normally when push is enabled and healthy", async () => {

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -181,12 +181,23 @@ function PushNotificationsSection() {
       const { publicKey } = await api.getVapidPublicKey();
       const subscription = await subscribeToPush(publicKey);
 
-      await api.createNotifier({
+      const { notifier } = await api.createNotifier({
         provider: "webpush",
         config: subscription,
         notify_time: "09:00",
         timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       });
+
+      // Verify the subscription actually works by sending a test push
+      const testResult = await api.testNotifier(notifier.id);
+      if (!testResult.success && testResult.message.toLowerCase().includes("subscription expired")) {
+        // Fresh subscription is already invalid — clean up
+        try { await unsubscribeFromPush(); } catch { /* ignore */ }
+        try { await api.deleteNotifier(notifier.id); } catch { /* ignore */ }
+        setErr("Could not establish a working push subscription. Please try clearing site data and re-enabling.");
+        await refresh();
+        return;
+      }
 
       setMsg("Push notifications enabled");
       await refresh();


### PR DESCRIPTION
## Summary
This PR improves the reliability of push notification subscriptions by adding verification and cleanup logic when enabling push notifications. It ensures that fresh subscriptions are actually valid before confirming to the user that push is enabled, and cleans up invalid subscriptions automatically.

## Key Changes
- **Force-clear existing subscriptions before creating new ones** (`push.ts`): Modified `subscribeToPush()` to unsubscribe from any existing subscription before requesting a new one. This guarantees a fresh endpoint from the push service, preventing reuse of potentially expired subscriptions.

- **Verify new subscriptions with test push** (`ProfilePage.tsx`): After creating a new push notifier, the code now sends a test notification to verify the subscription actually works. If the test fails due to an expired subscription, it automatically cleans up the notifier and unsubscribes.

- **Comprehensive test coverage** (`push.test.ts`, `ProfilePage.test.tsx`): 
  - Added unit tests for `subscribeToPush()` covering: unsubscribing existing subscriptions, handling unsubscribe failures, creating new subscriptions, and validation of subscription keys
  - Added integration test for the cleanup flow when a fresh subscription fails verification

## Implementation Details
- The unsubscribe operation in `subscribeToPush()` is best-effort; failures don't block the new subscription attempt
- The verification test checks for "subscription expired" in the error message to distinguish between temporary failures and invalid subscriptions
- Cleanup operations (unsubscribe and delete notifier) are wrapped in try-catch to prevent cascading failures
- User receives a clear error message if subscription verification fails, with guidance to clear site data

https://claude.ai/code/session_01CqAJd7CZGizSk9hSVt1qC6