### PR TITLE
Simplify provider display and enhance WatchButton styling

### DIFF
--- a/frontend/src/components/ReelsCard.tsx
+++ b/frontend/src/components/ReelsCard.tsx
@@ -133,22 +133,6 @@ export default function ReelsCard({ episode, caughtUp, onMarkWatched, index, tot
               </p>
             )}
 
-            {/* Provider icons */}
-            {providers.length > 0 && (
-              <div className="flex gap-2 mb-4">
-                {providers.map((p) => (
-                  <WatchButton
-                    key={p.provider_id}
-                    url={p.url}
-                    providerId={p.provider_id}
-                    providerName={p.provider_name}
-                    providerIconUrl={p.provider_icon_url}
-                    variant="compact"
-                  />
-                ))}
-              </div>
-            )}
-
             {/* Watch on provider button */}
             {providers.length > 0 && (
               <div className="mb-2">
@@ -158,6 +142,7 @@ export default function ReelsCard({ episode, caughtUp, onMarkWatched, index, tot
                   providerName={providers[0].provider_name}
                   providerIconUrl={providers[0].provider_icon_url}
                   variant="full"
+                  className="w-full justify-center px-6 py-3 rounded-xl text-base font-semibold"
                 />
               </div>
             )}

--- a/frontend/src/components/WatchButton.test.tsx
+++ b/frontend/src/components/WatchButton.test.tsx
@@ -81,4 +81,13 @@ describe("WatchButton", () => {
     );
     expect(container.textContent).not.toContain("Stream");
   });
+
+  it("applies custom className to full variant", () => {
+    const { container } = render(
+      <WatchButton {...defaultProps} variant="full" className="w-full justify-center" />
+    );
+    const link = container.querySelector("a");
+    expect(link!.className).toContain("w-full");
+    expect(link!.className).toContain("justify-center");
+  });
 });

--- a/frontend/src/components/WatchButton.tsx
+++ b/frontend/src/components/WatchButton.tsx
@@ -9,6 +9,7 @@ interface WatchButtonProps {
   providerIconUrl: string;
   variant?: "compact" | "full";
   monetizationType?: string;
+  className?: string;
 }
 
 function monetizationLabel(type?: string): string | null {
@@ -29,6 +30,7 @@ export default function WatchButton({
   providerIconUrl,
   variant = "compact",
   monetizationType,
+  className,
 }: WatchButtonProps) {
   const color = getProviderColor(providerId);
   const [hovered, setHovered] = useState(false);
@@ -66,7 +68,7 @@ export default function WatchButton({
       href={url}
       target="_blank"
       rel="noopener noreferrer"
-      className="inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-200"
+      className={`inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-200 ${className ?? ""}`}
       style={{
         backgroundColor: hovered ? color.hover : color.bg,
         color: color.text,


### PR DESCRIPTION
## Summary
This PR refactors the provider display in ReelsCard by removing the compact provider icon row and consolidating to a single full-width watch button. It also adds support for custom styling to the WatchButton component.

## Key Changes
- **Removed compact provider icons row** from ReelsCard that displayed multiple provider icons in a horizontal layout
- **Consolidated to single full-width watch button** showing only the primary provider with improved styling
- **Added `className` prop to WatchButton** to allow custom styling of the button element
- **Applied custom styling** to the full variant watch button with improved spacing and typography (`w-full justify-center px-6 py-3 rounded-xl text-base font-semibold`)
- **Added test coverage** for the new className prop functionality

## Implementation Details
- The className prop is optional and uses nullish coalescing to safely append custom classes to the base styles
- The full variant watch button now has more prominent styling with larger padding, rounded corners, and increased font size
- All existing functionality is preserved; this is purely a UI/UX improvement focused on simplifying the provider display

https://claude.ai/code/session_0133wSc1Bp4TRMbjJH5MA8Hq