### PR TITLE
fix: make passkey webauthn_user_id nullable

### DIFF
--- a/drizzle/0008_passkey_nullable_webauthn_user_id.sql
+++ b/drizzle/0008_passkey_nullable_webauthn_user_id.sql
@@ -1,0 +1,19 @@
+-- SQLite does not support ALTER COLUMN, so we recreate the table
+-- to make webauthn_user_id nullable (Better Auth sends null for it).
+CREATE TABLE `passkey_new` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text,
+	`public_key` text NOT NULL,
+	`user_id` text NOT NULL REFERENCES `users`(`id`) ON DELETE CASCADE,
+	`webauthn_user_id` text,
+	`counter` integer NOT NULL DEFAULT 0,
+	`device_type` text,
+	`backed_up` integer DEFAULT 0,
+	`transports` text,
+	`credential_id` text NOT NULL,
+	`aaguid` text,
+	`created_at` text DEFAULT (datetime('now'))
+);--> statement-breakpoint
+INSERT INTO `passkey_new` SELECT * FROM `passkey`;--> statement-breakpoint
+DROP TABLE `passkey`;--> statement-breakpoint
+ALTER TABLE `passkey_new` RENAME TO `passkey`;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1774752200000,
       "tag": "0007_add_passkey_aaguid",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1774752300000,
+      "tag": "0008_passkey_nullable_webauthn_user_id",
+      "breakpoints": true
     }
   ]
 }

--- a/server/auth/better-auth-passkey.test.ts
+++ b/server/auth/better-auth-passkey.test.ts
@@ -68,6 +68,37 @@ describe("passkey support", () => {
     expect(row!.transports).toBe(JSON.stringify(["internal"]));
   });
 
+  it("passkey can be inserted with null webauthnUserID", async () => {
+    const db = getDb();
+    await db.insert(users).values({
+      id: "user-2",
+      username: "testuser2",
+      email: "test2@example.com",
+      emailVerified: false,
+      authProvider: "local",
+      isAdmin: 0,
+    }).run();
+
+    await db.insert(passkeyTable)
+      .values({
+        id: "pk-2",
+        publicKey: "test-public-key-2",
+        userId: "user-2",
+        webauthnUserID: null,
+        counter: 0,
+        credentialID: "cred-2",
+      })
+      .run();
+
+    const row = await db
+      .select()
+      .from(passkeyTable)
+      .get();
+
+    expect(row).toBeDefined();
+    expect(row!.webauthnUserID).toBeNull();
+  });
+
   it("createAuth includes passkey plugin", () => {
     const db = getDb();
     const auth = createAuth(db, new BunPlatform());

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -129,10 +129,10 @@ describe("fixSkippedMigrations", () => {
     }>;
     expect(titleCols.some((c) => c.name === "genres")).toBe(false);
 
-    // All 8 migrations should be recorded
+    // All 9 migrations should be recorded
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(8);
+    expect(migrations.cnt).toBe(9);
   });
 });

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -295,7 +295,7 @@ export const passkey = sqliteTable("passkey", {
   userId: text("user_id")
     .notNull()
     .references(() => users.id, { onDelete: "cascade" }),
-  webauthnUserID: text("webauthn_user_id").notNull(),
+  webauthnUserID: text("webauthn_user_id"),
   counter: integer("counter").notNull().default(0),
   deviceType: text("device_type"),
   backedUp: integer("backed_up", { mode: "boolean" }).default(false),


### PR DESCRIPTION
## Summary
- Better Auth's passkey plugin sends `null` for `webauthn_user_id` during registration, causing a `NOT NULL` constraint violation on D1/SQLite
- Made `webauthn_user_id` nullable in schema and added a SQLite table-recreation migration (0008)
- Added regression test verifying null `webauthnUserID` inserts succeed

## Test plan
- [x] `bun run check` passes (852 tests, type checks clean)
- [ ] Verify passkey registration works on deployed D1 instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)