### PR TITLE
Add hide watched toggle to agenda view calendar

### DIFF
--- a/frontend/src/pages/CalendarPage.test.tsx
+++ b/frontend/src/pages/CalendarPage.test.tsx
@@ -87,4 +87,40 @@ describe("CalendarPage", () => {
     expect(screen.queryByTitle("Grid view")).toBeNull();
     expect(screen.queryByTitle("Agenda view")).toBeNull();
   });
+
+  it("shows hide watched toggle in agenda mode, selected by default", () => {
+    render(<CalendarPage />, { wrapper: Wrapper });
+
+    // Switch to agenda
+    fireEvent.click(screen.getByTitle("Agenda view"));
+
+    const toggle = screen.getByTitle("Show watched");
+    expect(toggle).toBeDefined();
+    // Active state = indigo background class
+    expect(toggle.className).toContain("bg-indigo-600");
+  });
+
+  it("toggles hide watched off when clicked", () => {
+    render(<CalendarPage />, { wrapper: Wrapper });
+
+    // Switch to agenda
+    fireEvent.click(screen.getByTitle("Agenda view"));
+
+    const toggle = screen.getByTitle("Show watched");
+    fireEvent.click(toggle);
+
+    // Now it should show "Hide watched" title (inactive state)
+    const toggleOff = screen.getByTitle("Hide watched");
+    expect(toggleOff).toBeDefined();
+    expect(toggleOff.className).not.toContain("bg-indigo-600");
+  });
+
+  it("shows hide watched toggle on mobile agenda", () => {
+    mockIsMobile = true;
+    render(<CalendarPage />, { wrapper: Wrapper });
+
+    const toggle = screen.getByTitle("Show watched");
+    expect(toggle).toBeDefined();
+    expect(toggle.className).toContain("bg-indigo-600");
+  });
 });

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { Link } from "react-router";
-import { ChevronLeftIcon, ChevronRightIcon, CheckCircleIcon, CircleIcon, LayoutGridIcon, ListIcon } from "lucide-react";
+import { ChevronLeftIcon, ChevronRightIcon, CheckCircleIcon, CircleIcon, LayoutGridIcon, ListIcon, EyeIcon, EyeOffIcon } from "lucide-react";
 import { getCalendarTitles, watchEpisode, unwatchEpisode, watchEpisodesBulk } from "../api";
 import { useIsMobile } from "../hooks/useIsMobile";
 import TitleList from "../components/TitleList";
@@ -128,6 +128,7 @@ interface AgendaMonth {
 
 function AgendaCalendar({ viewMode, onViewModeChange }: { viewMode?: ViewMode; onViewModeChange?: (mode: ViewMode) => void } = {}) {
   const [typeFilter, setTypeFilter] = useState("");
+  const [hideWatched, setHideWatched] = useState(true);
   const [months, setMonths] = useState<AgendaMonth[]>([]);
   const [loadingMore, setLoadingMore] = useState(false);
   const [initialLoading, setInitialLoading] = useState(true);
@@ -293,6 +294,7 @@ function AgendaCalendar({ viewMode, onViewModeChange }: { viewMode?: ViewMode; o
       }
       for (const ep of m.episodes) {
         if (!ep.air_date) continue;
+        if (hideWatched && ep.is_watched) continue;
         const arr = byDate.get(ep.air_date);
         if (arr) arr.push({ type: "episode", data: ep });
         else byDate.set(ep.air_date, [{ type: "episode", data: ep }]);
@@ -300,7 +302,7 @@ function AgendaCalendar({ viewMode, onViewModeChange }: { viewMode?: ViewMode; o
     }
 
     return new Map([...byDate.entries()].sort(([a], [b]) => a.localeCompare(b)));
-  }, [months]);
+  }, [months, hideWatched]);
 
   // Toggle watched
   const toggleWatched = async (episodeId: number, currentlyWatched: boolean) => {
@@ -369,6 +371,18 @@ function AgendaCalendar({ viewMode, onViewModeChange }: { viewMode?: ViewMode; o
               {f.label}
             </button>
           ))}
+          <button
+            onClick={() => setHideWatched((v) => !v)}
+            className={`ml-auto flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
+              hideWatched
+                ? "bg-indigo-600 text-white"
+                : "text-gray-400 hover:text-white hover:bg-gray-800"
+            }`}
+            title={hideWatched ? "Show watched" : "Hide watched"}
+          >
+            {hideWatched ? <EyeOffIcon className="size-4" /> : <EyeIcon className="size-4" />}
+            <span className="hidden sm:inline">Hide watched</span>
+          </button>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
Added a "Hide watched" toggle button to the agenda view in the calendar page, allowing users to filter out already-watched episodes from their calendar display.

## Key Changes
- Added `hideWatched` state to `AgendaCalendar` component, defaulting to `true` (watched episodes hidden by default)
- Imported `EyeIcon` and `EyeOffIcon` from lucide-react for visual toggle indicators
- Implemented filtering logic in the `byDate` useMemo hook to exclude watched episodes when `hideWatched` is enabled
- Added toggle button to the agenda view controls with:
  - Dynamic styling (indigo background when active, gray when inactive)
  - Icon that changes based on state (eye-off when hiding, eye when showing)
  - Text label "Hide watched" (hidden on mobile, visible on larger screens)
  - Appropriate title attributes for accessibility ("Show watched" / "Hide watched")
- Added comprehensive test coverage for the new feature:
  - Verifies toggle appears in agenda mode and is selected by default
  - Tests toggling behavior and state changes
  - Confirms toggle works on mobile agenda view

## Implementation Details
- The toggle is positioned with `ml-auto` to align right within the controls bar
- Uses conditional rendering to show/hide the text label based on screen size
- The filter is applied at the data aggregation level in the useMemo hook, ensuring efficient filtering
- Updated the useMemo dependency array to include `hideWatched` to ensure proper re-computation when filter state changes

https://claude.ai/code/session_0148oLKX5oo1Sbng6b6LmexW