### PR TITLE
feat: standardize API response format with ok() and err() helpers

### DIFF
--- a/server/routes/admin.test.ts
+++ b/server/routes/admin.test.ts
@@ -118,7 +118,7 @@ describe("PUT /admin/settings", () => {
     });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.success).toBe(true);
+    expect(body.oidc_configured).toBeDefined();
 
     // Verify settings persisted
     expect(await getSetting("oidc_issuer_url")).toBe("https://auth.example.com");
@@ -190,6 +190,6 @@ describe("PUT /admin/settings", () => {
     });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.success).toBe(true);
+    expect(body.oidc_configured).toBeDefined();
   });
 });

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -9,6 +9,7 @@ import {
 } from "../db/repository";
 import { CONFIG } from "../config";
 import type { AppEnv } from "../types";
+import { ok } from "./response";
 
 /**
  * Callback to recreate the auth instance after OIDC settings change.
@@ -57,7 +58,7 @@ app.get("/settings", async (c) => {
     },
   };
 
-  return c.json({
+  return ok(c, {
     oidc,
     oidc_configured: await isOidcConfigured(),
   });
@@ -83,7 +84,7 @@ app.put("/settings", async (c) => {
     await _onOidcSettingsChanged();
   }
 
-  return c.json({ success: true, oidc_configured: await isOidcConfigured() });
+  return ok(c, { oidc_configured: await isOidcConfigured() });
 });
 
 export default app;

--- a/server/routes/browse.ts
+++ b/server/routes/browse.ts
@@ -21,6 +21,7 @@ import {
 import { getTrackedTitleIds } from "../db/repository";
 import type { AppEnv } from "../types";
 import { logger } from "../logger";
+import { ok, err } from "./response";
 
 const log = logger.child({ module: "browse" });
 
@@ -109,7 +110,7 @@ app.get("/", async (c) => {
   const typeValues = type ? type.split(",").filter(Boolean) : [];
 
   if (!category || !VALID_CATEGORIES.includes(category as Category)) {
-    return c.json({ error: "Invalid category. Must be one of: popular, upcoming, top_rated" }, 400);
+    return err(c, "Invalid category. Must be one of: popular, upcoming, top_rated");
   }
 
   try {
@@ -199,10 +200,10 @@ app.get("/", async (c) => {
 
     const availableLanguages = tmdbLanguages;
 
-    return c.json({ titles: titlesWithTracked, page, totalPages, totalResults, availableGenres, availableProviders, availableLanguages });
-  } catch (err: any) {
-    log.error("Browse error", { error: err.message, stack: err.stack });
-    return c.json({ error: err.message }, 500);
+    return ok(c, { titles: titlesWithTracked, page, totalPages, totalResults, availableGenres, availableProviders, availableLanguages });
+  } catch (e: any) {
+    log.error("Browse error", { error: e.message, stack: e.stack });
+    return err(c, e.message, 500);
   }
 });
 

--- a/server/routes/calendar.ts
+++ b/server/routes/calendar.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { getTitlesByMonth, getEpisodesByMonth } from "../db/repository";
 import type { AppEnv } from "../types";
+import { ok, err } from "./response";
 
 const app = new Hono<AppEnv>();
 
@@ -8,19 +9,19 @@ app.get("/", async (c) => {
   const user = c.get("user");
   const month = c.req.query("month"); // format: 2026-03
   if (!month || !/^\d{4}-\d{2}$/.test(month)) {
-    return c.json({ error: "month parameter required (format: YYYY-MM)" }, 400);
+    return err(c, "month parameter required (format: YYYY-MM)");
   }
 
   const objectType = c.req.query("type");
   const provider = c.req.query("provider");
 
   if (objectType && !["MOVIE", "SHOW"].includes(objectType)) {
-    return c.json({ error: "Invalid type. Must be one of: MOVIE, SHOW" }, 400);
+    return err(c, "Invalid type. Must be one of: MOVIE, SHOW");
   }
 
   const titles = await getTitlesByMonth({ month, objectType, provider }, user?.id);
   const episodes = await getEpisodesByMonth({ month, objectType, provider }, user?.id);
-  return c.json({ titles, episodes, count: titles.length });
+  return ok(c, { titles, episodes, count: titles.length });
 });
 
 export default app;

--- a/server/routes/details.ts
+++ b/server/routes/details.ts
@@ -13,6 +13,7 @@ import {
 import { parseMovieDetails, parseTvDetails } from "../tmdb/parser";
 import type { AppEnv } from "../types";
 import { logger } from "../logger";
+import { ok, err } from "./response";
 
 const log = logger.child({ module: "details" });
 
@@ -56,7 +57,7 @@ async function getOrFetchTitle(titleId: string, userId?: string) {
 app.get("/movie/:id", async (c) => {
   const user = c.get("user");
   const title = await getOrFetchTitle(c.req.param("id"), user?.id);
-  if (!title) return c.json({ error: "Title not found" }, 404);
+  if (!title) return err(c, "Title not found", 404);
 
   let tmdb = null;
   if (title.tmdb_id && CONFIG.TMDB_API_KEY) {
@@ -67,17 +68,13 @@ app.get("/movie/:id", async (c) => {
     }
   }
 
-  return c.json({
-    title,
-    tmdb,
-    country,
-  });
+  return ok(c, { title, tmdb, country });
 });
 
 app.get("/show/:id", async (c) => {
   const user = c.get("user");
   const title = await getOrFetchTitle(c.req.param("id"), user?.id);
-  if (!title) return c.json({ error: "Title not found" }, 404);
+  if (!title) return err(c, "Title not found", 404);
 
   let tmdb = null;
   if (title.tmdb_id && CONFIG.TMDB_API_KEY) {
@@ -88,17 +85,13 @@ app.get("/show/:id", async (c) => {
     }
   }
 
-  return c.json({
-    title,
-    tmdb,
-    country,
-  });
+  return ok(c, { title, tmdb, country });
 });
 
 app.get("/show/:id/season/:season", async (c) => {
   const user = c.get("user");
   const title = await getOrFetchTitle(c.req.param("id"), user?.id);
-  if (!title) return c.json({ error: "Title not found" }, 404);
+  if (!title) return err(c, "Title not found", 404);
 
   const seasonNumber = Number(c.req.param("season"));
 
@@ -111,18 +104,13 @@ app.get("/show/:id/season/:season", async (c) => {
     }
   }
 
-  return c.json({
-    title,
-    tmdb,
-    seasonNumber,
-    country,
-  });
+  return ok(c, { title, tmdb, seasonNumber, country });
 });
 
 app.get("/show/:id/season/:season/episode/:episode", async (c) => {
   const user = c.get("user");
   const title = await getOrFetchTitle(c.req.param("id"), user?.id);
-  if (!title) return c.json({ error: "Title not found" }, 404);
+  if (!title) return err(c, "Title not found", 404);
 
   const seasonNumber = Number(c.req.param("season"));
   const episodeNumber = Number(c.req.param("episode"));
@@ -136,31 +124,25 @@ app.get("/show/:id/season/:season/episode/:episode", async (c) => {
     }
   }
 
-  return c.json({
-    title,
-    tmdb,
-    seasonNumber,
-    episodeNumber,
-    country,
-  });
+  return ok(c, { title, tmdb, seasonNumber, episodeNumber, country });
 });
 
 app.get("/person/:personId", async (c) => {
   const personId = Number(c.req.param("personId"));
   if (!personId || isNaN(personId)) {
-    return c.json({ error: "Invalid person ID" }, 400);
+    return err(c, "Invalid person ID");
   }
 
   if (!CONFIG.TMDB_API_KEY) {
-    return c.json({ error: "TMDB not configured" }, 503);
+    return err(c, "TMDB not configured", 503);
   }
 
   try {
     const person = await fetchPersonDetails(personId);
-    return c.json({ person });
+    return ok(c, { person });
   } catch (e) {
     log.error("TMDB person fetch failed", { personId, err: e });
-    return c.json({ error: "Person not found" }, 404);
+    return err(c, "Person not found", 404);
   }
 });
 

--- a/server/routes/episodes.test.ts
+++ b/server/routes/episodes.test.ts
@@ -77,7 +77,6 @@ describe("POST /episodes/sync", () => {
     const res = await app.request("/episodes/sync", { method: "POST" });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.success).toBe(true);
     expect(body.synced).toBe(5);
     expect(body.shows).toBe(2);
     expect(body.message).toContain("Synced 5 episodes from 2 shows");

--- a/server/routes/episodes.ts
+++ b/server/routes/episodes.ts
@@ -3,6 +3,7 @@ import * as sync from "../tmdb/sync";
 import { getEpisodesByDateRange, getUnwatchedEpisodes } from "../db/repository";
 import { CONFIG } from "../config";
 import type { AppEnv } from "../types";
+import { ok, err } from "./response";
 
 const app = new Hono<AppEnv>();
 
@@ -26,17 +27,16 @@ app.get("/upcoming", async (c) => {
 
   const unwatchedEpisodes = await getUnwatchedEpisodes(user.id);
 
-  return c.json({ today: todayEpisodes, upcoming: upcomingEpisodes, unwatched: unwatchedEpisodes });
+  return ok(c, { today: todayEpisodes, upcoming: upcomingEpisodes, unwatched: unwatchedEpisodes });
 });
 
 app.post("/sync", async (c) => {
   if (!CONFIG.TMDB_API_KEY) {
-    return c.json({ error: "TMDB_API_KEY not configured" }, 500);
+    return err(c, "TMDB_API_KEY not configured", 500);
   }
 
   const result = await sync.syncEpisodes();
-  return c.json({
-    success: true,
+  return ok(c, {
     ...result,
     message: `Synced ${result.synced} episodes from ${result.shows} shows`,
   });

--- a/server/routes/health.ts
+++ b/server/routes/health.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { getDb } from "../db/schema";
+import { ok, err } from "./response";
 
 const app = new Hono();
 
@@ -7,9 +8,9 @@ app.get("/", async (c) => {
   try {
     const db = getDb();
     await db.run(/* sql */ `SELECT 1`);
-    return c.json({ status: "ok" });
+    return ok(c, { status: "ok" });
   } catch {
-    return c.json({ status: "error" }, 503);
+    return err(c, "Database unavailable", 503);
   }
 });
 

--- a/server/routes/imdb.test.ts
+++ b/server/routes/imdb.test.ts
@@ -81,7 +81,6 @@ describe("POST /imdb", () => {
     });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.success).toBe(true);
     expect(body.title.title).toBe("IMDB Movie");
   });
 
@@ -182,6 +181,6 @@ describe("POST /imdb", () => {
     });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.success).toBe(true);
+    expect(body.title).toBeDefined();
   });
 });

--- a/server/routes/imdb.ts
+++ b/server/routes/imdb.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import * as resolver from "../imdb/resolver";
 import { upsertTitles, trackTitle } from "../db/repository";
 import type { AppEnv } from "../types";
+import { ok, err } from "./response";
 
 const app = new Hono<AppEnv>();
 
@@ -10,26 +11,26 @@ app.post("/", async (c) => {
   const body = await c.req.json().catch(() => ({}));
   const url = body.url;
   if (!url) {
-    return c.json({ error: "url is required" }, 400);
+    return err(c, "url is required");
   }
 
   const imdbId = resolver.extractImdbId(url);
   if (!imdbId) {
-    return c.json({ error: "Invalid IMDB URL or ID" }, 400);
+    return err(c, "Invalid IMDB URL or ID");
   }
 
   try {
     const title = await resolver.resolveImdbUrl(url);
     if (!title) {
-      return c.json({ error: "Title not found" }, 404);
+      return err(c, "Title not found", 404);
     }
 
     await upsertTitles([title]);
     await trackTitle(title.id, user.id);
 
-    return c.json({ success: true, title });
-  } catch (err: any) {
-    return c.json({ error: err.message }, 500);
+    return ok(c, { title });
+  } catch (e: any) {
+    return err(c, e.message, 500);
   }
 });
 

--- a/server/routes/jobs.test.ts
+++ b/server/routes/jobs.test.ts
@@ -102,7 +102,6 @@ describe("POST /jobs/:name", () => {
     expect(res.status).toBe(200);
 
     const body = await res.json();
-    expect(body.success).toBe(true);
     expect(body.jobId).toBeGreaterThan(0);
   });
 

--- a/server/routes/jobs.ts
+++ b/server/routes/jobs.ts
@@ -1,12 +1,13 @@
 import { Hono } from "hono";
 import { getJobStats, getCronJobs, getRecentJobs, enqueueJob } from "../jobs/queue";
 import type { AppEnv } from "../types";
+import { ok } from "./response";
 
 const app = new Hono<AppEnv>();
 
 // GET /api/jobs — job stats, cron schedules, and recent history
 app.get("/", (c) => {
-  return c.json({
+  return ok(c, {
     stats: getJobStats(),
     crons: getCronJobs(),
     recentJobs: getRecentJobs(),
@@ -17,7 +18,7 @@ app.get("/", (c) => {
 app.post("/:name", (c) => {
   const name = c.req.param("name");
   const id = enqueueJob(name);
-  return c.json({ success: true, jobId: id });
+  return ok(c, { jobId: id });
 });
 
 export default app;

--- a/server/routes/notifiers.ts
+++ b/server/routes/notifiers.ts
@@ -13,6 +13,7 @@ import { refreshNotificationSchedule } from "../jobs/schedule";
 import { getVapidPublicKey } from "../notifications/vapid";
 import { SubscriptionExpiredError } from "../notifications/webpush";
 import Sentry from "../sentry";
+import { ok, err } from "./response";
 
 const app = new Hono<AppEnv>();
 
@@ -37,21 +38,21 @@ function isValidTimezone(tz: string): boolean {
 app.get("/", async (c) => {
   const user = c.get("user")!;
   const notifiers = await getNotifiersByUser(user.id);
-  return c.json({ notifiers });
+  return ok(c, { notifiers });
 });
 
 // GET /providers — available provider types
 app.get("/providers", (c) => {
-  return c.json({ providers: getAvailableProviders() });
+  return ok(c, { providers: getAvailableProviders() });
 });
 
 // GET /vapid-public-key — VAPID public key for push subscriptions
 app.get("/vapid-public-key", async (c) => {
   try {
     const publicKey = await getVapidPublicKey();
-    return c.json({ publicKey });
+    return ok(c, { publicKey });
   } catch {
-    return c.json({ error: "VAPID keys not configured" }, 500);
+    return err(c, "VAPID keys not configured", 500);
   }
 });
 
@@ -63,32 +64,29 @@ app.post("/", async (c) => {
   const { provider, config, notify_time, timezone } = body;
 
   if (!provider || !config) {
-    return c.json({ error: "provider and config are required" }, 400);
+    return err(c, "provider and config are required");
   }
 
   const name = provider.charAt(0).toUpperCase() + provider.slice(1);
 
   const providerImpl = getProvider(provider);
   if (!providerImpl) {
-    return c.json(
-      { error: `Unknown provider: ${provider}. Available: ${getAvailableProviders().join(", ")}` },
-      400
-    );
+    return err(c, `Unknown provider: ${provider}. Available: ${getAvailableProviders().join(", ")}`);
   }
 
   const validation = providerImpl.validateConfig(config);
   if (!validation.valid) {
-    return c.json({ error: validation.error }, 400);
+    return err(c, validation.error ?? "Invalid config");
   }
 
   const time = notify_time || "09:00";
   if (!isValidTime(time)) {
-    return c.json({ error: "Invalid time format. Use HH:MM (24h)" }, 400);
+    return err(c, "Invalid time format. Use HH:MM (24h)");
   }
 
   const tz = timezone || "UTC";
   if (!isValidTimezone(tz)) {
-    return c.json({ error: "Invalid timezone" }, 400);
+    return err(c, "Invalid timezone");
   }
 
   const id = await createNotifier(user.id, provider, name, config, time, tz);
@@ -105,7 +103,7 @@ app.put("/:id", async (c) => {
 
   const existing = await getNotifierById(id, user.id);
   if (!existing) {
-    return c.json({ error: "Notifier not found" }, 404);
+    return err(c, "Notifier not found", 404);
   }
 
   // Validate config if provided
@@ -114,17 +112,17 @@ app.put("/:id", async (c) => {
     if (provider) {
       const validation = provider.validateConfig(body.config);
       if (!validation.valid) {
-        return c.json({ error: validation.error }, 400);
+        return err(c, validation.error ?? "Invalid config");
       }
     }
   }
 
   if (body.notify_time && !isValidTime(body.notify_time)) {
-    return c.json({ error: "Invalid time format. Use HH:MM (24h)" }, 400);
+    return err(c, "Invalid time format. Use HH:MM (24h)");
   }
 
   if (body.timezone && !isValidTimezone(body.timezone)) {
-    return c.json({ error: "Invalid timezone" }, 400);
+    return err(c, "Invalid timezone");
   }
 
   await updateNotifier(id, user.id, {
@@ -136,7 +134,7 @@ app.put("/:id", async (c) => {
   await refreshNotificationSchedule();
 
   const notifier = await getNotifierById(id, user.id);
-  return c.json({ notifier });
+  return ok(c, { notifier });
 });
 
 // DELETE /:id — delete notifier
@@ -146,12 +144,12 @@ app.delete("/:id", async (c) => {
 
   const existing = await getNotifierById(id, user.id);
   if (!existing) {
-    return c.json({ error: "Notifier not found" }, 404);
+    return err(c, "Notifier not found", 404);
   }
 
   await deleteNotifier(id, user.id);
   await refreshNotificationSchedule();
-  return c.json({ ok: true });
+  return ok(c, {});
 });
 
 // POST /:id/test — send test notification
@@ -161,12 +159,12 @@ app.post("/:id/test", async (c) => {
 
   const notifier = await getNotifierById(id, user.id);
   if (!notifier) {
-    return c.json({ error: "Notifier not found" }, 404);
+    return err(c, "Notifier not found", 404);
   }
 
   const providerImpl = getProvider(notifier.provider);
   if (!providerImpl) {
-    return c.json({ error: "Unknown provider" }, 400);
+    return err(c, "Unknown provider");
   }
 
   const today = new Date().toISOString().slice(0, 10);

--- a/server/routes/response.test.ts
+++ b/server/routes/response.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "bun:test";
+import { Hono } from "hono";
+import { ok, err } from "./response";
+
+describe("ok()", () => {
+  it("returns 200 with the provided data", async () => {
+    const app = new Hono();
+    app.get("/", (c) => ok(c, { titles: [], count: 0 }));
+
+    const res = await app.request("/");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ titles: [], count: 0 });
+  });
+
+  it("returns empty object when passed empty data", async () => {
+    const app = new Hono();
+    app.get("/", (c) => ok(c, {}));
+
+    const res = await app.request("/");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({});
+  });
+});
+
+describe("err()", () => {
+  it("returns 400 with error message by default", async () => {
+    const app = new Hono();
+    app.get("/", (c) => err(c, "Bad request"));
+
+    const res = await app.request("/");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Bad request" });
+  });
+
+  it("returns 404 with error message", async () => {
+    const app = new Hono();
+    app.get("/", (c) => err(c, "Not found", 404));
+
+    const res = await app.request("/");
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Not found" });
+  });
+
+  it("returns 500 with error message", async () => {
+    const app = new Hono();
+    app.get("/", (c) => err(c, "Internal server error", 500));
+
+    const res = await app.request("/");
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Internal server error" });
+  });
+
+  it("always uses 'error' key (not 'message' or 'ok')", async () => {
+    const app = new Hono();
+    app.get("/", (c) => err(c, "Something went wrong", 400));
+
+    const res = await app.request("/");
+    const body = await res.json();
+    expect(body.error).toBeDefined();
+    expect(body.message).toBeUndefined();
+    expect(body.ok).toBeUndefined();
+    expect(body.success).toBeUndefined();
+  });
+});

--- a/server/routes/response.ts
+++ b/server/routes/response.ts
@@ -1,0 +1,15 @@
+import type { Context } from "hono";
+
+/**
+ * Standard success response helper. Returns the provided data as JSON.
+ */
+export function ok<T extends Record<string, unknown>>(c: Context, data: T) {
+  return c.json(data);
+}
+
+/**
+ * Standard error response helper. Always returns `{ error: message }` with the given status code.
+ */
+export function err(c: Context, message: string, status: 400 | 401 | 403 | 404 | 500 | 503 = 400) {
+  return c.json({ error: message }, status);
+}

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { searchMulti, fetchMovieDetails, fetchTvDetails, getMovieGenres, getTvGenres } from "../tmdb/client";
 import { parseSearchResult, parseMovieDetails, parseTvDetails, type ParsedTitle } from "../tmdb/parser";
 import { getTrackedTitleIds } from "../db/repository";
+import { ok, err } from "./response";
 
 import type { AppEnv } from "../types";
 
@@ -10,7 +11,7 @@ const app = new Hono<AppEnv>();
 app.get("/", async (c) => {
   const query = c.req.query("q");
   if (!query) {
-    return c.json({ error: "Query parameter 'q' is required" }, 400);
+    return err(c, "Query parameter 'q' is required");
   }
 
   try {
@@ -51,9 +52,9 @@ app.get("/", async (c) => {
       isTracked: trackedIds.has(t.id),
     }));
 
-    return c.json({ titles: titlesWithTracked, count: titlesWithTracked.length });
-  } catch (err: any) {
-    return c.json({ error: err.message }, 500);
+    return ok(c, { titles: titlesWithTracked, count: titlesWithTracked.length });
+  } catch (e: any) {
+    return err(c, e.message, 500);
   }
 });
 

--- a/server/routes/sync.test.ts
+++ b/server/routes/sync.test.ts
@@ -53,7 +53,6 @@ describe("POST /sync", () => {
     });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.success).toBe(true);
     expect(body.count).toBe(1);
     expect(body.message).toContain("Synced");
 
@@ -74,7 +73,6 @@ describe("POST /sync", () => {
     });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.success).toBe(true);
     expect(body.count).toBe(0);
 
     expect(syncTitles.fetchNewReleases).toHaveBeenCalledWith({
@@ -94,7 +92,6 @@ describe("POST /sync", () => {
     });
     expect(res.status).toBe(500);
     const body = await res.json();
-    expect(body.success).toBe(false);
     expect(body.error).toBe("TMDB API down");
   });
 });

--- a/server/routes/sync.ts
+++ b/server/routes/sync.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import * as syncTitles from "../tmdb/sync-titles";
 import { upsertTitles } from "../db/repository";
+import { ok, err } from "./response";
 
 const app = new Hono();
 
@@ -9,7 +10,7 @@ app.post("/", async (c) => {
   try {
     body = await c.req.json();
   } catch {
-    return c.json({ error: "Invalid JSON in request body" }, 400);
+    return err(c, "Invalid JSON in request body");
   }
   const daysBack = (body.daysBack as number) || 30;
   const objectType = body.type as "MOVIE" | "SHOW" | undefined;
@@ -18,9 +19,9 @@ app.post("/", async (c) => {
   try {
     const titles = await syncTitles.fetchNewReleases({ daysBack, objectType, maxPages });
     const count = await upsertTitles(titles);
-    return c.json({ success: true, count, message: `Synced ${count} titles` });
-  } catch (err: any) {
-    return c.json({ success: false, error: err.message }, 500);
+    return ok(c, { count, message: `Synced ${count} titles` });
+  } catch (e: any) {
+    return err(c, e.message, 500);
   }
 });
 

--- a/server/routes/titles.ts
+++ b/server/routes/titles.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { getRecentTitles, getProviders, getGenres, getLanguages } from "../db/repository";
 import type { AppEnv } from "../types";
+import { ok } from "./response";
 
 const app = new Hono<AppEnv>();
 
@@ -21,22 +22,22 @@ app.get("/", async (c) => {
   const languages = languageParam ? languageParam.split(",").filter(Boolean) : [];
 
   const titles = await getRecentTitles({ daysBack, objectTypes, providers, genres, languages, excludeTracked, limit, offset }, user?.id);
-  return c.json({ titles, count: titles.length });
+  return ok(c, { titles, count: titles.length });
 });
 
 app.get("/providers", async (c) => {
   const providers = await getProviders();
-  return c.json({ providers });
+  return ok(c, { providers });
 });
 
 app.get("/genres", async (c) => {
   const genres = await getGenres();
-  return c.json({ genres });
+  return ok(c, { genres });
 });
 
 app.get("/languages", async (c) => {
   const languages = await getLanguages();
-  return c.json({ languages });
+  return ok(c, { languages });
 });
 
 export default app;

--- a/server/routes/track.test.ts
+++ b/server/routes/track.test.ts
@@ -82,7 +82,7 @@ describe("POST /track/:id", () => {
     });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.success).toBe(true);
+    expect(body.message).toContain("Tracking");
 
     // Verify it's tracked
     const listRes = await app.request("/track", { headers: headers() });

--- a/server/routes/track.ts
+++ b/server/routes/track.ts
@@ -5,6 +5,7 @@ import { CONFIG } from "../config";
 import { syncEpisodesForShow } from "../tmdb/sync";
 import type { AppEnv } from "../types";
 import { logger } from "../logger";
+import { ok } from "./response";
 
 const log = logger.child({ module: "track" });
 
@@ -13,7 +14,7 @@ const app = new Hono<AppEnv>();
 app.get("/", async (c) => {
   const user = c.get("user")!;
   const titles = await getTrackedTitles(user.id);
-  return c.json({ titles, count: titles.length });
+  return ok(c, { titles, count: titles.length });
 });
 
 // Convert frontend Title (snake_case) to ParsedTitle (camelCase) for upsert
@@ -77,7 +78,7 @@ app.post("/:id", async (c) => {
     }
   }
 
-  return c.json({ success: true, message: `Tracking ${titleId}` });
+  return ok(c, { message: `Tracking ${titleId}` });
 });
 
 app.delete("/:id", async (c) => {
@@ -85,7 +86,7 @@ app.delete("/:id", async (c) => {
   const titleId = c.req.param("id");
   await untrackTitle(titleId, user.id);
   await deleteEpisodesForTitle(titleId);
-  return c.json({ success: true, message: `Untracked ${titleId}` });
+  return ok(c, { message: `Untracked ${titleId}` });
 });
 
 export default app;

--- a/server/routes/watched.ts
+++ b/server/routes/watched.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { watchEpisode, unwatchEpisode, watchEpisodesBulk, unwatchEpisodesBulk, getEpisodeAirDate, getReleasedEpisodeIds } from "../db/repository";
 import type { AppEnv } from "../types";
+import { ok, err } from "./response";
 
 const app = new Hono<AppEnv>();
 
@@ -16,20 +17,20 @@ app.post("/bulk", async (c) => {
   const { episodeIds, watched } = body as { episodeIds: number[]; watched: boolean };
 
   if (!Array.isArray(episodeIds) || episodeIds.length === 0) {
-    return c.json({ error: "episodeIds must be a non-empty array" }, 400);
+    return err(c, "episodeIds must be a non-empty array");
   }
 
   if (watched) {
     const releasedIds = await getReleasedEpisodeIds(episodeIds);
     if (releasedIds.length === 0) {
-      return c.json({ error: "Cannot mark unreleased episodes as watched" }, 400);
+      return err(c, "Cannot mark unreleased episodes as watched");
     }
     await watchEpisodesBulk(releasedIds, user.id);
   } else {
     await unwatchEpisodesBulk(episodeIds, user.id);
   }
 
-  return c.json({ success: true });
+  return ok(c, {});
 });
 
 app.post("/:episodeId", async (c) => {
@@ -37,17 +38,17 @@ app.post("/:episodeId", async (c) => {
   const episodeId = Number(c.req.param("episodeId"));
   const airDate = await getEpisodeAirDate(episodeId);
   if (!isReleased(airDate)) {
-    return c.json({ error: "Cannot mark an unreleased episode as watched" }, 400);
+    return err(c, "Cannot mark an unreleased episode as watched");
   }
   await watchEpisode(episodeId, user.id);
-  return c.json({ success: true });
+  return ok(c, {});
 });
 
 app.delete("/:episodeId", async (c) => {
   const user = c.get("user")!;
   const episodeId = Number(c.req.param("episodeId"));
   await unwatchEpisode(episodeId, user.id);
-  return c.json({ success: true });
+  return ok(c, {});
 });
 
 export default app;


### PR DESCRIPTION
Fixes #139

## Summary

- Create `server/routes/response.ts` with `ok(c, data)` and `err(c, message, status)` helpers
- Apply consistently across all 16 route files
- Fix inconsistent patterns: `{ ok: true }`, `{ success: false, error }`, and bare `c.json` calls
- Update affected tests

Generated with [Claude Code](https://claude.ai/code)