### PR TITLE
Replace periodic cleanup with lazy cleanup in rate limiter

### DIFF
--- a/server/middleware/rate-limit.ts
+++ b/server/middleware/rate-limit.ts
@@ -29,25 +29,21 @@ export function rateLimiter(options: RateLimitOptions) {
     ((c) => c.req.header("x-forwarded-for") ?? "anonymous");
 
   const buckets = new Map<string, TokenBucket>();
-
-  // Periodically clean up stale buckets to prevent memory leaks
-  const cleanupInterval = setInterval(() => {
-    const now = Date.now();
-    for (const [key, bucket] of buckets) {
-      if (now - bucket.lastRefill > windowMs * 2) {
-        buckets.delete(key);
-      }
-    }
-  }, windowMs * 2);
-
-  // Allow the timer to not block process exit
-  if (cleanupInterval.unref) {
-    cleanupInterval.unref();
-  }
+  let lastCleanup = Date.now();
 
   return createMiddleware<AppEnv>(async (c, next) => {
     const key = keyGenerator(c);
     const now = Date.now();
+
+    // Lazy cleanup of stale buckets to prevent memory leaks
+    if (now - lastCleanup > windowMs * 2) {
+      for (const [k, bucket] of buckets) {
+        if (now - bucket.lastRefill > windowMs * 2) {
+          buckets.delete(k);
+        }
+      }
+      lastCleanup = now;
+    }
 
     let bucket = buckets.get(key);
     if (!bucket) {


### PR DESCRIPTION
## Summary
Refactored the rate limiter's bucket cleanup mechanism from a periodic interval-based approach to a lazy cleanup strategy that runs on-demand during request processing.

## Key Changes
- Removed `setInterval`-based periodic cleanup that ran every `windowMs * 2` milliseconds
- Replaced with lazy cleanup that only executes when a request is processed and the cleanup threshold is exceeded
- Changed from maintaining a `cleanupInterval` reference to tracking `lastCleanup` timestamp
- Eliminated the `unref()` call that was used to prevent the timer from blocking process exit

## Implementation Details
- Cleanup now occurs inline within the middleware request handler when `now - lastCleanup > windowMs * 2`
- This approach reduces unnecessary background work and eliminates the need for timer management
- The cleanup logic remains identical—removing buckets that haven't been refilled in over `windowMs * 2` milliseconds
- More efficient for applications with variable request rates, as cleanup only happens when needed rather than on a fixed schedule

https://claude.ai/code/session_01E56xYQekxuEb8FEsjWawRu