### PR TITLE
perf: replace correlated is_tracked subqueries with LEFT JOINs

### DIFF
--- a/server/db/repository.test.ts
+++ b/server/db/repository.test.ts
@@ -309,6 +309,27 @@ describe("getRecentTitles", () => {
     const results = await getRecentTitles({ daysBack: 0, excludeTracked: true });
     expect(results).toHaveLength(2);
   });
+
+  it("returns is_tracked=false without userId", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-1", releaseDate: "2025-01-01" })]);
+    const results = await getRecentTitles({ daysBack: 0 });
+    expect(results[0].is_tracked).toBe(false);
+  });
+
+  it("returns correct is_tracked via LEFT JOIN when userId is provided", async () => {
+    await upsertTitles([
+      makeParsedTitle({ id: "movie-1", title: "Tracked", releaseDate: "2025-01-01" }),
+      makeParsedTitle({ id: "movie-2", title: "Untracked", releaseDate: "2025-01-02" }),
+    ]);
+    const userId = await createUser("testuser2", "hash");
+    await trackTitle("movie-1", userId);
+
+    const results = await getRecentTitles({ daysBack: 0 }, userId);
+    const trackedResult = results.find((r) => r.id === "movie-1")!;
+    const untrackedResult = results.find((r) => r.id === "movie-2")!;
+    expect(trackedResult.is_tracked).toBe(true);
+    expect(untrackedResult.is_tracked).toBe(false);
+  });
 });
 
 describe("getGenres", () => {
@@ -361,6 +382,27 @@ describe("searchLocalTitles", () => {
   it("returns empty for no matches", async () => {
     await upsertTitles([makeParsedTitle()]);
     expect(await searchLocalTitles("NonExistent")).toHaveLength(0);
+  });
+
+  it("returns is_tracked=false without userId", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-1", title: "Test Movie" })]);
+    const results = await searchLocalTitles("Test");
+    expect(results[0].is_tracked).toBe(false);
+  });
+
+  it("returns correct is_tracked via LEFT JOIN when userId is provided", async () => {
+    await upsertTitles([
+      makeParsedTitle({ id: "movie-1", title: "Tracked Film" }),
+      makeParsedTitle({ id: "movie-2", title: "Untracked Film" }),
+    ]);
+    const userId = await createUser("searchuser", "hash");
+    await trackTitle("movie-1", userId);
+
+    const results = await searchLocalTitles("Film", 50, userId);
+    const trackedResult = results.find((r) => r.id === "movie-1")!;
+    const untrackedResult = results.find((r) => r.id === "movie-2")!;
+    expect(trackedResult.is_tracked).toBe(true);
+    expect(untrackedResult.is_tracked).toBe(false);
   });
 });
 

--- a/server/db/repository/titles.ts
+++ b/server/db/repository/titles.ts
@@ -121,11 +121,7 @@ export async function getTitleById(titleId: string, userId?: string) {
   return traceDbQuery("getTitleById", async () => {
     const db = getDb();
 
-    const trackedSubquery = userId
-      ? sql<number>`(SELECT EXISTS(SELECT 1 FROM tracked tr WHERE tr.title_id = ${titles.id} AND tr.user_id = ${userId}))`
-      : sql<number>`0`;
-
-    const row = await db
+    const queryBuilder = db
       .select({
         id: titles.id,
         object_type: titles.objectType,
@@ -146,12 +142,18 @@ export async function getTitleById(titleId: string, userId?: string) {
         imdb_score: scores.imdbScore,
         imdb_votes: scores.imdbVotes,
         tmdb_score: scores.tmdbScore,
-        is_tracked: trackedSubquery,
+        is_tracked: userId
+          ? sql<number>`CASE WHEN ${tracked.titleId} IS NOT NULL THEN 1 ELSE 0 END`
+          : sql<number>`0`,
       })
       .from(titles)
       .leftJoin(scores, eq(scores.titleId, titles.id))
-      .where(eq(titles.id, titleId))
-      .get();
+      .$dynamic();
+
+    const row = await (userId
+      ? queryBuilder.leftJoin(tracked, and(eq(tracked.titleId, titles.id), eq(tracked.userId, userId)))
+      : queryBuilder
+    ).where(eq(titles.id, titleId)).get();
 
     if (!row) return null;
 
@@ -233,11 +235,7 @@ export async function getRecentTitles(filters: TitleFilters = {}, userId?: strin
       );
     }
 
-    const trackedSubquery = userId
-      ? sql<number>`(SELECT EXISTS(SELECT 1 FROM tracked tr WHERE tr.title_id = ${titles.id} AND tr.user_id = ${userId}))`
-      : sql<number>`0`;
-
-    const rows = await db
+    const queryBuilder = db
       .select({
         id: titles.id,
         object_type: titles.objectType,
@@ -258,10 +256,18 @@ export async function getRecentTitles(filters: TitleFilters = {}, userId?: strin
         imdb_score: scores.imdbScore,
         imdb_votes: scores.imdbVotes,
         tmdb_score: scores.tmdbScore,
-        is_tracked: trackedSubquery,
+        is_tracked: userId
+          ? sql<number>`CASE WHEN ${tracked.titleId} IS NOT NULL THEN 1 ELSE 0 END`
+          : sql<number>`0`,
       })
       .from(titles)
       .leftJoin(scores, eq(scores.titleId, titles.id))
+      .$dynamic();
+
+    const rows = await (userId
+      ? queryBuilder.leftJoin(tracked, and(eq(tracked.titleId, titles.id), eq(tracked.userId, userId)))
+      : queryBuilder
+    )
       .where(conditions.length > 0 ? and(...conditions) : undefined)
       .orderBy(desc(titles.releaseDate))
       .limit(limit)
@@ -282,11 +288,7 @@ export async function searchLocalTitles(query: string, limit = 50, userId?: stri
   return traceDbQuery("searchLocalTitles", async () => {
     const db = getDb();
 
-    const trackedSubquery = userId
-      ? sql<number>`(SELECT EXISTS(SELECT 1 FROM tracked tr WHERE tr.title_id = ${titles.id} AND tr.user_id = ${userId}))`
-      : sql<number>`0`;
-
-    const rows = await db
+    const queryBuilder = db
       .select({
         id: titles.id,
         object_type: titles.objectType,
@@ -307,10 +309,18 @@ export async function searchLocalTitles(query: string, limit = 50, userId?: stri
         imdb_score: scores.imdbScore,
         imdb_votes: scores.imdbVotes,
         tmdb_score: scores.tmdbScore,
-        is_tracked: trackedSubquery,
+        is_tracked: userId
+          ? sql<number>`CASE WHEN ${tracked.titleId} IS NOT NULL THEN 1 ELSE 0 END`
+          : sql<number>`0`,
       })
       .from(titles)
       .leftJoin(scores, eq(scores.titleId, titles.id))
+      .$dynamic();
+
+    const rows = await (userId
+      ? queryBuilder.leftJoin(tracked, and(eq(tracked.titleId, titles.id), eq(tracked.userId, userId)))
+      : queryBuilder
+    )
       .where(like(titles.title, `%${query}%`))
       .orderBy(desc(titles.releaseDate))
       .limit(limit)


### PR DESCRIPTION
Replace per-row correlated subqueries for is_tracked in getTitleById, getRecentTitles, and searchLocalTitles with a conditional LEFT JOIN on the tracked table. Uses CASE WHEN to determine tracking status from the join result, reducing query complexity and allowing SQLite to use indexes more effectively.

Closes #134

Generated with [Claude Code](https://claude.ai/code)