### PR TITLE
feat: replace Loading text with skeleton UI

### DIFF
--- a/frontend/src/components/SkeletonComponents.tsx
+++ b/frontend/src/components/SkeletonComponents.tsx
@@ -1,0 +1,155 @@
+import { Skeleton } from "./ui/skeleton";
+
+/** Single title card skeleton matching TitleCard layout */
+export function TitleCardSkeleton() {
+  return (
+    <div className="bg-gray-900 rounded-xl overflow-hidden border border-gray-800 flex flex-col">
+      {/* Poster */}
+      <Skeleton className="aspect-[2/3] w-full rounded-none" />
+      {/* Title + meta */}
+      <div className="p-2 space-y-2">
+        <Skeleton className="h-3 w-3/4" />
+        <Skeleton className="h-3 w-1/2" />
+      </div>
+    </div>
+  );
+}
+
+/** Grid of title card skeletons */
+export function TitleGridSkeleton({ count = 12 }: { count?: number }) {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+      {Array.from({ length: count }).map((_, i) => (
+        <TitleCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}
+
+/** Single episode row skeleton */
+function EpisodeRowSkeleton({ compact = false }: { compact?: boolean }) {
+  return (
+    <div className={`bg-gray-900 rounded-xl border border-gray-800 ${compact ? "p-3" : "p-4"}`}>
+      <div className="flex gap-4">
+        <Skeleton className="w-16 h-24 rounded-lg flex-shrink-0" />
+        <div className="flex-1 space-y-2 pt-1">
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="h-3 w-24" />
+          <div className="space-y-1 mt-2">
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-3/4" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Episode list skeleton for HomePage / UpcomingPage */
+export function EpisodeListSkeleton() {
+  return (
+    <div className="space-y-8">
+      {/* Section heading */}
+      <section>
+        <Skeleton className="h-6 w-16 mb-4" />
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <EpisodeRowSkeleton key={i} />
+          ))}
+        </div>
+      </section>
+      <section>
+        <Skeleton className="h-5 w-24 mb-4" />
+        <div className="space-y-4">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <div key={i}>
+              <Skeleton className="h-3 w-32 mb-2" />
+              <div className="space-y-2">
+                <EpisodeRowSkeleton compact />
+                <EpisodeRowSkeleton compact />
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+/** Detail page hero skeleton (TitleDetailPage, SeasonDetailPage, EpisodeDetailPage, PersonPage) */
+export function DetailPageSkeleton() {
+  return (
+    <div className="space-y-8 pb-12">
+      {/* Breadcrumb */}
+      <Skeleton className="h-4 w-48" />
+      {/* Hero */}
+      <div className="flex flex-col sm:flex-row gap-6">
+        <Skeleton className="w-40 aspect-[2/3] rounded-xl mx-auto sm:mx-0 shrink-0" />
+        <div className="flex-1 space-y-3 pt-1">
+          <Skeleton className="h-7 w-3/4" />
+          <Skeleton className="h-4 w-1/2" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-2/3" />
+        </div>
+      </div>
+      {/* Episodes / cast section */}
+      <div className="space-y-3">
+        <Skeleton className="h-5 w-24" />
+        <div className="space-y-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="flex gap-4 bg-gray-900 rounded-xl border border-gray-800 p-3">
+              <Skeleton className="w-36 aspect-video rounded-lg shrink-0" />
+              <div className="flex-1 space-y-2 pt-1">
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-3 w-1/2" />
+                <Skeleton className="h-3 w-full" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Calendar / agenda list skeleton */
+export function CalendarSkeleton() {
+  return (
+    <div className="space-y-1">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i}>
+          <Skeleton className="h-8 w-full rounded-none mb-1" />
+          <div className="space-y-1 px-2 py-1">
+            {Array.from({ length: 3 }).map((_, j) => (
+              <div key={j} className="flex items-center gap-3 p-2.5 rounded-lg bg-gray-900/60">
+                <Skeleton className="w-5 h-5 rounded-full shrink-0" />
+                <Skeleton className="w-12 h-8 rounded shrink-0" />
+                <div className="flex-1 space-y-1">
+                  <Skeleton className="h-3 w-3/4" />
+                  <Skeleton className="h-3 w-1/2" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Reels page skeleton (full-height card) */
+export function ReelsSkeleton() {
+  return (
+    <div
+      className="flex items-center justify-center"
+      style={{ minHeight: "calc(100dvh - 5rem)" }}
+    >
+      <div className="w-full max-w-sm space-y-4 px-4">
+        <Skeleton className="w-full aspect-[2/3] rounded-2xl" />
+        <Skeleton className="h-5 w-3/4 mx-auto" />
+        <Skeleton className="h-4 w-1/2 mx-auto" />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -1,0 +1,12 @@
+import { cn } from "../../lib/utils";
+
+function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-gray-800", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -5,6 +5,7 @@ import { getCalendarTitles, watchEpisode, unwatchEpisode, watchEpisodesBulk } fr
 import { useIsMobile } from "../hooks/useIsMobile";
 import TitleList from "../components/TitleList";
 import type { Title, Episode, Offer } from "../types";
+import { CalendarSkeleton } from "../components/SkeletonComponents";
 
 function formatMonth(date: Date): string {
   const y = date.getFullYear();
@@ -387,7 +388,7 @@ function AgendaCalendar({ viewMode, onViewModeChange }: { viewMode?: ViewMode; o
       </div>
 
       {initialLoading ? (
-        <div className="text-center py-8 text-gray-500">Loading...</div>
+        <CalendarSkeleton />
       ) : (
         <>
           {/* Load more top sentinel */}

--- a/frontend/src/pages/EpisodeDetailPage.tsx
+++ b/frontend/src/pages/EpisodeDetailPage.tsx
@@ -3,6 +3,7 @@ import { useParams, Link } from "react-router";
 import * as api from "../api";
 import type { EpisodeDetailsResponse, CastMember, CrewMember } from "../types";
 import PersonCard from "../components/PersonCard";
+import { DetailPageSkeleton } from "../components/SkeletonComponents";
 
 const TMDB_IMG = "https://image.tmdb.org/t/p";
 
@@ -41,11 +42,7 @@ export default function EpisodeDetailPage() {
   }, [id, season, episode]);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <div className="text-gray-400">Loading episode details...</div>
-      </div>
-    );
+    return <DetailPageSkeleton />;
   }
 
   if (error || !data) {

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -12,6 +12,7 @@ import {
   WatchedIcon,
   ShowEpisodeGroup,
 } from "../components/EpisodeComponents";
+import { EpisodeListSkeleton } from "../components/SkeletonComponents";
 
 export function groupByShowAndSeason(episodes: Episode[]): Map<string, Map<number, Episode[]>> {
   const map = new Map<string, Map<number, Episode[]>>();
@@ -324,7 +325,7 @@ export default function HomePage() {
   };
 
   if (authLoading || loading) {
-    return <div className="text-gray-500 text-center py-12">Loading...</div>;
+    return <EpisodeListSkeleton />;
   }
 
   if (!user) {

--- a/frontend/src/pages/PersonPage.tsx
+++ b/frontend/src/pages/PersonPage.tsx
@@ -3,6 +3,7 @@ import { useParams, Link } from "react-router";
 import * as api from "../api";
 import type { PersonDetailsResponse, PersonCastCredit, PersonCrewCredit } from "../types";
 import ExternalLinks from "../components/ExternalLinks";
+import { DetailPageSkeleton } from "../components/SkeletonComponents";
 
 const TMDB_IMG = "https://image.tmdb.org/t/p";
 const BIO_TRUNCATE_LENGTH = 600;
@@ -106,11 +107,7 @@ export default function PersonPage() {
   }, [personId]);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <div className="text-gray-400">Loading...</div>
-      </div>
-    );
+    return <DetailPageSkeleton />;
   }
 
   if (error || !data) {

--- a/frontend/src/pages/ReelsPage.tsx
+++ b/frontend/src/pages/ReelsPage.tsx
@@ -5,6 +5,7 @@ import * as api from "../api";
 import type { Episode } from "../types";
 import ReelsCard from "../components/ReelsCard";
 import ReelsSeasonPanel from "../components/ReelsSeasonPanel";
+import { ReelsSkeleton } from "../components/SkeletonComponents";
 
 interface ShowCard {
   titleId: string;
@@ -277,11 +278,7 @@ export default function ReelsPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center" style={{ minHeight: "calc(100dvh - 5rem)" }}>
-        <p className="text-gray-500">Loading...</p>
-      </div>
-    );
+    return <ReelsSkeleton />;
   }
 
   if (error) {

--- a/frontend/src/pages/SeasonDetailPage.tsx
+++ b/frontend/src/pages/SeasonDetailPage.tsx
@@ -3,6 +3,7 @@ import { useParams, Link } from "react-router";
 import * as api from "../api";
 import type { SeasonDetailsResponse } from "../types";
 import PersonCard from "../components/PersonCard";
+import { DetailPageSkeleton } from "../components/SkeletonComponents";
 
 const TMDB_IMG = "https://image.tmdb.org/t/p";
 
@@ -41,11 +42,7 @@ export default function SeasonDetailPage() {
   }, [id, season]);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <div className="text-gray-400">Loading season details...</div>
-      </div>
-    );
+    return <DetailPageSkeleton />;
   }
 
   if (error || !data) {

--- a/frontend/src/pages/TitleDetailPage.tsx
+++ b/frontend/src/pages/TitleDetailPage.tsx
@@ -13,6 +13,7 @@ import type {
 } from "../types";
 import TrackButton from "../components/TrackButton";
 import PersonCard from "../components/PersonCard";
+import { DetailPageSkeleton } from "../components/SkeletonComponents";
 import ExternalLinks from "../components/ExternalLinks";
 
 const TMDB_IMG = "https://image.tmdb.org/t/p";
@@ -174,11 +175,7 @@ export default function TitleDetailPage() {
   }, [id]);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <div className="text-gray-400">Loading details...</div>
-      </div>
-    );
+    return <DetailPageSkeleton />;
   }
 
   if (error) {

--- a/frontend/src/pages/TrackedPage.tsx
+++ b/frontend/src/pages/TrackedPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import * as api from "../api";
 import type { Title } from "../types";
 import TitleList from "../components/TitleList";
+import { TitleGridSkeleton } from "../components/SkeletonComponents";
 
 export default function TrackedPage() {
   const [titles, setTitles] = useState<Title[]>([]);
@@ -27,7 +28,7 @@ export default function TrackedPage() {
     <div className="space-y-4">
       <h2 className="text-lg font-semibold">Tracked Titles ({titles.length})</h2>
       {loading ? (
-        <div className="text-center py-12 text-gray-500">Loading...</div>
+        <TitleGridSkeleton />
       ) : (
         <TitleList
           titles={titles}

--- a/frontend/src/pages/UpcomingPage.tsx
+++ b/frontend/src/pages/UpcomingPage.tsx
@@ -6,6 +6,7 @@ import {
   formatUpcomingDate,
   ShowEpisodeGroup,
 } from "../components/EpisodeComponents";
+import { EpisodeListSkeleton } from "../components/SkeletonComponents";
 
 export default function UpcomingPage() {
   const [today, setToday] = useState<Episode[]>([]);
@@ -51,7 +52,7 @@ export default function UpcomingPage() {
   };
 
   if (loading) {
-    return <div className="text-gray-500 text-center py-12">Loading...</div>;
+    return <EpisodeListSkeleton />;
   }
 
   if (error) {


### PR DESCRIPTION
Replace plain "Loading..." text with animated skeleton UI using the shadcn Skeleton component across all pages, eliminating layout shift and improving perceived performance.

Closes #146

Generated with [Claude Code](https://claude.ai/code)