### PR TITLE
feat: redesign hero banner with full-width layout and dominant color

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
         "better-auth": "^1.5.5",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "fast-average-color": "^9.5.0",
         "i18next": "^24.0.0",
         "lucide-react": "^0.577.0",
         "react": "^19.2.0",
@@ -1027,6 +1028,8 @@
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
     "express-rate-limit": ["express-rate-limit@8.3.1", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw=="],
+
+    "fast-average-color": ["fast-average-color@9.5.0", "", {}, "sha512-nC6x2YIlJ9xxgkMFMd1BNoM1ctMjNoRKfRliPmiEWW3S6rLTHiQcy9g3pt/xiKv/D0NAAkhb9VyV+WJFvTqMGg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "better-auth": "^1.5.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "fast-average-color": "^9.5.0",
     "i18next": "^24.0.0",
     "lucide-react": "^0.577.0",
     "react": "^19.2.0",

--- a/frontend/src/components/HeroBanner.test.ts
+++ b/frontend/src/components/HeroBanner.test.ts
@@ -72,6 +72,27 @@ describe("getHeroBannerSlides", () => {
     expect(slides).toHaveLength(1);
     expect(slides[0].sidebar).toHaveLength(0);
   });
+
+  it("includes posterUrl in sidebar items", () => {
+    const episodes = [
+      makeEpisode({ id: 1, title_id: "tv-1", show_title: "Show A", poster_url: "https://img/a.jpg" }),
+      makeEpisode({ id: 2, title_id: "tv-2", show_title: "Show B", poster_url: "https://img/b.jpg" }),
+    ];
+
+    const slides = getHeroBannerSlides(episodes);
+    expect(slides[0].sidebar[0].posterUrl).toBe("https://img/b.jpg");
+    expect(slides[1].sidebar[0].posterUrl).toBe("https://img/a.jpg");
+  });
+
+  it("sets posterUrl to null when poster_url is missing", () => {
+    const episodes = [
+      makeEpisode({ id: 1, title_id: "tv-1", show_title: "Show A" }),
+      makeEpisode({ id: 2, title_id: "tv-2", show_title: "Show B" }),
+    ];
+
+    const slides = getHeroBannerSlides(episodes);
+    expect(slides[0].sidebar[0].posterUrl).toBeNull();
+  });
 });
 
 describe("getHeroImageUrl", () => {

--- a/frontend/src/components/HeroBanner.tsx
+++ b/frontend/src/components/HeroBanner.tsx
@@ -1,13 +1,19 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { Link } from "react-router";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import type { Episode } from "../types";
 import { formatEpisodeCode } from "./EpisodeComponents";
+import { useDominantColors } from "./useDominantColor";
 
 export interface HeroBannerSlide {
   featured: Episode;
   remainingCount: number;
-  sidebar: { showTitle: string; episodeCode: string; titleId: string }[];
+  sidebar: {
+    showTitle: string;
+    episodeCode: string;
+    titleId: string;
+    posterUrl: string | null;
+  }[];
 }
 
 export function getHeroBannerSlides(unwatched: Episode[]): HeroBannerSlide[] {
@@ -39,6 +45,7 @@ export function getHeroBannerSlides(unwatched: Episode[]): HeroBannerSlide[] {
         showTitle: s.featured.show_title,
         episodeCode: formatEpisodeCode(s.featured),
         titleId: s.featured.title_id,
+        posterUrl: s.featured.poster_url ?? null,
       }));
   }
 
@@ -47,7 +54,8 @@ export function getHeroBannerSlides(unwatched: Episode[]): HeroBannerSlide[] {
 
 export function getHeroImageUrl(episode: Episode): string | null {
   if (episode.backdrop_url) return episode.backdrop_url;
-  if (episode.still_path) return `https://image.tmdb.org/t/p/w1280${episode.still_path}`;
+  if (episode.still_path)
+    return `https://image.tmdb.org/t/p/w1280${episode.still_path}`;
   if (episode.poster_url) return episode.poster_url;
   return null;
 }
@@ -57,6 +65,12 @@ export default function HeroBanner({ episodes }: { episodes: Episode[] }) {
   const [activeIndex, setActiveIndex] = useState(0);
   const [isPaused, setIsPaused] = useState(false);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const imageUrls = useMemo(
+    () => slides.map((s) => getHeroImageUrl(s.featured)),
+    [slides]
+  );
+  const colors = useDominantColors(imageUrls);
 
   const goTo = useCallback(
     (index: number) => {
@@ -79,91 +93,147 @@ export default function HeroBanner({ episodes }: { episodes: Episode[] }) {
   if (slides.length === 0) return null;
 
   const current = slides[activeIndex];
+  const currentPosterUrl = current.featured.poster_url;
 
   return (
     <div
-      className="hidden lg:block relative h-[450px] overflow-hidden rounded-xl"
+      className="hidden lg:block w-[100vw] relative left-[50%] ml-[-50vw] overflow-hidden h-[450px]"
       onMouseEnter={() => setIsPaused(true)}
       onMouseLeave={() => setIsPaused(false)}
     >
-      {/* Background image with gradient overlay */}
+      {/* Dominant color background layers - full viewport width */}
+      {slides.map((slide, i) => (
+        <div
+          key={`bg-${slide.featured.title_id}`}
+          className="absolute inset-0 transition-opacity duration-700"
+          style={{
+            opacity: i === activeIndex ? 1 : 0,
+            backgroundColor: colors[i]?.color ?? "rgb(24, 24, 27)",
+          }}
+        />
+      ))}
+
+      {/* Backdrop images - positioned mid-to-right */}
       {slides.map((slide, i) => {
         const url = getHeroImageUrl(slide.featured);
+        if (!url) return null;
         return (
           <div
-            key={slide.featured.title_id}
+            key={`img-${slide.featured.title_id}`}
             className="absolute inset-0 transition-opacity duration-700"
-            style={{
-              opacity: i === activeIndex ? 1 : 0,
-              backgroundImage: url
-                ? `linear-gradient(to right, rgba(3,7,18,0.95) 0%, rgba(3,7,18,0.7) 50%, rgba(3,7,18,0.4) 100%), url(${url})`
-                : "linear-gradient(to right, rgba(3,7,18,0.95) 0%, rgba(3,7,18,0.7) 50%, rgba(3,7,18,0.4) 100%)",
-              backgroundSize: "cover",
-              backgroundPosition: "center",
-            }}
-          />
+            style={{ opacity: i === activeIndex ? 1 : 0 }}
+          >
+            <img
+              src={url}
+              alt=""
+              className="absolute right-0 top-0 h-full w-[60%] object-cover"
+              style={{
+                maskImage:
+                  "linear-gradient(to right, transparent 0%, black 25%)",
+                WebkitMaskImage:
+                  "linear-gradient(to right, transparent 0%, black 25%)",
+              }}
+              loading={i === 0 ? "eager" : "lazy"}
+            />
+          </div>
         );
       })}
 
       {/* Content overlay */}
-      <div className="relative z-10 flex h-full">
-        {/* Left: episode info */}
-        <div className="flex-1 flex flex-col justify-center px-10 max-w-[65%]">
-          <p className="text-xs uppercase tracking-widest text-amber-400 font-medium mb-2">
-            Currently Watching
-          </p>
-          <Link to={`/title/${current.featured.title_id}`} className="group">
-            <h2 className="text-4xl font-bold text-white group-hover:text-amber-300 transition-colors">
-              {current.featured.show_title}
-            </h2>
-          </Link>
-          <p className="text-xl text-zinc-200 mt-2">
-            {formatEpisodeCode(current.featured)}
-            {current.featured.name && ` · ${current.featured.name}`}
-          </p>
-          {current.featured.overview && (
-            <p className="text-zinc-300 mt-3 line-clamp-3 max-w-xl">
-              {current.featured.overview}
-            </p>
-          )}
-          <p className="text-sm text-amber-300 mt-4">
-            {current.remainingCount} episode{current.remainingCount !== 1 ? "s" : ""} remaining
-          </p>
-        </div>
-
-        {/* Right: sidebar */}
+      <div className="relative z-10 h-full max-w-[1920px] mx-auto flex">
+        {/* Continue Watching card (left side) */}
         {current.sidebar.length > 0 && (
-          <div className="w-[35%] flex flex-col justify-center pr-10 pl-4">
-            <p className="text-xs uppercase tracking-widest text-zinc-400 font-medium mb-3">
-              Continue Watching
-            </p>
-            <div className="space-y-2">
-              {current.sidebar.map((item) => {
-                const slideIdx = slides.findIndex(
-                  (s) => s.featured.title_id === item.titleId
-                );
-                return (
-                  <button
-                    key={item.titleId}
-                    onClick={() => goTo(slideIdx)}
-                    className={`w-full text-left px-3 py-2 rounded-lg transition-colors cursor-pointer ${
-                      slideIdx === activeIndex
-                        ? "bg-white/10"
-                        : "hover:bg-white/5"
-                    }`}
-                  >
-                    <p className="font-semibold text-white text-sm truncate">
-                      {item.showTitle}
-                    </p>
-                    <p className="text-xs text-zinc-400 truncate">
-                      {item.episodeCode}
-                    </p>
-                  </button>
-                );
-              })}
+          <div className="w-72 shrink-0 flex items-center px-4">
+            <div className="w-full bg-zinc-900/80 backdrop-blur-sm rounded-xl p-4">
+              <p className="text-xs uppercase tracking-widest text-zinc-400 font-medium mb-3">
+                Continue Watching
+              </p>
+              <div className="space-y-1">
+                {current.sidebar.map((item) => {
+                  const slideIdx = slides.findIndex(
+                    (s) => s.featured.title_id === item.titleId
+                  );
+                  return (
+                    <button
+                      key={item.titleId}
+                      onClick={() => goTo(slideIdx)}
+                      className={`w-full flex items-center gap-3 px-2 py-1.5 rounded-lg transition-colors cursor-pointer ${
+                        slideIdx === activeIndex
+                          ? "bg-white/15"
+                          : "hover:bg-white/10"
+                      }`}
+                    >
+                      {item.posterUrl ? (
+                        <img
+                          src={item.posterUrl}
+                          alt={item.showTitle}
+                          className="w-8 h-12 rounded object-cover shrink-0"
+                          loading="lazy"
+                        />
+                      ) : (
+                        <div className="w-8 h-12 rounded bg-zinc-700 shrink-0" />
+                      )}
+                      <div className="min-w-0 text-left">
+                        <p className="text-sm font-semibold text-white truncate">
+                          {item.showTitle}
+                        </p>
+                        <p className="text-xs text-zinc-400 truncate">
+                          {item.episodeCode}
+                        </p>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
             </div>
           </div>
         )}
+
+        {/* Poster + text info */}
+        <div className="flex items-center gap-6 px-8">
+          {/* Show poster */}
+          {currentPosterUrl && (
+            <Link
+              to={`/title/${current.featured.title_id}`}
+              className="shrink-0"
+            >
+              <img
+                src={currentPosterUrl}
+                alt={current.featured.show_title}
+                className="h-[300px] rounded-lg shadow-2xl object-cover"
+                style={{ aspectRatio: "2/3" }}
+              />
+            </Link>
+          )}
+
+          {/* Episode info */}
+          <div className="flex flex-col justify-center max-w-md">
+            <p className="text-xs uppercase tracking-widest text-amber-400 font-medium mb-2">
+              Currently Watching
+            </p>
+            <Link
+              to={`/title/${current.featured.title_id}`}
+              className="group"
+            >
+              <h2 className="text-4xl font-bold text-white group-hover:text-amber-300 transition-colors">
+                {current.featured.show_title}
+              </h2>
+            </Link>
+            <p className="text-xl text-zinc-200 mt-2">
+              {formatEpisodeCode(current.featured)}
+              {current.featured.name && ` · ${current.featured.name}`}
+            </p>
+            {current.featured.overview && (
+              <p className="text-zinc-300 mt-3 line-clamp-3 max-w-xl">
+                {current.featured.overview}
+              </p>
+            )}
+            <p className="text-sm text-amber-300 mt-4">
+              {current.remainingCount} episode
+              {current.remainingCount !== 1 ? "s" : ""} remaining
+            </p>
+          </div>
+        </div>
       </div>
 
       {/* Navigation arrows */}
@@ -192,7 +262,9 @@ export default function HeroBanner({ episodes }: { episodes: Episode[] }) {
               key={i}
               onClick={() => goTo(i)}
               className={`w-2 h-2 rounded-full transition-colors cursor-pointer ${
-                i === activeIndex ? "bg-amber-400" : "bg-white/30 hover:bg-white/50"
+                i === activeIndex
+                  ? "bg-amber-400"
+                  : "bg-white/30 hover:bg-white/50"
               }`}
             />
           ))}

--- a/frontend/src/components/useDominantColor.test.ts
+++ b/frontend/src/components/useDominantColor.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, mock } from "bun:test";
+import { renderHook } from "@testing-library/react";
+import { useDominantColor, useDominantColors } from "./useDominantColor";
+
+// Mock fast-average-color — Image loading doesn't work in happy-dom
+mock.module("fast-average-color", () => ({
+  FastAverageColor: class {
+    getColor() {
+      return { hex: "#1a2b3c", isDark: true };
+    }
+  },
+}));
+
+describe("useDominantColor", () => {
+  it("returns default color for null URL", () => {
+    const { result } = renderHook(() => useDominantColor(null));
+    expect(result.current.color).toBe("rgb(24, 24, 27)");
+    expect(result.current.isDark).toBe(true);
+  });
+
+  it("returns default color initially for a URL (before image loads)", () => {
+    const { result } = renderHook(() =>
+      useDominantColor("https://example.com/img.jpg")
+    );
+    // Before the image loads, should still have the default
+    expect(result.current.isDark).toBe(true);
+  });
+});
+
+describe("useDominantColors", () => {
+  it("returns default colors for empty array", () => {
+    const { result } = renderHook(() => useDominantColors([]));
+    expect(result.current).toEqual([]);
+  });
+
+  it("returns default colors for null URLs", () => {
+    const { result } = renderHook(() => useDominantColors([null, null]));
+    expect(result.current).toHaveLength(2);
+    expect(result.current[0].color).toBe("rgb(24, 24, 27)");
+    expect(result.current[1].color).toBe("rgb(24, 24, 27)");
+  });
+
+  it("returns correct number of results matching input length", () => {
+    const urls = ["https://a.com/1.jpg", null, "https://b.com/2.jpg"];
+    const { result } = renderHook(() => useDominantColors(urls));
+    expect(result.current).toHaveLength(3);
+  });
+});

--- a/frontend/src/components/useDominantColor.ts
+++ b/frontend/src/components/useDominantColor.ts
@@ -1,0 +1,115 @@
+import { useState, useEffect } from "react";
+import { FastAverageColor } from "fast-average-color";
+
+const fac = new FastAverageColor();
+const cache = new Map<string, { color: string; isDark: boolean }>();
+
+const DEFAULT_COLOR = { color: "rgb(24, 24, 27)", isDark: true };
+
+function getCachedOrDefault(url: string | null): { color: string; isDark: boolean } {
+  if (!url) return DEFAULT_COLOR;
+  return cache.get(url) ?? DEFAULT_COLOR;
+}
+
+export function useDominantColor(imageUrl: string | null): {
+  color: string;
+  isDark: boolean;
+} {
+  const [result, setResult] = useState(() => getCachedOrDefault(imageUrl));
+
+  useEffect(() => {
+    if (!imageUrl || cache.has(imageUrl)) return;
+
+    let cancelled = false;
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    img.src = imageUrl;
+    img.onload = () => {
+      if (cancelled) return;
+      try {
+        const avgColor = fac.getColor(img);
+        const entry = { color: avgColor.hex, isDark: avgColor.isDark };
+        cache.set(imageUrl, entry);
+        setResult(entry);
+      } catch {
+        // Canvas extraction failed — keep default
+      }
+    };
+
+    return () => {
+      cancelled = true;
+    };
+  }, [imageUrl]);
+
+  // Sync with cache when URL changes (handles already-cached URLs on re-render)
+  const cached = imageUrl ? cache.get(imageUrl) : null;
+  const syncedResult = cached ?? result;
+  if (syncedResult !== result && cached) {
+    return cached;
+  }
+
+  return result;
+}
+
+/** Hook that precomputes dominant colors for multiple URLs at once */
+export function useDominantColors(
+  imageUrls: (string | null)[]
+): { color: string; isDark: boolean }[] {
+  const urlKey = imageUrls.join(",");
+
+  const [results, setResults] = useState<{ color: string; isDark: boolean }[]>(
+    () => imageUrls.map((url) => getCachedOrDefault(url))
+  );
+
+  useEffect(() => {
+    // Check if any URLs need fetching
+    const urls = urlKey.split(",").map((u) => (u === "" ? null : u));
+    const uncached = urls.filter((url) => url && !cache.has(url));
+    if (uncached.length === 0) {
+      // All cached or null — set from cache
+      return;
+    }
+
+    let cancelled = false;
+    const pending = urls.map((url, i) => {
+      if (!url || cache.has(url)) {
+        return Promise.resolve({ index: i, result: getCachedOrDefault(url) });
+      }
+
+      return new Promise<{
+        index: number;
+        result: { color: string; isDark: boolean };
+      }>((resolve) => {
+        const img = new Image();
+        img.crossOrigin = "anonymous";
+        img.src = url;
+        img.onload = () => {
+          try {
+            const avgColor = fac.getColor(img);
+            const entry = { color: avgColor.hex, isDark: avgColor.isDark };
+            cache.set(url, entry);
+            resolve({ index: i, result: entry });
+          } catch {
+            resolve({ index: i, result: DEFAULT_COLOR });
+          }
+        };
+        img.onerror = () => resolve({ index: i, result: DEFAULT_COLOR });
+      });
+    });
+
+    Promise.all(pending).then((entries) => {
+      if (cancelled) return;
+      const newResults = urls.map((url) => getCachedOrDefault(url));
+      for (const { index, result } of entries) {
+        newResults[index] = result;
+      }
+      setResults(newResults);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [urlKey]);
+
+  return results;
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -436,8 +436,12 @@ export default function HomePage() {
 
   return (
     <div className="space-y-8">
-      {/* Hero Banner (desktop only) */}
-      {unwatched.length > 0 && <HeroBanner episodes={unwatched} />}
+      {/* Hero Banner (desktop only, full-width) */}
+      {unwatched.length > 0 && (
+        <div className="-mt-6">
+          <HeroBanner episodes={unwatched} />
+        </div>
+      )}
 
       {/* Unwatched Episodes */}
       {unwatched.length > 0 && (
@@ -446,7 +450,7 @@ export default function HomePage() {
             <h2 className="text-xl font-bold text-white">{t("home.unwatched")}</h2>
             <Link
               to="/reels"
-              className="flex items-center gap-1 text-xs text-zinc-400 hover:text-amber-400 transition-colors"
+              className="flex items-center gap-1 text-xs text-zinc-400 hover:text-amber-400 transition-colors sm:hidden"
               title="Full-screen reels view"
             >
               <Maximize2 size={14} />


### PR DESCRIPTION
## Summary
- Redesign hero banner to span full viewport width edge-to-edge with dominant color extraction from backdrop images
- Backdrop image covers the right ~60% with a CSS mask fade into the extracted dominant color
- Added show poster next to the text content for a more cinematic look
- "Continue Watching" sidebar is now a card with poster thumbnails on the left side of the banner
- Added `fast-average-color` dependency (~2KB) with a custom `useDominantColors` hook with module-level caching

## Test plan
- [ ] Verify banner spans full viewport width on desktop (edge-to-edge)
- [ ] Verify dominant color fills the left portion and transitions smoothly between slides
- [ ] Verify backdrop image fades into dominant color via CSS mask
- [ ] Verify show poster appears to the left of the text content
- [ ] Verify "Continue Watching" card with poster thumbnails renders on the left
- [ ] Verify auto-rotation and click navigation still work
- [ ] Verify single-show case (no sidebar) renders correctly
- [ ] Verify `bun run check` passes (type check + lint + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)