### PR TITLE
feat: add www.remindarr.app custom domain

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,7 +5,8 @@ compatibility_flags = ["nodejs_compat"]
 
 # Custom domain
 routes = [
-  { pattern = "remindarr.app", custom_domain = true }
+  { pattern = "remindarr.app", custom_domain = true },
+  { pattern = "www.remindarr.app", custom_domain = true }
 ]
 
 # Static frontend assets — binding required for SPA fallback in worker


### PR DESCRIPTION
## Summary
- Adds `www.remindarr.app` as a custom domain route in `wrangler.toml` so the app is reachable at both `remindarr.app` and `www.remindarr.app`

## Test plan
- [ ] Deploy with `wrangler deploy` and verify `www.remindarr.app` resolves and serves the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)