### PR TITLE
fix: use correct input names for claude-code-action

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -51,20 +51,26 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          direct_prompt: |
+          prompt: |
             Read the entire codebase and the current README.md. Update the README.md
             to accurately reflect the current state of the project. Keep the existing
             style and structure but update any sections that are out of date —
             features, stack, configuration, project structure, API routes, etc.
             Only make changes if something is actually out of date. Commit any
             changes with a clear message.
-          allowed_tools: |
-            Bash(git diff:*)
-            Bash(git log:*)
-            Bash(git add:*)
-            Bash(git commit:*)
-            Bash(git push:*)
-            Read
-            Glob
-            Grep
-            Edit
+          settings: |
+            {
+              "permissions": {
+                "allow": [
+                  "Bash(git diff:*)",
+                  "Bash(git log:*)",
+                  "Bash(git add:*)",
+                  "Bash(git commit:*)",
+                  "Bash(git push:*)",
+                  "Read",
+                  "Glob",
+                  "Grep",
+                  "Edit"
+                ]
+              }
+            }


### PR DESCRIPTION
## Summary
- Renamed `direct_prompt` to `prompt` — the correct input for agent mode in claude-code-action
- Moved `allowed_tools` into a `settings` JSON block — there is no top-level `allowed_tools` input

This was causing the daily README update workflow to skip with "No trigger found, skipping remaining steps" because the action didn't receive a valid prompt.

## Test plan
- [ ] Trigger the workflow manually via `workflow_dispatch` and verify it actually runs the prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)