### PR TITLE
feat: improve passkey UX with autofill, rename, and default naming

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -125,6 +125,9 @@
     "deletePasskey": "Delete",
     "deletingPasskey": "Deleting...",
     "passkeyDeleted": "Passkey deleted",
+    "passkeyRenamed": "Passkey renamed",
+    "renamePasskey": "Rename",
+    "renamingPasskey": "Renaming...",
     "noPasskeys": "No passkeys registered. Add one to enable passwordless sign-in.",
     "passkeyUnnamed": "Unnamed passkey"
   },
@@ -169,6 +172,8 @@
   },
   "common": {
     "loading": "Loading...",
-    "error": "An error occurred"
+    "error": "An error occurred",
+    "save": "Save",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -38,6 +38,29 @@ export default function LoginPage() {
     if (oidcError) setError(t("login.loginFailed", { error: oidcError }));
   }, [searchParams]);
 
+  // Enable passkey autofill (conditional UI)
+  useEffect(() => {
+    if (!passkeyAvailable) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const available = typeof PublicKeyCredential.isConditionalMediationAvailable === "function"
+          && await PublicKeyCredential.isConditionalMediationAvailable();
+        if (!available || cancelled) return;
+        const result = await authClient.signIn.passkey({ autoFill: true });
+        if (cancelled) return;
+        if (result?.error) return;
+        const session = await authClient.getSession();
+        if (session.data?.user && !cancelled) {
+          window.location.href = "/";
+        }
+      } catch {
+        // Autofill silently fails if user doesn't select a passkey
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [passkeyAvailable]);
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError("");
@@ -147,7 +170,7 @@ export default function LoginPage() {
                   onChange={(e) => setUsername(e.target.value)}
                   className="w-full px-3 py-2 bg-zinc-800 border border-white/[0.08] rounded-lg text-white placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-transparent"
                   placeholder={usernamePlaceholder}
-                  autoComplete="username"
+                  autoComplete="username webauthn"
                   required
                 />
               </div>
@@ -176,14 +199,15 @@ export default function LoginPage() {
               </button>
             </form>
 
-            <p className="mt-6 text-center text-sm text-zinc-500">
-              {t("login.noAccount")}{" "}
-              <Link to="/signup" className="text-amber-400 hover:text-amber-300 transition-colors">
-                {t("login.signUp")}
-              </Link>
-            </p>
           </>
         )}
+
+        <p className="mt-6 text-center text-sm text-zinc-500">
+          {t("login.noAccount")}{" "}
+          <Link to="/signup" className="text-amber-400 hover:text-amber-300 transition-colors">
+            {t("login.signUp")}
+          </Link>
+        </p>
       </div>
     </div>
   );

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -152,11 +152,14 @@ interface PasskeyItem {
 }
 
 function PasskeySection() {
+  const { user } = useAuth();
   const { t } = useTranslation();
   const [passkeys, setPasskeys] = useState<PasskeyItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [adding, setAdding] = useState(false);
   const [deleting, setDeleting] = useState<string | null>(null);
+  const [editing, setEditing] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
   const [passkeyName, setPasskeyName] = useState("");
   const [msg, setMsg] = useState("");
   const [err, setErr] = useState("");
@@ -190,7 +193,7 @@ function PasskeySection() {
     setAdding(true);
     try {
       const result = await authClient.passkey.addPasskey({
-        name: passkeyName || undefined,
+        name: passkeyName || user?.username || undefined,
       });
       if (result?.error) {
         throw new Error(String(result.error.message || t("profile.passkeyAddFailed")));
@@ -225,6 +228,24 @@ function PasskeySection() {
     }
   }
 
+  async function handleRenamePasskey(id: string) {
+    if (!editName.trim()) return;
+    setMsg("");
+    setErr("");
+    try {
+      const result = await authClient.passkey.updatePasskey({ id, name: editName.trim() });
+      if (result?.error) {
+        throw new Error(String(result.error.message || "Failed to rename passkey"));
+      }
+      setMsg(t("profile.passkeyRenamed"));
+      setEditing(null);
+      setEditName("");
+      await loadPasskeys();
+    } catch (e: any) {
+      setErr(e.message);
+    }
+  }
+
   if (!webauthnSupported) return null;
 
   return (
@@ -252,23 +273,61 @@ function PasskeySection() {
               <ul className="space-y-2">
                 {passkeys.map((pk) => (
                   <li key={pk.id} className="flex items-center justify-between bg-zinc-800 rounded-lg px-4 py-3">
-                    <div>
-                      <span className="text-white text-sm font-medium">
-                        {pk.name || t("profile.passkeyUnnamed")}
-                      </span>
-                      {pk.createdAt && (
-                        <span className="text-zinc-500 text-xs ml-2">
-                          {new Date(pk.createdAt).toLocaleDateString()}
-                        </span>
-                      )}
-                    </div>
-                    <button
-                      onClick={() => handleDeletePasskey(pk.id)}
-                      disabled={deleting === pk.id}
-                      className="text-red-400 hover:text-red-300 text-sm transition-colors disabled:opacity-50 cursor-pointer"
-                    >
-                      {deleting === pk.id ? t("profile.deletingPasskey") : t("profile.deletePasskey")}
-                    </button>
+                    {editing === pk.id ? (
+                      <form
+                        className="flex items-center gap-2 flex-1 mr-2"
+                        onSubmit={(e) => { e.preventDefault(); handleRenamePasskey(pk.id); }}
+                      >
+                        <input
+                          type="text"
+                          value={editName}
+                          onChange={(e) => setEditName(e.target.value)}
+                          className="flex-1 px-2 py-1 bg-zinc-700 border border-white/[0.08] rounded text-white text-sm focus:outline-none focus:ring-2 focus:ring-amber-500/50"
+                          autoFocus
+                        />
+                        <button
+                          type="submit"
+                          className="text-amber-400 hover:text-amber-300 text-sm cursor-pointer"
+                        >
+                          {t("common.save")}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => { setEditing(null); setEditName(""); }}
+                          className="text-zinc-400 hover:text-zinc-300 text-sm cursor-pointer"
+                        >
+                          {t("common.cancel")}
+                        </button>
+                      </form>
+                    ) : (
+                      <>
+                        <div>
+                          <span className="text-white text-sm font-medium">
+                            {pk.name || t("profile.passkeyUnnamed")}
+                          </span>
+                          {pk.createdAt && (
+                            <span className="text-zinc-500 text-xs ml-2">
+                              {new Date(pk.createdAt).toLocaleDateString()}
+                            </span>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-3">
+                          <button
+                            onClick={() => { setEditing(pk.id); setEditName(pk.name || ""); }}
+                            className="text-zinc-400 hover:text-zinc-300 text-sm transition-colors cursor-pointer"
+                          >
+                            {t("profile.renamePasskey")}
+                          </button>
+                          <button
+                            onClick={() => handleDeletePasskey(pk.id)}
+                            disabled={deleting === pk.id}
+                            className="text-red-400 hover:text-red-300 text-sm transition-colors disabled:opacity-50 cursor-pointer"
+                          >
+                            {deleting === pk.id ? t("profile.deletingPasskey") : t("profile.deletePasskey")}
+                          </button>
+                        </div>
+                      </>
+                    )}
                   </li>
                 ))}
               </ul>


### PR DESCRIPTION
## Summary
- **Passkey autofill**: Enable WebAuthn conditional UI on the login page, allowing browsers and password managers (1Password, etc.) to suggest passkeys in the username field's autofill dropdown
- **Passkey rename**: Add inline rename support on the profile page using Better Auth's `updatePasskey` API
- **Default passkey name**: When no custom name is provided, default to the user's username (which Better Auth also uses as the WebAuthn `userName` for password managers)
- **Always-visible signup link**: Move the "Don't have an account? Sign up" link outside the local login form so it's visible regardless of active login method

## Test plan
- [ ] Verify passkey autofill appears in browser/password manager on the login page
- [ ] Verify clicking a passkey suggestion from autofill completes sign-in
- [ ] Verify renaming a passkey from the profile page works and persists
- [ ] Verify new passkeys default to username when no custom name is given
- [ ] Verify the signup link is visible when only passkey/OIDC login is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)