### PR TITLE
fix: add missing aaguid column to passkey schema

### DIFF
--- a/drizzle/0007_add_passkey_aaguid.sql
+++ b/drizzle/0007_add_passkey_aaguid.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `passkey` ADD `aaguid` text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1774752100000,
       "tag": "0006_add_passkey",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1774752200000,
+      "tag": "0007_add_passkey_aaguid",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -129,10 +129,10 @@ describe("fixSkippedMigrations", () => {
     }>;
     expect(titleCols.some((c) => c.name === "genres")).toBe(false);
 
-    // All 7 migrations should be recorded
+    // All 8 migrations should be recorded
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(7);
+    expect(migrations.cnt).toBe(8);
   });
 });

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -301,6 +301,7 @@ export const passkey = sqliteTable("passkey", {
   backedUp: integer("backed_up", { mode: "boolean" }).default(false),
   transports: text("transports"),
   credentialID: text("credential_id").notNull(),
+  aaguid: text("aaguid"),
   createdAt: dateText("created_at").default(sql`(datetime('now'))`),
 });
 


### PR DESCRIPTION
## Summary
- Adds the missing `aaguid` text column to the `passkey` Drizzle schema, fixing WebAuthn registration failures
- Includes D1 migration (`0007_add_passkey_aaguid.sql`) to alter the existing table
- Run `wrangler d1 migrations apply remindarr` after deploy

## Test plan
- [x] `bun run check` passes (851 tests, type checks clean)
- [ ] Deploy and apply D1 migration
- [ ] Verify passkey registration works on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)