### PR TITLE
feat: add Prometheus metrics endpoint (/164)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -23,6 +23,7 @@ import browseRoutes from "./routes/browse";
 import detailsRoutes from "./routes/details";
 import notifierRoutes from "./routes/notifiers";
 import healthRoutes from "./routes/health";
+import metricsRoutes from "./routes/metrics";
 import type { AppEnv } from "./types";
 import Sentry from "./sentry";
 import { logger, requestLogger } from "./logger";
@@ -107,6 +108,9 @@ app.use("/api/*", requestLogger());
 
 // Health check (public — used by Sentry uptime monitoring)
 app.route("/api/health", healthRoutes);
+
+// Prometheus metrics (public — protect via reverse proxy if needed)
+app.route("/metrics", metricsRoutes);
 
 // Custom auth routes (providers endpoint) — must be before better-auth catch-all
 app.route("/api/auth/custom", authCustomRoutes);

--- a/server/jobs/worker.ts
+++ b/server/jobs/worker.ts
@@ -1,5 +1,6 @@
 import Sentry from "../sentry";
 import { logger } from "../logger";
+import { jobsTotal, jobDurationSeconds } from "../metrics";
 
 const log = logger.child({ module: "jobs" });
 
@@ -40,6 +41,7 @@ export async function processJobs() {
         }
       : undefined;
 
+    const jobStart = performance.now();
     try {
       if (cronExpr) {
         await Sentry.withMonitor(
@@ -53,11 +55,17 @@ export async function processJobs() {
         await handler(job);
       }
       completeJob(job.id);
+      const duration = (performance.now() - jobStart) / 1000;
+      jobsTotal.inc({ name, status: "completed" });
+      jobDurationSeconds.observe({ name }, duration);
       log.info("Completed job", { name, jobId: job.id });
     } catch (err) {
       Sentry.captureException(err);
       const message = err instanceof Error ? err.message : String(err);
       failJob(job.id, message);
+      const duration = (performance.now() - jobStart) / 1000;
+      jobsTotal.inc({ name, status: "failed" });
+      jobDurationSeconds.observe({ name }, duration);
       log.error("Failed job", { name, jobId: job.id, attempt: job.attempts, maxAttempts: job.max_attempts, error: message });
     }
   }

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -1,5 +1,6 @@
 import type { MiddlewareHandler } from "hono";
 import { CONFIG } from "./config";
+import { httpRequestsTotal, httpRequestDurationSeconds } from "./metrics";
 
 export type LogLevel = "debug" | "info" | "warn" | "error";
 
@@ -110,10 +111,17 @@ export function requestLogger(): MiddlewareHandler {
   return async (c, next) => {
     const start = performance.now();
     await next();
-    const duration = Math.round(performance.now() - start);
+    const durationMs = performance.now() - start;
     const status = c.res.status;
+    const method = c.req.method;
+    const route = c.req.path;
+
     const level: LogLevel =
       status >= 500 ? "error" : status >= 400 ? "warn" : "info";
-    log[level](`${c.req.method} ${c.req.path}`, { status, duration });
+    log[level](`${method} ${c.req.path}`, { status, duration: Math.round(durationMs) });
+
+    const statusStr = String(status);
+    httpRequestsTotal.inc({ method, route, status: statusStr });
+    httpRequestDurationSeconds.observe({ method, route, status: statusStr }, durationMs / 1000);
   };
 }

--- a/server/metrics/index.ts
+++ b/server/metrics/index.ts
@@ -1,0 +1,75 @@
+import { Counter, Gauge, Histogram, DB_BUCKETS } from "./registry";
+
+// ─── HTTP Metrics ────────────────────────────────────────────────────────────
+
+export const httpRequestsTotal = new Counter(
+  "http_requests_total",
+  "Total number of HTTP requests",
+);
+
+export const httpRequestDurationSeconds = new Histogram(
+  "http_request_duration_seconds",
+  "HTTP request latency in seconds",
+);
+
+// ─── DB Metrics ──────────────────────────────────────────────────────────────
+
+export const dbQueryDurationSeconds = new Histogram(
+  "db_query_duration_seconds",
+  "Database query duration in seconds",
+  DB_BUCKETS,
+);
+
+// ─── Job Metrics ─────────────────────────────────────────────────────────────
+
+export const jobsTotal = new Counter(
+  "jobs_total",
+  "Total number of job executions",
+);
+
+export const jobDurationSeconds = new Histogram(
+  "job_duration_seconds",
+  "Job execution duration in seconds",
+);
+
+// ─── TMDB Metrics ────────────────────────────────────────────────────────────
+
+export const tmdbRequestsTotal = new Counter(
+  "tmdb_requests_total",
+  "Total number of TMDB API requests",
+);
+
+export const tmdbRequestDurationSeconds = new Histogram(
+  "tmdb_request_duration_seconds",
+  "TMDB API request duration in seconds",
+);
+
+// ─── Session Gauge ───────────────────────────────────────────────────────────
+
+export const activeSessionsGauge = new Gauge(
+  "active_sessions",
+  "Number of currently active (non-expired) user sessions",
+);
+
+// ─── Registry ────────────────────────────────────────────────────────────────
+
+const allMetrics = [
+  httpRequestsTotal,
+  httpRequestDurationSeconds,
+  dbQueryDurationSeconds,
+  jobsTotal,
+  jobDurationSeconds,
+  tmdbRequestsTotal,
+  tmdbRequestDurationSeconds,
+  activeSessionsGauge,
+];
+
+export function renderMetrics(): string {
+  return allMetrics.map((m) => m.render()).join("\n\n") + "\n";
+}
+
+export function resetMetrics(): void {
+  for (const m of allMetrics) {
+    m.reset();
+  }
+}

--- a/server/metrics/registry.test.ts
+++ b/server/metrics/registry.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { Counter, Gauge, Histogram } from "./registry";
+
+describe("Counter", () => {
+  let counter: Counter;
+
+  beforeEach(() => {
+    counter = new Counter("test_total", "Test counter");
+  });
+
+  it("renders zero when no observations", () => {
+    const out = counter.render();
+    expect(out).toContain("# HELP test_total Test counter");
+    expect(out).toContain("# TYPE test_total counter");
+    expect(out).toContain("test_total 0");
+  });
+
+  it("increments without labels", () => {
+    counter.inc();
+    counter.inc();
+    const out = counter.render();
+    expect(out).toContain("test_total 2");
+  });
+
+  it("increments with labels", () => {
+    counter.inc({ method: "GET", status: "200" });
+    counter.inc({ method: "GET", status: "200" });
+    counter.inc({ method: "POST", status: "201" });
+    const out = counter.render();
+    expect(out).toContain('test_total{method="GET",status="200"} 2');
+    expect(out).toContain('test_total{method="POST",status="201"} 1');
+  });
+
+  it("increments by custom amount", () => {
+    counter.inc({}, 5);
+    expect(counter.render()).toContain("test_total 5");
+  });
+
+  it("resets values", () => {
+    counter.inc();
+    counter.reset();
+    expect(counter.render()).toContain("test_total 0");
+  });
+
+  it("escapes label values", () => {
+    counter.inc({ label: 'val"ue' });
+    expect(counter.render()).toContain('label="val\\"ue"');
+  });
+
+  it("sorts labels alphabetically for consistent keys", () => {
+    counter.inc({ z: "1", a: "2" });
+    const out = counter.render();
+    expect(out).toContain('test_total{a="2",z="1"} 1');
+  });
+});
+
+describe("Gauge", () => {
+  let gauge: Gauge;
+
+  beforeEach(() => {
+    gauge = new Gauge("test_gauge", "Test gauge");
+  });
+
+  it("renders zero when not set", () => {
+    const out = gauge.render();
+    expect(out).toContain("# TYPE test_gauge gauge");
+    expect(out).toContain("test_gauge 0");
+  });
+
+  it("sets a value", () => {
+    gauge.set({}, 42);
+    expect(gauge.render()).toContain("test_gauge 42");
+  });
+
+  it("sets with labels", () => {
+    gauge.set({ kind: "active" }, 7);
+    expect(gauge.render()).toContain('test_gauge{kind="active"} 7');
+  });
+
+  it("overwrites previous value", () => {
+    gauge.set({}, 10);
+    gauge.set({}, 5);
+    expect(gauge.render()).toContain("test_gauge 5");
+  });
+
+  it("resets values", () => {
+    gauge.set({}, 99);
+    gauge.reset();
+    expect(gauge.render()).toContain("test_gauge 0");
+  });
+});
+
+describe("Histogram", () => {
+  let hist: Histogram;
+
+  beforeEach(() => {
+    hist = new Histogram("test_duration_seconds", "Test histogram", [0.01, 0.1, 1]);
+  });
+
+  it("renders no data when no observations", () => {
+    const out = hist.render();
+    expect(out).toContain("# TYPE test_duration_seconds histogram");
+    // No data lines when no observations
+    expect(out).not.toContain("_bucket");
+  });
+
+  it("records observations into cumulative buckets", () => {
+    hist.observe({}, 0.005); // falls in le=0.01, 0.1, 1 buckets
+    hist.observe({}, 0.05);  // falls in le=0.1, 1 buckets
+    hist.observe({}, 0.5);   // falls in le=1 bucket only
+
+    const out = hist.render();
+    expect(out).toContain('test_duration_seconds_bucket{le="0.01"} 1');
+    expect(out).toContain('test_duration_seconds_bucket{le="0.1"} 2');
+    expect(out).toContain('test_duration_seconds_bucket{le="1"} 3');
+    expect(out).toContain('test_duration_seconds_bucket{le="+Inf"} 3');
+    expect(out).toContain("test_duration_seconds_count 3");
+  });
+
+  it("records sum correctly", () => {
+    hist.observe({}, 0.1);
+    hist.observe({}, 0.2);
+    const out = hist.render();
+    expect(out).toContain("test_duration_seconds_sum 0.30000000000000004"); // floating point
+  });
+
+  it("records observations with labels", () => {
+    hist.observe({ method: "GET" }, 0.005);
+    hist.observe({ method: "POST" }, 0.5);
+
+    const out = hist.render();
+    expect(out).toContain('test_duration_seconds_bucket{method="GET",le="0.01"} 1');
+    expect(out).toContain('test_duration_seconds_bucket{method="POST",le="0.01"} 0');
+    expect(out).toContain('test_duration_seconds_bucket{method="POST",le="1"} 1');
+  });
+
+  it("resets data", () => {
+    hist.observe({}, 0.5);
+    hist.reset();
+    const out = hist.render();
+    expect(out).not.toContain("_bucket");
+  });
+});

--- a/server/metrics/registry.ts
+++ b/server/metrics/registry.ts
@@ -1,0 +1,141 @@
+type Labels = Record<string, string>;
+
+function escapeLabel(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+}
+
+function labelsKey(labels: Labels): string {
+  return Object.entries(labels)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}="${escapeLabel(v)}"`)
+    .join(",");
+}
+
+export class Counter {
+  private values = new Map<string, number>();
+
+  constructor(
+    public readonly name: string,
+    public readonly help: string,
+  ) {}
+
+  inc(labels: Labels = {}, amount = 1): void {
+    const key = labelsKey(labels);
+    this.values.set(key, (this.values.get(key) ?? 0) + amount);
+  }
+
+  reset(): void {
+    this.values = new Map();
+  }
+
+  render(): string {
+    const lines = [
+      `# HELP ${this.name} ${this.help}`,
+      `# TYPE ${this.name} counter`,
+    ];
+    if (this.values.size === 0) {
+      lines.push(`${this.name} 0`);
+    } else {
+      for (const [key, value] of this.values) {
+        lines.push(`${this.name}${key ? `{${key}}` : ""} ${value}`);
+      }
+    }
+    return lines.join("\n");
+  }
+}
+
+export class Gauge {
+  private values = new Map<string, number>();
+
+  constructor(
+    public readonly name: string,
+    public readonly help: string,
+  ) {}
+
+  set(labels: Labels = {}, value: number): void {
+    this.values.set(labelsKey(labels), value);
+  }
+
+  reset(): void {
+    this.values = new Map();
+  }
+
+  render(): string {
+    const lines = [
+      `# HELP ${this.name} ${this.help}`,
+      `# TYPE ${this.name} gauge`,
+    ];
+    if (this.values.size === 0) {
+      lines.push(`${this.name} 0`);
+    } else {
+      for (const [key, value] of this.values) {
+        lines.push(`${this.name}${key ? `{${key}}` : ""} ${value}`);
+      }
+    }
+    return lines.join("\n");
+  }
+}
+
+// Default buckets for HTTP latency (seconds)
+export const DEFAULT_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10];
+
+// Tighter buckets for DB queries (seconds)
+export const DB_BUCKETS = [0.0001, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1];
+
+interface HistogramEntry {
+  counts: number[];
+  sum: number;
+  count: number;
+}
+
+export class Histogram {
+  private data = new Map<string, HistogramEntry>();
+
+  constructor(
+    public readonly name: string,
+    public readonly help: string,
+    public readonly buckets: number[] = DEFAULT_BUCKETS,
+  ) {}
+
+  observe(labels: Labels = {}, value: number): void {
+    const key = labelsKey(labels);
+    if (!this.data.has(key)) {
+      this.data.set(key, {
+        counts: new Array(this.buckets.length).fill(0),
+        sum: 0,
+        count: 0,
+      });
+    }
+    const entry = this.data.get(key)!;
+    // Counts are cumulative: each bucket counts all values <= its upper bound
+    for (let i = 0; i < this.buckets.length; i++) {
+      if (value <= this.buckets[i]) {
+        entry.counts[i]++;
+      }
+    }
+    entry.sum += value;
+    entry.count++;
+  }
+
+  reset(): void {
+    this.data = new Map();
+  }
+
+  render(): string {
+    const lines = [
+      `# HELP ${this.name} ${this.help}`,
+      `# TYPE ${this.name} histogram`,
+    ];
+    for (const [labelKey, entry] of this.data) {
+      const prefix = labelKey ? `${labelKey},` : "";
+      const suffix = labelKey ? `{${labelKey}}` : "";
+      for (let i = 0; i < this.buckets.length; i++) {
+        lines.push(`${this.name}_bucket{${prefix}le="${this.buckets[i]}"} ${entry.counts[i]}`);
+      }
+      lines.push(`${this.name}_bucket{${prefix}le="+Inf"} ${entry.count}`);
+      lines.push(`${this.name}_sum${suffix} ${entry.sum}`);
+      lines.push(`${this.name}_count${suffix} ${entry.count}`);
+    }
+    return lines.join("\n");
+  }
+}

--- a/server/routes/metrics.test.ts
+++ b/server/routes/metrics.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { resetMetrics, httpRequestsTotal, jobsTotal } from "../metrics";
+import metricsApp from "./metrics";
+
+let app: Hono;
+
+beforeEach(() => {
+  setupTestDb();
+  resetMetrics();
+  app = new Hono();
+  app.route("/metrics", metricsApp);
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+describe("GET /metrics", () => {
+  it("returns 200 with Prometheus content type", async () => {
+    const res = await app.request("/metrics");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/plain");
+    expect(res.headers.get("Content-Type")).toContain("version=0.0.4");
+  });
+
+  it("includes all expected metric families", async () => {
+    const res = await app.request("/metrics");
+    const body = await res.text();
+
+    expect(body).toContain("http_requests_total");
+    expect(body).toContain("http_request_duration_seconds");
+    expect(body).toContain("db_query_duration_seconds");
+    expect(body).toContain("jobs_total");
+    expect(body).toContain("job_duration_seconds");
+    expect(body).toContain("tmdb_requests_total");
+    expect(body).toContain("tmdb_request_duration_seconds");
+    expect(body).toContain("active_sessions");
+  });
+
+  it("reflects incremented counters", async () => {
+    httpRequestsTotal.inc({ method: "GET", route: "/api/titles", status: "200" });
+    httpRequestsTotal.inc({ method: "GET", route: "/api/titles", status: "200" });
+
+    const res = await app.request("/metrics");
+    const body = await res.text();
+    expect(body).toContain('http_requests_total{method="GET",route="/api/titles",status="200"} 2');
+  });
+
+  it("reflects job counters", async () => {
+    jobsTotal.inc({ name: "sync-titles", status: "completed" });
+
+    const res = await app.request("/metrics");
+    const body = await res.text();
+    expect(body).toContain('jobs_total{name="sync-titles",status="completed"} 1');
+  });
+
+  it("includes active sessions gauge from DB", async () => {
+    // No sessions in test DB, should be 0
+    const res = await app.request("/metrics");
+    const body = await res.text();
+    expect(body).toContain("active_sessions 0");
+  });
+
+  it("ends with a newline", async () => {
+    const res = await app.request("/metrics");
+    const body = await res.text();
+    expect(body.endsWith("\n")).toBe(true);
+  });
+});

--- a/server/routes/metrics.ts
+++ b/server/routes/metrics.ts
@@ -1,0 +1,22 @@
+import { Hono } from "hono";
+import { getRawDb } from "../db/bun-db";
+import { activeSessionsGauge, renderMetrics } from "../metrics";
+
+const app = new Hono();
+
+// GET /metrics — Prometheus text format metrics
+// Public endpoint (protect via reverse proxy or METRICS_TOKEN env var if needed)
+app.get("/", (c) => {
+  // Query active (non-expired) session count on-demand
+  const db = getRawDb();
+  const row = db
+    .prepare("SELECT COUNT(*) as count FROM sessions WHERE expires_at > datetime('now')")
+    .get() as { count: number } | null;
+  activeSessionsGauge.set({}, row?.count ?? 0);
+
+  return new Response(renderMetrics(), {
+    headers: { "Content-Type": "text/plain; version=0.0.4; charset=utf-8" },
+  });
+});
+
+export default app;

--- a/server/tracing.ts
+++ b/server/tracing.ts
@@ -1,11 +1,13 @@
 import Sentry from "./sentry";
+import { dbQueryDurationSeconds, tmdbRequestsTotal, tmdbRequestDurationSeconds } from "./metrics";
 
 /**
- * Wraps a DB operation in a Sentry span.
+ * Wraps a DB operation in a Sentry span and records query duration metrics.
  * Supports both sync (bun:sqlite) and async (D1) return types.
  */
 export function traceDbQuery<T>(operation: string, fn: () => T): T {
-  return Sentry.startSpan(
+  const start = performance.now();
+  const result = Sentry.startSpan(
     {
       name: operation,
       op: "db.query",
@@ -13,13 +15,25 @@ export function traceDbQuery<T>(operation: string, fn: () => T): T {
     },
     fn
   );
+  const r = result as unknown;
+  if (r instanceof Promise) {
+    // Side-effect: record duration when the promise settles (does not alter return type)
+    void r.then(
+      () => dbQueryDurationSeconds.observe({ operation }, (performance.now() - start) / 1000),
+      () => dbQueryDurationSeconds.observe({ operation }, (performance.now() - start) / 1000),
+    );
+    return result;
+  }
+  dbQueryDurationSeconds.observe({ operation }, (performance.now() - start) / 1000);
+  return result;
 }
 
 /**
- * Wraps an async outbound HTTP call in a Sentry span.
+ * Wraps an async outbound HTTP call in a Sentry span and records TMDB metrics.
  */
 export function traceHttp<T>(method: string, url: string, fn: () => Promise<T>): Promise<T> {
   const parsedUrl = new URL(url);
+  const start = performance.now();
   return Sentry.startSpan(
     {
       name: `${method} ${parsedUrl.pathname}`,
@@ -30,6 +44,17 @@ export function traceHttp<T>(method: string, url: string, fn: () => Promise<T>):
         "server.address": parsedUrl.hostname,
       },
     },
-    fn
+    async () => {
+      try {
+        const result = await fn();
+        tmdbRequestsTotal.inc({ method, status: "success" });
+        tmdbRequestDurationSeconds.observe({ method }, (performance.now() - start) / 1000);
+        return result;
+      } catch (err) {
+        tmdbRequestsTotal.inc({ method, status: "error" });
+        tmdbRequestDurationSeconds.observe({ method }, (performance.now() - start) / 1000);
+        throw err;
+      }
+    }
   );
 }


### PR DESCRIPTION
Implements a `/metrics` endpoint exposing Prometheus-format metrics for Grafana dashboards and alerting.

Closes #164

Generated with [Claude Code](https://claude.ai/code)