### PR TITLE
feat: add startup validation for required configuration

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -34,6 +34,10 @@ import { setScheduleCallback } from "./jobs/schedule";
 import { BunPlatform } from "./platform/bun";
 import { createAuthWithOidc, type BetterAuthInstance } from "./auth/better-auth";
 import { migrateAuthData } from "./db/migrate-auth";
+import { validateStartup } from "./startup-validation";
+
+// Validate required configuration before anything else
+validateStartup();
 
 // Initialize DB on startup
 initBunDb();

--- a/server/startup-validation.test.ts
+++ b/server/startup-validation.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { CONFIG } from "./config";
+
+const originalTmdbApiKey = CONFIG.TMDB_API_KEY;
+const originalDbPath = CONFIG.DB_PATH;
+
+// Mock process.exit so tests don't actually terminate
+const mockExit = spyOn(process, "exit").mockImplementation((() => {
+  throw new Error("process.exit called");
+}) as never);
+
+// Suppress logger output during tests
+const mockConsoleError = spyOn(console, "error").mockImplementation(() => {});
+const mockConsoleLog = spyOn(console, "log").mockImplementation(() => {});
+
+describe("validateStartup", () => {
+  afterEach(() => {
+    CONFIG.TMDB_API_KEY = originalTmdbApiKey;
+    CONFIG.DB_PATH = originalDbPath;
+    mockExit.mockClear();
+  });
+
+  it("exits when TMDB_API_KEY is not set", async () => {
+    CONFIG.TMDB_API_KEY = "";
+    const { validateStartup } = await import("./startup-validation");
+    expect(() => validateStartup()).toThrow("process.exit called");
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("exits when DB directory is not writable", async () => {
+    CONFIG.TMDB_API_KEY = "test-key";
+    CONFIG.DB_PATH = "/nonexistent-dir-abc123/remindarr.db";
+    const { validateStartup } = await import("./startup-validation");
+    expect(() => validateStartup()).toThrow("process.exit called");
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("passes validation when config is valid", async () => {
+    CONFIG.TMDB_API_KEY = "test-key";
+    CONFIG.DB_PATH = "./remindarr.db";
+    const { validateStartup } = await import("./startup-validation");
+    expect(() => validateStartup()).not.toThrow();
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+});

--- a/server/startup-validation.ts
+++ b/server/startup-validation.ts
@@ -1,0 +1,64 @@
+import fs from "node:fs";
+import path from "node:path";
+import { CONFIG } from "./config";
+import { logger } from "./logger";
+
+const log = logger.child({ module: "startup" });
+
+function mask(value: string, visibleChars = 4): string {
+  if (!value) return "(not set)";
+  if (value.length <= visibleChars) return "****";
+  return value.slice(0, visibleChars) + "****";
+}
+
+function checkDbWritable(dbPath: string): void {
+  const dir = path.dirname(path.resolve(dbPath));
+  try {
+    fs.accessSync(dir, fs.constants.W_OK);
+  } catch {
+    log.error("DB directory is not writable — database writes will fail", {
+      dbPath,
+      dir,
+    });
+    process.exit(1);
+  }
+}
+
+function logActiveConfig(): void {
+  log.info("Active configuration", {
+    PORT: CONFIG.PORT,
+    LOG_LEVEL: CONFIG.LOG_LEVEL,
+    DB_PATH: CONFIG.DB_PATH,
+    TMDB_API_KEY: mask(CONFIG.TMDB_API_KEY),
+    TMDB_BASE_URL: CONFIG.TMDB_BASE_URL,
+    TMDB_API_TIMEOUT_MS: CONFIG.TMDB_API_TIMEOUT_MS,
+    COUNTRY: CONFIG.COUNTRY,
+    FALLBACK_COUNTRIES: CONFIG.FALLBACK_COUNTRIES,
+    LANGUAGE: CONFIG.LANGUAGE,
+    SYNC_TITLES_CRON: CONFIG.SYNC_TITLES_CRON,
+    SYNC_EPISODES_CRON: CONFIG.SYNC_EPISODES_CRON,
+    BETTER_AUTH_SECRET: mask(CONFIG.BETTER_AUTH_SECRET),
+    OIDC_ISSUER_URL: CONFIG.OIDC_ISSUER_URL || "(not set)",
+    OIDC_CLIENT_ID: CONFIG.OIDC_CLIENT_ID || "(not set)",
+    OIDC_CLIENT_SECRET: mask(CONFIG.OIDC_CLIENT_SECRET),
+    OIDC_REDIRECT_URI: CONFIG.OIDC_REDIRECT_URI || "(not set)",
+    CORS_ORIGIN: CONFIG.CORS_ORIGIN || "(not set)",
+    VAPID_PUBLIC_KEY: mask(CONFIG.VAPID_PUBLIC_KEY),
+    VAPID_PRIVATE_KEY: mask(CONFIG.VAPID_PRIVATE_KEY),
+    VAPID_SUBJECT: CONFIG.VAPID_SUBJECT || "(not set)",
+    SENTRY_DSN: CONFIG.SENTRY_DSN ? "(set)" : "(not set)",
+  });
+}
+
+export function validateStartup(): void {
+  if (!CONFIG.TMDB_API_KEY) {
+    log.error(
+      "TMDB_API_KEY is not set — all TMDB requests will fail. Set the TMDB_API_KEY environment variable and restart.",
+    );
+    process.exit(1);
+  }
+
+  checkDbWritable(CONFIG.DB_PATH);
+
+  logActiveConfig();
+}


### PR DESCRIPTION
Add startup validation that exits early with clear error messages if TMDB_API_KEY is missing or the DB directory is not writable, and logs all active configuration at startup with secrets masked.

Closes #154

Generated with [Claude Code](https://claude.ai/code)