### PR TITLE
Extract notification scheduling logic to portable module

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -29,7 +29,8 @@ import { logger, requestLogger } from "./logger";
 import { registerSyncJobs } from "./jobs/sync";
 import { registerNotificationJobs } from "./jobs/notifications";
 import { startWorker, stopWorker } from "./jobs/worker";
-import { initJobsSchema } from "./jobs/queue";
+import { initJobsSchema, registerCron } from "./jobs/queue";
+import { setScheduleCallback } from "./jobs/schedule";
 import { BunPlatform } from "./platform/bun";
 
 // Initialize DB on startup
@@ -157,6 +158,7 @@ setInterval(() => {
 
 // Start background job queue
 initJobsSchema();
+setScheduleCallback(registerCron);
 registerSyncJobs();
 await registerNotificationJobs();
 startWorker();

--- a/server/jobs/notifications.ts
+++ b/server/jobs/notifications.ts
@@ -1,18 +1,20 @@
 import { logger } from "../logger";
 import { registerHandler } from "./worker";
-
-const log = logger.child({ module: "notifications" });
-import { registerCron } from "./queue";
 import {
   getDueNotifiers,
   getDistinctNotifierTimezones,
-  getEnabledNotifierSchedules,
   markNotifierSent,
   disableNotifier,
 } from "../db/repository";
 import { getProvider } from "../notifications/registry";
 import { buildNotificationContent } from "../notifications/content";
 import { SubscriptionExpiredError } from "../notifications/webpush";
+import { refreshNotificationSchedule } from "./schedule";
+
+// Re-export portable scheduling functions for backward compatibility (tests import from here)
+export { convertToLocalTime, computeNotificationCron, refreshNotificationSchedule } from "./schedule";
+
+const log = logger.child({ module: "notifications" });
 
 function getCurrentTimeInTimezone(tz: string): { time: string; date: string } {
   const now = new Date();
@@ -32,84 +34,6 @@ function getCurrentTimeInTimezone(tz: string): { time: string; date: string } {
     time: timeFormatter.format(now), // "09:00"
     date: dateFormatter.format(now), // "2026-03-12"
   };
-}
-
-/**
- * Convert a time in a given timezone to server-local time.
- * Returns the equivalent hour and minute in the server's local timezone.
- */
-export function convertToLocalTime(
-  time: string,
-  fromTz: string,
-  now: Date = new Date()
-): { hour: number; minute: number } {
-  const [h, m] = time.split(":").map(Number);
-
-  // Get current time in source timezone
-  const tzFormatter = new Intl.DateTimeFormat("en-GB", {
-    timeZone: fromTz,
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  });
-  const localFormatter = new Intl.DateTimeFormat("en-GB", {
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  });
-
-  const [tzH, tzM] = tzFormatter.format(now).split(":").map(Number);
-  const [localH, localM] = localFormatter.format(now).split(":").map(Number);
-
-  // Offset = source_tz - server_local (in minutes)
-  const tzMinutes = tzH * 60 + tzM;
-  const localMinutes = localH * 60 + localM;
-  let offset = tzMinutes - localMinutes;
-  if (offset > 720) offset -= 1440;
-  if (offset < -720) offset += 1440;
-
-  // Convert target time: local_target = tz_target - offset
-  let targetMinutes = h * 60 + m - offset;
-  if (targetMinutes < 0) targetMinutes += 1440;
-  if (targetMinutes >= 1440) targetMinutes -= 1440;
-
-  return {
-    hour: Math.floor(targetMinutes / 60),
-    minute: targetMinutes % 60,
-  };
-}
-
-/**
- * Compute a cron expression that fires only at times when notifications
- * could be due, based on all enabled notifiers' configured times and timezones.
- * Includes ±1 hour buffer around each computed hour to handle DST transitions.
- */
-export async function computeNotificationCron(): Promise<string | null> {
-  const schedules = await getEnabledNotifierSchedules();
-  if (schedules.length === 0) return null;
-
-  const hours = new Set<number>();
-  const minutes = new Set<number>();
-
-  for (const { notify_time, timezone } of schedules) {
-    try {
-      const local = convertToLocalTime(notify_time, timezone);
-      // Add ±1 hour buffer for DST transitions
-      hours.add((local.hour - 1 + 24) % 24);
-      hours.add(local.hour);
-      hours.add((local.hour + 1) % 24);
-      minutes.add(local.minute);
-    } catch {
-      // Invalid timezone — skip, will be warned at send time
-    }
-  }
-
-  if (hours.size === 0 || minutes.size === 0) return null;
-
-  const sortedMinutes = [...minutes].sort((a, b) => a - b);
-  const sortedHours = [...hours].sort((a, b) => a - b);
-
-  return `${sortedMinutes.join(",")} ${sortedHours.join(",")} * * *`;
 }
 
 let handlerRegistered = false;
@@ -172,20 +96,4 @@ export async function registerNotificationJobs() {
   }
 
   await refreshNotificationSchedule();
-}
-
-/**
- * Recompute and re-register the notification cron schedule based on
- * currently enabled notifiers. Call this when notifiers are created,
- * updated, or deleted.
- */
-export async function refreshNotificationSchedule() {
-  const cron = await computeNotificationCron();
-  if (cron) {
-    registerCron("send-notifications", cron);
-  } else {
-    // No enabled notifiers — use a daily check as a fallback
-    // (in case notifiers are added later, the CRUD routes will refresh)
-    registerCron("send-notifications", "0 0 * * *");
-  }
 }

--- a/server/jobs/schedule.test.ts
+++ b/server/jobs/schedule.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { createUser, createNotifier } from "../db/repository";
+import {
+  setScheduleCallback,
+  refreshNotificationSchedule,
+  computeNotificationCron,
+  convertToLocalTime,
+} from "./schedule";
+
+let userId: string;
+
+beforeEach(async () => {
+  setupTestDb();
+  userId = await createUser("testuser", "hash");
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+describe("setScheduleCallback", () => {
+  it("refreshNotificationSchedule is a no-op when no callback is set", async () => {
+    setScheduleCallback(null as any);
+    await createNotifier(userId, "discord", "Test", { webhookUrl: "https://discord.com/api/webhooks/1/a" }, "09:00", "UTC");
+    // Should not throw
+    await refreshNotificationSchedule();
+  });
+
+  it("calls the registered callback with computed cron", async () => {
+    const calls: { name: string; cron: string }[] = [];
+    setScheduleCallback((name, cron) => calls.push({ name, cron }));
+
+    await createNotifier(userId, "discord", "Test", { webhookUrl: "https://discord.com/api/webhooks/1/a" }, "09:00", "UTC");
+    await refreshNotificationSchedule();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].name).toBe("send-notifications");
+    expect(calls[0].cron).toContain("* * *");
+  });
+
+  it("uses fallback cron when no notifiers exist", async () => {
+    const calls: { name: string; cron: string }[] = [];
+    setScheduleCallback((name, cron) => calls.push({ name, cron }));
+
+    await refreshNotificationSchedule();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].cron).toBe("0 0 * * *");
+  });
+});

--- a/server/jobs/schedule.ts
+++ b/server/jobs/schedule.ts
@@ -1,0 +1,123 @@
+/**
+ * Portable notification scheduling logic.
+ *
+ * This module is intentionally free of bun:sqlite dependencies so that
+ * the CF Workers entry point can import it without pulling in Bun-only code.
+ * The actual cron registration is injected via setScheduleCallback().
+ */
+import { logger } from "../logger";
+import { getEnabledNotifierSchedules } from "../db/repository";
+
+const log = logger.child({ module: "schedule" });
+
+type ScheduleCallback = (name: string, cron: string) => void;
+let scheduleCallback: ScheduleCallback | null = null;
+
+/**
+ * Register the function that persists cron schedules (e.g. registerCron from queue.ts).
+ * On CF Workers this is never called, so refreshNotificationSchedule becomes a no-op.
+ */
+export function setScheduleCallback(cb: ScheduleCallback) {
+  scheduleCallback = cb;
+}
+
+/**
+ * Convert a time in a given timezone to server-local time.
+ * Returns the equivalent hour and minute in the server's local timezone.
+ */
+export function convertToLocalTime(
+  time: string,
+  fromTz: string,
+  now: Date = new Date()
+): { hour: number; minute: number } {
+  const [h, m] = time.split(":").map(Number);
+
+  // Get current time in source timezone
+  const tzFormatter = new Intl.DateTimeFormat("en-GB", {
+    timeZone: fromTz,
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  const localFormatter = new Intl.DateTimeFormat("en-GB", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+
+  const [tzH, tzM] = tzFormatter.format(now).split(":").map(Number);
+  const [localH, localM] = localFormatter.format(now).split(":").map(Number);
+
+  // Offset = source_tz - server_local (in minutes)
+  const tzMinutes = tzH * 60 + tzM;
+  const localMinutes = localH * 60 + localM;
+  let offset = tzMinutes - localMinutes;
+  if (offset > 720) offset -= 1440;
+  if (offset < -720) offset += 1440;
+
+  // Convert target time: local_target = tz_target - offset
+  let targetMinutes = h * 60 + m - offset;
+  if (targetMinutes < 0) targetMinutes += 1440;
+  if (targetMinutes >= 1440) targetMinutes -= 1440;
+
+  return {
+    hour: Math.floor(targetMinutes / 60),
+    minute: targetMinutes % 60,
+  };
+}
+
+/**
+ * Compute a cron expression that fires only at times when notifications
+ * could be due, based on all enabled notifiers' configured times and timezones.
+ * Includes ±1 hour buffer around each computed hour to handle DST transitions.
+ */
+export async function computeNotificationCron(): Promise<string | null> {
+  const schedules = await getEnabledNotifierSchedules();
+  if (schedules.length === 0) return null;
+
+  const hours = new Set<number>();
+  const minutes = new Set<number>();
+
+  for (const { notify_time, timezone } of schedules) {
+    try {
+      const local = convertToLocalTime(notify_time, timezone);
+      // Add ±1 hour buffer for DST transitions
+      hours.add((local.hour - 1 + 24) % 24);
+      hours.add(local.hour);
+      hours.add((local.hour + 1) % 24);
+      minutes.add(local.minute);
+    } catch {
+      // Invalid timezone — skip, will be warned at send time
+    }
+  }
+
+  if (hours.size === 0 || minutes.size === 0) return null;
+
+  const sortedMinutes = [...minutes].sort((a, b) => a - b);
+  const sortedHours = [...hours].sort((a, b) => a - b);
+
+  return `${sortedMinutes.join(",")} ${sortedHours.join(",")} * * *`;
+}
+
+/**
+ * Recompute and re-register the notification cron schedule based on
+ * currently enabled notifiers. Call this when notifiers are created,
+ * updated, or deleted.
+ *
+ * On CF Workers (where no callback is registered), this is a no-op
+ * because cron triggers are defined statically in wrangler.toml.
+ */
+export async function refreshNotificationSchedule() {
+  if (!scheduleCallback) {
+    log.debug("No schedule callback registered, skipping cron update");
+    return;
+  }
+  const cron = await computeNotificationCron();
+  if (cron) {
+    scheduleCallback("send-notifications", cron);
+  } else {
+    // No enabled notifiers — use a daily check as a fallback
+    // (in case notifiers are added later, the CRUD routes will refresh)
+    scheduleCallback("send-notifications", "0 0 * * *");
+  }
+}

--- a/server/routes/notifiers.ts
+++ b/server/routes/notifiers.ts
@@ -9,7 +9,7 @@ import {
 } from "../db/repository";
 import { getProvider, getAvailableProviders } from "../notifications/registry";
 import { buildNotificationContent } from "../notifications/content";
-import { refreshNotificationSchedule } from "../jobs/notifications";
+import { refreshNotificationSchedule } from "../jobs/schedule";
 import { getVapidPublicKey } from "../notifications/vapid";
 import { SubscriptionExpiredError } from "../notifications/webpush";
 import * as Sentry from "@sentry/bun";


### PR DESCRIPTION
## Summary
Refactored notification scheduling logic into a new portable module (`server/jobs/schedule.ts`) that is free of Bun-specific dependencies. This enables the scheduling logic to be imported and used by CF Workers without pulling in Bun-only code, while maintaining backward compatibility for existing code.

## Key Changes
- **New module `server/jobs/schedule.ts`**: Contains portable scheduling functions (`convertToLocalTime`, `computeNotificationCron`, `refreshNotificationSchedule`) and a callback injection mechanism (`setScheduleCallback`) for registering cron schedules
- **Refactored `server/jobs/notifications.ts`**: Moved scheduling logic to the new module and re-exported functions for backward compatibility with existing tests and imports
- **Updated `server/index.ts`**: Added initialization of the schedule callback by calling `setScheduleCallback(registerCron)` during startup
- **Updated `server/routes/notifiers.ts`**: Changed import to use `refreshNotificationSchedule` from the new schedule module
- **Added `server/jobs/schedule.test.ts`**: New test suite covering the schedule callback mechanism and cron computation

## Implementation Details
- The scheduling logic is now decoupled from the job queue implementation through dependency injection via `setScheduleCallback()`
- On CF Workers, the callback is never registered, making `refreshNotificationSchedule()` a no-op (cron triggers are defined statically in wrangler.toml)
- Backward compatibility is maintained through re-exports in `notifications.ts`, so existing test imports continue to work
- The module includes comprehensive documentation explaining the portable design and callback injection pattern

https://claude.ai/code/session_01BhazSqCUksYtjJZy6yDUdS