### PR TITLE
fix: show OIDC login button even when session cookie is invalid

### DIFF
--- a/frontend/src/context/AuthContext.test.tsx
+++ b/frontend/src/context/AuthContext.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, mock, afterEach } from "bun:test";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import type { ReactNode } from "react";
+
+// Initialize i18n before anything else
+import "../i18n";
+
+// Track getSession behavior per test
+let mockGetSession: () => Promise<any>;
+
+mock.module("../lib/auth-client", () => ({
+  authClient: {
+    getSession: () => mockGetSession(),
+    signIn: { social: mock(() => {}) },
+    signUp: { email: mock(() => Promise.resolve({})) },
+    signOut: mock(() => Promise.resolve()),
+  },
+}));
+
+// Import after mocks
+const { AuthProvider } = await import("./AuthContext");
+const { default: LoginPage } = await import("../pages/LoginPage");
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <MemoryRouter>
+      <AuthProvider>{children}</AuthProvider>
+    </MemoryRouter>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AuthContext", () => {
+  it("loads providers even when getSession rejects", async () => {
+    // Simulate invalid session (e.g. BETTER_AUTH_SECRET changed)
+    mockGetSession = () => Promise.reject(new Error("Invalid session signature"));
+
+    // Mock fetch for providers endpoint
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock((url: string) => {
+      if (typeof url === "string" && url.includes("/api/auth/custom/providers")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              local: true,
+              oidc: { name: "PocketID", providerId: "pocketid" },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } }
+          )
+        );
+      }
+      return originalFetch(url);
+    }) as typeof fetch;
+
+    try {
+      render(<LoginPage />, { wrapper: Wrapper });
+
+      // The OIDC button should appear even though session check failed
+      await waitFor(() => {
+        expect(screen.getByText(/PocketID/)).toBeDefined();
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("sets user when session is valid", async () => {
+    mockGetSession = () =>
+      Promise.resolve({
+        data: {
+          user: {
+            id: "u1",
+            name: "Test User",
+            username: "testuser",
+            role: "admin",
+          },
+        },
+      });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock((url: string) => {
+      if (typeof url === "string" && url.includes("/api/auth/custom/providers")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ local: true, oidc: null }),
+            { status: 200, headers: { "Content-Type": "application/json" } }
+          )
+        );
+      }
+      return originalFetch(url);
+    }) as typeof fetch;
+
+    try {
+      render(<LoginPage />, { wrapper: Wrapper });
+
+      // With a valid session and no OIDC, local login form should render
+      await waitFor(() => {
+        expect(screen.getByLabelText(/username/i)).toBeDefined();
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -67,18 +67,27 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   useEffect(() => {
-    Promise.all([
-      authClient.getSession().then((r) => r.data),
-      fetch("/api/auth/custom/providers").then((r) => r.json()),
-    ])
-      .then(([sessionData, provData]) => {
-        setUser(mapSessionToUser(sessionData));
-        setProviders(provData);
-      })
-      .catch(() => {
+    async function init() {
+      try {
+        const [sessionResult, provData] = await Promise.allSettled([
+          authClient.getSession().then((r) => r.data),
+          fetch("/api/auth/custom/providers").then((r) => r.json()),
+        ]);
+        setUser(
+          sessionResult.status === "fulfilled"
+            ? mapSessionToUser(sessionResult.value)
+            : null
+        );
+        if (provData.status === "fulfilled") {
+          setProviders(provData.value);
+        }
+      } catch {
         setUser(null);
-      })
-      .finally(() => setLoading(false));
+      } finally {
+        setLoading(false);
+      }
+    }
+    init();
   }, []);
 
   // Listen for 401 events from api.ts


### PR DESCRIPTION
## Summary
- **Bug:** When `BETTER_AUTH_SECRET` is set or changed, existing session cookies become invalid. `authClient.getSession()` rejects, and since it was coupled with the providers fetch via `Promise.all`, the entire init failed — leaving `providers` as `null` and hiding the OIDC login button.
- **Fix:** Switch from `Promise.all` to `Promise.allSettled` in `AuthContext.tsx` so the session check and providers fetch resolve independently. A failed session no longer prevents the OIDC button from appearing.
- **Test:** Added `AuthContext.test.tsx` verifying the OIDC button renders even when `getSession()` rejects.

## Test plan
- [x] `bun run check` passes (type checks + 790 tests, 0 failures)
- [ ] Manual: change `BETTER_AUTH_SECRET`, restart, verify OIDC button appears on login page
- [ ] Manual: verify normal login flow (both local and OIDC) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)