### PR TITLE
Fix missing stream buttons by preserving offers during sync fallback

### DIFF
--- a/server/db/repository.test.ts
+++ b/server/db/repository.test.ts
@@ -161,6 +161,15 @@ describe("upsertTitles", () => {
     expect(offers).toHaveLength(1);
     expect(offers[0].provider_id).toBe(337);
   });
+
+  it("preserves existing offers when re-upserting with empty offers", async () => {
+    await upsertTitles([makeParsedTitle({ offers: [makeParsedOffer({ providerId: 8 })] })]);
+    await upsertTitles([makeParsedTitle({ offers: [] })]);
+
+    const offers = await getOffersForTitle("movie-123");
+    expect(offers).toHaveLength(1);
+    expect(offers[0].provider_id).toBe(8);
+  });
 });
 
 // ─── Title Queries ──────────────────────────────────────────────────────────

--- a/server/db/repository/titles.ts
+++ b/server/db/repository/titles.ts
@@ -98,21 +98,23 @@ export async function upsertTitles(parsedTitles: ParsedTitle[]) {
         await db.insert(titleGenres).values({ titleId: t.id, genre }).onConflictDoNothing().run();
       }
 
-      // Replace offers
-      await db.delete(offers).where(eq(offers.titleId, t.id)).run();
-      for (const o of t.offers) {
-        await db.insert(offers)
-          .values({
-            titleId: o.titleId,
-            providerId: o.providerId,
-            monetizationType: o.monetizationType,
-            presentationType: o.presentationType,
-            priceValue: o.priceValue,
-            priceCurrency: o.priceCurrency,
-            url: o.url,
-            availableTo: o.availableTo,
-          })
-          .run();
+      // Replace offers only when new data includes them (prevents sync fallback from wiping existing offers)
+      if (t.offers.length > 0) {
+        await db.delete(offers).where(eq(offers.titleId, t.id)).run();
+        for (const o of t.offers) {
+          await db.insert(offers)
+            .values({
+              titleId: o.titleId,
+              providerId: o.providerId,
+              monetizationType: o.monetizationType,
+              presentationType: o.presentationType,
+              priceValue: o.priceValue,
+              priceCurrency: o.priceCurrency,
+              url: o.url,
+              availableTo: o.availableTo,
+            })
+            .run();
+        }
       }
 
       // Upsert scores

--- a/server/routes/browse.test.ts
+++ b/server/routes/browse.test.ts
@@ -4,7 +4,7 @@ import type { TmdbDiscoverMovieResult, TmdbDiscoverTvResult } from "../tmdb/type
 import type { AppEnv } from "../types";
 import { CONFIG } from "../config";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
-import { upsertTitles, trackTitle, createUser } from "../db/repository";
+import { upsertTitles, trackTitle, createUser, getOffersForTitle } from "../db/repository";
 import { makeParsedTitle, makeTmdbDiscoverMovie, makeTmdbDiscoverTv, makeTmdbMovieDetails, makeTmdbTvDetails } from "../test-utils/fixtures";
 import * as tmdbClient from "../tmdb/client";
 
@@ -323,6 +323,35 @@ describe("GET /browse", () => {
     const body = await res.json();
 
     expect(body.titles[0].isTracked).toBe(true);
+  });
+
+  it("persists titles with offers to database", async () => {
+    const movie = makeTmdbDiscoverMovie({ id: 900 });
+    (tmdbClient.discoverMovies as any).mockResolvedValueOnce({
+      results: [movie], total_pages: 1, total_results: 1, page: 1,
+    });
+    (tmdbClient.fetchMovieDetails as any).mockResolvedValueOnce(makeTmdbMovieDetails({
+      id: 900,
+      "watch/providers": {
+        id: 900,
+        results: {
+          [CONFIG.COUNTRY]: {
+            link: "https://tmdb.org",
+            flatrate: [{ logo_path: "/nf.jpg", provider_id: 8, provider_name: "Netflix", display_priority: 1 }],
+          },
+        },
+      },
+    }));
+
+    const res = await app.request("/browse?category=popular&type=MOVIE");
+    expect(res.status).toBe(200);
+
+    // Wait for fire-and-forget upsert to complete
+    await new Promise((r) => setTimeout(r, 100));
+
+    const offers = await getOffersForTitle("movie-900");
+    expect(offers.length).toBeGreaterThan(0);
+    expect(offers[0].provider_name).toBe("Netflix");
   });
 
   describe("genre filtering", () => {

--- a/server/routes/browse.ts
+++ b/server/routes/browse.ts
@@ -18,7 +18,7 @@ import {
   parseTvDetails,
   type ParsedTitle,
 } from "../tmdb/parser";
-import { getTrackedTitleIds } from "../db/repository";
+import { getTrackedTitleIds, upsertTitles } from "../db/repository";
 import type { AppEnv } from "../types";
 import { logger } from "../logger";
 import { ok, err } from "./response";
@@ -180,6 +180,14 @@ app.get("/", async (c) => {
         }
       })
     );
+
+    // Persist titles with offers to DB so stream buttons appear on subsequent views
+    const titlesWithOffers = titles.filter((t) => t.offers.length > 0);
+    if (titlesWithOffers.length > 0) {
+      upsertTitles(titlesWithOffers).catch((e) => {
+        log.error("Failed to persist browse titles", { error: (e as Error).message });
+      });
+    }
 
     const user = c.get("user");
     const trackedIds = user ? await getTrackedTitleIds(user.id) : new Set<string>();

--- a/server/routes/search.test.ts
+++ b/server/routes/search.test.ts
@@ -3,7 +3,8 @@ import { Hono } from "hono";
 import type { AppEnv } from "../types";
 import type { TmdbSearchMultiResult } from "../tmdb/types";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
-import { upsertTitles, trackTitle, createUser } from "../db/repository";
+import { CONFIG } from "../config";
+import { upsertTitles, trackTitle, createUser, getOffersForTitle } from "../db/repository";
 import { makeParsedTitle, makeTmdbSearchMultiMovie, makeTmdbMovieDetails } from "../test-utils/fixtures";
 import * as tmdbClient from "../tmdb/client";
 
@@ -57,6 +58,35 @@ describe("GET /search", () => {
     const body = await res.json();
     expect(body.titles).toHaveLength(1);
     expect(body.titles[0].isTracked).toBe(false);
+  });
+
+  it("persists titles with offers to database", async () => {
+    const movie = makeTmdbSearchMultiMovie({ id: 42 });
+    (tmdbClient.searchMulti as any).mockResolvedValueOnce({
+      results: [movie], total_pages: 1, total_results: 1, page: 1,
+    });
+    (tmdbClient.fetchMovieDetails as any).mockResolvedValueOnce(makeTmdbMovieDetails({
+      id: 42,
+      "watch/providers": {
+        id: 42,
+        results: {
+          [CONFIG.COUNTRY]: {
+            link: "https://tmdb.org",
+            flatrate: [{ logo_path: "/nf.jpg", provider_id: 8, provider_name: "Netflix", display_priority: 1 }],
+          },
+        },
+      },
+    }));
+
+    const res = await app.request("/search?q=test");
+    expect(res.status).toBe(200);
+
+    // Wait for fire-and-forget upsert to complete
+    await new Promise((r) => setTimeout(r, 100));
+
+    const offers = await getOffersForTitle("movie-42");
+    expect(offers.length).toBeGreaterThan(0);
+    expect(offers[0].provider_name).toBe("Netflix");
   });
 
   it("returns isTracked=true for tracked titles when user is authenticated", async () => {

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -1,7 +1,10 @@
 import { Hono } from "hono";
 import { searchMulti, fetchMovieDetails, fetchTvDetails, getMovieGenres, getTvGenres } from "../tmdb/client";
 import { parseSearchResult, parseMovieDetails, parseTvDetails, type ParsedTitle } from "../tmdb/parser";
-import { getTrackedTitleIds } from "../db/repository";
+import { getTrackedTitleIds, upsertTitles } from "../db/repository";
+import { logger } from "../logger";
+
+const log = logger.child({ module: "search" });
 import { ok, err } from "./response";
 
 import type { AppEnv } from "../types";
@@ -44,6 +47,14 @@ app.get("/", async (c) => {
         }
       })
     );
+
+    // Persist titles with offers to DB so stream buttons appear on subsequent views
+    const titlesWithOffers = titles.filter((t) => t.offers.length > 0);
+    if (titlesWithOffers.length > 0) {
+      upsertTitles(titlesWithOffers).catch((e) => {
+        log.error("Failed to persist search titles", { error: (e as Error).message });
+      });
+    }
 
     const user = c.get("user");
     const trackedIds = user ? await getTrackedTitleIds(user.id) : new Set<string>();


### PR DESCRIPTION
## Summary

- **Guard offer deletion in `upsertTitles()`**: Only delete and replace offers when new data actually includes them. When sync falls back to discover data (empty offers), existing offers are now preserved instead of wiped.
- **Persist browse/search results to DB**: Browse and search routes now fire-and-forget persist titles with offers to the database, so stream buttons appear on subsequent views (e.g., tracked page).
- **Added regression tests** for offer preservation and DB persistence in browse/search routes.

## Test plan

- [x] `bun run check` passes (887 tests, 0 failures)
- [ ] Trigger a sync and verify titles retain their stream buttons even if some TMDB detail fetches fail
- [ ] Browse/search for a title, then check the tracked page — stream buttons should persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)