### PR TITLE
Fix watch provider button duplication and add type labels

### DIFF
--- a/frontend/src/components/HeroBanner.tsx
+++ b/frontend/src/components/HeroBanner.tsx
@@ -2,8 +2,9 @@ import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { Link } from "react-router";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import type { Episode } from "../types";
-import { formatEpisodeCode } from "./EpisodeComponents";
+import { formatEpisodeCode, getUniqueProviders } from "./EpisodeComponents";
 import { useDominantColors } from "./useDominantColor";
+import WatchButton from "./WatchButton";
 
 export interface HeroBannerSlide {
   featured: Episode;
@@ -232,6 +233,25 @@ export default function HeroBanner({ episodes }: { episodes: Episode[] }) {
               {current.remainingCount} episode
               {current.remainingCount !== 1 ? "s" : ""} remaining
             </p>
+            {(() => {
+              const providers = getUniqueProviders(current.featured.offers);
+              if (providers.length === 0) return null;
+              return (
+                <div className="flex gap-2 mt-3">
+                  {providers.slice(0, 4).map((o) => (
+                    <WatchButton
+                      key={o.provider_id}
+                      url={o.url}
+                      providerId={o.provider_id}
+                      providerName={o.provider_name}
+                      providerIconUrl={o.provider_icon_url}
+                      monetizationType={o.monetization_type}
+                      variant="full"
+                    />
+                  ))}
+                </div>
+              );
+            })()}
           </div>
         </div>
       </div>

--- a/frontend/src/components/WatchButton.test.tsx
+++ b/frontend/src/components/WatchButton.test.tsx
@@ -43,4 +43,42 @@ describe("WatchButton", () => {
     expect(img).toBeTruthy();
     expect(img!.getAttribute("src")).toBe("https://example.com/netflix.png");
   });
+
+  it("renders monetization label in full variant when provided", () => {
+    const { container } = render(
+      <WatchButton {...defaultProps} variant="full" monetizationType="FLATRATE" />
+    );
+    const link = container.querySelector("a");
+    expect(link!.textContent).toContain("Stream");
+    expect(link!.textContent).toContain("Netflix");
+  });
+
+  it("renders Rent label for RENT monetization type", () => {
+    const { container } = render(
+      <WatchButton {...defaultProps} variant="full" monetizationType="RENT" />
+    );
+    expect(container.querySelector("a")!.textContent).toContain("Rent");
+  });
+
+  it("renders Buy label for BUY monetization type", () => {
+    const { container } = render(
+      <WatchButton {...defaultProps} variant="full" monetizationType="BUY" />
+    );
+    expect(container.querySelector("a")!.textContent).toContain("Buy");
+  });
+
+  it("omits monetization label in full variant when not provided", () => {
+    const { container } = render(<WatchButton {...defaultProps} variant="full" />);
+    const text = container.querySelector("a")!.textContent!;
+    expect(text).not.toContain("Stream");
+    expect(text).not.toContain("Rent");
+    expect(text).not.toContain("Buy");
+  });
+
+  it("does not render monetization label in compact variant", () => {
+    const { container } = render(
+      <WatchButton {...defaultProps} variant="compact" monetizationType="FLATRATE" />
+    );
+    expect(container.textContent).not.toContain("Stream");
+  });
 });

--- a/frontend/src/components/WatchButton.tsx
+++ b/frontend/src/components/WatchButton.tsx
@@ -8,6 +8,18 @@ interface WatchButtonProps {
   providerName: string;
   providerIconUrl: string;
   variant?: "compact" | "full";
+  monetizationType?: string;
+}
+
+function monetizationLabel(type?: string): string | null {
+  switch (type) {
+    case "FLATRATE": return "Stream";
+    case "FREE": return "Free";
+    case "ADS": return "Ads";
+    case "RENT": return "Rent";
+    case "BUY": return "Buy";
+    default: return null;
+  }
 }
 
 export default function WatchButton({
@@ -16,6 +28,7 @@ export default function WatchButton({
   providerName,
   providerIconUrl,
   variant = "compact",
+  monetizationType,
 }: WatchButtonProps) {
   const color = getProviderColor(providerId);
   const [hovered, setHovered] = useState(false);
@@ -46,6 +59,8 @@ export default function WatchButton({
     );
   }
 
+  const label = monetizationLabel(monetizationType);
+
   return (
     <a
       href={url}
@@ -59,6 +74,7 @@ export default function WatchButton({
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
+      {label && <span className="opacity-75">{label}</span>}
       <img
         src={providerIconUrl}
         alt=""

--- a/frontend/src/pages/TitleDetailPage.tsx
+++ b/frontend/src/pages/TitleDetailPage.tsx
@@ -337,6 +337,7 @@ function MovieDetail({ data }: { data: MovieDetailsResponse }) {
                     providerId={streamingOffer.provider_id}
                     providerName={streamingOffer.provider_name}
                     providerIconUrl={streamingOffer.provider_icon_url}
+                    monetizationType={streamingOffer.monetization_type}
                     variant="full"
                   />
                 );
@@ -416,51 +417,44 @@ function MovieDetail({ data }: { data: MovieDetailsResponse }) {
       )}
 
       {/* Streaming Availability */}
-      {watchProviders && (
-        <Section title="Where to Watch">
-          <div className="space-y-3">
-            <ProviderRow label="Stream" providers={watchProviders.flatrate || []} watchLink={watchProviders.link} />
-            <ProviderRow label="Free" providers={watchProviders.free || []} watchLink={watchProviders.link} />
-            <ProviderRow label="Ads" providers={watchProviders.ads || []} watchLink={watchProviders.link} />
-            <ProviderRow label="Rent" providers={watchProviders.rent || []} watchLink={watchProviders.link} />
-            <ProviderRow label="Buy" providers={watchProviders.buy || []} watchLink={watchProviders.link} />
-          </div>
-          {title.offers.length > 0 && (
-            <div className="mt-4 pt-4 border-t border-white/[0.06]">
-              <p className="text-xs text-zinc-500 mb-2">Direct links</p>
+      {(() => {
+        const offerGroups = groupOffersByType(title.offers);
+        if (offerGroups.length > 0) {
+          return (
+            <Section title="Where to Watch">
               <div className="flex flex-wrap gap-2">
-                {dedupeOffers(title.offers).map((offer) => (
-                  <WatchButton
-                    key={offer.id}
-                    url={offer.url}
-                    providerId={offer.provider_id}
-                    providerName={offer.provider_name}
-                    providerIconUrl={offer.provider_icon_url}
-                    variant="full"
-                  />
-                ))}
+                {offerGroups.flatMap(({ offers }) =>
+                  offers.map((offer) => (
+                    <WatchButton
+                      key={offer.id}
+                      url={offer.url}
+                      providerId={offer.provider_id}
+                      providerName={offer.provider_name}
+                      providerIconUrl={offer.provider_icon_url}
+                      monetizationType={offer.monetization_type}
+                      variant="full"
+                    />
+                  ))
+                )}
               </div>
-            </div>
-          )}
-        </Section>
-      )}
-
-      {!watchProviders && title.offers.length > 0 && (
-        <Section title="Where to Watch">
-          <div className="flex flex-wrap gap-2">
-            {dedupeOffers(title.offers).map((offer) => (
-              <WatchButton
-                key={offer.id}
-                url={offer.url}
-                providerId={offer.provider_id}
-                providerName={offer.provider_name}
-                providerIconUrl={offer.provider_icon_url}
-                variant="full"
-              />
-            ))}
-          </div>
-        </Section>
-      )}
+            </Section>
+          );
+        }
+        if (watchProviders) {
+          return (
+            <Section title="Where to Watch">
+              <div className="space-y-3">
+                <ProviderRow label="Stream" providers={watchProviders.flatrate || []} watchLink={watchProviders.link} />
+                <ProviderRow label="Free" providers={watchProviders.free || []} watchLink={watchProviders.link} />
+                <ProviderRow label="Ads" providers={watchProviders.ads || []} watchLink={watchProviders.link} />
+                <ProviderRow label="Rent" providers={watchProviders.rent || []} watchLink={watchProviders.link} />
+                <ProviderRow label="Buy" providers={watchProviders.buy || []} watchLink={watchProviders.link} />
+              </div>
+            </Section>
+          );
+        }
+        return null;
+      })()}
 
       {/* External Links */}
       {tmdb && (
@@ -637,6 +631,7 @@ function ShowDetail({ data }: { data: ShowDetailsResponse }) {
                     providerId={streamingOffer.provider_id}
                     providerName={streamingOffer.provider_name}
                     providerIconUrl={streamingOffer.provider_icon_url}
+                    monetizationType={streamingOffer.monetization_type}
                     variant="full"
                   />
                 );
@@ -712,51 +707,44 @@ function ShowDetail({ data }: { data: ShowDetailsResponse }) {
       )}
 
       {/* Streaming Availability */}
-      {watchProviders && (
-        <Section title="Where to Watch">
-          <div className="space-y-3">
-            <ProviderRow label="Stream" providers={watchProviders.flatrate || []} watchLink={watchProviders.link} />
-            <ProviderRow label="Free" providers={watchProviders.free || []} watchLink={watchProviders.link} />
-            <ProviderRow label="Ads" providers={watchProviders.ads || []} watchLink={watchProviders.link} />
-            <ProviderRow label="Rent" providers={watchProviders.rent || []} watchLink={watchProviders.link} />
-            <ProviderRow label="Buy" providers={watchProviders.buy || []} watchLink={watchProviders.link} />
-          </div>
-          {title.offers.length > 0 && (
-            <div className="mt-4 pt-4 border-t border-white/[0.06]">
-              <p className="text-xs text-zinc-500 mb-2">Direct links</p>
+      {(() => {
+        const offerGroups = groupOffersByType(title.offers);
+        if (offerGroups.length > 0) {
+          return (
+            <Section title="Where to Watch">
               <div className="flex flex-wrap gap-2">
-                {dedupeOffers(title.offers).map((offer) => (
-                  <WatchButton
-                    key={offer.id}
-                    url={offer.url}
-                    providerId={offer.provider_id}
-                    providerName={offer.provider_name}
-                    providerIconUrl={offer.provider_icon_url}
-                    variant="full"
-                  />
-                ))}
+                {offerGroups.flatMap(({ offers }) =>
+                  offers.map((offer) => (
+                    <WatchButton
+                      key={offer.id}
+                      url={offer.url}
+                      providerId={offer.provider_id}
+                      providerName={offer.provider_name}
+                      providerIconUrl={offer.provider_icon_url}
+                      monetizationType={offer.monetization_type}
+                      variant="full"
+                    />
+                  ))
+                )}
               </div>
-            </div>
-          )}
-        </Section>
-      )}
-
-      {!watchProviders && title.offers.length > 0 && (
-        <Section title="Where to Watch">
-          <div className="flex flex-wrap gap-2">
-            {dedupeOffers(title.offers).map((offer) => (
-              <WatchButton
-                key={offer.id}
-                url={offer.url}
-                providerId={offer.provider_id}
-                providerName={offer.provider_name}
-                providerIconUrl={offer.provider_icon_url}
-                variant="full"
-              />
-            ))}
-          </div>
-        </Section>
-      )}
+            </Section>
+          );
+        }
+        if (watchProviders) {
+          return (
+            <Section title="Where to Watch">
+              <div className="space-y-3">
+                <ProviderRow label="Stream" providers={watchProviders.flatrate || []} watchLink={watchProviders.link} />
+                <ProviderRow label="Free" providers={watchProviders.free || []} watchLink={watchProviders.link} />
+                <ProviderRow label="Ads" providers={watchProviders.ads || []} watchLink={watchProviders.link} />
+                <ProviderRow label="Rent" providers={watchProviders.rent || []} watchLink={watchProviders.link} />
+                <ProviderRow label="Buy" providers={watchProviders.buy || []} watchLink={watchProviders.link} />
+              </div>
+            </Section>
+          );
+        }
+        return null;
+      })()}
 
       {/* External Links */}
       {tmdb && (
@@ -826,4 +814,28 @@ function dedupeOffers(offers: Title["offers"]) {
     }
   }
   return Array.from(map.values());
+}
+
+const MONETIZATION_ORDER = [
+  { type: "FLATRATE", label: "Stream" },
+  { type: "FREE", label: "Free" },
+  { type: "ADS", label: "Ads" },
+  { type: "RENT", label: "Rent" },
+  { type: "BUY", label: "Buy" },
+] as const;
+
+function groupOffersByType(offers: Title["offers"]) {
+  const groups: { type: string; label: string; offers: Title["offers"] }[] = [];
+  for (const { type, label } of MONETIZATION_ORDER) {
+    const deduped = new Map<number, Title["offers"][0]>();
+    for (const o of offers) {
+      if (o.monetization_type === type && !deduped.has(o.provider_id)) {
+        deduped.set(o.provider_id, o);
+      }
+    }
+    if (deduped.size > 0) {
+      groups.push({ type, label, offers: Array.from(deduped.values()) });
+    }
+  }
+  return groups;
 }


### PR DESCRIPTION
## Summary
- **Fix doubled buttons**: Consolidated the "Where to Watch" section on detail pages — removed the duplicate TMDB ProviderRow + "Direct links" sections. DB offers (with direct deep links) are now preferred, grouped by monetization type. Falls back to TMDB chip-style providers when no DB offers exist.
- **Add type labels**: WatchButton full variant now shows "Stream", "Rent", "Buy", "Free", or "Ads" prefix before the provider icon and name.
- **Add provider buttons to HeroBanner**: The "Currently Watching" hero banner now shows streaming provider buttons (up to 4) below the episode info.

## Test plan
- [ ] Open a title detail page with DB offers — verify single set of provider buttons grouped by type, no "Direct links" duplication
- [ ] Open a title detail page without DB offers (IMDB import) — verify TMDB provider chips still show as fallback
- [ ] Verify hero area buttons on detail pages show "Stream [icon] Provider" format
- [ ] Check HeroBanner on home page shows provider buttons for tracked shows with offers
- [ ] Verify compact WatchButtons (on cards) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)