### PR TITLE
fix: resolve SPA navigation errors from stale chunks after deploy

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,19 +9,31 @@ import BottomTabBar from "./components/BottomTabBar";
 import OfflineIndicator from "./components/OfflineIndicator";
 import { navLinkClass } from "./nav-utils";
 
-const HomePage = lazy(() => import("./pages/HomePage"));
-const BrowsePage = lazy(() => import("./pages/BrowsePage"));
-const TrackedPage = lazy(() => import("./pages/TrackedPage"));
-const CalendarPage = lazy(() => import("./pages/CalendarPage"));
-const LoginPage = lazy(() => import("./pages/LoginPage"));
-const SignupPage = lazy(() => import("./pages/SignupPage"));
-const ProfilePage = lazy(() => import("./pages/ProfilePage"));
-const TitleDetailPage = lazy(() => import("./pages/TitleDetailPage"));
-const SeasonDetailPage = lazy(() => import("./pages/SeasonDetailPage"));
-const EpisodeDetailPage = lazy(() => import("./pages/EpisodeDetailPage"));
-const PersonPage = lazy(() => import("./pages/PersonPage"));
-const ReelsPage = lazy(() => import("./pages/ReelsPage"));
-const UpcomingPage = lazy(() => import("./pages/UpcomingPage"));
+// Retry dynamic imports once on failure (handles stale chunks after deploy)
+function lazyWithRetry(factory: () => Promise<{ default: React.ComponentType }>) {
+  return lazy(() =>
+    factory().catch(() => {
+      // Chunk likely changed after a new deploy — reload to get fresh assets
+      window.location.reload();
+      // Return a never-resolving promise so React doesn't render before reload
+      return new Promise(() => {});
+    })
+  );
+}
+
+const HomePage = lazyWithRetry(() => import("./pages/HomePage"));
+const BrowsePage = lazyWithRetry(() => import("./pages/BrowsePage"));
+const TrackedPage = lazyWithRetry(() => import("./pages/TrackedPage"));
+const CalendarPage = lazyWithRetry(() => import("./pages/CalendarPage"));
+const LoginPage = lazyWithRetry(() => import("./pages/LoginPage"));
+const SignupPage = lazyWithRetry(() => import("./pages/SignupPage"));
+const ProfilePage = lazyWithRetry(() => import("./pages/ProfilePage"));
+const TitleDetailPage = lazyWithRetry(() => import("./pages/TitleDetailPage"));
+const SeasonDetailPage = lazyWithRetry(() => import("./pages/SeasonDetailPage"));
+const EpisodeDetailPage = lazyWithRetry(() => import("./pages/EpisodeDetailPage"));
+const PersonPage = lazyWithRetry(() => import("./pages/PersonPage"));
+const ReelsPage = lazyWithRetry(() => import("./pages/ReelsPage"));
+const UpcomingPage = lazyWithRetry(() => import("./pages/UpcomingPage"));
 
 function MobileHomeRedirect() {
   const { user, loading } = useAuth();

--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -1,5 +1,5 @@
 /// <reference lib="webworker" />
-import { precacheAndRoute, cleanupOutdatedCaches } from "workbox-precaching";
+import { precacheAndRoute, cleanupOutdatedCaches, createHandlerBoundToURL } from "workbox-precaching";
 import { registerRoute, NavigationRoute } from "workbox-routing";
 import { StaleWhileRevalidate, NetworkFirst, NetworkOnly } from "workbox-strategies";
 import { ExpirationPlugin } from "workbox-expiration";
@@ -13,11 +13,7 @@ cleanupOutdatedCaches();
 
 // Navigation fallback — serve index.html for all navigation requests except /api/
 const navigationRoute = new NavigationRoute(
-  async ({ request }) => {
-    const cache = await caches.open("workbox-precache-v2");
-    const cachedResponse = await cache.match("/index.html");
-    return cachedResponse || fetch(request);
-  },
+  createHandlerBoundToURL("/index.html"),
   { denylist: [/^\/api\//] }
 );
 registerRoute(navigationRoute);


### PR DESCRIPTION
## Summary
- Fixed service worker navigation handler using `createHandlerBoundToURL` instead of manual cache lookup that failed due to workbox revision query params
- Added `lazyWithRetry` wrapper for all lazy imports to auto-reload on chunk load failure after deploys

## Test plan
- [ ] Deploy and verify direct navigation to `/calendar`, `/tracked`, etc. works without errors
- [ ] Deploy a second time with different chunks and verify existing tabs gracefully reload instead of showing "Something went wrong"
- [ ] Verify `bun run check` passes (type check + lint + 865 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)