### PR TITLE
fix: await upsertTitles in CLI sync

### DIFF
--- a/server/cli/sync.ts
+++ b/server/cli/sync.ts
@@ -16,7 +16,7 @@ getDb();
 
 try {
   const titles = await fetchNewReleases({ daysBack, objectType: type });
-  const count = upsertTitles(titles);
+  const count = await upsertTitles(titles);
   log.info("Sync complete", { count });
 } catch (err) {
   log.error("Sync failed", { err });


### PR DESCRIPTION
Add missing `await` before `upsertTitles(titles)` in `server/cli/sync.ts`. Without it, `count` received a Promise object instead of the actual number, causing log output to print `[object Promise]`.

Fixes #131

Generated with [Claude Code](https://claude.ai/code)