### PR TITLE
Refactor worker initialization and add platform-agnostic Sentry wrapper

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -24,7 +24,7 @@ import detailsRoutes from "./routes/details";
 import notifierRoutes from "./routes/notifiers";
 import healthRoutes from "./routes/health";
 import type { AppEnv } from "./types";
-import * as Sentry from "@sentry/bun";
+import Sentry from "./sentry";
 import { logger, requestLogger } from "./logger";
 import { registerSyncJobs } from "./jobs/sync";
 import { registerNotificationJobs } from "./jobs/notifications";

--- a/server/instrument.test.ts
+++ b/server/instrument.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
-import * as Sentry from "@sentry/bun";
+import Sentry from "./sentry";
 
 describe("instrument", () => {
   it("captureException is callable and does not throw without DSN", () => {

--- a/server/instrument.ts
+++ b/server/instrument.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/bun";
+import Sentry from "./sentry";
 
 const dsn = process.env.SENTRY_DSN;
 

--- a/server/jobs/worker.test.ts
+++ b/server/jobs/worker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterAll, mock, spyOn } from "bun:test";
-import * as Sentry from "@sentry/bun";
+import Sentry from "../sentry";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
 import { enqueueJob, registerCron, getCronExpression } from "./queue";
 import { registerHandler, processJobs, stopWorker } from "./worker";

--- a/server/jobs/worker.ts
+++ b/server/jobs/worker.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/bun";
+import Sentry from "../sentry";
 import { logger } from "../logger";
 
 const log = logger.child({ module: "jobs" });

--- a/server/routes/notifiers.test.ts
+++ b/server/routes/notifiers.test.ts
@@ -7,7 +7,7 @@ import { CONFIG } from "../config";
 import notifierApp from "./notifiers";
 import type { AppEnv } from "../types";
 import * as registry from "../notifications/registry";
-import * as Sentry from "@sentry/bun";
+import Sentry from "../sentry";
 import { SubscriptionExpiredError } from "../notifications/webpush";
 
 let app: Hono<AppEnv>;

--- a/server/routes/notifiers.ts
+++ b/server/routes/notifiers.ts
@@ -12,7 +12,7 @@ import { buildNotificationContent } from "../notifications/content";
 import { refreshNotificationSchedule } from "../jobs/schedule";
 import { getVapidPublicKey } from "../notifications/vapid";
 import { SubscriptionExpiredError } from "../notifications/webpush";
-import * as Sentry from "@sentry/bun";
+import Sentry from "../sentry";
 
 const app = new Hono<AppEnv>();
 

--- a/server/sentry.ts
+++ b/server/sentry.ts
@@ -1,0 +1,38 @@
+/**
+ * Platform-agnostic Sentry wrapper.
+ *
+ * On Bun, re-exports @sentry/bun. On Cloudflare Workers (where the package
+ * isn't available), provides no-op stubs so the rest of the codebase can
+ * import Sentry unconditionally without crashing at module-evaluation time.
+ */
+
+interface SentryLike {
+  captureException(err: unknown): string;
+  startSpan<T>(opts: { name: string; op?: string; attributes?: Record<string, string> }, fn: () => T): T;
+  withMonitor<T>(monitorSlug: string, fn: () => Promise<T>, config?: unknown): Promise<T>;
+  flush(timeoutMs?: number): Promise<boolean>;
+  init(opts: Record<string, unknown>): void;
+  honoIntegration(): Record<string, unknown>;
+  setupHonoErrorHandler?(...args: unknown[]): void;
+  [key: string]: unknown;
+}
+
+const noopSentry: SentryLike = {
+  captureException: () => "",
+  startSpan: (_opts, fn) => fn(),
+  withMonitor: (_slug, fn) => fn(),
+  flush: () => Promise.resolve(true),
+  init: () => {},
+  honoIntegration: () => ({}),
+};
+
+let sentry: SentryLike;
+
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  sentry = require("@sentry/bun");
+} catch {
+  sentry = noopSentry;
+}
+
+export default sentry;

--- a/server/tmdb/client.test.ts
+++ b/server/tmdb/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, test, expect, spyOn, afterEach, beforeEach } from "bun:test";
-import * as Sentry from "@sentry/bun";
+import Sentry from "../sentry";
 
 // ─── Mock tracing to pass through ───────────────────────────────────────────
 let sentrySpy: ReturnType<typeof spyOn>;

--- a/server/tracing.test.ts
+++ b/server/tracing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, spyOn, afterEach } from "bun:test";
-import * as Sentry from "@sentry/bun";
+import Sentry from "./sentry";
 import { traceDbQuery, traceHttp } from "./tracing";
 
 describe("traceDbQuery", () => {

--- a/server/tracing.ts
+++ b/server/tracing.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/bun";
+import Sentry from "./sentry";
 
 /**
  * Wraps a DB operation in a Sentry span.

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -73,8 +73,16 @@ interface Env {
   VAPID_SUBJECT?: string;
 }
 
-function createApp() {
+const platform = new CloudflarePlatform();
+
+function createApp(env: Env) {
   const app = new Hono<AppEnv>();
+
+  // Inject platform into context for route handlers
+  app.use("*", async (c, next) => {
+    c.set("platform", platform);
+    await next();
+  });
 
   app.onError((err, c) => {
     if (err instanceof HTTPException) {
@@ -83,6 +91,12 @@ function createApp() {
     logger.error("Unhandled error", { error: err.message });
     return c.json({ error: "Internal server error" }, 500);
   });
+
+  // CORS — restricted to explicit origins via CORS_ORIGIN env var
+  if (env.CORS_ORIGIN) {
+    const origins = env.CORS_ORIGIN.split(",").map((o) => o.trim()).filter(Boolean);
+    app.use("/api/*", cors({ origin: origins, credentials: true }));
+  }
 
   // Request logging
   app.use("/api/*", requestLogger());
@@ -155,69 +169,76 @@ function createApp() {
   return app;
 }
 
-const app = createApp();
+let app: Hono<AppEnv> | null = null;
+let adminChecked = false;
+
+function getApp(env: Env): Hono<AppEnv> {
+  if (!app) {
+    app = createApp(env);
+  }
+  return app;
+}
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-    const db = drizzle(env.DB, { schema: schemaExports }) as unknown as DrizzleDb;
-    const platform = new CloudflarePlatform();
+    ctx.passThroughOnException();
+    try {
+      const db = drizzle(env.DB, { schema: schemaExports }) as unknown as DrizzleDb;
+      const honoApp = getApp(env);
 
-    return runWithDb(db, async () => {
-      // Inject platform + CORS
-      const originalFetch = app.fetch;
+      return await runWithDb(db, async () => {
+        // Create admin on first request if no users exist
+        if (!adminChecked) {
+          adminChecked = true;
+          const userCount = await getUserCount();
+          if (userCount === 0) {
+            const password = crypto.randomUUID().slice(0, 16);
+            const hash = await platform.hashPassword(password);
+            await createUser("admin", hash, "Admin", "local", undefined, true);
+            logger.info("Admin account created", { username: "admin", password });
+          }
+        }
 
-      // Set up CORS if configured
-      if (env.CORS_ORIGIN) {
-        const origins = env.CORS_ORIGIN.split(",").map((o) => o.trim()).filter(Boolean);
-        app.use(
-          "/api/*",
-          cors({ origin: origins, credentials: true })
-        );
-      }
-
-      // Create admin on first request if no users exist
-      const userCount = await getUserCount();
-      if (userCount === 0) {
-        const password = crypto.randomUUID().slice(0, 16);
-        const hash = await platform.hashPassword(password);
-        await createUser("admin", hash, "Admin", "local", undefined, true);
-        logger.info("Admin account created", { username: "admin", password });
-      }
-
-      // Use a middleware-like approach to inject platform
-      const url = new URL(request.url);
-      const c = { set: () => {} }; // Hono will handle this via middleware
-
-      return app.fetch(request, { ...env, platform } as any, ctx as any);
-    });
+        return honoApp.fetch(request, env, ctx as any);
+      });
+    } catch (err) {
+      logger.error("Worker fetch error", {
+        error: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
+      });
+      return new Response("Internal Server Error", { status: 500 });
+    }
   },
 
   async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext): Promise<void> {
-    const db = drizzle(env.DB, { schema: schemaExports }) as unknown as DrizzleDb;
+    try {
+      const db = drizzle(env.DB, { schema: schemaExports }) as unknown as DrizzleDb;
 
-    await runWithDb(db, async () => {
-      const cron = event.cron;
-      logger.info("Scheduled event", { cron });
+      await runWithDb(db, async () => {
+        const cron = event.cron;
+        logger.info("Scheduled event", { cron });
 
-      switch (cron) {
-        case "0 3 * * *":
-          // sync-titles
-          logger.info("Running sync-titles cron");
-          break;
-        case "30 3 * * *":
-          // sync-episodes
-          logger.info("Running sync-episodes cron");
-          break;
-        case "*/5 * * * *":
-          // send-notifications
-          logger.info("Running send-notifications cron");
-          break;
-        case "0 0 * * *":
-          // cleanup
-          await deleteExpiredSessions();
-          logger.info("Cleanup complete");
-          break;
-      }
-    });
+        switch (cron) {
+          case "0 3 * * *":
+            logger.info("Running sync-titles cron");
+            break;
+          case "30 3 * * *":
+            logger.info("Running sync-episodes cron");
+            break;
+          case "*/5 * * * *":
+            logger.info("Running send-notifications cron");
+            break;
+          case "0 0 * * *":
+            await deleteExpiredSessions();
+            logger.info("Cleanup complete");
+            break;
+        }
+      });
+    } catch (err) {
+      logger.error("Worker scheduled error", {
+        cron: event.cron,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   },
 };


### PR DESCRIPTION
## Summary
This PR refactors the Cloudflare Workers initialization to improve app lifecycle management and adds a platform-agnostic Sentry wrapper to support running the codebase on both Bun and Cloudflare Workers environments.

## Key Changes

- **Worker app initialization**: Moved app creation from module-level to lazy initialization via `getApp()` function, allowing the app to be created once per worker instance with proper environment context
- **Platform injection**: Moved `CloudflarePlatform` instantiation to module-level and injected it into route handlers via middleware instead of passing through fetch context
- **CORS configuration**: Moved CORS setup from the fetch handler into the app creation phase for cleaner initialization
- **Admin account creation**: Changed from per-request check to single-check pattern using `adminChecked` flag to avoid redundant database queries
- **Error handling**: Added comprehensive try-catch blocks in both `fetch` and `scheduled` handlers with proper error logging
- **Sentry abstraction**: Created `server/sentry.ts` wrapper that conditionally imports `@sentry/bun` on Bun runtime and provides no-op stubs on Cloudflare Workers, allowing the codebase to import Sentry unconditionally without runtime failures
- **Updated imports**: Changed all Sentry imports across the codebase from `@sentry/bun` to the new platform-agnostic wrapper

## Implementation Details

- The `CloudflarePlatform` instance is now created once at module load and reused across all requests
- App initialization is deferred until the first request, ensuring environment variables are available
- The Sentry wrapper uses a try-catch at module evaluation time to gracefully handle missing `@sentry/bun` package on Cloudflare Workers
- Error handling now includes proper logging with stack traces for debugging
- `ctx.passThroughOnException()` is called to ensure Cloudflare Workers can handle exceptions appropriately

https://claude.ai/code/session_011b6AyVRh1EscU7HjdUY2kq