### PR TITLE
fix: use @sentry/cloudflare SDK for Workers runtime

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@better-auth/passkey": "^1.5.6",
         "@sentry/bun": "^10.43.0",
+        "@sentry/cloudflare": "^10.46.0",
         "@simplewebauthn/server": "^13.3.0",
         "better-auth": "^1.5.5",
         "cron-parser": "^4.9.0",
@@ -624,6 +625,8 @@
     "@sentry/browser": ["@sentry/browser@10.45.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.45.0", "@sentry-internal/feedback": "10.45.0", "@sentry-internal/replay": "10.45.0", "@sentry-internal/replay-canvas": "10.45.0", "@sentry/core": "10.45.0" } }, "sha512-e/a8UMiQhqqv706McSIcG6XK+AoQf9INthi2pD+giZfNRTzXTdqHzUT5OIO5hg8Am6eF63nDJc+vrYNPhzs51Q=="],
 
     "@sentry/bun": ["@sentry/bun@10.45.0", "", { "dependencies": { "@sentry/core": "10.45.0", "@sentry/node": "10.45.0" } }, "sha512-f9+24fp1Ew09qcqQ2DMKo0Dh/4WIE8G4D3/CLh8pgdwjP8A+5cvTQLcdUsqZll361P4jmXS+ZEi5KlmPv/ddGw=="],
+
+    "@sentry/cloudflare": ["@sentry/cloudflare@10.46.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@sentry/core": "10.46.0" }, "peerDependencies": { "@cloudflare/workers-types": "^4.x" }, "optionalPeers": ["@cloudflare/workers-types"] }, "sha512-gN+S56kStf8jvutSQ+RCkapB8YgVXAmXLddDsbO8Oz5G1ts7Af6QLqSS4FoSGF/JLdV8QFMmBLBhx0P/KD3ngw=="],
 
     "@sentry/core": ["@sentry/core@10.45.0", "", {}, "sha512-s69UXxvefeQxuZ5nY7/THtTrIEvJxNVCp3ns4kwoCw1qMpgpvn/296WCKVmM7MiwnaAdzEKnAvLAwaxZc2nM7Q=="],
 
@@ -1932,6 +1935,8 @@
     "@rollup/pluginutils/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "@rollup/pluginutils/rollup": ["rollup@2.80.0", "", { "optionalDependencies": { "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ=="],
+
+    "@sentry/cloudflare/@sentry/core": ["@sentry/core@10.46.0", "", {}, "sha512-N3fj4zqBQOhXliS1Ne9euqIKuciHCGOJfPGQLwBoW9DNz03jF+NB8+dUKtrJ79YLoftjVgf8nbgwtADK7NR+2Q=="],
 
     "@surma/rollup-plugin-off-main-thread/magic-string": ["magic-string@0.25.9", "", { "dependencies": { "sourcemap-codec": "^1.4.8" } }, "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ=="],
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@better-auth/passkey": "^1.5.6",
     "@sentry/bun": "^10.43.0",
+    "@sentry/cloudflare": "^10.46.0",
     "@simplewebauthn/server": "^13.3.0",
     "better-auth": "^1.5.5",
     "cron-parser": "^4.9.0",

--- a/server/sentry.ts
+++ b/server/sentry.ts
@@ -1,9 +1,9 @@
 /**
  * Platform-agnostic Sentry wrapper.
  *
- * On Bun, re-exports @sentry/bun. On Cloudflare Workers (where the package
- * isn't available), provides no-op stubs so the rest of the codebase can
- * import Sentry unconditionally without crashing at module-evaluation time.
+ * On Bun, re-exports @sentry/bun. On Cloudflare Workers, re-exports
+ * @sentry/cloudflare. If neither is available, provides no-op stubs so the
+ * rest of the codebase can import Sentry unconditionally without crashing.
  */
 
 interface SentryLike {
@@ -32,7 +32,13 @@ try {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   sentry = require("@sentry/bun");
 } catch {
-  sentry = noopSentry;
+  try {
+    // Cloudflare Workers: @sentry/bun isn't available, use @sentry/cloudflare
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    sentry = require("@sentry/cloudflare");
+  } catch {
+    sentry = noopSentry;
+  }
 }
 
 export default sentry;

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -62,6 +62,7 @@ import type { AppEnv } from "./types";
 import { logger, requestLogger, resetLogLevel } from "./logger";
 import { patchConfig } from "./config";
 import Sentry from "./sentry";
+import { withSentry } from "@sentry/cloudflare";
 import { CloudflarePlatform } from "./platform/cloudflare";
 import { processPendingJobs, enqueueCronJob, cleanupOldJobs } from "./jobs/processor";
 import { createAuth } from "./auth/better-auth";
@@ -330,7 +331,7 @@ function getApp(env: Env): Hono<AppEnv> {
   return app;
 }
 
-export default {
+const handler = {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     ctx.passThroughOnException();
     patchConfigFromEnv(env);
@@ -419,3 +420,12 @@ export default {
     }
   },
 };
+
+export default withSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    tracesSampleRate: 1.0,
+    sendDefaultPii: true,
+  }),
+  handler,
+);


### PR DESCRIPTION
## Summary
- The Cloudflare Workers deployment was silently dropping all Sentry events because `server/sentry.ts` only tried `@sentry/bun` (unavailable on CF Workers) and fell back to no-op stubs
- Added `@sentry/cloudflare` as a dependency and updated `sentry.ts` to use it as a fallback before no-op
- Wrapped the `worker.ts` handler export with `withSentry()` for proper request-scoped SDK initialization

## Test plan
- [x] `bun run check` passes (865 tests, 0 errors)
- [ ] Deploy to Cloudflare and verify events appear in `remindarr-cf` Sentry project
- [ ] Trigger a test error and confirm it shows up in Sentry dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)