### PR TITLE
fix: guard setInterval.unref() for CF Workers compatibility

### DIFF
--- a/server/middleware/rate-limit.ts
+++ b/server/middleware/rate-limit.ts
@@ -35,7 +35,7 @@ export function rateLimiter(options: RateLimitOptions) {
   const buckets = new Map<string, TokenBucket>();
 
   // Periodic cleanup so stale entries are removed even on low-traffic instances.
-  // unref() ensures the timer doesn't prevent the process from exiting.
+  // unref() ensures the timer doesn't prevent the process from exiting (Node/Bun only).
   const cleanupTimer = setInterval(() => {
     const now = Date.now();
     for (const [k, bucket] of buckets) {
@@ -44,7 +44,9 @@ export function rateLimiter(options: RateLimitOptions) {
       }
     }
   }, cleanupIntervalMs);
-  cleanupTimer.unref();
+  if (typeof cleanupTimer === "object" && "unref" in cleanupTimer) {
+    cleanupTimer.unref();
+  }
 
   return createMiddleware<AppEnv>(async (c, next) => {
     const key = keyGenerator(c);


### PR DESCRIPTION
## Summary
- `setInterval` returns a plain number on Cloudflare Workers (not a Node.js `Timeout` object), so calling `.unref()` on it throws `TypeError: cleanupTimer.unref is not a function`
- This crash happens during `createApp()` initialization in `rateLimiter()`, causing **every** HTTP fetch request to return 500
- Cron jobs were unaffected because the `scheduled` handler doesn't call `createApp()`
- Fix: guard `.unref()` with a capability check

## Test plan
- [x] `bun run check` passes (768 tests, type checks)
- [ ] Deploy to CF Workers and verify `/api/health`, `/api/auth/get-session`, and login work

🤖 Generated with [Claude Code](https://claude.com/claude-code)