### PR TITLE
fix: validate numeric route params to prevent NaN propagation

### DIFF
--- a/server/routes/details.test.ts
+++ b/server/routes/details.test.ts
@@ -134,6 +134,35 @@ describe("GET /details/show/:id/season/:season", () => {
     expect(body.seasonNumber).toBe(1);
     expect(tmdbClient.fetchTvDetails).toHaveBeenCalledWith(555);
   });
+
+  it("returns 400 for non-numeric season param", async () => {
+    upsertTitles([makeParsedTitle({ id: "tv-555", objectType: "SHOW", title: "Season Show", tmdbId: "555" })]);
+
+    const res = await app.request("/details/show/tv-555/season/abc");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid season number");
+  });
+});
+
+describe("GET /details/show/:id/season/:season/episode/:episode", () => {
+  it("returns 400 for non-numeric season param", async () => {
+    upsertTitles([makeParsedTitle({ id: "tv-555", objectType: "SHOW", title: "Season Show", tmdbId: "555" })]);
+
+    const res = await app.request("/details/show/tv-555/season/abc/episode/1");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid season or episode number");
+  });
+
+  it("returns 400 for non-numeric episode param", async () => {
+    upsertTitles([makeParsedTitle({ id: "tv-555", objectType: "SHOW", title: "Season Show", tmdbId: "555" })]);
+
+    const res = await app.request("/details/show/tv-555/season/1/episode/abc");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid season or episode number");
+  });
 });
 
 describe("GET /details/person/:personId", () => {

--- a/server/routes/details.ts
+++ b/server/routes/details.ts
@@ -101,6 +101,7 @@ app.get("/show/:id/season/:season", async (c) => {
   if (!title) return c.json({ error: "Title not found" }, 404);
 
   const seasonNumber = Number(c.req.param("season"));
+  if (isNaN(seasonNumber)) return c.json({ error: "Invalid season number" }, 400);
 
   let tmdb = null;
   if (title.tmdb_id && CONFIG.TMDB_API_KEY) {
@@ -126,6 +127,7 @@ app.get("/show/:id/season/:season/episode/:episode", async (c) => {
 
   const seasonNumber = Number(c.req.param("season"));
   const episodeNumber = Number(c.req.param("episode"));
+  if (isNaN(seasonNumber) || isNaN(episodeNumber)) return c.json({ error: "Invalid season or episode number" }, 400);
 
   let tmdb = null;
   if (title.tmdb_id && CONFIG.TMDB_API_KEY) {

--- a/server/routes/watched.test.ts
+++ b/server/routes/watched.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { createUser } from "../db/repository";
+import watchedApp from "./watched";
+import type { AppEnv } from "../types";
+
+let app: Hono<AppEnv>;
+let userId: string;
+
+beforeEach(async () => {
+  setupTestDb();
+  userId = await createUser("watcheduser", "hash");
+
+  app = new Hono<AppEnv>();
+  app.use("*", async (c, next) => {
+    c.set("user", { id: userId, username: "watcheduser", name: null, role: null, is_admin: false });
+    await next();
+  });
+  app.route("/watched", watchedApp);
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+describe("POST /watched/:episodeId", () => {
+  it("returns 400 for non-numeric episodeId", async () => {
+    const res = await app.request("/watched/abc", { method: "POST" });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid episodeId");
+  });
+});
+
+describe("DELETE /watched/:episodeId", () => {
+  it("returns 400 for non-numeric episodeId", async () => {
+    const res = await app.request("/watched/abc", { method: "DELETE" });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid episodeId");
+  });
+});

--- a/server/routes/watched.ts
+++ b/server/routes/watched.ts
@@ -35,6 +35,7 @@ app.post("/bulk", async (c) => {
 app.post("/:episodeId", async (c) => {
   const user = c.get("user")!;
   const episodeId = Number(c.req.param("episodeId"));
+  if (isNaN(episodeId)) return c.json({ error: "Invalid episodeId" }, 400);
   const airDate = await getEpisodeAirDate(episodeId);
   if (!isReleased(airDate)) {
     return c.json({ error: "Cannot mark an unreleased episode as watched" }, 400);
@@ -46,6 +47,7 @@ app.post("/:episodeId", async (c) => {
 app.delete("/:episodeId", async (c) => {
   const user = c.get("user")!;
   const episodeId = Number(c.req.param("episodeId"));
+  if (isNaN(episodeId)) return c.json({ error: "Invalid episodeId" }, 400);
   await unwatchEpisode(episodeId, user.id);
   return c.json({ success: true });
 });


### PR DESCRIPTION
Add NaN guards for episodeId in watched routes and seasonNumber/episodeNumber in details routes. Add regression tests covering the invalid-param cases.

Fixes #132

Generated with [Claude Code](https://claude.ai/code)