### PR TITLE
Backfill streaming offers for imported and existing titles

### DIFF
--- a/server/jobs/migrate-offers.test.ts
+++ b/server/jobs/migrate-offers.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, afterAll, spyOn } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { makeParsedTitle, makeParsedOffer } from "../test-utils/fixtures";
+import { upsertTitles } from "../db/repository";
+import { getRawDb } from "../db/bun-db";
+import { CONFIG } from "../config";
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+import * as tmdbClient from "../tmdb/client";
+import * as tmdbParser from "../tmdb/parser";
+import * as repository from "../db/repository";
+
+const mockFetchMovieDetails = spyOn(tmdbClient, "fetchMovieDetails").mockResolvedValue({} as any);
+const mockFetchTvDetails = spyOn(tmdbClient, "fetchTvDetails").mockResolvedValue({} as any);
+
+const mockParseMovieDetails = spyOn(tmdbParser, "parseMovieDetails").mockReturnValue(
+  makeParsedTitle({ offers: [] })
+);
+const mockParseTvDetails = spyOn(tmdbParser, "parseTvDetails").mockReturnValue(
+  makeParsedTitle({ id: "tv-1", objectType: "SHOW", offers: [] })
+);
+
+const mockUpsertTitles = spyOn(repository, "upsertTitles");
+
+// ─── Import after mocks ─────────────────────────────────────────────────────
+import { migrateOffers } from "./migrate-offers";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function insertTitle(id: string, objectType: string, tmdbId: string) {
+  const db = getRawDb();
+  db.prepare(
+    `INSERT INTO titles (id, object_type, tmdb_id, title, release_date) VALUES (?, ?, ?, ?, '2024-01-01')`
+  ).run(id, objectType, tmdbId, `Title ${id}`);
+}
+
+function insertOffer(titleId: string) {
+  const db = getRawDb();
+  db.prepare(`INSERT OR IGNORE INTO providers (id, name) VALUES (8, 'Netflix')`).run();
+  db.prepare(
+    `INSERT INTO offers (title_id, provider_id, monetization_type) VALUES (?, 8, 'FLATRATE')`
+  ).run(titleId);
+}
+
+function countOffers(titleId: string): number {
+  const db = getRawDb();
+  const row = db.prepare("SELECT COUNT(*) as cnt FROM offers WHERE title_id = ?").get(titleId) as any;
+  return row.cnt;
+}
+
+// ─── Setup ───────────────────────────────────────────────────────────────────
+
+const originalApiKey = CONFIG.TMDB_API_KEY;
+
+beforeEach(() => {
+  setupTestDb();
+  mockFetchMovieDetails.mockClear();
+  mockFetchTvDetails.mockClear();
+  mockParseMovieDetails.mockClear();
+  mockParseTvDetails.mockClear();
+  mockUpsertTitles.mockClear();
+  // Restore real upsertTitles for integration-style tests
+  mockUpsertTitles.mockRestore();
+  CONFIG.TMDB_API_KEY = "test-api-key";
+});
+
+afterAll(() => {
+  CONFIG.TMDB_API_KEY = originalApiKey;
+  mockFetchMovieDetails.mockRestore();
+  mockFetchTvDetails.mockRestore();
+  mockParseMovieDetails.mockRestore();
+  mockParseTvDetails.mockRestore();
+  teardownTestDb();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("migrateOffers", () => {
+  it("returns early when TMDB_API_KEY is not configured", async () => {
+    CONFIG.TMDB_API_KEY = "";
+
+    const result = await migrateOffers();
+
+    expect(result).toEqual({ updated: 0, skipped: 0, failed: 0 });
+    expect(mockFetchMovieDetails).not.toHaveBeenCalled();
+    expect(mockFetchTvDetails).not.toHaveBeenCalled();
+  });
+
+  it("returns zeros when no titles exist", async () => {
+    const result = await migrateOffers();
+
+    expect(result).toEqual({ updated: 0, skipped: 0, failed: 0 });
+  });
+
+  it("skips titles that already have offers", async () => {
+    insertTitle("movie-100", "MOVIE", "100");
+    insertOffer("movie-100");
+
+    const result = await migrateOffers();
+
+    expect(result).toEqual({ updated: 0, skipped: 0, failed: 0 });
+    expect(mockFetchMovieDetails).not.toHaveBeenCalled();
+  });
+
+  it("fetches and upserts offers for a movie without offers", async () => {
+    insertTitle("movie-200", "MOVIE", "200");
+
+    const parsedTitle = makeParsedTitle({
+      id: "movie-200",
+      tmdbId: "200",
+      offers: [makeParsedOffer({ titleId: "movie-200" })],
+    });
+    mockFetchMovieDetails.mockResolvedValueOnce({} as any);
+    mockParseMovieDetails.mockReturnValueOnce(parsedTitle);
+
+    const result = await migrateOffers();
+
+    expect(result).toEqual({ updated: 1, skipped: 0, failed: 0 });
+    expect(mockFetchMovieDetails).toHaveBeenCalledWith(200);
+    expect(countOffers("movie-200")).toBe(1);
+  });
+
+  it("fetches TV details for shows", async () => {
+    insertTitle("tv-300", "SHOW", "300");
+
+    const parsedTitle = makeParsedTitle({
+      id: "tv-300",
+      objectType: "SHOW",
+      tmdbId: "300",
+      offers: [makeParsedOffer({ titleId: "tv-300" })],
+    });
+    mockFetchTvDetails.mockResolvedValueOnce({} as any);
+    mockParseTvDetails.mockReturnValueOnce(parsedTitle);
+
+    const result = await migrateOffers();
+
+    expect(result).toEqual({ updated: 1, skipped: 0, failed: 0 });
+    expect(mockFetchTvDetails).toHaveBeenCalledWith(300);
+    expect(countOffers("tv-300")).toBe(1);
+  });
+
+  it("counts as skipped when TMDB returns no offers", async () => {
+    insertTitle("movie-400", "MOVIE", "400");
+
+    mockFetchMovieDetails.mockResolvedValueOnce({} as any);
+    mockParseMovieDetails.mockReturnValueOnce(makeParsedTitle({ id: "movie-400", offers: [] }));
+
+    const result = await migrateOffers();
+
+    expect(result).toEqual({ updated: 0, skipped: 1, failed: 0 });
+    expect(countOffers("movie-400")).toBe(0);
+  });
+
+  it("counts failures when TMDB fetch throws", async () => {
+    insertTitle("movie-500", "MOVIE", "500");
+
+    mockFetchMovieDetails.mockRejectedValueOnce(new Error("TMDB 500"));
+
+    const result = await migrateOffers();
+
+    expect(result).toEqual({ updated: 0, skipped: 0, failed: 1 });
+  });
+
+  it("continues after a failure and processes remaining titles", async () => {
+    insertTitle("movie-600", "MOVIE", "600");
+    insertTitle("movie-601", "MOVIE", "601");
+
+    mockFetchMovieDetails.mockRejectedValueOnce(new Error("API error"));
+    const parsedTitle = makeParsedTitle({
+      id: "movie-601",
+      tmdbId: "601",
+      offers: [makeParsedOffer({ titleId: "movie-601" })],
+    });
+    mockFetchMovieDetails.mockResolvedValueOnce({} as any);
+    mockParseMovieDetails.mockReturnValueOnce(parsedTitle);
+
+    const result = await migrateOffers();
+
+    expect(result).toEqual({ updated: 1, skipped: 0, failed: 1 });
+  });
+});

--- a/server/jobs/migrate-offers.ts
+++ b/server/jobs/migrate-offers.ts
@@ -1,0 +1,72 @@
+import { getDb } from "../db/schema";
+import { titles, offers } from "../db/schema";
+import { isNotNull, sql } from "drizzle-orm";
+import { logger } from "../logger";
+import { fetchMovieDetails, fetchTvDetails } from "../tmdb/client";
+import { parseMovieDetails, parseTvDetails } from "../tmdb/parser";
+import { upsertTitles } from "../db/repository";
+import { CONFIG } from "../config";
+
+const log = logger.child({ module: "migrate-offers" });
+
+const DELAY_MS = 500;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * One-time migration: fetches watch provider offers from TMDB
+ * for all existing titles that have no offers in the database.
+ */
+export async function migrateOffers(): Promise<{ updated: number; skipped: number; failed: number }> {
+  if (!CONFIG.TMDB_API_KEY) {
+    log.info("Skipping offers migration", { reason: "TMDB_API_KEY not configured" });
+    return { updated: 0, skipped: 0, failed: 0 };
+  }
+
+  const db = getDb();
+  const rows = await db
+    .select({ id: titles.id, objectType: titles.objectType, tmdbId: titles.tmdbId })
+    .from(titles)
+    .where(
+      sql`${titles.tmdbId} IS NOT NULL AND NOT EXISTS (SELECT 1 FROM ${offers} WHERE ${offers.titleId} = ${titles.id})`
+    )
+    .all();
+
+  if (rows.length === 0) {
+    log.info("No titles need offers migration");
+    return { updated: 0, skipped: 0, failed: 0 };
+  }
+
+  log.info("Migrating offers", { count: rows.length });
+  let updated = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const row of rows) {
+    try {
+      const tmdbId = parseInt(row.tmdbId!, 10);
+      const isMovie = row.objectType === "MOVIE" || row.id.startsWith("movie-");
+
+      const title = isMovie
+        ? parseMovieDetails(await fetchMovieDetails(tmdbId))
+        : parseTvDetails(await fetchTvDetails(tmdbId));
+
+      if (title.offers.length > 0) {
+        await upsertTitles([title]);
+        updated++;
+      } else {
+        skipped++;
+      }
+    } catch (err) {
+      log.error("Failed to migrate offers", { titleId: row.id, err });
+      failed++;
+    }
+
+    await delay(DELAY_MS);
+  }
+
+  log.info("Offers migration complete", { updated, skipped, failed });
+  return { updated, skipped, failed };
+}

--- a/server/jobs/sync.test.ts
+++ b/server/jobs/sync.test.ts
@@ -25,6 +25,16 @@ import * as syncModule from "../tmdb/sync";
 const mockSyncEpisodes = spyOn(syncModule, "syncEpisodes").mockResolvedValue({ synced: 0, shows: 0 });
 const mockSyncEpisodesForShow = spyOn(syncModule, "syncEpisodesForShow").mockResolvedValue(0);
 
+// Mock TMDB client for backfill-title-offers
+import * as tmdbClient from "../tmdb/client";
+const mockFetchMovieDetails = spyOn(tmdbClient, "fetchMovieDetails").mockResolvedValue({} as any);
+const mockFetchTvDetails = spyOn(tmdbClient, "fetchTvDetails").mockResolvedValue({} as any);
+
+// Mock parser
+import * as parser from "../tmdb/parser";
+const mockParseMovieDetails = spyOn(parser, "parseMovieDetails").mockReturnValue({ id: "movie-1", title: "Test", offers: [], scores: { imdbScore: null, imdbVotes: null, tmdbScore: null } } as any);
+const mockParseTvDetails = spyOn(parser, "parseTvDetails").mockReturnValue({ id: "tv-1", title: "Test", offers: [], scores: { imdbScore: null, imdbVotes: null, tmdbScore: null } } as any);
+
 // Mock episode repository functions for watched episode restoration
 const mockGetEpisodeIdsBySE = spyOn(repository, "getEpisodeIdsBySE").mockResolvedValue([]);
 const mockWatchEpisodesBulk = spyOn(repository, "watchEpisodesBulk").mockResolvedValue(undefined);
@@ -32,6 +42,10 @@ const mockWatchEpisodesBulk = spyOn(repository, "watchEpisodesBulk").mockResolve
 // Mock migrate-titles — use spyOn
 import * as migrateTitlesModule from "./migrate-titles";
 const mockMigrateTitles = spyOn(migrateTitlesModule, "migrateTitles").mockResolvedValue({ updated: 0, failed: 0 });
+
+// Mock migrate-offers — use spyOn
+import * as migrateOffersModule from "./migrate-offers";
+const mockMigrateOffers = spyOn(migrateOffersModule, "migrateOffers").mockResolvedValue({ updated: 0, skipped: 0, failed: 0 });
 
 import { CONFIG } from "../config";
 
@@ -49,6 +63,11 @@ beforeEach(() => {
   mockGetEpisodeIdsBySE.mockClear();
   mockWatchEpisodesBulk.mockClear();
   mockMigrateTitles.mockClear();
+  mockMigrateOffers.mockClear();
+  mockFetchMovieDetails.mockClear();
+  mockFetchTvDetails.mockClear();
+  mockParseMovieDetails.mockClear();
+  mockParseTvDetails.mockClear();
   captureExceptionSpy.mockClear();
 });
 
@@ -63,6 +82,11 @@ afterAll(() => {
   mockGetEpisodeIdsBySE.mockRestore();
   mockWatchEpisodesBulk.mockRestore();
   mockMigrateTitles.mockRestore();
+  mockMigrateOffers.mockRestore();
+  mockFetchMovieDetails.mockRestore();
+  mockFetchTvDetails.mockRestore();
+  mockParseMovieDetails.mockRestore();
+  mockParseTvDetails.mockRestore();
 });
 
 // ─── registerSyncJobs ────────────────────────────────────────────────────────
@@ -97,6 +121,14 @@ describe("registerSyncJobs", () => {
     expect(job).not.toBeNull();
     expect(job!.name).toBe("migrate-titles");
   });
+
+  it("enqueues a one-time migrate-offers job on registration", () => {
+    registerSyncJobs();
+
+    const job = claimNextJob("migrate-offers");
+    expect(job).not.toBeNull();
+    expect(job!.name).toBe("migrate-offers");
+  });
 });
 
 // ─── sync-titles handler ─────────────────────────────────────────────────────
@@ -106,6 +138,8 @@ describe("sync-titles handler", () => {
     registerSyncJobs();
     // Drain the auto-enqueued migrate-titles job to avoid interfering with assertions
     claimNextJob("migrate-titles");
+    claimNextJob("migrate-backdrops");
+    claimNextJob("migrate-offers");
   });
 
   it("fetches new releases and upserts them", async () => {
@@ -162,8 +196,9 @@ describe("sync-episodes handler", () => {
 
   beforeEach(() => {
     registerSyncJobs();
-    // Drain the auto-enqueued migrate-titles job to avoid interfering with assertions
     claimNextJob("migrate-titles");
+    claimNextJob("migrate-backdrops");
+    claimNextJob("migrate-offers");
   });
 
   afterAll(() => {
@@ -236,6 +271,8 @@ describe("sync-show-episodes handler", () => {
   beforeEach(() => {
     registerSyncJobs();
     claimNextJob("migrate-titles");
+    claimNextJob("migrate-backdrops");
+    claimNextJob("migrate-offers");
     CONFIG.TMDB_API_KEY = "test-api-key";
   });
 
@@ -308,5 +345,73 @@ describe("sync-show-episodes handler", () => {
     await processJobs();
 
     expect(mockSyncEpisodesForShow).not.toHaveBeenCalled();
+  });
+});
+
+// ─── backfill-title-offers handler ──────────────────────────────────────────
+
+describe("backfill-title-offers handler", () => {
+  const originalApiKey = CONFIG.TMDB_API_KEY;
+
+  beforeEach(() => {
+    registerSyncJobs();
+    claimNextJob("migrate-titles");
+    claimNextJob("migrate-backdrops");
+    claimNextJob("migrate-offers");
+    CONFIG.TMDB_API_KEY = "test-api-key";
+  });
+
+  afterAll(() => {
+    CONFIG.TMDB_API_KEY = originalApiKey;
+  });
+
+  it("fetches movie details and upserts when offers are found", async () => {
+    const fakeTitle = { id: "movie-50", title: "Backfill Movie", offers: [{ providerId: 1 }] } as any;
+    mockFetchMovieDetails.mockResolvedValueOnce({} as any);
+    mockParseMovieDetails.mockReturnValueOnce(fakeTitle);
+    mockUpsertTitles.mockResolvedValueOnce(1);
+
+    enqueueJob("backfill-title-offers", { tmdbId: "50", objectType: "MOVIE" });
+    await processJobs();
+
+    expect(mockFetchMovieDetails).toHaveBeenCalledWith(50);
+    expect(mockParseMovieDetails).toHaveBeenCalled();
+    expect(mockUpsertTitles).toHaveBeenCalledWith([fakeTitle]);
+  });
+
+  it("fetches TV details for SHOW type", async () => {
+    const fakeTitle = { id: "tv-60", title: "Backfill Show", offers: [{ providerId: 2 }] } as any;
+    mockFetchTvDetails.mockResolvedValueOnce({} as any);
+    mockParseTvDetails.mockReturnValueOnce(fakeTitle);
+    mockUpsertTitles.mockResolvedValueOnce(1);
+
+    enqueueJob("backfill-title-offers", { tmdbId: "60", objectType: "SHOW" });
+    await processJobs();
+
+    expect(mockFetchTvDetails).toHaveBeenCalledWith(60);
+    expect(mockParseTvDetails).toHaveBeenCalled();
+    expect(mockUpsertTitles).toHaveBeenCalledWith([fakeTitle]);
+  });
+
+  it("does not upsert when no offers are found", async () => {
+    const fakeTitle = { id: "movie-70", title: "No Offers Movie", offers: [] } as any;
+    mockFetchMovieDetails.mockResolvedValueOnce({} as any);
+    mockParseMovieDetails.mockReturnValueOnce(fakeTitle);
+
+    enqueueJob("backfill-title-offers", { tmdbId: "70", objectType: "MOVIE" });
+    await processJobs();
+
+    expect(mockFetchMovieDetails).toHaveBeenCalledWith(70);
+    expect(mockUpsertTitles).not.toHaveBeenCalled();
+  });
+
+  it("skips when TMDB_API_KEY is not set", async () => {
+    CONFIG.TMDB_API_KEY = "";
+
+    enqueueJob("backfill-title-offers", { tmdbId: "80", objectType: "MOVIE" });
+    await processJobs();
+
+    expect(mockFetchMovieDetails).not.toHaveBeenCalled();
+    expect(mockFetchTvDetails).not.toHaveBeenCalled();
   });
 });

--- a/server/jobs/sync.ts
+++ b/server/jobs/sync.ts
@@ -7,8 +7,11 @@ import { CONFIG } from "../config";
 import { fetchNewReleases } from "../tmdb/sync-titles";
 import { upsertTitles, getEpisodeIdsBySE, watchEpisodesBulk } from "../db/repository";
 import { syncEpisodes, syncEpisodesForShow } from "../tmdb/sync";
+import { fetchMovieDetails, fetchTvDetails } from "../tmdb/client";
+import { parseMovieDetails, parseTvDetails } from "../tmdb/parser";
 import { migrateTitles } from "./migrate-titles";
 import { migrateBackdrops } from "./migrate-backdrops";
+import { migrateOffers } from "./migrate-offers";
 
 export function registerSyncJobs() {
   // ─── Handlers ───────────────────────────────────────────────────────────
@@ -54,12 +57,37 @@ export function registerSyncJobs() {
     }
   });
 
+  registerHandler("backfill-title-offers", async (job) => {
+    if (!CONFIG.TMDB_API_KEY) {
+      log.info("Skipping offers backfill", { reason: "TMDB_API_KEY not configured" });
+      return;
+    }
+    const data = job.data ? JSON.parse(job.data) : null;
+    if (!data?.tmdbId || !data?.objectType) {
+      throw new Error("backfill-title-offers job missing required data fields");
+    }
+    const tmdbId = Number(data.tmdbId);
+    const title = data.objectType === "MOVIE"
+      ? parseMovieDetails(await fetchMovieDetails(tmdbId))
+      : parseTvDetails(await fetchTvDetails(tmdbId));
+    if (title.offers.length > 0) {
+      await upsertTitles([title]);
+      log.info("Backfilled offers for title", { title: title.title, offers: title.offers.length });
+    } else {
+      log.info("No offers found for title", { title: title.title });
+    }
+  });
+
   registerHandler("migrate-titles", async () => {
     await migrateTitles();
   });
 
   registerHandler("migrate-backdrops", async () => {
     await migrateBackdrops();
+  });
+
+  registerHandler("migrate-offers", async () => {
+    await migrateOffers();
   });
 
   // ─── Cron Schedules ────────────────────────────────────────────────────
@@ -72,4 +100,7 @@ export function registerSyncJobs() {
 
   // Enqueue one-time backdrop backfill (will no-op if all titles already have backdrop_url)
   enqueueJob("migrate-backdrops", undefined, { maxAttempts: 1 });
+
+  // Enqueue one-time offers backfill (will no-op if all titles already have offers)
+  enqueueJob("migrate-offers", undefined, { maxAttempts: 1 });
 }

--- a/server/routes/track.test.ts
+++ b/server/routes/track.test.ts
@@ -410,6 +410,87 @@ describe("POST /track/import", () => {
     CONFIG.TMDB_API_KEY = originalKey;
   });
 
+  it("enqueues backfill-title-offers job for imported titles with tmdb_id", async () => {
+    const originalKey = CONFIG.TMDB_API_KEY;
+    CONFIG.TMDB_API_KEY = "test-key";
+
+    const exportData = {
+      version: 1,
+      exported_at: "2026-01-01T00:00:00Z",
+      titles: [
+        {
+          id: "movie-600",
+          tmdb_id: "600",
+          object_type: "MOVIE",
+          title: "Backfill Movie",
+          genres: [],
+          watched_episodes: [],
+        },
+        {
+          id: "tv-601",
+          tmdb_id: "601",
+          object_type: "SHOW",
+          title: "Backfill Show",
+          genres: [],
+          watched_episodes: [],
+        },
+      ],
+    };
+
+    const res = await app.request("/track/import", {
+      method: "POST",
+      headers: { ...headers(), "Content-Type": "application/json" },
+      body: JSON.stringify(exportData),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.imported).toBe(2);
+
+    const db = getRawDb();
+    const movieJob = db.prepare("SELECT * FROM jobs WHERE name = 'backfill-title-offers' AND json_extract(data, '$.tmdbId') = '600' LIMIT 1").get() as any;
+    expect(movieJob).toBeTruthy();
+    expect(JSON.parse(movieJob.data)).toMatchObject({ tmdbId: "600", objectType: "MOVIE" });
+
+    const showJob = db.prepare("SELECT * FROM jobs WHERE name = 'backfill-title-offers' AND json_extract(data, '$.tmdbId') = '601' LIMIT 1").get() as any;
+    expect(showJob).toBeTruthy();
+    expect(JSON.parse(showJob.data)).toMatchObject({ tmdbId: "601", objectType: "SHOW" });
+
+    CONFIG.TMDB_API_KEY = originalKey;
+  });
+
+  it("does not enqueue backfill-title-offers when TMDB_API_KEY is not set", async () => {
+    const originalKey = CONFIG.TMDB_API_KEY;
+    CONFIG.TMDB_API_KEY = "";
+
+    const exportData = {
+      version: 1,
+      exported_at: "2026-01-01T00:00:00Z",
+      titles: [
+        {
+          id: "movie-602",
+          tmdb_id: "602",
+          object_type: "MOVIE",
+          title: "No Key Movie",
+          genres: [],
+          watched_episodes: [],
+        },
+      ],
+    };
+
+    const res = await app.request("/track/import", {
+      method: "POST",
+      headers: { ...headers(), "Content-Type": "application/json" },
+      body: JSON.stringify(exportData),
+    });
+    expect(res.status).toBe(200);
+
+    const db = getRawDb();
+    const job = db.prepare("SELECT * FROM jobs WHERE name = 'backfill-title-offers' AND json_extract(data, '$.tmdbId') = '602' LIMIT 1").get();
+    expect(job).toBeNull();
+
+    CONFIG.TMDB_API_KEY = originalKey;
+  });
+
   it("does not enqueue sync-show-episodes for MOVIE titles", async () => {
     const originalKey = CONFIG.TMDB_API_KEY;
     CONFIG.TMDB_API_KEY = "test-key";

--- a/server/routes/track.ts
+++ b/server/routes/track.ts
@@ -191,6 +191,14 @@ app.post("/import", async (c) => {
         await watchTitle(item.id, user.id);
       }
 
+      // Backfill watch provider offers from TMDB
+      if (item.tmdb_id && CONFIG.TMDB_API_KEY) {
+        await enqueueJobDrizzle("backfill-title-offers", {
+          tmdbId: item.tmdb_id,
+          objectType: item.object_type,
+        });
+      }
+
       const hasWatched = Array.isArray(item.watched_episodes) && item.watched_episodes.length > 0;
       const canSyncEpisodes = item.object_type === "SHOW" && item.tmdb_id && CONFIG.TMDB_API_KEY;
 


### PR DESCRIPTION
## Summary
- Watchlist import was creating title records with `offers: []`, so stream buttons never appeared for imported titles
- Adds a `backfill-title-offers` job that fetches full TMDB details (with watch providers) for each title during import
- Adds a one-time `migrate-offers` migration job that backfills all existing titles missing offers on next deploy
- ~96% of shows in prod DB (352/365) currently have no offers — this will fix them

## Test plan
- [x] All 902 tests pass (`bun run check`)
- [ ] Deploy and verify `migrate-offers` job runs and populates offers for existing titles
- [ ] Import a new watchlist and verify stream buttons appear after backfill jobs complete
- [ ] Verify titles that already have offers are not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)