### PR TITLE
feat: add useApiCall hook for standardized data fetching

### DIFF
--- a/frontend/src/hooks/useApiCall.test.ts
+++ b/frontend/src/hooks/useApiCall.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { renderHook, act } from "@testing-library/react";
+import { useApiCall } from "./useApiCall";
+
+describe("useApiCall", () => {
+  beforeEach(() => {
+    globalThis.AbortController = AbortController;
+    globalThis.DOMException = DOMException;
+  });
+
+  it("returns loading=true initially", () => {
+    const fetcher = mock(() => new Promise(() => {}));
+    const { result } = renderHook(() => useApiCall(fetcher, []));
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("resolves data and sets loading=false on success", async () => {
+    const fetcher = mock(() => Promise.resolve({ value: 42 }));
+    const { result } = renderHook(() => useApiCall(fetcher, []));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toEqual({ value: 42 });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error on failure", async () => {
+    const fetcher = mock(() => Promise.reject(new Error("network error")));
+    const { result } = renderHook(() => useApiCall(fetcher, []));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBe("network error");
+  });
+
+  it("calls onSuccess callback with data", async () => {
+    const onSuccess = mock(() => {});
+    const fetcher = mock(() => Promise.resolve("hello"));
+
+    const { result } = renderHook(() =>
+      useApiCall(fetcher, [], { onSuccess }),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledWith("hello");
+    expect(result.current.data).toBe("hello");
+  });
+
+  it("calls onError callback on failure", async () => {
+    const onError = mock(() => {});
+    const err = new Error("oops");
+    const fetcher = mock(() => Promise.reject(err));
+
+    renderHook(() => useApiCall(fetcher, [], { onError }));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(err);
+  });
+
+  it("refetch triggers a new fetch", async () => {
+    let callCount = 0;
+    const fetcher = mock(() => {
+      callCount++;
+      return Promise.resolve(callCount);
+    });
+
+    const { result } = renderHook(() => useApiCall(fetcher, []));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.data).toBe(1);
+
+    await act(async () => {
+      result.current.refetch();
+      await Promise.resolve();
+    });
+
+    expect(result.current.data).toBe(2);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("reruns when deps change", async () => {
+    let id = 1;
+    const fetcher = mock(() => Promise.resolve(`data-${id}`));
+
+    const { result, rerender } = renderHook(() => useApiCall(fetcher, [id]));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.data).toBe("data-1");
+
+    id = 2;
+    rerender();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.data).toBe("data-2");
+  });
+
+  it("does not update state after unmount", async () => {
+    let resolve!: (value: string) => void;
+    const fetcher = mock(
+      () => new Promise<string>((res) => { resolve = res; }),
+    );
+
+    const { result, unmount } = renderHook(() => useApiCall(fetcher, []));
+
+    unmount();
+
+    await act(async () => {
+      resolve("late data");
+      await Promise.resolve();
+    });
+
+    // State should not have been updated — data remains null
+    expect(result.current.data).toBeNull();
+    expect(result.current.loading).toBe(true);
+  });
+
+  it("retries on failure with retry option", async () => {
+    let attempts = 0;
+    const fetcher = mock(() => {
+      attempts++;
+      if (attempts < 3) return Promise.reject(new Error("fail"));
+      return Promise.resolve("success");
+    });
+
+    const { result } = renderHook(() =>
+      useApiCall(fetcher, [], { retry: 2, retryDelay: 0 }),
+    );
+
+    // Wait for retries (retryDelay=0 so they resolve synchronously-ish)
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(result.current.data).toBe("success");
+    expect(result.current.error).toBeNull();
+    expect(attempts).toBe(3);
+  });
+});

--- a/frontend/src/hooks/useApiCall.ts
+++ b/frontend/src/hooks/useApiCall.ts
@@ -1,0 +1,94 @@
+import { useState, useEffect, useCallback, useRef, type DependencyList } from "react";
+
+export interface UseApiCallOptions<T> {
+  onSuccess?: (data: T) => void;
+  onError?: (error: Error) => void;
+  /** Number of retry attempts on failure (default: 0) */
+  retry?: number;
+  /** Base delay in ms for exponential backoff (default: 1000) */
+  retryDelay?: number;
+}
+
+export interface UseApiCallResult<T> {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+async function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(resolve, ms);
+    signal.addEventListener("abort", () => {
+      clearTimeout(timeout);
+      reject(new DOMException("Aborted", "AbortError"));
+    }, { once: true });
+  });
+}
+
+async function fetchWithRetry<T>(
+  fetcher: () => Promise<T>,
+  retries: number,
+  retryDelay: number,
+  signal: AbortSignal,
+): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    if (signal.aborted) throw new DOMException("Aborted", "AbortError");
+    try {
+      return await fetcher();
+    } catch (err) {
+      lastError = err;
+      if (signal.aborted) throw err;
+      if (attempt < retries) {
+        await sleep(retryDelay * Math.pow(2, attempt), signal);
+      }
+    }
+  }
+  throw lastError;
+}
+
+export function useApiCall<T>(
+  fetcher: () => Promise<T>,
+  deps: DependencyList,
+  options?: UseApiCallOptions<T>,
+): UseApiCallResult<T> {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const { signal } = controller;
+    const { retry = 0, retryDelay = 1000, onSuccess, onError } = optionsRef.current ?? {};
+
+    setLoading(true);
+    setError(null);
+
+    fetchWithRetry(fetcher, retry, retryDelay, signal)
+      .then((result) => {
+        if (signal.aborted) return;
+        setData(result);
+        onSuccess?.(result);
+      })
+      .catch((err: unknown) => {
+        if (signal.aborted) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message);
+        onError?.(err instanceof Error ? err : new Error(message));
+      })
+      .finally(() => {
+        if (!signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...deps, tick]);
+
+  const refetch = useCallback(() => setTick((t) => t + 1), []);
+
+  return { data, loading, error, refetch };
+}

--- a/frontend/src/pages/EpisodeDetailPage.tsx
+++ b/frontend/src/pages/EpisodeDetailPage.tsx
@@ -1,9 +1,9 @@
-import { useState, useEffect } from "react";
 import { useParams, Link } from "react-router";
 import * as api from "../api";
 import type { EpisodeDetailsResponse, CastMember, CrewMember } from "../types";
 import PersonCard from "../components/PersonCard";
 import { DetailPageSkeleton } from "../components/SkeletonComponents";
+import { useApiCall } from "../hooks/useApiCall";
 
 const TMDB_IMG = "https://image.tmdb.org/t/p";
 
@@ -16,30 +16,11 @@ function formatDate(dateStr: string | null | undefined): string {
 
 export default function EpisodeDetailPage() {
   const { id, season, episode } = useParams<{ id: string; season: string; episode: string }>();
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [data, setData] = useState<EpisodeDetailsResponse | null>(null);
 
-  useEffect(() => {
-    if (!id || !season || !episode) return;
-    let cancelled = false;
-
-    async function load() {
-      setLoading(true);
-      setError(null);
-      try {
-        const result = await api.getEpisodeDetails(id!, Number(season), Number(episode));
-        if (!cancelled) setData(result);
-      } catch (e: any) {
-        if (!cancelled) setError(e.message || "Failed to load episode details");
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-
-    load();
-    return () => { cancelled = true; };
-  }, [id, season, episode]);
+  const { data, loading, error } = useApiCall<EpisodeDetailsResponse>(
+    () => api.getEpisodeDetails(id!, Number(season), Number(episode)),
+    [id, season, episode],
+  );
 
   if (loading) {
     return <DetailPageSkeleton />;

--- a/frontend/src/pages/PersonPage.tsx
+++ b/frontend/src/pages/PersonPage.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useParams, Link } from "react-router";
 import * as api from "../api";
 import type { PersonDetailsResponse, PersonCastCredit, PersonCrewCredit } from "../types";
 import ExternalLinks from "../components/ExternalLinks";
 import { DetailPageSkeleton } from "../components/SkeletonComponents";
+import { useApiCall } from "../hooks/useApiCall";
 
 const TMDB_IMG = "https://image.tmdb.org/t/p";
 const BIO_TRUNCATE_LENGTH = 600;
@@ -80,31 +81,12 @@ function CreditCard({ credit, subtitle }: { credit: PersonCastCredit | PersonCre
 
 export default function PersonPage() {
   const { personId } = useParams<{ personId: string }>();
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [data, setData] = useState<PersonDetailsResponse | null>(null);
   const [bioExpanded, setBioExpanded] = useState(false);
 
-  useEffect(() => {
-    if (!personId) return;
-    let cancelled = false;
-
-    async function load() {
-      setLoading(true);
-      setError(null);
-      try {
-        const resp = await api.getPersonDetails(Number(personId));
-        if (!cancelled) setData(resp);
-      } catch (e: any) {
-        if (!cancelled) setError(e.message || "Failed to load person details");
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-
-    load();
-    return () => { cancelled = true; };
-  }, [personId]);
+  const { data, loading, error } = useApiCall<PersonDetailsResponse>(
+    () => api.getPersonDetails(Number(personId)),
+    [personId],
+  );
 
   if (loading) {
     return <DetailPageSkeleton />;

--- a/frontend/src/pages/SeasonDetailPage.tsx
+++ b/frontend/src/pages/SeasonDetailPage.tsx
@@ -1,9 +1,9 @@
-import { useState, useEffect } from "react";
 import { useParams, Link } from "react-router";
 import * as api from "../api";
 import type { SeasonDetailsResponse } from "../types";
 import PersonCard from "../components/PersonCard";
 import { DetailPageSkeleton } from "../components/SkeletonComponents";
+import { useApiCall } from "../hooks/useApiCall";
 
 const TMDB_IMG = "https://image.tmdb.org/t/p";
 
@@ -16,30 +16,11 @@ function formatDate(dateStr: string | null | undefined): string {
 
 export default function SeasonDetailPage() {
   const { id, season } = useParams<{ id: string; season: string }>();
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [data, setData] = useState<SeasonDetailsResponse | null>(null);
 
-  useEffect(() => {
-    if (!id || !season) return;
-    let cancelled = false;
-
-    async function load() {
-      setLoading(true);
-      setError(null);
-      try {
-        const result = await api.getSeasonDetails(id!, Number(season));
-        if (!cancelled) setData(result);
-      } catch (e: any) {
-        if (!cancelled) setError(e.message || "Failed to load season details");
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-
-    load();
-    return () => { cancelled = true; };
-  }, [id, season]);
+  const { data, loading, error } = useApiCall<SeasonDetailsResponse>(
+    () => api.getSeasonDetails(id!, Number(season)),
+    [id, season],
+  );
 
   if (loading) {
     return <DetailPageSkeleton />;

--- a/frontend/src/pages/TrackedPage.tsx
+++ b/frontend/src/pages/TrackedPage.tsx
@@ -1,30 +1,14 @@
-import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import * as api from "../api";
 import type { Title } from "../types";
 import TitleList from "../components/TitleList";
 import { TitleGridSkeleton } from "../components/SkeletonComponents";
+import { useApiCall } from "../hooks/useApiCall";
 
 export default function TrackedPage() {
-  const [titles, setTitles] = useState<Title[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { data, loading, refetch } = useApiCall(() => api.getTrackedTitles(), []);
+  const titles: Title[] = data?.titles ?? [];
   const { t } = useTranslation();
-
-  const fetchTracked = useCallback(async () => {
-    setLoading(true);
-    try {
-      const res = await api.getTrackedTitles();
-      setTitles(res.titles);
-    } catch (err) {
-      console.error("Failed to fetch tracked titles:", err);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchTracked();
-  }, [fetchTracked]);
 
   return (
     <div className="space-y-4">
@@ -34,7 +18,7 @@ export default function TrackedPage() {
       ) : (
         <TitleList
           titles={titles}
-          onTrackToggle={fetchTracked}
+          onTrackToggle={refetch}
           emptyMessage={t("tracked.empty")}
         />
       )}

--- a/frontend/src/pages/UpcomingPage.tsx
+++ b/frontend/src/pages/UpcomingPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import * as api from "../api";
@@ -9,28 +9,23 @@ import {
   ShowEpisodeGroup,
 } from "../components/EpisodeComponents";
 import { EpisodeListSkeleton } from "../components/SkeletonComponents";
+import { useApiCall } from "../hooks/useApiCall";
 
 export default function UpcomingPage() {
   const [today, setToday] = useState<Episode[]>([]);
   const [upcoming, setUpcoming] = useState<Episode[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState("");
   const { t } = useTranslation();
 
-  useEffect(() => {
-    async function load() {
-      try {
-        const data = await api.getUpcomingEpisodes();
+  const { loading, error } = useApiCall(
+    () => api.getUpcomingEpisodes(),
+    [],
+    {
+      onSuccess: (data) => {
         setToday(data.today);
         setUpcoming(data.upcoming);
-      } catch (err: any) {
-        setError(err.message);
-      } finally {
-        setLoading(false);
-      }
-    }
-    load();
-  }, []);
+      },
+    },
+  );
 
   const toggleWatched = async (episodeId: number, currentlyWatched: boolean) => {
     const updateAll = (eps: Episode[]) =>


### PR DESCRIPTION
Creates a shared `useApiCall<T>` hook that centralizes the loading/error/data pattern across pages with AbortController cleanup, optional retry, and callbacks. Refactors PersonPage, EpisodeDetailPage, SeasonDetailPage, UpcomingPage, and TrackedPage.

Closes #158

Generated with [Claude Code](https://claude.ai/code)