### PR TITLE
fix: wire up CF Workers job processing for episode sync

### DIFF
--- a/server/jobs/processor.test.ts
+++ b/server/jobs/processor.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, beforeEach, afterAll, spyOn } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { getDb, jobs } from "../db/schema";
+import { eq } from "drizzle-orm";
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+import * as syncTitlesModule from "../tmdb/sync-titles";
+const mockFetchNewReleases = spyOn(syncTitlesModule, "fetchNewReleases").mockResolvedValue([]);
+
+import * as repository from "../db/repository";
+const mockUpsertTitles = spyOn(repository, "upsertTitles").mockResolvedValue(0);
+const mockDeleteExpiredSessions = spyOn(repository, "deleteExpiredSessions").mockResolvedValue();
+
+import * as syncModule from "../tmdb/sync";
+const mockSyncEpisodes = spyOn(syncModule, "syncEpisodes").mockResolvedValue({ synced: 0, shows: 0 });
+const mockSyncEpisodesForShow = spyOn(syncModule, "syncEpisodesForShow").mockResolvedValue(0);
+
+import { CONFIG } from "../config";
+
+import { processPendingJobs, enqueueCronJob, cleanupOldJobs } from "./processor";
+
+// ─── Setup ───────────────────────────────────────────────────────────────────
+
+const originalApiKey = CONFIG.TMDB_API_KEY;
+
+beforeEach(() => {
+  setupTestDb();
+  CONFIG.TMDB_API_KEY = "test-key";
+  mockFetchNewReleases.mockClear();
+  mockUpsertTitles.mockClear();
+  mockSyncEpisodes.mockClear();
+  mockSyncEpisodesForShow.mockClear();
+  mockDeleteExpiredSessions.mockClear();
+});
+
+afterAll(() => {
+  teardownTestDb();
+  CONFIG.TMDB_API_KEY = originalApiKey;
+  mockFetchNewReleases.mockRestore();
+  mockUpsertTitles.mockRestore();
+  mockSyncEpisodes.mockRestore();
+  mockSyncEpisodesForShow.mockRestore();
+  mockDeleteExpiredSessions.mockRestore();
+});
+
+async function insertJob(name: string, data?: Record<string, unknown>, status = "pending") {
+  const db = getDb();
+  await db.insert(jobs).values({
+    name,
+    data: data ? JSON.stringify(data) : null,
+    status,
+    runAt: new Date().toISOString(),
+  });
+}
+
+async function getJobById(id: number) {
+  const db = getDb();
+  return db.select().from(jobs).where(eq(jobs.id, id)).get();
+}
+
+async function getAllJobs() {
+  const db = getDb();
+  return db.select().from(jobs).all();
+}
+
+// ─── processPendingJobs ──────────────────────────────────────────────────────
+
+describe("processPendingJobs", () => {
+  it("returns 0 when no pending jobs exist", async () => {
+    const count = await processPendingJobs();
+    expect(count).toBe(0);
+  });
+
+  it("processes sync-titles job", async () => {
+    mockFetchNewReleases.mockResolvedValueOnce([{ id: "movie-1" }] as any[]);
+    mockUpsertTitles.mockResolvedValueOnce(1);
+
+    await insertJob("sync-titles");
+    const count = await processPendingJobs();
+
+    expect(count).toBe(1);
+    expect(mockFetchNewReleases).toHaveBeenCalledTimes(1);
+    expect(mockUpsertTitles).toHaveBeenCalledTimes(1);
+
+    const allJobs = await getAllJobs();
+    expect(allJobs[0].status).toBe("completed");
+  });
+
+  it("processes sync-episodes job", async () => {
+    mockSyncEpisodes.mockResolvedValueOnce({ synced: 10, shows: 3 });
+
+    await insertJob("sync-episodes");
+    const count = await processPendingJobs();
+
+    expect(count).toBe(1);
+    expect(mockSyncEpisodes).toHaveBeenCalledTimes(1);
+  });
+
+  it("processes sync-show-episodes job with data", async () => {
+    mockSyncEpisodesForShow.mockResolvedValueOnce(8);
+
+    await insertJob("sync-show-episodes", {
+      titleId: "tv-95557",
+      tmdbId: "95557",
+      title: "Invincible",
+    });
+    const count = await processPendingJobs();
+
+    expect(count).toBe(1);
+    expect(mockSyncEpisodesForShow).toHaveBeenCalledWith("tv-95557", "95557", "Invincible");
+
+    const allJobs = await getAllJobs();
+    expect(allJobs[0].status).toBe("completed");
+  });
+
+  it("fails sync-show-episodes job when data is missing", async () => {
+    await insertJob("sync-show-episodes", { titleId: "tv-123" });
+    const count = await processPendingJobs();
+
+    expect(count).toBe(0);
+    const allJobs = await getAllJobs();
+    // Should be re-queued for retry (attempts < maxAttempts)
+    expect(allJobs[0].status).toBe("pending");
+    expect(allJobs[0].error).toContain("missing required data fields");
+  });
+
+  it("skips jobs not yet ready to run", async () => {
+    const db = getDb();
+    await db.insert(jobs).values({
+      name: "sync-titles",
+      status: "pending",
+      runAt: new Date(Date.now() + 60_000).toISOString(), // 1 minute in future
+    });
+
+    const count = await processPendingJobs();
+    expect(count).toBe(0);
+    expect(mockFetchNewReleases).not.toHaveBeenCalled();
+  });
+
+  it("skips already completed jobs", async () => {
+    await insertJob("sync-titles", undefined, "completed");
+    const count = await processPendingJobs();
+
+    expect(count).toBe(0);
+    expect(mockFetchNewReleases).not.toHaveBeenCalled();
+  });
+
+  it("retries failed jobs with exponential backoff", async () => {
+    mockFetchNewReleases.mockRejectedValueOnce(new Error("TMDB timeout"));
+
+    await insertJob("sync-titles");
+    await processPendingJobs();
+
+    const allJobs = await getAllJobs();
+    expect(allJobs[0].status).toBe("pending"); // Re-queued for retry
+    expect(allJobs[0].error).toBe("TMDB timeout");
+    expect(allJobs[0].attempts).toBe(1);
+    // run_at should be in the future (backoff)
+    expect(new Date(allJobs[0].runAt).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("marks job as permanently failed after max attempts", async () => {
+    mockFetchNewReleases.mockRejectedValueOnce(new Error("TMDB timeout"));
+
+    const db = getDb();
+    await db.insert(jobs).values({
+      name: "sync-titles",
+      status: "pending",
+      attempts: 2, // Already tried twice
+      maxAttempts: 3,
+      runAt: new Date().toISOString(),
+    });
+
+    await processPendingJobs();
+
+    const allJobs = await getAllJobs();
+    expect(allJobs[0].status).toBe("failed");
+    expect(allJobs[0].completedAt).not.toBeNull();
+  });
+
+  it("marks unknown job types as failed", async () => {
+    await insertJob("unknown-job-type");
+    await processPendingJobs();
+
+    const allJobs = await getAllJobs();
+    expect(allJobs[0].status).toBe("failed");
+    expect(allJobs[0].error).toContain("Unknown job type");
+  });
+
+  it("processes multiple jobs in order", async () => {
+    mockFetchNewReleases.mockResolvedValue([]);
+    mockUpsertTitles.mockResolvedValue(0);
+    mockSyncEpisodes.mockResolvedValue({ synced: 0, shows: 0 });
+
+    await insertJob("sync-titles");
+    await insertJob("sync-episodes");
+
+    const count = await processPendingJobs();
+    expect(count).toBe(2);
+    expect(mockFetchNewReleases).toHaveBeenCalledTimes(1);
+    expect(mockSyncEpisodes).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips episode sync when TMDB_API_KEY is not set", async () => {
+    CONFIG.TMDB_API_KEY = "";
+
+    await insertJob("sync-episodes");
+    const count = await processPendingJobs();
+
+    expect(count).toBe(1); // Still completes, just skips the actual sync
+    expect(mockSyncEpisodes).not.toHaveBeenCalled();
+  });
+});
+
+// ─── enqueueCronJob ──────────────────────────────────────────────────────────
+
+describe("enqueueCronJob", () => {
+  it("enqueues a job when none is pending", async () => {
+    await enqueueCronJob("sync-titles");
+
+    const allJobs = await getAllJobs();
+    expect(allJobs.length).toBe(1);
+    expect(allJobs[0].name).toBe("sync-titles");
+    expect(allJobs[0].status).toBe("pending");
+  });
+
+  it("does not enqueue duplicate when job is already pending", async () => {
+    await insertJob("sync-titles");
+    await enqueueCronJob("sync-titles");
+
+    const allJobs = await getAllJobs();
+    expect(allJobs.length).toBe(1);
+  });
+
+  it("does not enqueue duplicate when job is running", async () => {
+    await insertJob("sync-titles", undefined, "running");
+    await enqueueCronJob("sync-titles");
+
+    const allJobs = await getAllJobs();
+    expect(allJobs.length).toBe(1);
+  });
+
+  it("enqueues when previous job is completed", async () => {
+    await insertJob("sync-titles", undefined, "completed");
+    await enqueueCronJob("sync-titles");
+
+    const allJobs = await getAllJobs();
+    expect(allJobs.length).toBe(2);
+  });
+});
+
+// ─── cleanupOldJobs ──────────────────────────────────────────────────────────
+
+describe("cleanupOldJobs", () => {
+  it("removes old completed jobs", async () => {
+    const db = getDb();
+    const oldDate = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000).toISOString();
+    await db.insert(jobs).values({
+      name: "sync-titles",
+      status: "completed",
+      completedAt: oldDate,
+      runAt: oldDate,
+    });
+
+    await cleanupOldJobs(30);
+
+    const allJobs = await getAllJobs();
+    expect(allJobs.length).toBe(0);
+  });
+
+  it("keeps recent completed jobs", async () => {
+    const db = getDb();
+    const recentDate = new Date().toISOString();
+    await db.insert(jobs).values({
+      name: "sync-titles",
+      status: "completed",
+      completedAt: recentDate,
+      runAt: recentDate,
+    });
+
+    await cleanupOldJobs(30);
+
+    const allJobs = await getAllJobs();
+    expect(allJobs.length).toBe(1);
+  });
+});

--- a/server/jobs/processor.ts
+++ b/server/jobs/processor.ts
@@ -1,0 +1,267 @@
+/**
+ * Portable job processor that uses Drizzle ORM (no bun:sqlite dependency).
+ *
+ * Used by the CF Workers scheduled handler to claim and execute pending jobs
+ * from the `jobs` table. The Bun server uses its own polling worker instead.
+ */
+import { eq, and, lte, asc, sql, inArray } from "drizzle-orm";
+import { getDb, jobs } from "../db/schema";
+import { CONFIG } from "../config";
+import { logger } from "../logger";
+import { upsertTitles, deleteExpiredSessions } from "../db/repository";
+import {
+  getDueNotifiers,
+  getDistinctNotifierTimezones,
+  markNotifierSent,
+  disableNotifier,
+} from "../db/repository";
+import { fetchNewReleases } from "../tmdb/sync-titles";
+import { syncEpisodes, syncEpisodesForShow } from "../tmdb/sync";
+import { getProvider } from "../notifications/registry";
+import { buildNotificationContent } from "../notifications/content";
+import { SubscriptionExpiredError } from "../notifications/webpush";
+
+const log = logger.child({ module: "job-processor" });
+
+// ─── Job Handlers ──────────────────────────────────────────────────────────
+
+async function handleSyncTitles(): Promise<void> {
+  const titles = await fetchNewReleases({ daysBack: CONFIG.DEFAULT_DAYS_BACK });
+  const count = await upsertTitles(titles);
+  log.info("Synced titles from TMDB", { count });
+}
+
+async function handleSyncEpisodes(): Promise<void> {
+  if (!CONFIG.TMDB_API_KEY) {
+    log.info("Skipping episode sync", { reason: "TMDB_API_KEY not configured" });
+    return;
+  }
+  const result = await syncEpisodes();
+  log.info("Synced episodes", { synced: result.synced, shows: result.shows });
+}
+
+async function handleSyncShowEpisodes(data: string | null): Promise<void> {
+  if (!CONFIG.TMDB_API_KEY) {
+    log.info("Skipping show episode sync", { reason: "TMDB_API_KEY not configured" });
+    return;
+  }
+  const parsed = data ? JSON.parse(data) : null;
+  if (!parsed?.titleId || !parsed?.tmdbId || !parsed?.title) {
+    throw new Error("sync-show-episodes job missing required data fields");
+  }
+  const count = await syncEpisodesForShow(parsed.titleId, parsed.tmdbId, parsed.title);
+  log.info("Synced show episodes via job", { title: parsed.title, episodes: count });
+}
+
+function getCurrentTimeInTimezone(tz: string): { time: string; date: string } {
+  const now = new Date();
+  const timeFormatter = new Intl.DateTimeFormat("en-GB", {
+    timeZone: tz,
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  const dateFormatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  return {
+    time: timeFormatter.format(now),
+    date: dateFormatter.format(now),
+  };
+}
+
+async function handleSendNotifications(): Promise<void> {
+  const timezones = await getDistinctNotifierTimezones();
+  if (timezones.length === 0) return;
+
+  const timesByTimezone = new Map<string, { time: string; date: string }>();
+  for (const tz of timezones) {
+    try {
+      timesByTimezone.set(tz, getCurrentTimeInTimezone(tz));
+    } catch {
+      log.warn("Invalid timezone", { timezone: tz });
+    }
+  }
+
+  const dueNotifiers = await getDueNotifiers(timesByTimezone);
+  if (dueNotifiers.length === 0) return;
+
+  log.info("Processing due notifiers", { count: dueNotifiers.length });
+
+  for (const notifier of dueNotifiers) {
+    try {
+      const provider = getProvider(notifier.provider);
+      if (!provider) {
+        log.warn("Unknown provider", { provider: notifier.provider, notifierId: notifier.id });
+        continue;
+      }
+
+      const content = await buildNotificationContent(notifier.user_id, notifier.todayDate);
+
+      if (content.episodes.length === 0 && content.movies.length === 0) {
+        await markNotifierSent(notifier.id, notifier.todayDate);
+        continue;
+      }
+
+      await provider.send(notifier.config, content);
+      await markNotifierSent(notifier.id, notifier.todayDate);
+      log.info("Sent notification", { provider: notifier.provider, userId: notifier.user_id });
+    } catch (err) {
+      if (err instanceof SubscriptionExpiredError) {
+        log.warn("Push subscription expired, disabling notifier", { notifierId: notifier.id });
+        await disableNotifier(notifier.id);
+        continue;
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      log.error("Failed to send notification", {
+        provider: notifier.provider,
+        notifierId: notifier.id,
+        error: message,
+      });
+    }
+  }
+}
+
+// ─── Job Dispatcher ────────────────────────────────────────────────────────
+
+const handlers: Record<string, (data: string | null) => Promise<void>> = {
+  "sync-titles": () => handleSyncTitles(),
+  "sync-episodes": () => handleSyncEpisodes(),
+  "sync-show-episodes": (data) => handleSyncShowEpisodes(data),
+  "send-notifications": () => handleSendNotifications(),
+};
+
+interface JobRow {
+  id: number;
+  name: string;
+  data: string | null;
+  status: string;
+  attempts: number;
+  maxAttempts: number;
+}
+
+/**
+ * Process all pending jobs from the `jobs` table.
+ * Each job is claimed (set to running), executed, then marked completed or failed.
+ */
+export async function processPendingJobs(): Promise<number> {
+  const db = getDb();
+  const now = new Date().toISOString();
+
+  const pendingJobs = await db
+    .select()
+    .from(jobs)
+    .where(and(eq(jobs.status, "pending"), lte(jobs.runAt, now)))
+    .orderBy(asc(jobs.runAt))
+    .all();
+
+  if (pendingJobs.length === 0) return 0;
+
+  log.info("Processing pending jobs", { count: pendingJobs.length });
+  let processed = 0;
+
+  for (const job of pendingJobs) {
+    const handler = handlers[job.name];
+    if (!handler) {
+      log.warn("Unknown job type, marking failed", { name: job.name, jobId: job.id });
+      await db
+        .update(jobs)
+        .set({ status: "failed", error: `Unknown job type: ${job.name}`, completedAt: now })
+        .where(eq(jobs.id, job.id));
+      continue;
+    }
+
+    // Claim the job
+    await db
+      .update(jobs)
+      .set({ status: "running", startedAt: now, attempts: job.attempts + 1 })
+      .where(eq(jobs.id, job.id));
+
+    try {
+      await handler(job.data);
+      await db
+        .update(jobs)
+        .set({ status: "completed", completedAt: new Date().toISOString() })
+        .where(eq(jobs.id, job.id));
+      log.info("Completed job", { name: job.name, jobId: job.id });
+      processed++;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const newAttempts = job.attempts + 1;
+
+      if (newAttempts < job.maxAttempts) {
+        // Re-queue with exponential backoff: 2^attempts * 30 seconds
+        const delaySec = Math.pow(2, newAttempts) * 30;
+        const retryAt = new Date(Date.now() + delaySec * 1000).toISOString();
+        await db
+          .update(jobs)
+          .set({ status: "pending", error: message, runAt: retryAt })
+          .where(eq(jobs.id, job.id));
+        log.warn("Job failed, will retry", {
+          name: job.name,
+          jobId: job.id,
+          attempt: newAttempts,
+          maxAttempts: job.maxAttempts,
+          retryAt,
+          error: message,
+        });
+      } else {
+        await db
+          .update(jobs)
+          .set({ status: "failed", error: message, completedAt: new Date().toISOString() })
+          .where(eq(jobs.id, job.id));
+        log.error("Job failed permanently", {
+          name: job.name,
+          jobId: job.id,
+          attempts: newAttempts,
+          error: message,
+        });
+      }
+    }
+  }
+
+  return processed;
+}
+
+/**
+ * Enqueue a cron-triggered job if one isn't already pending for that name.
+ */
+export async function enqueueCronJob(name: string): Promise<void> {
+  const db = getDb();
+  const existing = await db
+    .select({ id: jobs.id })
+    .from(jobs)
+    .where(and(eq(jobs.name, name), inArray(jobs.status, ["pending", "running"])))
+    .get();
+
+  if (existing) {
+    log.debug("Cron job already pending/running, skipping", { name });
+    return;
+  }
+
+  await db.insert(jobs).values({
+    name,
+    runAt: new Date().toISOString(),
+  });
+  log.info("Enqueued cron job", { name });
+}
+
+/**
+ * Clean up old completed/failed jobs.
+ */
+export async function cleanupOldJobs(retentionDays: number = 30): Promise<number> {
+  const db = getDb();
+  const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000).toISOString();
+  const result = await db
+    .delete(jobs)
+    .where(
+      and(
+        inArray(jobs.status, ["completed", "failed"]),
+        lte(jobs.completedAt, cutoff)
+      )
+    );
+  return result.rowsAffected ?? 0;
+}

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -57,6 +57,7 @@ import { logger, requestLogger, resetLogLevel } from "./logger";
 import { patchConfig } from "./config";
 import Sentry from "./sentry";
 import { CloudflarePlatform } from "./platform/cloudflare";
+import { processPendingJobs, enqueueCronJob, cleanupOldJobs } from "./jobs/processor";
 import { createAuth } from "./auth/better-auth";
 import { migrateAuthData } from "./db/migrate-auth";
 import type { DrizzleDb } from "./platform/types";
@@ -327,7 +328,20 @@ export default {
       const db = drizzle(env.DB, { schema: schemaExports }) as unknown as DrizzleDb;
       const honoApp = getApp(env);
 
-      return await runWithDb(db, () => honoApp.fetch(request, env, ctx as any));
+      const response = await runWithDb(db, () => honoApp.fetch(request, env, ctx as any));
+
+      // Process pending jobs in the background after each request.
+      // This ensures ad-hoc jobs (e.g. sync-show-episodes queued on track)
+      // are picked up promptly without waiting for the next cron trigger.
+      ctx.waitUntil(
+        runWithDb(db, () => processPendingJobs()).catch((err) => {
+          logger.error("Background job processing error", {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        })
+      );
+
+      return response;
     } catch (err) {
       Sentry.captureException(err);
       logger.error("Worker fetch error", {
@@ -352,23 +366,32 @@ export default {
         const cron = event.cron;
         logger.info("Scheduled event", { cron });
 
+        // Map cron triggers to job names and enqueue if not already pending
         switch (cron) {
           case "0 3 * * *":
-            logger.info("Running sync-titles cron");
+            await enqueueCronJob("sync-titles");
             break;
           case "30 3 * * *":
-            logger.info("Running sync-episodes cron");
+            await enqueueCronJob("sync-episodes");
             break;
           case "*/5 * * * *":
-            logger.info("Running send-notifications cron");
+            await enqueueCronJob("send-notifications");
             break;
           case "0 0 * * *":
             await deleteExpiredSessions();
+            await cleanupOldJobs(30);
             logger.info("Cleanup complete");
             break;
         }
+
+        // Process all pending jobs (cron-triggered + ad-hoc like sync-show-episodes)
+        const processed = await processPendingJobs();
+        if (processed > 0) {
+          logger.info("Processed jobs", { count: processed, cron });
+        }
       });
     } catch (err) {
+      Sentry.captureException(err);
       logger.error("Worker scheduled error", {
         cron: event.cron,
         error: err instanceof Error ? err.message : String(err),


### PR DESCRIPTION
## Summary
- The CF Workers `scheduled` handler was a **stub** — cron triggers only logged messages without processing any jobs from the `jobs` table
- Episode sync jobs enqueued when users tracked shows (`sync-show-episodes`) were never executed, leaving the `episodes` table empty and the **calendar/upcoming pages permanently blank**
- Adds `server/jobs/processor.ts`: a portable job processor using Drizzle ORM (no `bun:sqlite` dependency) that claims, executes, and completes/fails pending jobs with exponential backoff retry
- Wires the `scheduled` handler to enqueue cron jobs and process all pending jobs
- Also processes pending jobs in the background after each `fetch` request via `ctx.waitUntil()` so ad-hoc jobs are picked up immediately (not waiting up to 5 min for the next cron)

## Root Cause
Verified via D1 production database query: **7 `sync-show-episodes` jobs stuck in `pending` status** with `attempts: 0`, `started_at: null` — some from 24+ hours ago. Zero rows in the `episodes` table despite tracked shows existing.

## Test plan
- [x] `bun run check` passes (788 tests, 0 failures)
- [x] New unit tests for `processPendingJobs`, `enqueueCronJob`, and `cleanupOldJobs`
- [ ] Deploy to CF Workers and verify:
  - Track a show → episode sync job completes within seconds
  - Calendar shows episodes for tracked shows
  - Cron jobs (sync-titles, sync-episodes, notifications) execute on schedule
  - Failed jobs retry with backoff, then mark as permanently failed after 3 attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)