### PR TITLE
feat: add watchlist export/import functionality

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -107,6 +107,28 @@ export async function getTrackedTitles(): Promise<{ titles: Title[]; count: numb
   return fetchJson("/track");
 }
 
+export async function exportWatchlist(): Promise<void> {
+  const res = await fetch(`${BASE}/track/export`, { credentials: "include" });
+  if (!res.ok) throw new Error("Export failed");
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  const disposition = res.headers.get("Content-Disposition") || "";
+  const match = disposition.match(/filename="([^"]+)"/);
+  a.href = url;
+  a.download = match ? match[1] : "watchlist.json";
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export async function importWatchlist(file: File): Promise<{ success: boolean; imported: number; skipped: number }> {
+  const text = await file.text();
+  return fetchJson("/track/import", {
+    method: "POST",
+    body: text,
+  });
+}
+
 export async function resolveImdb(url: string): Promise<{ success: boolean; title: SearchTitle }> {
   return fetchJson("/imdb", {
     method: "POST",

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -14,6 +14,7 @@ export default function ProfilePage() {
   return (
     <div className="max-w-2xl mx-auto space-y-8">
       <UserSection />
+      <WatchlistSection />
       {isPushSupported() && <PushNotificationsSection />}
       <NotificationsSection />
       {user.is_admin && <BackgroundJobsSection />}
@@ -117,6 +118,89 @@ function UserSection() {
           </form>
         </div>
       )}
+    </section>
+  );
+}
+
+function WatchlistSection() {
+  const [exporting, setExporting] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const [msg, setMsg] = useState("");
+  const [err, setErr] = useState("");
+
+  async function handleExport() {
+    setMsg("");
+    setErr("");
+    setExporting(true);
+    try {
+      await api.exportWatchlist();
+    } catch (e: any) {
+      setErr(e.message);
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  async function handleImport(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setMsg("");
+    setErr("");
+    setImporting(true);
+    try {
+      const result = await api.importWatchlist(file);
+      setMsg(`Import complete: ${result.imported} titles added${result.skipped > 0 ? `, ${result.skipped} skipped` : ""}.`);
+    } catch (e: any) {
+      setErr(e.message);
+    } finally {
+      setImporting(false);
+      e.target.value = "";
+    }
+  }
+
+  return (
+    <section>
+      <h2 className="text-xl font-bold text-white mb-4">Watchlist</h2>
+
+      {msg && (
+        <div className="mb-4 p-3 rounded-lg bg-green-900/50 border border-green-700 text-green-200 text-sm">
+          {msg}
+        </div>
+      )}
+      {err && (
+        <div className="mb-4 p-3 rounded-lg bg-red-900/50 border border-red-700 text-red-200 text-sm">
+          {err}
+        </div>
+      )}
+
+      <div className="bg-gray-900 rounded-lg p-5 space-y-4">
+        <div>
+          <p className="text-white font-medium mb-1">Export Watchlist</p>
+          <p className="text-sm text-gray-400 mb-3">Download your tracked titles and watched episode history as a JSON file.</p>
+          <button
+            onClick={handleExport}
+            disabled={exporting}
+            className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded-lg transition-colors disabled:opacity-50 cursor-pointer"
+          >
+            {exporting ? "Exporting..." : "Export"}
+          </button>
+        </div>
+
+        <div className="border-t border-gray-800 pt-4">
+          <p className="text-white font-medium mb-1">Import Watchlist</p>
+          <p className="text-sm text-gray-400 mb-3">Restore a previously exported watchlist. Existing tracked titles will not be removed.</p>
+          <label className={`px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white font-medium rounded-lg transition-colors cursor-pointer ${importing ? "opacity-50 pointer-events-none" : ""}`}>
+            {importing ? "Importing..." : "Import"}
+            <input
+              type="file"
+              accept=".json,application/json"
+              onChange={handleImport}
+              className="hidden"
+              disabled={importing}
+            />
+          </label>
+        </div>
+      </div>
     </section>
   );
 }

--- a/server/db/repository/episodes.ts
+++ b/server/db/repository/episodes.ts
@@ -272,3 +272,44 @@ export async function unwatchEpisodesBulk(episodeIds: number[], userId: string) 
     }
   });
 }
+
+export async function getWatchedEpisodesForExport(userId: string): Promise<Map<string, Array<{ season: number; episode: number }>>> {
+  return traceDbQuery("getWatchedEpisodesForExport", async () => {
+    const db = getDb();
+    const rows = await db
+      .select({
+        titleId: episodes.titleId,
+        season: episodes.seasonNumber,
+        episode: episodes.episodeNumber,
+      })
+      .from(watchedEpisodes)
+      .innerJoin(episodes, eq(watchedEpisodes.episodeId, episodes.id))
+      .where(eq(watchedEpisodes.userId, userId))
+      .all();
+
+    const map = new Map<string, Array<{ season: number; episode: number }>>();
+    for (const row of rows) {
+      if (!map.has(row.titleId)) map.set(row.titleId, []);
+      map.get(row.titleId)!.push({ season: row.season, episode: row.episode });
+    }
+    return map;
+  });
+}
+
+export async function getEpisodeIdsBySE(
+  titleId: string,
+  sePairs: Array<{ season: number; episode: number }>
+): Promise<number[]> {
+  return traceDbQuery("getEpisodeIdsBySE", async () => {
+    if (sePairs.length === 0) return [];
+    const db = getDb();
+    const rows = await db
+      .select({ id: episodes.id, season: episodes.seasonNumber, episode: episodes.episodeNumber })
+      .from(episodes)
+      .where(eq(episodes.titleId, titleId))
+      .all();
+
+    const wanted = new Set(sePairs.map((p) => `${p.season}:${p.episode}`));
+    return rows.filter((r) => wanted.has(`${r.season}:${r.episode}`)).map((r) => r.id);
+  });
+}

--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -27,6 +27,8 @@ export {
   unwatchEpisode,
   watchEpisodesBulk,
   unwatchEpisodesBulk,
+  getWatchedEpisodesForExport,
+  getEpisodeIdsBySE,
 } from "./episodes";
 
 export {

--- a/server/routes/track.test.ts
+++ b/server/routes/track.test.ts
@@ -115,3 +115,131 @@ describe("DELETE /track/:id", () => {
     expect(listBody.titles).toHaveLength(0);
   });
 });
+
+describe("GET /track/export", () => {
+  it("returns empty export when nothing tracked", async () => {
+    const res = await app.request("/track/export", { headers: headers() });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.version).toBe(1);
+    expect(body.titles).toHaveLength(0);
+    expect(body.exported_at).toBeTruthy();
+  });
+
+  it("returns tracked titles in export", async () => {
+    await upsertTitles([makeParsedTitle()]);
+    await app.request("/track/movie-123", {
+      method: "POST",
+      headers: { ...headers(), "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    const res = await app.request("/track/export", { headers: headers() });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.titles).toHaveLength(1);
+    expect(body.titles[0].id).toBe("movie-123");
+    expect(body.titles[0].tmdb_id).toBe("123");
+    expect(body.titles[0].title).toBe("Test Movie");
+    expect(body.titles[0].watched_episodes).toEqual([]);
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await app.request("/track/export");
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /track/import", () => {
+  it("imports titles from export data", async () => {
+    const exportData = {
+      version: 1,
+      exported_at: "2026-01-01T00:00:00Z",
+      titles: [
+        {
+          id: "movie-123",
+          tmdb_id: "123",
+          object_type: "MOVIE",
+          title: "Test Movie",
+          original_title: null,
+          release_year: 2024,
+          release_date: "2024-06-15",
+          runtime_minutes: 120,
+          short_description: "A test movie",
+          genres: ["Action"],
+          original_language: "en",
+          imdb_id: "tt1234567",
+          poster_url: null,
+          age_certification: null,
+          tmdb_url: null,
+          tracked_at: "2026-01-01T00:00:00Z",
+          notes: null,
+          watched_episodes: [],
+        },
+      ],
+    };
+
+    const res = await app.request("/track/import", {
+      method: "POST",
+      headers: { ...headers(), "Content-Type": "application/json" },
+      body: JSON.stringify(exportData),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.imported).toBe(1);
+    expect(body.skipped).toBe(0);
+
+    // Verify tracked
+    const listRes = await app.request("/track", { headers: headers() });
+    const listBody = await listRes.json();
+    expect(listBody.titles).toHaveLength(1);
+    expect(listBody.titles[0].id).toBe("movie-123");
+  });
+
+  it("skips items with missing required fields", async () => {
+    const exportData = {
+      version: 1,
+      exported_at: "2026-01-01T00:00:00Z",
+      titles: [
+        { id: "movie-123" }, // missing title and object_type
+        {
+          id: "movie-456",
+          tmdb_id: "456",
+          object_type: "MOVIE",
+          title: "Another Movie",
+          genres: [],
+          watched_episodes: [],
+        },
+      ],
+    };
+
+    const res = await app.request("/track/import", {
+      method: "POST",
+      headers: { ...headers(), "Content-Type": "application/json" },
+      body: JSON.stringify(exportData),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.imported).toBe(1);
+    expect(body.skipped).toBe(1);
+  });
+
+  it("returns 400 for invalid JSON structure", async () => {
+    const res = await app.request("/track/import", {
+      method: "POST",
+      headers: { ...headers(), "Content-Type": "application/json" },
+      body: JSON.stringify({ invalid: true }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await app.request("/track/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ titles: [] }),
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/server/routes/track.ts
+++ b/server/routes/track.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { trackTitle, untrackTitle, getTrackedTitles, upsertTitles, deleteEpisodesForTitle } from "../db/repository";
+import { trackTitle, untrackTitle, getTrackedTitles, upsertTitles, deleteEpisodesForTitle, getWatchedEpisodesForExport, getEpisodeIdsBySE, watchEpisodesBulk } from "../db/repository";
 import type { ParsedTitle } from "../tmdb/parser";
 import { CONFIG } from "../config";
 import { syncEpisodesForShow } from "../tmdb/sync";
@@ -54,6 +54,103 @@ function toParsedTitle(t: any): ParsedTitle {
     },
   };
 }
+
+app.get("/export", async (c) => {
+  const user = c.get("user")!;
+  const tracked = await getTrackedTitles(user.id);
+  const watchedByTitle = await getWatchedEpisodesForExport(user.id);
+
+  const exportData = {
+    version: 1,
+    exported_at: new Date().toISOString(),
+    titles: tracked.map((t) => ({
+      id: t.id,
+      tmdb_id: t.tmdb_id,
+      object_type: t.object_type,
+      title: t.title,
+      original_title: t.original_title,
+      release_year: t.release_year,
+      release_date: t.release_date,
+      runtime_minutes: t.runtime_minutes,
+      short_description: t.short_description,
+      genres: t.genres,
+      original_language: t.original_language,
+      imdb_id: t.imdb_id,
+      poster_url: t.poster_url,
+      age_certification: t.age_certification,
+      tmdb_url: t.tmdb_url,
+      tracked_at: t.tracked_at,
+      notes: t.notes,
+      watched_episodes: watchedByTitle.get(t.id) ?? [],
+    })),
+  };
+
+  c.header("Content-Disposition", `attachment; filename="watchlist-${new Date().toISOString().slice(0, 10)}.json"`);
+  return c.json(exportData);
+});
+
+app.post("/import", async (c) => {
+  const user = c.get("user")!;
+
+  let data: any;
+  try {
+    data = await c.req.json();
+  } catch {
+    return c.json({ error: "Invalid JSON" }, 400);
+  }
+
+  if (!data || typeof data !== "object" || !Array.isArray(data.titles)) {
+    return c.json({ error: "Invalid export format: expected { titles: [...] }" }, 400);
+  }
+
+  let imported = 0;
+  let skipped = 0;
+
+  for (const item of data.titles) {
+    if (!item.id || !item.title || !item.object_type) {
+      skipped++;
+      continue;
+    }
+
+    try {
+      await upsertTitles([{
+        id: item.id,
+        objectType: item.object_type,
+        title: item.title,
+        originalTitle: item.original_title ?? null,
+        releaseYear: item.release_year ?? null,
+        releaseDate: item.release_date ?? null,
+        runtimeMinutes: item.runtime_minutes ?? null,
+        shortDescription: item.short_description ?? null,
+        genres: Array.isArray(item.genres) ? item.genres : [],
+        originalLanguage: item.original_language ?? null,
+        imdbId: item.imdb_id ?? null,
+        tmdbId: item.tmdb_id ?? null,
+        posterUrl: item.poster_url ?? null,
+        ageCertification: item.age_certification ?? null,
+        tmdbUrl: item.tmdb_url ?? null,
+        offers: [],
+        scores: { imdbScore: null, imdbVotes: null, tmdbScore: null },
+      }]);
+
+      await trackTitle(item.id, user.id, item.notes ?? undefined);
+
+      if (Array.isArray(item.watched_episodes) && item.watched_episodes.length > 0) {
+        const episodeIds = await getEpisodeIdsBySE(item.id, item.watched_episodes);
+        if (episodeIds.length > 0) {
+          await watchEpisodesBulk(episodeIds, user.id);
+        }
+      }
+
+      imported++;
+    } catch (err) {
+      log.warn("Failed to import title", { titleId: item.id, err });
+      skipped++;
+    }
+  }
+
+  return c.json({ success: true, imported, skipped });
+});
 
 app.post("/:id", async (c) => {
   const user = c.get("user")!;


### PR DESCRIPTION
Adds export/import functionality for user watchlists from the Profile page.

## Changes
- `GET /api/track/export` — download tracked titles as JSON (includes TMDB IDs, tracking date, watched episode status)
- `POST /api/track/import` — restore watchlist from exported JSON
- WatchlistSection on ProfilePage with Export and Import controls
- Tests for both endpoints

Closes #162

Generated with [Claude Code](https://claude.ai/code)