### PR TITLE
feat: add scheduled SQLite backup job

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -23,6 +23,11 @@ export const CONFIG = {
   SYNC_TITLES_CRON: process.env.SYNC_TITLES_CRON || "0 3 * * *",
   SYNC_EPISODES_CRON: process.env.SYNC_EPISODES_CRON || "30 3 * * *",
 
+  // Backup
+  BACKUP_DIR: process.env.BACKUP_DIR || "",
+  BACKUP_CRON: process.env.BACKUP_CRON || "0 2 * * *",
+  BACKUP_RETAIN: Number(process.env.BACKUP_RETAIN) || 7,
+
   // Auth
   BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET || "",
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -28,6 +28,7 @@ import Sentry from "./sentry";
 import { logger, requestLogger } from "./logger";
 import { registerSyncJobs } from "./jobs/sync";
 import { registerNotificationJobs } from "./jobs/notifications";
+import { registerBackupJob } from "./jobs/backup";
 import { startWorker, stopWorker } from "./jobs/worker";
 import { registerCron } from "./jobs/queue";
 import { setScheduleCallback } from "./jobs/schedule";
@@ -185,6 +186,7 @@ app.use("/*", serveStatic({ root: "./frontend/dist", path: "/index.html" }));
 setScheduleCallback(registerCron);
 registerSyncJobs();
 await registerNotificationJobs();
+registerBackupJob();
 startWorker();
 
 process.on("SIGTERM", async () => {

--- a/server/jobs/backup.test.ts
+++ b/server/jobs/backup.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { CONFIG } from "../config";
+import { runBackup } from "./backup";
+
+describe("runBackup", () => {
+  let tmpDir: string;
+  let originalBackupDir: string;
+  let originalBackupRetain: number;
+
+  beforeEach(() => {
+    setupTestDb();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "remindarr-backup-test-"));
+    originalBackupDir = CONFIG.BACKUP_DIR;
+    originalBackupRetain = CONFIG.BACKUP_RETAIN;
+  });
+
+  afterEach(() => {
+    CONFIG.BACKUP_DIR = originalBackupDir;
+    CONFIG.BACKUP_RETAIN = originalBackupRetain;
+    teardownTestDb();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("skips backup when BACKUP_DIR is not configured", async () => {
+    CONFIG.BACKUP_DIR = "";
+    const result = await runBackup();
+    expect(result.path).toBe("");
+    expect(result.pruned).toBe(0);
+  });
+
+  it("creates a backup file in the configured directory", async () => {
+    CONFIG.BACKUP_DIR = tmpDir;
+    const result = await runBackup();
+
+    expect(result.path).toStartWith(tmpDir);
+    expect(result.path).toMatch(/remindarr-.*\.db$/);
+    expect(fs.existsSync(result.path)).toBe(true);
+  });
+
+  it("creates the backup directory if it does not exist", async () => {
+    const nested = path.join(tmpDir, "nested", "backups");
+    CONFIG.BACKUP_DIR = nested;
+    const result = await runBackup();
+
+    expect(fs.existsSync(nested)).toBe(true);
+    expect(fs.existsSync(result.path)).toBe(true);
+  });
+
+  it("prunes old backups beyond BACKUP_RETAIN", async () => {
+    CONFIG.BACKUP_DIR = tmpDir;
+    CONFIG.BACKUP_RETAIN = 2;
+
+    // Create fake old backup files with earlier timestamps
+    const oldFiles = [
+      "remindarr-2026-01-01T00-00-00-000Z.db",
+      "remindarr-2026-01-02T00-00-00-000Z.db",
+      "remindarr-2026-01-03T00-00-00-000Z.db",
+    ];
+    for (const f of oldFiles) {
+      fs.writeFileSync(path.join(tmpDir, f), "");
+    }
+
+    const result = await runBackup();
+
+    // After backup: 3 old + 1 new = 4 total, retain 2 → pruned 2
+    expect(result.pruned).toBe(2);
+
+    // The two oldest should be deleted
+    expect(fs.existsSync(path.join(tmpDir, oldFiles[0]))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, oldFiles[1]))).toBe(false);
+
+    // The new backup and the most recent old file should remain
+    expect(fs.existsSync(path.join(tmpDir, oldFiles[2]))).toBe(true);
+    expect(fs.existsSync(result.path)).toBe(true);
+  });
+
+  it("does not prune when backup count is within BACKUP_RETAIN limit", async () => {
+    CONFIG.BACKUP_DIR = tmpDir;
+    CONFIG.BACKUP_RETAIN = 7;
+
+    const result = await runBackup();
+
+    expect(result.pruned).toBe(0);
+    expect(fs.existsSync(result.path)).toBe(true);
+  });
+
+  it("only prunes files matching the backup filename pattern", async () => {
+    CONFIG.BACKUP_DIR = tmpDir;
+    CONFIG.BACKUP_RETAIN = 1;
+
+    // These files should NOT be pruned (wrong pattern)
+    const unrelatedFiles = ["other.db", "remindarr.db", "backup.txt"];
+    for (const f of unrelatedFiles) {
+      fs.writeFileSync(path.join(tmpDir, f), "");
+    }
+
+    // One valid old backup that SHOULD be pruned
+    const oldBackup = "remindarr-2026-01-01T00-00-00-000Z.db";
+    fs.writeFileSync(path.join(tmpDir, oldBackup), "");
+
+    const result = await runBackup();
+
+    // Old backup pruned, unrelated files untouched
+    expect(result.pruned).toBe(1);
+    expect(fs.existsSync(path.join(tmpDir, oldBackup))).toBe(false);
+    for (const f of unrelatedFiles) {
+      expect(fs.existsSync(path.join(tmpDir, f))).toBe(true);
+    }
+  });
+});

--- a/server/jobs/backup.ts
+++ b/server/jobs/backup.ts
@@ -1,0 +1,66 @@
+import path from "node:path";
+import fs from "node:fs";
+import { getRawDb } from "../db/bun-db";
+import { logger } from "../logger";
+import { CONFIG } from "../config";
+import { registerHandler } from "./worker";
+import { registerCron } from "./queue";
+
+const log = logger.child({ module: "backup" });
+
+const BACKUP_FILE_PATTERN = /^remindarr-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.db$/;
+
+/**
+ * Creates a backup of the SQLite database using VACUUM INTO and prunes old backups.
+ * Returns the backup path and the number of old backups pruned.
+ */
+export async function runBackup(): Promise<{ path: string; pruned: number }> {
+  const backupDir = CONFIG.BACKUP_DIR;
+  if (!backupDir) {
+    log.info("Skipping backup", { reason: "BACKUP_DIR not configured" });
+    return { path: "", pruned: 0 };
+  }
+
+  fs.mkdirSync(backupDir, { recursive: true });
+
+  // Build a timestamped filename with only safe characters
+  const timestamp = new Date().toISOString().replace(/:/g, "-").replace(".", "-");
+  const backupPath = path.join(path.resolve(backupDir), `remindarr-${timestamp}.db`);
+
+  // VACUUM INTO creates a defragmented, consistent snapshot of the database.
+  // The path is constructed from server-controlled values (env var + timestamp),
+  // not from user input, so string interpolation is safe here.
+  const db = getRawDb();
+  db.exec(`VACUUM INTO '${backupPath.replace(/'/g, "''")}'`);
+  log.info("Database backup created", { path: backupPath });
+
+  // Prune oldest backups beyond the retention limit
+  const entries = fs
+    .readdirSync(backupDir)
+    .filter((f) => BACKUP_FILE_PATTERN.test(f))
+    .sort(); // ISO timestamps sort lexicographically
+
+  const retain = CONFIG.BACKUP_RETAIN;
+  const toDelete = entries.slice(0, Math.max(0, entries.length - retain));
+  for (const name of toDelete) {
+    const filePath = path.join(backupDir, name);
+    fs.unlinkSync(filePath);
+    log.info("Pruned old backup", { path: filePath });
+  }
+
+  return { path: backupPath, pruned: toDelete.length };
+}
+
+export function registerBackupJob() {
+  if (!CONFIG.BACKUP_DIR) {
+    log.info("Backup job disabled", { reason: "BACKUP_DIR not configured" });
+    return;
+  }
+
+  registerHandler("backup-db", async () => {
+    const result = await runBackup();
+    log.info("Backup complete", { path: result.path, pruned: result.pruned });
+  });
+
+  registerCron("backup-db", CONFIG.BACKUP_CRON);
+}


### PR DESCRIPTION
Closes #165

Implements Option 1 from #165: a scheduled backup job using SQLite's `VACUUM INTO` API to create consistent, defragmented database snapshots.

**New env vars:**
- `BACKUP_DIR` — directory to store backups (disabled when empty)
- `BACKUP_CRON` — cron schedule (default: `0 2 * * *`, daily at 2am)
- `BACKUP_RETAIN` — number of backups to keep (default: 7)

Generated with [Claude Code](https://claude.ai/code)