### PR TITLE
feat: add toast notifications for silent API failures

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,7 @@
         "react-dom": "^19.2.0",
         "react-router": "^7.13.1",
         "shadcn": "^4.0.3",
+        "sonner": "^2.0.3",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "react-dom": "^19.2.0",
     "react-router": "^7.13.1",
     "shadcn": "^4.0.3",
+    "sonner": "^2.0.3",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { Routes, Route, NavLink, Link, Navigate, useLocation } from "react-router";
+import { Toaster } from "sonner";
 import { useAuth } from "./context/AuthContext";
 import { useIsMobile } from "./hooks/useIsMobile";
 import HomePage from "./pages/HomePage";
@@ -128,6 +129,7 @@ export default function App() {
       </main>
       <BottomTabBar />
       <OfflineIndicator />
+      <Toaster theme="dark" position="bottom-center" richColors />
     </div>
   );
 }

--- a/frontend/src/components/TrackButton.test.tsx
+++ b/frontend/src/components/TrackButton.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/re
 import type { ReactNode } from "react";
 import TrackButton from "./TrackButton";
 import * as api from "../api";
+import * as sonner from "sonner";
 import { AuthContext } from "../context/AuthContext";
 
 const mockUser = { id: "1", username: "test", display_name: null, auth_provider: "local", is_admin: false };
@@ -26,6 +27,8 @@ beforeEach(() => {
   spies = [
     spyOn(api, "trackTitle").mockResolvedValue(undefined as any),
     spyOn(api, "untrackTitle").mockResolvedValue(undefined as any),
+    spyOn(sonner.toast, "success").mockImplementation(() => "1" as any),
+    spyOn(sonner.toast, "error").mockImplementation(() => "1" as any),
   ];
 });
 
@@ -94,6 +97,40 @@ describe("TrackButton", () => {
   it("has aria-pressed=true when tracked", () => {
     render(<TrackButton titleId="123" isTracked={true} />, { wrapper: Wrapper });
     expect(screen.getByRole("button", { name: "Tracked" }).getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("shows success toast when tracking", async () => {
+    render(<TrackButton titleId="123" isTracked={false} />, { wrapper: Wrapper });
+    fireEvent.click(screen.getByRole("button", { name: "Track" }));
+    await waitFor(() => {
+      expect(sonner.toast.success).toHaveBeenCalledWith("Added to watchlist");
+    });
+  });
+
+  it("shows success toast when untracking", async () => {
+    render(<TrackButton titleId="456" isTracked={true} />, { wrapper: Wrapper });
+    fireEvent.click(screen.getByRole("button", { name: "Tracked" }));
+    await waitFor(() => {
+      expect(sonner.toast.success).toHaveBeenCalledWith("Removed from watchlist");
+    });
+  });
+
+  it("shows error toast when track fails", async () => {
+    (api.trackTitle as any).mockRejectedValueOnce(new Error("Network error"));
+    render(<TrackButton titleId="123" isTracked={false} />, { wrapper: Wrapper });
+    fireEvent.click(screen.getByRole("button", { name: "Track" }));
+    await waitFor(() => {
+      expect(sonner.toast.error).toHaveBeenCalledWith("Failed to update watchlist");
+    });
+  });
+
+  it("shows error toast when untrack fails", async () => {
+    (api.untrackTitle as any).mockRejectedValueOnce(new Error("Network error"));
+    render(<TrackButton titleId="456" isTracked={true} />, { wrapper: Wrapper });
+    fireEvent.click(screen.getByRole("button", { name: "Tracked" }));
+    await waitFor(() => {
+      expect(sonner.toast.error).toHaveBeenCalledWith("Failed to update watchlist");
+    });
   });
 
   it("shows loading indicator while toggling", async () => {

--- a/frontend/src/components/TrackButton.tsx
+++ b/frontend/src/components/TrackButton.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { toast } from "sonner";
 import * as api from "../api";
 import type { Title } from "../types";
 import { useAuth } from "../context/AuthContext";
@@ -24,13 +25,16 @@ export default function TrackButton({ titleId, isTracked, onToggle, titleData }:
         await api.untrackTitle(titleId);
         setTracked(false);
         onToggle?.(false);
+        toast.success("Removed from watchlist");
       } else {
         await api.trackTitle(titleId, undefined, titleData);
         setTracked(true);
         onToggle?.(true);
+        toast.success("Added to watchlist");
       }
     } catch (err) {
       console.error("Track toggle failed:", err);
+      toast.error("Failed to update watchlist");
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback, memo } from "react";
 import { Link } from "react-router";
 import { Maximize2 } from "lucide-react";
+import { toast } from "sonner";
 import { useAuth } from "../context/AuthContext";
 import * as api from "../api";
 import type { Episode } from "../types";
@@ -304,6 +305,7 @@ export default function HomePage() {
           setUnwatched(data.unwatched);
         } catch {}
       }
+      toast.error("Failed to update watched status");
       console.error("Failed to toggle watched:", err);
     }
   }, []);
@@ -320,6 +322,7 @@ export default function HomePage() {
         const data = await api.getUpcomingEpisodes();
         setUnwatched(data.unwatched);
       } catch {}
+      toast.error("Failed to mark season as watched");
       console.error("Failed to bulk mark watched:", err);
     }
   }, []);

--- a/frontend/src/pages/ReelsPage.tsx
+++ b/frontend/src/pages/ReelsPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { Link } from "react-router";
 import { Undo2 } from "lucide-react";
+import { toast } from "sonner";
 import * as api from "../api";
 import type { Episode } from "../types";
 import ReelsCard from "../components/ReelsCard";
@@ -223,6 +224,7 @@ export default function ReelsPage() {
         })
       );
       setUndoAction(null);
+      toast.error("Failed to mark episode as watched");
       console.error("Failed to mark watched:", err);
     }
   }, []);
@@ -247,6 +249,7 @@ export default function ReelsPage() {
     try {
       await api.unwatchEpisode(undoAction.episodeId);
     } catch (err) {
+      toast.error("Failed to undo");
       console.error("Failed to undo:", err);
     }
   }, [undoAction]);
@@ -260,6 +263,7 @@ export default function ReelsPage() {
       setCards(getFirstUnwatchedPerShow(data.unwatched));
       setSeasonPanel(null);
     } catch (err) {
+      toast.error("Failed to mark episodes as watched");
       console.error("Failed to bulk mark watched:", err);
     }
   }, []);
@@ -276,6 +280,7 @@ export default function ReelsPage() {
       const data = await api.getUpcomingEpisodes();
       setCards(getFirstUnwatchedPerShow(data.unwatched));
     } catch (err) {
+      toast.error("Failed to update watched status");
       console.error("Failed to toggle watched:", err);
     }
   }, []);

--- a/frontend/src/pages/UpcomingPage.tsx
+++ b/frontend/src/pages/UpcomingPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { toast } from "sonner";
 import * as api from "../api";
 import type { Episode } from "../types";
 import {
@@ -47,6 +48,7 @@ export default function UpcomingPage() {
     } catch (err) {
       setToday((prev) => revertAll(prev));
       setUpcoming((prev) => revertAll(prev));
+      toast.error("Failed to update watched status");
       console.error("Failed to toggle watched:", err);
     }
   };


### PR DESCRIPTION
Adds `sonner` toast notifications to surface feedback for previously-silent async operations: track/untrack, watched status changes, undo, and bulk watch failures.

Fixes #147

Generated with [Claude Code](https://claude.ai/code)