### PR TITLE
chore: provision Cloudflare KV namespace for distributed cache

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -23,11 +23,9 @@ database_id = "b15b2224-6af6-4962-b1a8-7e51f771635c"
 migrations_dir = "drizzle"
 
 # KV namespace for distributed cache
-# Create with: wrangler kv namespace create CACHE_KV
-# Then update the id below with the returned namespace ID.
-# [[kv_namespaces]]
-# binding = "CACHE_KV"
-# id = "<your-kv-namespace-id>"
+[[kv_namespaces]]
+binding = "CACHE_KV"
+id = "c41afddb53d045738dc0ffd1b082b46b"
 
 # Non-secret config (override via wrangler.toml or dashboard)
 [vars]


### PR DESCRIPTION
## Summary
- Provisioned `remindarr-CACHE_KV` KV namespace on Cloudflare
- Enabled the `CACHE_KV` binding in `wrangler.toml` (previously commented out from #211)

## Test plan
- [ ] Deploy and verify `CACHE_KV` binding is available in the worker
- [ ] Confirm TMDB responses are cached in KV (check via Cloudflare dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)