### PR TITLE
perf: add React.memo and useCallback to reduce unnecessary re-renders

### DIFF
--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import MultiSelectDropdown from "./MultiSelectDropdown";
 
 interface ProviderOption {
@@ -61,7 +62,7 @@ function toggleType(current: string[], value: string): string[] {
   return next;
 }
 
-export default function FilterBar({
+const FilterBar = memo(function FilterBar({
   type,
   onTypeChange,
   daysBack,
@@ -181,4 +182,6 @@ export default function FilterBar({
       )}
     </div>
   );
-}
+});
+
+export default FilterBar;

--- a/frontend/src/components/TitleCard.tsx
+++ b/frontend/src/components/TitleCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { Link } from "react-router";
 import type { Title } from "../types";
 import TrackButton from "./TrackButton";
@@ -7,7 +8,7 @@ interface Props {
   onTrackToggle?: () => void;
 }
 
-export default function TitleCard({ title, onTrackToggle }: Props) {
+const TitleCard = memo(function TitleCard({ title, onTrackToggle }: Props) {
   // Deduplicate offers by provider (keep best quality)
   const uniqueProviders = new Map<number, Title["offers"][0]>();
   for (const offer of title.offers) {
@@ -88,11 +89,14 @@ export default function TitleCard({ title, onTrackToggle }: Props) {
           <TrackButton
             titleId={title.id}
             isTracked={title.is_tracked}
-            onToggle={onTrackToggle ? () => onTrackToggle() : undefined}
+            onToggle={onTrackToggle}
             titleData={title}
           />
         </div>
       </div>
     </div>
   );
-}
+});
+
+export default TitleCard;
+

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, memo } from "react";
 import { Link } from "react-router";
 import { Maximize2 } from "lucide-react";
 import { useAuth } from "../context/AuthContext";
@@ -26,7 +26,7 @@ export function groupByShowAndSeason(episodes: Episode[]): Map<string, Map<numbe
 
 export const EPISODES_PER_PAGE = 5;
 
-function UnwatchedShowGroup({ showTitle, seasonNumber, episodes, posterUrl, onToggleWatched, onMarkSeasonWatched }: {
+const UnwatchedShowGroup = memo(function UnwatchedShowGroup({ showTitle, seasonNumber, episodes, posterUrl, onToggleWatched, onMarkSeasonWatched }: {
   showTitle: string;
   seasonNumber: number;
   episodes: Episode[];
@@ -102,13 +102,13 @@ function UnwatchedShowGroup({ showTitle, seasonNumber, episodes, posterUrl, onTo
       </div>
     </div>
   );
-}
+});
 
-function UnwatchedShowCard({ titleId, seasonMap, expanded, onToggleExpand, onToggleWatched, onMarkSeasonWatched }: {
+const UnwatchedShowCard = memo(function UnwatchedShowCard({ titleId, seasonMap, expanded, onToggleExpand, onToggleWatched, onMarkSeasonWatched }: {
   titleId: string;
   seasonMap: Map<number, Episode[]>;
   expanded: boolean;
-  onToggleExpand: () => void;
+  onToggleExpand: (titleId: string) => void;
   onToggleWatched: (id: number, current: boolean) => void;
   onMarkSeasonWatched: (episodeIds: number[]) => void;
 }) {
@@ -131,7 +131,7 @@ function UnwatchedShowCard({ titleId, seasonMap, expanded, onToggleExpand, onTog
         ))}
         {sortedSeasons.length > 1 && (
           <button
-            onClick={onToggleExpand}
+            onClick={() => onToggleExpand(titleId)}
             className="text-xs text-gray-400 hover:text-indigo-400 transition-colors cursor-pointer w-full text-center"
           >
             Collapse seasons
@@ -165,7 +165,7 @@ function UnwatchedShowCard({ titleId, seasonMap, expanded, onToggleExpand, onTog
         />
         {extraSeasons > 0 && (
           <button
-            onClick={onToggleExpand}
+            onClick={() => onToggleExpand(titleId)}
             className="w-full text-center text-xs text-gray-400 hover:text-indigo-400 transition-colors py-2 cursor-pointer"
           >
             +{extraSeasons} more season{extraSeasons > 1 ? "s" : ""}
@@ -174,7 +174,7 @@ function UnwatchedShowCard({ titleId, seasonMap, expanded, onToggleExpand, onTog
       </div>
     </div>
   );
-}
+});
 
 function UnwatchedCarousel({ children }: { children: React.ReactNode }) {
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -272,7 +272,7 @@ export default function HomePage() {
     load();
   }, [user, authLoading]);
 
-  const toggleWatched = async (episodeId: number, currentlyWatched: boolean) => {
+  const toggleWatched = useCallback(async (episodeId: number, currentlyWatched: boolean) => {
     const updateAll = (eps: Episode[]) =>
       eps.map((ep) => (ep.id === episodeId ? { ...ep, is_watched: !currentlyWatched } : ep));
     const revertAll = (eps: Episode[]) =>
@@ -305,9 +305,9 @@ export default function HomePage() {
       }
       console.error("Failed to toggle watched:", err);
     }
-  };
+  }, []);
 
-  const markSeasonWatched = async (episodeIds: number[]) => {
+  const markSeasonWatched = useCallback(async (episodeIds: number[]) => {
     const idSet = new Set(episodeIds);
     setUnwatched((prev) => prev.filter((ep) => !idSet.has(ep.id)));
 
@@ -321,7 +321,16 @@ export default function HomePage() {
       } catch {}
       console.error("Failed to bulk mark watched:", err);
     }
-  };
+  }, []);
+
+  const handleToggleExpand = useCallback((titleId: string) => {
+    setExpandedShows((prev) => {
+      const next = new Set(prev);
+      if (next.has(titleId)) next.delete(titleId);
+      else next.add(titleId);
+      return next;
+    });
+  }, []);
 
   if (authLoading || loading) {
     return <div className="text-gray-500 text-center py-12">Loading...</div>;
@@ -378,12 +387,7 @@ export default function HomePage() {
                   titleId={titleId}
                   seasonMap={seasonMap}
                   expanded={expandedShows.has(titleId)}
-                  onToggleExpand={() => setExpandedShows((prev) => {
-                    const next = new Set(prev);
-                    if (next.has(titleId)) next.delete(titleId);
-                    else next.add(titleId);
-                    return next;
-                  })}
+                  onToggleExpand={handleToggleExpand}
                   onToggleWatched={toggleWatched}
                   onMarkSeasonWatched={markSeasonWatched}
                 />


### PR DESCRIPTION
Wraps TitleCard, FilterBar, UnwatchedShowCard, and UnwatchedShowGroup with React.memo and stabilizes callbacks in HomePage with useCallback to prevent unnecessary re-renders in list views.

Fixes #143

Generated with [Claude Code](https://claude.ai/code)