### PR TITLE
perf: add in-memory TTL cache for getGenres and getLanguages

### DIFF
--- a/server/db/repository.test.ts
+++ b/server/db/repository.test.ts
@@ -16,6 +16,7 @@ import {
   getProviders,
   getGenres,
   getLanguages,
+  invalidateFilterCaches,
   upsertEpisodes,
   deleteEpisodesForTitle,
   watchEpisode,
@@ -47,6 +48,7 @@ import { CONFIG } from "../config";
 
 beforeEach(() => {
   setupTestDb();
+  invalidateFilterCaches();
 });
 
 afterAll(() => {
@@ -324,6 +326,21 @@ describe("getGenres", () => {
   it("returns empty array when no titles exist", async () => {
     expect(await getGenres()).toEqual([]);
   });
+
+  it("returns cached value on subsequent calls without upsert", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-1", genres: ["Drama"] })]);
+    const first = await getGenres();
+    // Cache is populated; result should be identical reference
+    const second = await getGenres();
+    expect(second).toBe(first);
+  });
+
+  it("reflects new genres after upsertTitles invalidates cache", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-1", genres: ["Drama"] })]);
+    expect(await getGenres()).toEqual(["Drama"]);
+    await upsertTitles([makeParsedTitle({ id: "movie-2", genres: ["Comedy"] })]);
+    expect(await getGenres()).toEqual(["Comedy", "Drama"]);
+  });
 });
 
 describe("getLanguages", () => {
@@ -344,6 +361,20 @@ describe("getLanguages", () => {
     ]);
     const languages = await getLanguages();
     expect(languages).toEqual(["en"]);
+  });
+
+  it("returns cached value on subsequent calls without upsert", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-1", originalLanguage: "en" })]);
+    const first = await getLanguages();
+    const second = await getLanguages();
+    expect(second).toBe(first);
+  });
+
+  it("reflects new languages after upsertTitles invalidates cache", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-1", originalLanguage: "en" })]);
+    expect(await getLanguages()).toEqual(["en"]);
+    await upsertTitles([makeParsedTitle({ id: "movie-2", originalLanguage: "ja" })]);
+    expect(await getLanguages()).toEqual(["en", "ja"]);
   });
 });
 

--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -12,6 +12,7 @@ export {
   getProviders,
   getGenres,
   getLanguages,
+  invalidateFilterCaches,
 } from "./titles";
 export type { TitleFilters, MonthFilters } from "./titles";
 

--- a/server/db/repository/titles.ts
+++ b/server/db/repository/titles.ts
@@ -6,6 +6,23 @@ import { extractProviders } from "../../tmdb/parser";
 import { traceDbQuery } from "../../tracing";
 import { getOffersForTitle, getOffersForTitles } from "./offers";
 
+// ─── Filter caches (genres & languages change only on sync) ──────────────────
+
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+interface FilterCache<T> {
+  value: T;
+  expiresAt: number;
+}
+
+let genresCache: FilterCache<string[]> | null = null;
+let languagesCache: FilterCache<string[]> | null = null;
+
+export function invalidateFilterCaches(): void {
+  genresCache = null;
+  languagesCache = null;
+}
+
 // ─── Title / Offer / Score upserts ───────────────────────────────────────────
 
 export async function upsertTitles(parsedTitles: ParsedTitle[]) {
@@ -111,6 +128,7 @@ export async function upsertTitles(parsedTitles: ParsedTitle[]) {
         .run();
     }
 
+    invalidateFilterCaches();
     return parsedTitles.length;
   });
 }
@@ -451,7 +469,12 @@ export async function getProviders() {
 }
 
 export async function getGenres(): Promise<string[]> {
-  return traceDbQuery("getGenres", async () => {
+  const now = Date.now();
+  if (genresCache && now < genresCache.expiresAt) {
+    return genresCache.value;
+  }
+
+  const result = await traceDbQuery("getGenres", async () => {
     const db = getDb();
     const rows = await db
       .selectDistinct({ genres: titles.genres })
@@ -471,10 +494,18 @@ export async function getGenres(): Promise<string[]> {
     }
     return Array.from(genreSet).sort();
   });
+
+  genresCache = { value: result, expiresAt: now + CACHE_TTL_MS };
+  return result;
 }
 
 export async function getLanguages(): Promise<string[]> {
-  return traceDbQuery("getLanguages", async () => {
+  const now = Date.now();
+  if (languagesCache && now < languagesCache.expiresAt) {
+    return languagesCache.value;
+  }
+
+  const result = await traceDbQuery("getLanguages", async () => {
     const db = getDb();
     const rows = await db
       .selectDistinct({ original_language: titles.originalLanguage })
@@ -484,4 +515,7 @@ export async function getLanguages(): Promise<string[]> {
       .all();
     return rows.map((r) => r.original_language!);
   });
+
+  languagesCache = { value: result, expiresAt: now + CACHE_TTL_MS };
+  return result;
 }


### PR DESCRIPTION
Adds a 1-hour in-memory cache to `getGenres()` and `getLanguages()` to avoid full table scans on every call. The cache is automatically invalidated when `upsertTitles()` runs (i.e. on sync), so data stays fresh.

Closes #135

Generated with [Claude Code](https://claude.ai/code)