### PR TITLE
feat: add watched status for movies

### DIFF
--- a/drizzle/0005_watched_titles.sql
+++ b/drizzle/0005_watched_titles.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS `watched_titles` (
+	`title_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`watched_at` text DEFAULT (datetime('now')),
+	PRIMARY KEY(`title_id`, `user_id`),
+	FOREIGN KEY (`title_id`) REFERENCES `titles`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_watched_titles_user_id` ON `watched_titles` (`user_id`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1774666000000,
       "tag": "0004_add_backdrop_url",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1774752000000,
+      "tag": "0005_watched_titles",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -185,6 +185,16 @@ export async function watchEpisodesBulk(episodeIds: number[], watched: boolean):
   });
 }
 
+// ─── Watched Movies ──────────────────────────────────────────────────────────
+
+export async function watchMovie(titleId: string): Promise<void> {
+  await fetchJson(`/watched/movies/${encodeURIComponent(titleId)}`, { method: "POST" });
+}
+
+export async function unwatchMovie(titleId: string): Promise<void> {
+  await fetchJson(`/watched/movies/${encodeURIComponent(titleId)}`, { method: "DELETE" });
+}
+
 // ─── Details ────────────────────────────────────────────────────────────────
 
 export async function getMovieDetails(titleId: string): Promise<MovieDetailsResponse> {

--- a/frontend/src/components/TitleCard.tsx
+++ b/frontend/src/components/TitleCard.tsx
@@ -41,6 +41,14 @@ const TitleCard = memo(function TitleCard({ title, onTrackToggle }: Props) {
             TV
           </span>
         )}
+        {title.is_watched && (
+          <span className="absolute bottom-2 left-2 bg-emerald-500 text-white text-[10px] font-bold px-1.5 py-0.5 rounded flex items-center gap-0.5">
+            <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clipRule="evenodd" />
+            </svg>
+            Watched
+          </span>
+        )}
         {title.imdb_score && (
           <span className="absolute top-2 right-2 bg-yellow-500 text-black text-[11px] font-bold px-1.5 py-0.5 rounded">
             {title.imdb_score.toFixed(1)}

--- a/frontend/src/pages/TitleDetailPage.tsx
+++ b/frontend/src/pages/TitleDetailPage.tsx
@@ -12,6 +12,7 @@ import type {
   SeasonSummary,
 } from "../types";
 import TrackButton from "../components/TrackButton";
+import { WatchedIcon } from "../components/EpisodeComponents";
 import PersonCard from "../components/PersonCard";
 import { DetailPageSkeleton } from "../components/SkeletonComponents";
 import ExternalLinks from "../components/ExternalLinks";
@@ -196,6 +197,21 @@ export default function TitleDetailPage() {
 
 function MovieDetail({ data }: { data: MovieDetailsResponse }) {
   const { title, tmdb, country } = data;
+  const [watched, setWatched] = useState(title.is_watched ?? false);
+
+  async function toggleWatched() {
+    const prev = watched;
+    setWatched(!prev);
+    try {
+      if (prev) {
+        await api.unwatchMovie(title.id);
+      } else {
+        await api.watchMovie(title.id);
+      }
+    } catch {
+      setWatched(prev);
+    }
+  }
   const overview = tmdb?.overview || title.short_description;
   const genres = tmdb?.genres?.map(g => g.name) || title.genres;
   const certification = title.age_certification;
@@ -290,8 +306,9 @@ function MovieDetail({ data }: { data: MovieDetailsResponse }) {
               <RatingBadge label="TMDB" score={tmdb?.vote_average ?? title.tmdb_score} />
             </div>
 
-            <div className="pt-2">
+            <div className="pt-2 flex items-center gap-3">
               <TrackButton titleId={title.id} isTracked={title.is_tracked} titleData={title} />
+              <WatchedIcon watched={watched} onClick={toggleWatched} />
             </div>
           </div>
         </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -40,6 +40,7 @@ export interface Title {
   imdb_votes: number | null;
   tmdb_score: number | null;
   is_tracked: boolean;
+  is_watched?: boolean;
   offers: Offer[];
   tracked_at?: string;
   notes?: string;
@@ -413,6 +414,7 @@ export function normalizeSearchTitle(t: SearchTitle): Title {
     imdb_votes: t.scores.imdbVotes,
     tmdb_score: t.scores.tmdbScore,
     is_tracked: t.isTracked ?? false,
+    is_watched: false,
     offers: t.offers.map((o, i) => ({
       id: i,
       title_id: t.id,

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -129,10 +129,10 @@ describe("fixSkippedMigrations", () => {
     }>;
     expect(titleCols.some((c) => c.name === "genres")).toBe(false);
 
-    // All 5 migrations should be recorded
+    // All 6 migrations should be recorded
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(5);
+    expect(migrations.cnt).toBe(6);
   });
 });

--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -67,6 +67,12 @@ export {
 } from "./settings";
 
 export {
+  watchTitle,
+  unwatchTitle,
+  getWatchedTitleIds,
+} from "./watched-titles";
+
+export {
   createNotifier,
   updateNotifier,
   deleteNotifier,

--- a/server/db/repository/titles.ts
+++ b/server/db/repository/titles.ts
@@ -1,6 +1,6 @@
 import { eq, and, or, sql, gte, lt, desc, asc, exists, notExists, inArray, like } from "drizzle-orm";
 import { getDb } from "../schema";
-import { titles, providers, offers, scores, tracked, titleGenres } from "../schema";
+import { titles, providers, offers, scores, tracked, titleGenres, watchedTitles } from "../schema";
 import type { ParsedTitle } from "../../tmdb/parser";
 import { extractProviders } from "../../tmdb/parser";
 import { traceDbQuery } from "../../tracing";
@@ -187,6 +187,9 @@ export async function getTitleById(titleId: string, userId?: string) {
         is_tracked: userId
           ? sql<number>`CASE WHEN ${tracked.titleId} IS NOT NULL THEN 1 ELSE 0 END`
           : sql<number>`0`,
+        is_watched: userId
+          ? sql<number>`EXISTS(SELECT 1 FROM watched_titles wt WHERE wt.title_id = ${titles.id} AND wt.user_id = ${userId})`
+          : sql<number>`0`,
       })
       .from(titles)
       .leftJoin(scores, eq(scores.titleId, titles.id))
@@ -204,6 +207,7 @@ export async function getTitleById(titleId: string, userId?: string) {
       ...row,
       genres: genreMap.get(row.id) ?? [],
       is_tracked: Boolean(row.is_tracked),
+      is_watched: Boolean(row.is_watched),
       offers: await getOffersForTitle(row.id),
     };
   });
@@ -308,6 +312,9 @@ export async function getRecentTitles(filters: TitleFilters = {}, userId?: strin
         is_tracked: userId
           ? sql<number>`CASE WHEN ${tracked.titleId} IS NOT NULL THEN 1 ELSE 0 END`
           : sql<number>`0`,
+        is_watched: userId
+          ? sql<number>`EXISTS(SELECT 1 FROM watched_titles wt WHERE wt.title_id = ${titles.id} AND wt.user_id = ${userId})`
+          : sql<number>`0`,
       })
       .from(titles)
       .leftJoin(scores, eq(scores.titleId, titles.id))
@@ -332,6 +339,7 @@ export async function getRecentTitles(filters: TitleFilters = {}, userId?: strin
       ...row,
       genres: genresByTitle.get(row.id) ?? [],
       is_tracked: Boolean(row.is_tracked),
+      is_watched: Boolean(row.is_watched),
       offers: offersByTitle.get(row.id) ?? [],
     }));
   });
@@ -364,6 +372,9 @@ export async function searchLocalTitles(query: string, limit = 50, userId?: stri
         is_tracked: userId
           ? sql<number>`CASE WHEN ${tracked.titleId} IS NOT NULL THEN 1 ELSE 0 END`
           : sql<number>`0`,
+        is_watched: userId
+          ? sql<number>`EXISTS(SELECT 1 FROM watched_titles wt WHERE wt.title_id = ${titles.id} AND wt.user_id = ${userId})`
+          : sql<number>`0`,
       })
       .from(titles)
       .leftJoin(scores, eq(scores.titleId, titles.id))
@@ -387,6 +398,7 @@ export async function searchLocalTitles(query: string, limit = 50, userId?: stri
       ...row,
       genres: genresByTitle.get(row.id) ?? [],
       is_tracked: Boolean(row.is_tracked),
+      is_watched: Boolean(row.is_watched),
       offers: offersByTitle.get(row.id) ?? [],
     }));
   });
@@ -482,6 +494,9 @@ export async function getTitlesByMonth(filters: MonthFilters, userId?: string) {
       imdb_votes: scores.imdbVotes,
       tmdb_score: scores.tmdbScore,
       is_tracked: sql<number>`1`,
+      is_watched: userId
+        ? sql<number>`EXISTS(SELECT 1 FROM watched_titles wt WHERE wt.title_id = ${titles.id} AND wt.user_id = ${userId})`
+        : sql<number>`0`,
     })
     .from(titles)
     .leftJoin(scores, eq(scores.titleId, titles.id))
@@ -498,6 +513,7 @@ export async function getTitlesByMonth(filters: MonthFilters, userId?: string) {
     ...row,
     genres: genresByTitle.get(row.id) ?? [],
     is_tracked: Boolean(row.is_tracked),
+    is_watched: Boolean(row.is_watched),
     offers: offersByTitle.get(row.id) ?? [],
   }));
   });

--- a/server/db/repository/tracked.ts
+++ b/server/db/repository/tracked.ts
@@ -1,6 +1,6 @@
 import { eq, and, sql, desc, inArray } from "drizzle-orm";
 import { getDb } from "../schema";
-import { titles, scores, tracked, titleGenres } from "../schema";
+import { titles, scores, tracked, titleGenres, watchedTitles } from "../schema";
 import { traceDbQuery } from "../../tracing";
 import { getOffersForTitles } from "./offers";
 
@@ -81,6 +81,7 @@ export async function getTrackedTitles(userId: string) {
         tracked_at: tracked.trackedAt,
         notes: tracked.notes,
         is_tracked: sql<number>`1`,
+        is_watched: sql<number>`EXISTS(SELECT 1 FROM watched_titles wt WHERE wt.title_id = ${titles.id} AND wt.user_id = ${userId})`,
       })
       .from(tracked)
       .innerJoin(titles, eq(titles.id, tracked.titleId))
@@ -98,6 +99,7 @@ export async function getTrackedTitles(userId: string) {
       ...row,
       genres: genresByTitle.get(row.id) ?? [],
       is_tracked: true,
+      is_watched: Boolean(row.is_watched),
       offers: offersByTitle.get(row.id) ?? [],
     }));
   });

--- a/server/db/repository/watched-titles.test.ts
+++ b/server/db/repository/watched-titles.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
+import { makeParsedTitle } from "../../test-utils/fixtures";
+import { upsertTitles, createUser } from "../repository";
+import { watchTitle, unwatchTitle, getWatchedTitleIds } from "./watched-titles";
+
+let userId: string;
+
+beforeEach(async () => {
+  setupTestDb();
+  userId = await createUser("testuser", "hash");
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+describe("watchTitle", () => {
+  it("inserts a watched record", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-1" })]);
+    await watchTitle("movie-1", userId);
+
+    const ids = await getWatchedTitleIds(userId);
+    expect(ids.has("movie-1")).toBe(true);
+  });
+
+  it("is idempotent — calling twice does not error", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-2" })]);
+    await watchTitle("movie-2", userId);
+    await watchTitle("movie-2", userId);
+
+    const ids = await getWatchedTitleIds(userId);
+    expect(ids.has("movie-2")).toBe(true);
+  });
+});
+
+describe("unwatchTitle", () => {
+  it("removes a watched record", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-3" })]);
+    await watchTitle("movie-3", userId);
+    await unwatchTitle("movie-3", userId);
+
+    const ids = await getWatchedTitleIds(userId);
+    expect(ids.has("movie-3")).toBe(false);
+  });
+
+  it("is a no-op on an unwatched title", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-4" })]);
+    await unwatchTitle("movie-4", userId);
+
+    const ids = await getWatchedTitleIds(userId);
+    expect(ids.has("movie-4")).toBe(false);
+  });
+});
+
+describe("getWatchedTitleIds", () => {
+  it("returns correct set of watched title IDs", async () => {
+    await upsertTitles([
+      makeParsedTitle({ id: "movie-5" }),
+      makeParsedTitle({ id: "movie-6" }),
+      makeParsedTitle({ id: "movie-7" }),
+    ]);
+    await watchTitle("movie-5", userId);
+    await watchTitle("movie-7", userId);
+
+    const ids = await getWatchedTitleIds(userId);
+    expect(ids.size).toBe(2);
+    expect(ids.has("movie-5")).toBe(true);
+    expect(ids.has("movie-6")).toBe(false);
+    expect(ids.has("movie-7")).toBe(true);
+  });
+
+  it("returns empty set when no titles are watched", async () => {
+    const ids = await getWatchedTitleIds(userId);
+    expect(ids.size).toBe(0);
+  });
+});

--- a/server/db/repository/watched-titles.ts
+++ b/server/db/repository/watched-titles.ts
@@ -1,0 +1,35 @@
+import { eq, and, inArray } from "drizzle-orm";
+import { getDb } from "../schema";
+import { watchedTitles } from "../schema";
+import { traceDbQuery } from "../../tracing";
+
+export async function watchTitle(titleId: string, userId: string) {
+  return traceDbQuery("watchTitle", async () => {
+    const db = getDb();
+    await db.insert(watchedTitles)
+      .values({ titleId, userId })
+      .onConflictDoNothing()
+      .run();
+  });
+}
+
+export async function unwatchTitle(titleId: string, userId: string) {
+  return traceDbQuery("unwatchTitle", async () => {
+    const db = getDb();
+    await db.delete(watchedTitles)
+      .where(and(eq(watchedTitles.titleId, titleId), eq(watchedTitles.userId, userId)))
+      .run();
+  });
+}
+
+export async function getWatchedTitleIds(userId: string): Promise<Set<string>> {
+  return traceDbQuery("getWatchedTitleIds", async () => {
+    const db = getDb();
+    const rows = await db
+      .select({ titleId: watchedTitles.titleId })
+      .from(watchedTitles)
+      .where(eq(watchedTitles.userId, userId))
+      .all();
+    return new Set(rows.map((r) => r.titleId));
+  });
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -248,6 +248,23 @@ export const watchedEpisodes = sqliteTable(
   ]
 );
 
+export const watchedTitles = sqliteTable(
+  "watched_titles",
+  {
+    titleId: text("title_id")
+      .notNull()
+      .references(() => titles.id),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    watchedAt: text("watched_at").default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.titleId, table.userId] }),
+    index("idx_watched_titles_user_id").on(table.userId),
+  ]
+);
+
 export const notifiers = sqliteTable(
   "notifiers",
   {
@@ -363,6 +380,11 @@ export const watchedEpisodesRelations = relations(watchedEpisodes, ({ one }) => 
   user: one(users, { fields: [watchedEpisodes.userId], references: [users.id] }),
 }));
 
+export const watchedTitlesRelations = relations(watchedTitles, ({ one }) => ({
+  title: one(titles, { fields: [watchedTitles.titleId], references: [titles.id] }),
+  user: one(users, { fields: [watchedTitles.userId], references: [users.id] }),
+}));
+
 export const notifiersRelations = relations(notifiers, ({ one }) => ({
   user: one(users, { fields: [notifiers.userId], references: [users.id] }),
 }));
@@ -370,9 +392,9 @@ export const notifiersRelations = relations(notifiers, ({ one }) => ({
 // ─── Database Instance ──────────────────────────────────────────────────────
 
 export const schemaExports = {
-  titles, providers, offers, scores, titleGenres, episodes, users, sessions, account, verification, settings, tracked, watchedEpisodes, notifiers, oidcStates, jobs, cronJobs,
+  titles, providers, offers, scores, titleGenres, episodes, users, sessions, account, verification, settings, tracked, watchedEpisodes, watchedTitles, notifiers, oidcStates, jobs, cronJobs,
   titlesRelations, providersRelations, offersRelations, scoresRelations, titleGenresRelations, episodesRelations,
-  usersRelations, sessionsRelations, accountRelations, trackedRelations, watchedEpisodesRelations, notifiersRelations,
+  usersRelations, sessionsRelations, accountRelations, trackedRelations, watchedEpisodesRelations, watchedTitlesRelations, notifiersRelations,
 };
 
 // Re-export the union type from platform for convenience

--- a/server/routes/track.ts
+++ b/server/routes/track.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { trackTitle, untrackTitle, getTrackedTitles, upsertTitles, deleteEpisodesForTitle, getWatchedEpisodesForExport, getEpisodeIdsBySE, watchEpisodesBulk } from "../db/repository";
+import { trackTitle, untrackTitle, getTrackedTitles, upsertTitles, deleteEpisodesForTitle, getWatchedEpisodesForExport, getEpisodeIdsBySE, watchEpisodesBulk, getWatchedTitleIds, watchTitle } from "../db/repository";
 import type { ParsedTitle } from "../tmdb/parser";
 import { CONFIG } from "../config";
 import { getDb } from "../db/schema";
@@ -107,6 +107,7 @@ app.get("/export", async (c) => {
   const user = c.get("user")!;
   const tracked = await getTrackedTitles(user.id);
   const watchedByTitle = await getWatchedEpisodesForExport(user.id);
+  const watchedTitleIds = await getWatchedTitleIds(user.id);
 
   const exportData = {
     version: 1,
@@ -129,6 +130,7 @@ app.get("/export", async (c) => {
       tmdb_url: t.tmdb_url,
       tracked_at: t.tracked_at,
       notes: t.notes,
+      is_watched: watchedTitleIds.has(t.id),
       watched_episodes: watchedByTitle.get(t.id) ?? [],
     })),
   };
@@ -183,6 +185,11 @@ app.post("/import", async (c) => {
       }]);
 
       await trackTitle(item.id, user.id, item.notes ?? undefined);
+
+      // Restore movie watched status
+      if (item.is_watched) {
+        await watchTitle(item.id, user.id);
+      }
 
       const hasWatched = Array.isArray(item.watched_episodes) && item.watched_episodes.length > 0;
       const canSyncEpisodes = item.object_type === "SHOW" && item.tmdb_id && CONFIG.TMDB_API_KEY;

--- a/server/routes/watched.test.ts
+++ b/server/routes/watched.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterAll } from "bun:test";
 import { Hono } from "hono";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
 import { makeParsedTitle } from "../test-utils/fixtures";
-import { upsertTitles, upsertEpisodes, createUser } from "../db/repository";
+import { upsertTitles, upsertEpisodes, createUser, getTitleById } from "../db/repository";
 import { getRawDb } from "../db/bun-db";
 import watchedApp from "./watched";
 import type { AppEnv } from "../types";
@@ -278,5 +278,49 @@ describe("POST /watched/bulk", () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toContain("episodeIds");
+  });
+});
+
+describe("POST /watched/movies/:titleId", () => {
+  it("marks a movie as watched", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-w1", objectType: "MOVIE" })]);
+
+    const app = makeAuthedApp();
+    const res = await app.request("/watched/movies/movie-w1", { method: "POST" });
+    expect(res.status).toBe(200);
+
+    const title = await getTitleById("movie-w1", userId);
+    expect(title!.is_watched).toBe(true);
+  });
+
+  it("is idempotent — marking twice does not error", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-w2", objectType: "MOVIE" })]);
+
+    const app = makeAuthedApp();
+    await app.request("/watched/movies/movie-w2", { method: "POST" });
+    const res = await app.request("/watched/movies/movie-w2", { method: "POST" });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("DELETE /watched/movies/:titleId", () => {
+  it("unmarks a watched movie", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-w3", objectType: "MOVIE" })]);
+
+    const app = makeAuthedApp();
+    await app.request("/watched/movies/movie-w3", { method: "POST" });
+    const res = await app.request("/watched/movies/movie-w3", { method: "DELETE" });
+    expect(res.status).toBe(200);
+
+    const title = await getTitleById("movie-w3", userId);
+    expect(title!.is_watched).toBe(false);
+  });
+
+  it("unwatch on an unwatched movie is a no-op", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-w4", objectType: "MOVIE" })]);
+
+    const app = makeAuthedApp();
+    const res = await app.request("/watched/movies/movie-w4", { method: "DELETE" });
+    expect(res.status).toBe(200);
   });
 });

--- a/server/routes/watched.ts
+++ b/server/routes/watched.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { watchEpisode, unwatchEpisode, watchEpisodesBulk, unwatchEpisodesBulk, getEpisodeAirDate, getReleasedEpisodeIds } from "../db/repository";
+import { watchEpisode, unwatchEpisode, watchEpisodesBulk, unwatchEpisodesBulk, getEpisodeAirDate, getReleasedEpisodeIds, watchTitle, unwatchTitle } from "../db/repository";
 import { localDateForTimezone } from "../utils/timezone";
 import type { AppEnv } from "../types";
 import { ok, err } from "./response";
@@ -53,6 +53,22 @@ app.delete("/:episodeId", async (c) => {
   const episodeId = Number(c.req.param("episodeId"));
   if (isNaN(episodeId)) return c.json({ error: "Invalid episodeId" }, 400);
   await unwatchEpisode(episodeId, user.id);
+  return ok(c, {});
+});
+
+// ─── Movie Watched ───────────────────────────────────────────────────────────
+
+app.post("/movies/:titleId", async (c) => {
+  const user = c.get("user")!;
+  const titleId = c.req.param("titleId");
+  await watchTitle(titleId, user.id);
+  return ok(c, {});
+});
+
+app.delete("/movies/:titleId", async (c) => {
+  const user = c.get("user")!;
+  const titleId = c.req.param("titleId");
+  await unwatchTitle(titleId, user.id);
   return ok(c, {});
 });
 


### PR DESCRIPTION
## Summary
- Adds ability to mark movies as watched, extending the existing episode watched functionality
- New `watched_titles` DB table with migration, repository functions (`watchTitle`, `unwatchTitle`, `getWatchedTitleIds`), and API routes (`POST/DELETE /api/watched/movies/:titleId`)
- `is_watched` field added to all title queries so watched status flows through the entire stack
- Movie detail page shows a WatchedIcon toggle next to the Track button; TitleCard shows a "Watched" badge on the poster
- Export/import includes movie watched status for data portability

## Test plan
- [x] Repository unit tests: watchTitle, unwatchTitle, getWatchedTitleIds (idempotency, no-op unwatching)
- [x] Route tests: POST/DELETE `/api/watched/movies/:titleId` (mark, unmark, idempotent, verify `is_watched` via `getTitleById`)
- [x] All 584 server tests pass, 0 failures
- [x] Type checks pass (server + frontend)
- [ ] Manual: open movie detail page, toggle watched icon, verify state persists on reload
- [ ] Manual: check TrackedPage shows watched badge on movie cards

https://claude.ai/code/session_01Gakv7g7QrgHeuLDcwXo5yy