### PR TITLE
Improve hero banner navigation button visibility on hover

### DIFF
--- a/frontend/src/components/HeroBanner.tsx
+++ b/frontend/src/components/HeroBanner.tsx
@@ -97,7 +97,7 @@ export default function HeroBanner({ episodes }: { episodes: Episode[] }) {
 
   return (
     <div
-      className="hidden lg:block w-[100vw] relative left-[50%] ml-[-50vw] overflow-hidden h-[450px]"
+      className="group hidden lg:block w-[100vw] relative left-[50%] ml-[-50vw] overflow-hidden h-[450px]"
       onMouseEnter={() => setIsPaused(true)}
       onMouseLeave={() => setIsPaused(false)}
     >
@@ -241,13 +241,13 @@ export default function HeroBanner({ episodes }: { episodes: Episode[] }) {
         <>
           <button
             onClick={() => goTo(activeIndex - 1)}
-            className="absolute left-3 top-1/2 -translate-y-1/2 z-20 bg-black/50 hover:bg-black/70 text-white rounded-full w-9 h-9 flex items-center justify-center opacity-0 hover:opacity-100 transition-opacity cursor-pointer"
+            className="absolute left-3 top-1/2 -translate-y-1/2 z-20 bg-black/50 hover:bg-black/70 text-white rounded-full w-9 h-9 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
           >
             <ChevronLeft size={20} />
           </button>
           <button
             onClick={() => goTo(activeIndex + 1)}
-            className="absolute right-3 top-1/2 -translate-y-1/2 z-20 bg-black/50 hover:bg-black/70 text-white rounded-full w-9 h-9 flex items-center justify-center opacity-0 hover:opacity-100 transition-opacity cursor-pointer"
+            className="absolute right-3 top-1/2 -translate-y-1/2 z-20 bg-black/50 hover:bg-black/70 text-white rounded-full w-9 h-9 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
           >
             <ChevronRight size={20} />
           </button>


### PR DESCRIPTION
## Summary
Updated the HeroBanner component to use Tailwind CSS group hover utilities for better control over navigation button visibility. This ensures the chevron buttons only appear when hovering over the entire banner container, rather than just the individual buttons.

## Changes
- Added `group` class to the main banner container div to enable group hover state management
- Changed left navigation button from `hover:opacity-100` to `group-hover:opacity-100`
- Changed right navigation button from `hover:opacity-100` to `group-hover:opacity-100`

## Implementation Details
This change improves the UX by making the navigation buttons appear when the user hovers anywhere over the hero banner, not just when hovering directly over the buttons themselves. The buttons remain hidden by default (opacity-0) and become visible (opacity-100) when the parent container is hovered, creating a more cohesive interactive experience.

https://claude.ai/code/session_01X5PjaBzYNE3ngJWZVteoMS