### PR TITLE
fix: eliminate OIDC admin status race condition with per-request nonces

### DIFF
--- a/server/auth/better-auth.test.ts
+++ b/server/auth/better-auth.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect } from "bun:test";
+import { checkAdminClaim } from "./better-auth";
+
+describe("checkAdminClaim", () => {
+  test("returns false when claimName is empty", () => {
+    expect(checkAdminClaim({ role: "admin" }, "", "admin")).toBe(false);
+  });
+
+  test("returns false when claimValue is empty", () => {
+    expect(checkAdminClaim({ role: "admin" }, "role", "")).toBe(false);
+  });
+
+  test("returns false when claim is missing", () => {
+    expect(checkAdminClaim({}, "role", "admin")).toBe(false);
+  });
+
+  test("returns false when claim is null", () => {
+    expect(checkAdminClaim({ role: null }, "role", "admin")).toBe(false);
+  });
+
+  test("returns true when scalar claim matches", () => {
+    expect(checkAdminClaim({ role: "admin" }, "role", "admin")).toBe(true);
+  });
+
+  test("returns false when scalar claim does not match", () => {
+    expect(checkAdminClaim({ role: "user" }, "role", "admin")).toBe(false);
+  });
+
+  test("coerces non-string scalar to string for comparison", () => {
+    expect(checkAdminClaim({ level: 1 }, "level", "1")).toBe(true);
+  });
+
+  test("returns true when array claim contains the value", () => {
+    expect(checkAdminClaim({ groups: ["admins", "users"] }, "groups", "admins")).toBe(true);
+  });
+
+  test("returns false when array claim does not contain the value", () => {
+    expect(checkAdminClaim({ groups: ["users"] }, "groups", "admins")).toBe(false);
+  });
+
+  test("coerces array elements to string for comparison", () => {
+    expect(checkAdminClaim({ flags: [1, 2, 3] }, "flags", "2")).toBe(true);
+  });
+});

--- a/server/auth/better-auth.ts
+++ b/server/auth/better-auth.ts
@@ -13,9 +13,6 @@ import type { DrizzleDb } from "../platform/types";
 
 const log = logger.child({ module: "auth" });
 
-// Cache for OIDC admin status (sub → isAdmin) during OAuth callback flow
-const _pendingOidcAdminStatus = new Map<string, boolean>();
-
 /** Check if OIDC claims grant admin status based on configured claim/value. */
 export function checkAdminClaim(
   claims: Record<string, unknown>,
@@ -41,6 +38,12 @@ export function createAuth(db: DrizzleDb, platform: Platform, oidcConfig?: {
   adminClaim: string;
   adminValue: string;
 }) {
+  // Per-request nonce → isAdmin mapping to avoid race conditions when the same
+  // sub logs in concurrently. Each getUserInfo call generates a unique nonce,
+  // and the corresponding database hook dequeues it in FIFO order.
+  const pendingOidcAdminStatus = new Map<string, boolean>(); // nonce → isAdmin
+  const pendingNoncesByAccountId = new Map<string, string[]>(); // sub → nonce queue
+
   const plugins: any[] = [
     username({
       minUsernameLength: 1,
@@ -91,10 +94,15 @@ export function createAuth(db: DrizzleDb, platform: Platform, oidcConfig?: {
 
             if (!claims.sub) return null;
 
-            // Cache admin status for the database hooks to pick up
+            // Enqueue admin status keyed by a per-request nonce so that
+            // concurrent logins for the same sub don't overwrite each other.
             if (oidcConfig.adminClaim && oidcConfig.adminValue) {
               const isAdmin = checkAdminClaim(claims, oidcConfig.adminClaim, oidcConfig.adminValue);
-              _pendingOidcAdminStatus.set(String(claims.sub), isAdmin);
+              const nonce = crypto.randomUUID();
+              pendingOidcAdminStatus.set(nonce, isAdmin);
+              const queue = pendingNoncesByAccountId.get(String(claims.sub)) ?? [];
+              queue.push(nonce);
+              pendingNoncesByAccountId.set(String(claims.sub), queue);
             }
 
             return {
@@ -170,13 +178,18 @@ export function createAuth(db: DrizzleDb, platform: Platform, oidcConfig?: {
           after: async (acc) => {
             // Sync admin role for new OIDC users
             if (acc.providerId === "pocketid") {
-              const isAdmin = _pendingOidcAdminStatus.get(acc.accountId);
-              if (isAdmin !== undefined) {
-                _pendingOidcAdminStatus.delete(acc.accountId);
-                const role = isAdmin ? "admin" : "user";
-                const currentDb = getDb();
-                await currentDb.update(users).set({ role }).where(eq(users.id, acc.userId)).run();
-                log.info("Set OIDC user role", { userId: acc.userId, role });
+              const queue = pendingNoncesByAccountId.get(acc.accountId);
+              if (queue && queue.length > 0) {
+                const nonce = queue.shift()!;
+                if (queue.length === 0) pendingNoncesByAccountId.delete(acc.accountId);
+                const isAdmin = pendingOidcAdminStatus.get(nonce);
+                if (isAdmin !== undefined) {
+                  pendingOidcAdminStatus.delete(nonce);
+                  const role = isAdmin ? "admin" : "user";
+                  const currentDb = getDb();
+                  await currentDb.update(users).set({ role }).where(eq(users.id, acc.userId)).run();
+                  log.info("Set OIDC user role", { userId: acc.userId, role });
+                }
               }
             }
           },
@@ -186,7 +199,7 @@ export function createAuth(db: DrizzleDb, platform: Platform, oidcConfig?: {
         create: {
           after: async (sess) => {
             // Sync admin role for returning OIDC users
-            if (_pendingOidcAdminStatus.size === 0) return;
+            if (pendingNoncesByAccountId.size === 0) return;
 
             const currentDb = getDb();
             const acc = await currentDb
@@ -201,12 +214,17 @@ export function createAuth(db: DrizzleDb, platform: Platform, oidcConfig?: {
               .get();
 
             if (acc) {
-              const isAdmin = _pendingOidcAdminStatus.get(acc.accountId);
-              if (isAdmin !== undefined) {
-                _pendingOidcAdminStatus.delete(acc.accountId);
-                const role = isAdmin ? "admin" : "user";
-                await currentDb.update(users).set({ role }).where(eq(users.id, sess.userId)).run();
-                log.info("Synced OIDC user role", { userId: sess.userId, role });
+              const queue = pendingNoncesByAccountId.get(acc.accountId);
+              if (queue && queue.length > 0) {
+                const nonce = queue.shift()!;
+                if (queue.length === 0) pendingNoncesByAccountId.delete(acc.accountId);
+                const isAdmin = pendingOidcAdminStatus.get(nonce);
+                if (isAdmin !== undefined) {
+                  pendingOidcAdminStatus.delete(nonce);
+                  const role = isAdmin ? "admin" : "user";
+                  await currentDb.update(users).set({ role }).where(eq(users.id, sess.userId)).run();
+                  log.info("Synced OIDC user role", { userId: sess.userId, role });
+                }
               }
             }
           },


### PR DESCRIPTION
Fixes #137

## Summary

- Replace module-level `_pendingOidcAdminStatus` Map (keyed by `sub`) with two closure-scoped maps inside `createAuth`
- Each `getUserInfo` call generates a UUID nonce; database hooks dequeue FIFO, so concurrent logins for the same `sub` cannot overwrite or steal each other's admin status
- Adds unit tests for `checkAdminClaim`

Generated with [Claude Code](https://claude.ai/code)