### PR TITLE
Simplify streaming provider display to show only primary provider

### DIFF
--- a/frontend/src/components/EpisodeComponents.tsx
+++ b/frontend/src/components/EpisodeComponents.tsx
@@ -123,10 +123,8 @@ export function EpisodeCard({ episode, compact, onToggleWatched }: { episode: Ep
           </Link>
         </div>
         {providers.length > 0 && (
-          <div className="flex gap-1 flex-shrink-0">
-            {providers.slice(0, 3).map((o) => (
-              <WatchButton key={o.provider_id} url={o.url} providerId={o.provider_id} providerName={o.provider_name} providerIconUrl={o.provider_icon_url} variant="compact" />
-            ))}
+          <div className="flex-shrink-0">
+            <WatchButton url={providers[0].url} providerId={providers[0].provider_id} providerName={providers[0].provider_name} providerIconUrl={providers[0].provider_icon_url} monetizationType={providers[0].monetization_type} variant="full" />
           </div>
         )}
       </div>
@@ -161,10 +159,8 @@ export function EpisodeCard({ episode, compact, onToggleWatched }: { episode: Ep
             <p className="text-sm text-zinc-400 mt-2 line-clamp-2">{episode.overview}</p>
           )}
           {providers.length > 0 && (
-            <div className="flex gap-1.5 mt-3">
-              {providers.map((o) => (
-                <WatchButton key={o.provider_id} url={o.url} providerId={o.provider_id} providerName={o.provider_name} providerIconUrl={o.provider_icon_url} variant="compact" />
-              ))}
+            <div className="mt-3">
+              <WatchButton url={providers[0].url} providerId={providers[0].provider_id} providerName={providers[0].provider_name} providerIconUrl={providers[0].provider_icon_url} monetizationType={providers[0].monetization_type} variant="full" />
             </div>
           )}
         </div>
@@ -210,10 +206,8 @@ export function ShowEpisodeGroup({ showTitle, episodes, posterUrl, compact, onTo
           </div>
         </div>
         {providers.length > 0 && (
-          <div className="flex gap-1 flex-shrink-0">
-            {providers.slice(0, 3).map((o) => (
-              <WatchButton key={o.provider_id} url={o.url} providerId={o.provider_id} providerName={o.provider_name} providerIconUrl={o.provider_icon_url} variant="compact" />
-            ))}
+          <div className="flex-shrink-0">
+            <WatchButton url={providers[0].url} providerId={providers[0].provider_id} providerName={providers[0].provider_name} providerIconUrl={providers[0].provider_icon_url} monetizationType={providers[0].monetization_type} variant="full" />
           </div>
         )}
       </div>
@@ -244,10 +238,8 @@ export function ShowEpisodeGroup({ showTitle, episodes, posterUrl, compact, onTo
             ))}
           </div>
           {providers.length > 0 && (
-            <div className="flex gap-1.5 mt-3">
-              {providers.map((o) => (
-                <WatchButton key={o.provider_id} url={o.url} providerId={o.provider_id} providerName={o.provider_name} providerIconUrl={o.provider_icon_url} variant="compact" />
-              ))}
+            <div className="mt-3">
+              <WatchButton url={providers[0].url} providerId={providers[0].provider_id} providerName={providers[0].provider_name} providerIconUrl={providers[0].provider_icon_url} monetizationType={providers[0].monetization_type} variant="full" />
             </div>
           )}
         </div>

--- a/frontend/src/components/EpisodeShowCard.tsx
+++ b/frontend/src/components/EpisodeShowCard.tsx
@@ -70,12 +70,10 @@ export const EpisodeShowCard = memo(function EpisodeShowCard({
           {t("home.season", { number: episode.season_number })} · {t("home.episodesRemaining", { count: episodeCount })}
         </p>
 
-        {/* Provider icons */}
+        {/* Stream button */}
         {providers.length > 0 && (
-          <div className="flex gap-1.5 mt-2">
-            {providers.slice(0, 4).map((o) => (
-              <WatchButton key={o.provider_id} url={o.url} providerId={o.provider_id} providerName={o.provider_name} providerIconUrl={o.provider_icon_url} variant="compact" />
-            ))}
+          <div className="mt-2">
+            <WatchButton url={providers[0].url} providerId={providers[0].provider_id} providerName={providers[0].provider_name} providerIconUrl={providers[0].provider_icon_url} monetizationType={providers[0].monetization_type} variant="full" />
           </div>
         )}
 

--- a/frontend/src/components/ReelsCard.tsx
+++ b/frontend/src/components/ReelsCard.tsx
@@ -133,22 +133,6 @@ export default function ReelsCard({ episode, caughtUp, onMarkWatched, index, tot
               </p>
             )}
 
-            {/* Provider icons */}
-            {providers.length > 0 && (
-              <div className="flex gap-2 mb-4">
-                {providers.map((p) => (
-                  <WatchButton
-                    key={p.provider_id}
-                    url={p.url}
-                    providerId={p.provider_id}
-                    providerName={p.provider_name}
-                    providerIconUrl={p.provider_icon_url}
-                    variant="compact"
-                  />
-                ))}
-              </div>
-            )}
-
             {/* Watch on provider button */}
             {providers.length > 0 && (
               <div className="mb-2">
@@ -157,6 +141,7 @@ export default function ReelsCard({ episode, caughtUp, onMarkWatched, index, tot
                   providerId={providers[0].provider_id}
                   providerName={providers[0].provider_name}
                   providerIconUrl={providers[0].provider_icon_url}
+                  monetizationType={providers[0].monetization_type}
                   variant="full"
                 />
               </div>

--- a/frontend/src/components/TitleCard.test.tsx
+++ b/frontend/src/components/TitleCard.test.tsx
@@ -156,7 +156,7 @@ describe("TitleCard", () => {
     expect(screen.getByText(/142m/)).toBeDefined();
   });
 
-  it("renders streaming provider icons", () => {
+  it("renders streaming provider button", () => {
     const title = makeTitle({
       offers: [
         {
@@ -177,12 +177,12 @@ describe("TitleCard", () => {
     });
     render(<TitleCard title={title} />, { wrapper: NoUserWrapper });
 
-    const providerImg = screen.getByAltText("Netflix");
-    expect(providerImg).toBeDefined();
-    expect(providerImg.getAttribute("src")).toBe("https://example.com/netflix.png");
+    // Full variant renders provider name as text and "Stream" label
+    expect(screen.getByText("Netflix")).toBeDefined();
+    expect(screen.getByText("Stream")).toBeDefined();
   });
 
-  it("deduplicates providers by provider_id", () => {
+  it("deduplicates providers and shows only first", () => {
     const title = makeTitle({
       offers: [
         {
@@ -205,8 +205,11 @@ describe("TitleCard", () => {
     });
     render(<TitleCard title={title} />, { wrapper: NoUserWrapper });
 
-    const icons = screen.getAllByAltText("Netflix");
-    expect(icons.length).toBe(1);
+    // Only one provider button should be rendered (deduped + only first shown)
+    const links = screen.getAllByRole("link").filter(
+      (link) => link.getAttribute("href") === "https://netflix.com/hd"
+    );
+    expect(links.length).toBe(1);
   });
 
   it("links to title detail page", () => {

--- a/frontend/src/components/TitleCard.tsx
+++ b/frontend/src/components/TitleCard.tsx
@@ -72,19 +72,17 @@ const TitleCard = memo(function TitleCard({ title, onTrackToggle }: Props) {
           </p>
         </div>
 
-        {/* Streaming providers */}
+        {/* Streaming provider */}
         {streamingOffers.length > 0 && (
-          <div className="flex flex-wrap gap-1.5">
-            {streamingOffers.map((offer) => (
-              <WatchButton
-                key={offer.provider_id}
-                url={offer.url}
-                providerId={offer.provider_id}
-                providerName={offer.provider_name}
-                providerIconUrl={offer.provider_icon_url}
-                variant="compact"
-              />
-            ))}
+          <div>
+            <WatchButton
+              url={streamingOffers[0].url}
+              providerId={streamingOffers[0].provider_id}
+              providerName={streamingOffers[0].provider_name}
+              providerIconUrl={streamingOffers[0].provider_icon_url}
+              monetizationType={streamingOffers[0].monetization_type}
+              variant="full"
+            />
           </div>
         )}
 


### PR DESCRIPTION
## Summary
This PR refactors the streaming provider display across multiple components to show only the primary (first) provider using the full-width button variant, instead of displaying multiple providers with compact icon buttons.

## Key Changes
- **EpisodeComponents.tsx**: Updated `EpisodeCard` and `ShowEpisodeGroup` to display only the first provider with `variant="full"` instead of mapping up to 3 providers with `variant="compact"`
- **TitleCard.tsx**: Changed from displaying multiple provider icons to showing a single full-width provider button; updated comment from "Streaming providers" to "Streaming provider"
- **ReelsCard.tsx**: Removed the provider icons row entirely and updated the existing full-width button to include `monetizationType` prop
- **EpisodeShowCard.tsx**: Simplified from showing up to 4 provider icons to displaying a single full-width button
- **TitleCard.test.tsx**: Updated test cases to reflect the new behavior:
  - Changed test name from "renders streaming provider icons" to "renders streaming provider button"
  - Updated assertions to check for provider name text and "Stream" label instead of image alt text
  - Updated deduplication test to verify only one provider button is rendered

## Implementation Details
- All provider displays now use `providers[0]` to access the primary provider
- The `monetizationType` prop is now passed to `WatchButton` components where it was previously missing
- Removed flex layout utilities (`flex gap-1`, `flex gap-1.5`, `flex gap-2`, `flex flex-wrap`) that were used for multi-provider layouts
- Maintained the `flex-shrink-0` class in compact layouts where appropriate

https://claude.ai/code/session_01A1pZPXMzbcFuApqMTNAF9o