### PR TITLE
refactor(reels): clarify cardsRef is derived from state, not independent

### DIFF
--- a/frontend/src/pages/ReelsPage.tsx
+++ b/frontend/src/pages/ReelsPage.tsx
@@ -51,7 +51,10 @@ export function getFirstUnwatchedPerShow(episodes: Episode[]): ShowCard[] {
 export default function ReelsPage() {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [cards, setCards] = useState<ShowCard[]>([]);
-  const cardsRef = useRef<ShowCard[]>([]);
+  // Ref is always derived from state — never updated independently.
+  // Callbacks read from this ref to access the latest value without
+  // needing to be recreated whenever `cards` changes.
+  const cardsRef = useRef(cards);
   cardsRef.current = cards;
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");


### PR DESCRIPTION
Fixes #144

**What changed**:
- Changed `useRef<ShowCard[]>([])` → `useRef(cards)` so the ref is visibly initialized from state
- Added a comment explaining the invariant: the ref is always overwritten from state each render and must never be written to independently

Generated with [Claude Code](https://claude.ai/code)