### PR TITLE
Sync episodes on watchlist import and restore watched state

### DIFF
--- a/server/jobs/sync.test.ts
+++ b/server/jobs/sync.test.ts
@@ -20,9 +20,14 @@ const mockFetchNewReleases = spyOn(syncTitlesModule, "fetchNewReleases").mockRes
 import * as repository from "../db/repository";
 const mockUpsertTitles = spyOn(repository, "upsertTitles").mockResolvedValue(0);
 
-// Mock tmdb/sync syncEpisodes — use spyOn
+// Mock tmdb/sync syncEpisodes and syncEpisodesForShow — use spyOn
 import * as syncModule from "../tmdb/sync";
 const mockSyncEpisodes = spyOn(syncModule, "syncEpisodes").mockResolvedValue({ synced: 0, shows: 0 });
+const mockSyncEpisodesForShow = spyOn(syncModule, "syncEpisodesForShow").mockResolvedValue(0);
+
+// Mock episode repository functions for watched episode restoration
+const mockGetEpisodeIdsBySE = spyOn(repository, "getEpisodeIdsBySE").mockResolvedValue([]);
+const mockWatchEpisodesBulk = spyOn(repository, "watchEpisodesBulk").mockResolvedValue(undefined);
 
 // Mock migrate-titles — use spyOn
 import * as migrateTitlesModule from "./migrate-titles";
@@ -40,6 +45,9 @@ beforeEach(() => {
   mockFetchNewReleases.mockClear();
   mockUpsertTitles.mockClear();
   mockSyncEpisodes.mockClear();
+  mockSyncEpisodesForShow.mockClear();
+  mockGetEpisodeIdsBySE.mockClear();
+  mockWatchEpisodesBulk.mockClear();
   mockMigrateTitles.mockClear();
   captureExceptionSpy.mockClear();
 });
@@ -51,6 +59,9 @@ afterAll(() => {
   mockFetchNewReleases.mockRestore();
   mockUpsertTitles.mockRestore();
   mockSyncEpisodes.mockRestore();
+  mockSyncEpisodesForShow.mockRestore();
+  mockGetEpisodeIdsBySE.mockRestore();
+  mockWatchEpisodesBulk.mockRestore();
   mockMigrateTitles.mockRestore();
 });
 
@@ -214,5 +225,88 @@ describe("migrate-titles handler", () => {
     await processJobs();
 
     expect(captureExceptionSpy).toHaveBeenCalledWith(error);
+  });
+});
+
+// ─── sync-show-episodes handler ─────────────────────────────────────────────
+
+describe("sync-show-episodes handler", () => {
+  const originalApiKey = CONFIG.TMDB_API_KEY;
+
+  beforeEach(() => {
+    registerSyncJobs();
+    claimNextJob("migrate-titles");
+    CONFIG.TMDB_API_KEY = "test-api-key";
+  });
+
+  afterAll(() => {
+    CONFIG.TMDB_API_KEY = originalApiKey;
+  });
+
+  it("restores watched episodes after syncing when watchedEpisodes and userId are in job data", async () => {
+    mockSyncEpisodesForShow.mockResolvedValueOnce(10);
+    mockGetEpisodeIdsBySE.mockResolvedValueOnce([1, 2, 3]);
+
+    enqueueJob("sync-show-episodes", {
+      titleId: "tv-100",
+      tmdbId: "100",
+      title: "Test Show",
+      watchedEpisodes: [{ season: 1, episode: 1 }, { season: 1, episode: 2 }, { season: 1, episode: 3 }],
+      userId: "user-abc",
+    });
+    await processJobs();
+
+    expect(mockSyncEpisodesForShow).toHaveBeenCalledWith("tv-100", "100", "Test Show");
+    expect(mockGetEpisodeIdsBySE).toHaveBeenCalledWith("tv-100", [
+      { season: 1, episode: 1 },
+      { season: 1, episode: 2 },
+      { season: 1, episode: 3 },
+    ]);
+    expect(mockWatchEpisodesBulk).toHaveBeenCalledWith([1, 2, 3], "user-abc");
+  });
+
+  it("does not attempt watched restoration when watchedEpisodes is not in job data", async () => {
+    mockSyncEpisodesForShow.mockResolvedValueOnce(5);
+
+    enqueueJob("sync-show-episodes", {
+      titleId: "tv-200",
+      tmdbId: "200",
+      title: "Another Show",
+    });
+    await processJobs();
+
+    expect(mockSyncEpisodesForShow).toHaveBeenCalledWith("tv-200", "200", "Another Show");
+    expect(mockGetEpisodeIdsBySE).not.toHaveBeenCalled();
+    expect(mockWatchEpisodesBulk).not.toHaveBeenCalled();
+  });
+
+  it("does not call watchEpisodesBulk when no episode IDs are resolved", async () => {
+    mockSyncEpisodesForShow.mockResolvedValueOnce(10);
+    mockGetEpisodeIdsBySE.mockResolvedValueOnce([]);
+
+    enqueueJob("sync-show-episodes", {
+      titleId: "tv-300",
+      tmdbId: "300",
+      title: "No Match Show",
+      watchedEpisodes: [{ season: 99, episode: 99 }],
+      userId: "user-xyz",
+    });
+    await processJobs();
+
+    expect(mockGetEpisodeIdsBySE).toHaveBeenCalled();
+    expect(mockWatchEpisodesBulk).not.toHaveBeenCalled();
+  });
+
+  it("skips sync when TMDB_API_KEY is not set", async () => {
+    CONFIG.TMDB_API_KEY = "";
+
+    enqueueJob("sync-show-episodes", {
+      titleId: "tv-400",
+      tmdbId: "400",
+      title: "Skip Show",
+    });
+    await processJobs();
+
+    expect(mockSyncEpisodesForShow).not.toHaveBeenCalled();
   });
 });

--- a/server/jobs/sync.ts
+++ b/server/jobs/sync.ts
@@ -5,7 +5,7 @@ const log = logger.child({ module: "sync" });
 import { registerCron, enqueueJob } from "./queue";
 import { CONFIG } from "../config";
 import { fetchNewReleases } from "../tmdb/sync-titles";
-import { upsertTitles } from "../db/repository";
+import { upsertTitles, getEpisodeIdsBySE, watchEpisodesBulk } from "../db/repository";
 import { syncEpisodes, syncEpisodesForShow } from "../tmdb/sync";
 import { migrateTitles } from "./migrate-titles";
 
@@ -38,6 +38,19 @@ export function registerSyncJobs() {
     }
     const count = await syncEpisodesForShow(data.titleId, data.tmdbId, data.title);
     log.info("Synced show episodes via job", { title: data.title, episodes: count });
+
+    // Restore watched episodes if provided (from watchlist import)
+    if (Array.isArray(data.watchedEpisodes) && data.watchedEpisodes.length > 0 && data.userId) {
+      const episodeIds = await getEpisodeIdsBySE(data.titleId, data.watchedEpisodes);
+      if (episodeIds.length > 0) {
+        await watchEpisodesBulk(episodeIds, data.userId);
+        log.info("Restored watched episodes from import", {
+          title: data.title,
+          watched: episodeIds.length,
+          requested: data.watchedEpisodes.length,
+        });
+      }
+    }
   });
 
   registerHandler("migrate-titles", async () => {

--- a/server/routes/track.test.ts
+++ b/server/routes/track.test.ts
@@ -301,4 +301,145 @@ describe("POST /track/import", () => {
     });
     expect(res.status).toBe(401);
   });
+
+  it("enqueues sync-show-episodes job for SHOW titles with tmdb_id and watched_episodes", async () => {
+    const originalKey = CONFIG.TMDB_API_KEY;
+    CONFIG.TMDB_API_KEY = "test-key";
+
+    const exportData = {
+      version: 1,
+      exported_at: "2026-01-01T00:00:00Z",
+      titles: [
+        {
+          id: "tv-999",
+          tmdb_id: "999",
+          object_type: "SHOW",
+          title: "Test Show",
+          genres: [],
+          watched_episodes: [{ season: 1, episode: 1 }, { season: 1, episode: 2 }],
+        },
+      ],
+    };
+
+    const res = await app.request("/track/import", {
+      method: "POST",
+      headers: { ...headers(), "Content-Type": "application/json" },
+      body: JSON.stringify(exportData),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.imported).toBe(1);
+
+    const db = getRawDb();
+    const job = db.prepare("SELECT * FROM jobs WHERE name = 'sync-show-episodes' AND json_extract(data, '$.titleId') = 'tv-999' LIMIT 1").get() as any;
+    expect(job).toBeTruthy();
+    const jobData = JSON.parse(job.data);
+    expect(jobData).toMatchObject({ titleId: "tv-999", tmdbId: "999", title: "Test Show" });
+    expect(jobData.watchedEpisodes).toEqual([{ season: 1, episode: 1 }, { season: 1, episode: 2 }]);
+    expect(jobData.userId).toBeTruthy();
+
+    CONFIG.TMDB_API_KEY = originalKey;
+  });
+
+  it("enqueues sync-show-episodes job without watchedEpisodes when show has no watched data", async () => {
+    const originalKey = CONFIG.TMDB_API_KEY;
+    CONFIG.TMDB_API_KEY = "test-key";
+
+    const exportData = {
+      version: 1,
+      exported_at: "2026-01-01T00:00:00Z",
+      titles: [
+        {
+          id: "tv-888",
+          tmdb_id: "888",
+          object_type: "SHOW",
+          title: "Unwatched Show",
+          genres: [],
+          watched_episodes: [],
+        },
+      ],
+    };
+
+    const res = await app.request("/track/import", {
+      method: "POST",
+      headers: { ...headers(), "Content-Type": "application/json" },
+      body: JSON.stringify(exportData),
+    });
+    expect(res.status).toBe(200);
+
+    const db = getRawDb();
+    const job = db.prepare("SELECT * FROM jobs WHERE name = 'sync-show-episodes' AND json_extract(data, '$.titleId') = 'tv-888' LIMIT 1").get() as any;
+    expect(job).toBeTruthy();
+    const jobData = JSON.parse(job.data);
+    expect(jobData.watchedEpisodes).toBeUndefined();
+    expect(jobData.userId).toBeUndefined();
+
+    CONFIG.TMDB_API_KEY = originalKey;
+  });
+
+  it("does not enqueue sync-show-episodes when TMDB_API_KEY is not set", async () => {
+    const originalKey = CONFIG.TMDB_API_KEY;
+    CONFIG.TMDB_API_KEY = "";
+
+    const exportData = {
+      version: 1,
+      exported_at: "2026-01-01T00:00:00Z",
+      titles: [
+        {
+          id: "tv-777",
+          tmdb_id: "777",
+          object_type: "SHOW",
+          title: "No Key Show",
+          genres: [],
+          watched_episodes: [],
+        },
+      ],
+    };
+
+    const res = await app.request("/track/import", {
+      method: "POST",
+      headers: { ...headers(), "Content-Type": "application/json" },
+      body: JSON.stringify(exportData),
+    });
+    expect(res.status).toBe(200);
+
+    const db = getRawDb();
+    const job = db.prepare("SELECT * FROM jobs WHERE name = 'sync-show-episodes' AND json_extract(data, '$.titleId') = 'tv-777' LIMIT 1").get();
+    expect(job).toBeNull();
+
+    CONFIG.TMDB_API_KEY = originalKey;
+  });
+
+  it("does not enqueue sync-show-episodes for MOVIE titles", async () => {
+    const originalKey = CONFIG.TMDB_API_KEY;
+    CONFIG.TMDB_API_KEY = "test-key";
+
+    const exportData = {
+      version: 1,
+      exported_at: "2026-01-01T00:00:00Z",
+      titles: [
+        {
+          id: "movie-555",
+          tmdb_id: "555",
+          object_type: "MOVIE",
+          title: "Test Movie",
+          genres: [],
+          watched_episodes: [],
+        },
+      ],
+    };
+
+    const res = await app.request("/track/import", {
+      method: "POST",
+      headers: { ...headers(), "Content-Type": "application/json" },
+      body: JSON.stringify(exportData),
+    });
+    expect(res.status).toBe(200);
+
+    const db = getRawDb();
+    const job = db.prepare("SELECT * FROM jobs WHERE name = 'sync-show-episodes' AND json_extract(data, '$.titleId') = 'movie-555' LIMIT 1").get();
+    expect(job).toBeNull();
+
+    CONFIG.TMDB_API_KEY = originalKey;
+  });
 });

--- a/server/routes/track.ts
+++ b/server/routes/track.ts
@@ -182,7 +182,21 @@ app.post("/import", async (c) => {
 
       await trackTitle(item.id, user.id, item.notes ?? undefined);
 
-      if (Array.isArray(item.watched_episodes) && item.watched_episodes.length > 0) {
+      const hasWatched = Array.isArray(item.watched_episodes) && item.watched_episodes.length > 0;
+      const canSyncEpisodes = item.object_type === "SHOW" && item.tmdb_id && CONFIG.TMDB_API_KEY;
+
+      if (canSyncEpisodes) {
+        const jobData: Record<string, unknown> = {
+          titleId: item.id,
+          tmdbId: item.tmdb_id,
+          title: item.title,
+        };
+        if (hasWatched) {
+          jobData.watchedEpisodes = item.watched_episodes;
+          jobData.userId = user.id;
+        }
+        await enqueueJobDrizzle("sync-show-episodes", jobData);
+      } else if (hasWatched) {
         const episodeIds = await getEpisodeIdsBySE(item.id, item.watched_episodes);
         if (episodeIds.length > 0) {
           await watchEpisodesBulk(episodeIds, user.id);


### PR DESCRIPTION
## Summary

- When importing a watchlist, SHOW titles now enqueue `sync-show-episodes` jobs to fetch episodes from TMDB (matching the behavior of the single-track endpoint)
- The `sync-show-episodes` job handler is extended to accept optional `watchedEpisodes`/`userId` data, restoring watched episode state after the sync completes
- This eliminates the need to import a watchlist twice — episodes are synced and watched state is restored in one pass

## Test plan

- [x] Server type check passes
- [x] Frontend type check passes
- [x] All 569 server tests pass (8 new tests added across `track.test.ts` and `sync.test.ts`)
- [ ] Manual: export watchlist with tracked shows, untrack them, re-import → shows get tracked, episodes sync via jobs, watched episodes restored

https://claude.ai/code/session_01F9T799LYzjHj7iwnRjHFd4