### PR TITLE
Add Streaming Availability API for deep links

### DIFF
--- a/drizzle/0009_add_deep_link_and_sa_fetched.sql
+++ b/drizzle/0009_add_deep_link_and_sa_fetched.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `offers` ADD `deep_link` text;--> statement-breakpoint
+ALTER TABLE `titles` ADD `sa_fetched_at` text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1774752300000,
       "tag": "0008_passkey_nullable_webauthn_user_id",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1774852400000,
+      "tag": "0009_add_deep_link_and_sa_fetched",
+      "breakpoints": true
     }
   ]
 }

--- a/server/config.ts
+++ b/server/config.ts
@@ -53,6 +53,11 @@ export const CONFIG = {
   VAPID_PRIVATE_KEY: process.env.VAPID_PRIVATE_KEY || "",
   VAPID_SUBJECT: process.env.VAPID_SUBJECT || "",
 
+  // Streaming Availability API (deep links)
+  STREAMING_AVAILABILITY_API_KEY: process.env.STREAMING_AVAILABILITY_API_KEY || "",
+  SYNC_DEEP_LINKS_CRON: process.env.SYNC_DEEP_LINKS_CRON || "0 4 * * *",
+  SA_DAILY_BUDGET: Number(process.env.SA_DAILY_BUDGET) || 95,
+
   // Sentry
   SENTRY_DSN: process.env.SENTRY_DSN || "",
 

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -129,10 +129,10 @@ describe("fixSkippedMigrations", () => {
     }>;
     expect(titleCols.some((c) => c.name === "genres")).toBe(false);
 
-    // All 9 migrations should be recorded
+    // All 10 migrations should be recorded
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(9);
+    expect(migrations.cnt).toBe(10);
   });
 });

--- a/server/db/repository.test.ts
+++ b/server/db/repository.test.ts
@@ -170,6 +170,47 @@ describe("upsertTitles", () => {
     expect(offers).toHaveLength(1);
     expect(offers[0].provider_id).toBe(8);
   });
+
+  it("returns deep_link via COALESCE when available", async () => {
+    await upsertTitles([makeParsedTitle({ offers: [makeParsedOffer({ providerId: 8, url: "https://tmdb.org/movie/123" })] })]);
+
+    // Manually set deep_link
+    const db = getRawDb();
+    db.prepare("UPDATE offers SET deep_link = ? WHERE title_id = ?").run(
+      "https://www.netflix.com/watch/123",
+      "movie-123",
+    );
+
+    const offers = await getOffersForTitle("movie-123");
+    expect(offers).toHaveLength(1);
+    expect(offers[0].url).toBe("https://www.netflix.com/watch/123");
+  });
+
+  it("falls back to url when deep_link is null", async () => {
+    await upsertTitles([makeParsedTitle({ offers: [makeParsedOffer({ providerId: 8, url: "https://tmdb.org/movie/123" })] })]);
+
+    const offers = await getOffersForTitle("movie-123");
+    expect(offers).toHaveLength(1);
+    expect(offers[0].url).toBe("https://tmdb.org/movie/123");
+  });
+
+  it("preserves deep_link when re-upserting offers from TMDB", async () => {
+    await upsertTitles([makeParsedTitle({ offers: [makeParsedOffer({ providerId: 8, url: "https://tmdb.org/movie/123" })] })]);
+
+    // Set deep_link
+    const db = getRawDb();
+    db.prepare("UPDATE offers SET deep_link = ? WHERE title_id = ?").run(
+      "https://www.netflix.com/watch/123",
+      "movie-123",
+    );
+
+    // Re-upsert with TMDB data (same provider)
+    await upsertTitles([makeParsedTitle({ offers: [makeParsedOffer({ providerId: 8, url: "https://tmdb.org/movie/123-updated" })] })]);
+
+    const offers = await getOffersForTitle("movie-123");
+    expect(offers).toHaveLength(1);
+    expect(offers[0].url).toBe("https://www.netflix.com/watch/123");
+  });
 });
 
 // ─── Title Queries ──────────────────────────────────────────────────────────

--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -1,7 +1,7 @@
 // Re-exports all repository functions for backward compatibility.
 // Individual modules can be imported directly for smaller dependency scope.
 
-export { getOffersForTitle, getOffersForTitles } from "./offers";
+export { getOffersForTitle, getOffersForTitles, getTitlesNeedingSaEnrichment } from "./offers";
 
 export {
   upsertTitles,

--- a/server/db/repository/offers.ts
+++ b/server/db/repository/offers.ts
@@ -1,26 +1,28 @@
-import { eq, inArray } from "drizzle-orm";
+import { eq, inArray, sql, isNull, asc, desc } from "drizzle-orm";
 import { getDb } from "../schema";
-import { offers, providers } from "../schema";
+import { offers, providers, titles, tracked } from "../schema";
 import { traceDbQuery } from "../../tracing";
+
+const offerColumns = {
+  id: offers.id,
+  title_id: offers.titleId,
+  provider_id: offers.providerId,
+  monetization_type: offers.monetizationType,
+  presentation_type: offers.presentationType,
+  price_value: offers.priceValue,
+  price_currency: offers.priceCurrency,
+  url: sql<string>`COALESCE(${offers.deepLink}, ${offers.url})`.as("url"),
+  available_to: offers.availableTo,
+  provider_name: providers.name,
+  provider_technical_name: providers.technicalName,
+  provider_icon_url: providers.iconUrl,
+};
 
 export async function getOffersForTitle(titleId: string) {
   return traceDbQuery("getOffersForTitle", async () => {
     const db = getDb();
     return await db
-      .select({
-        id: offers.id,
-        title_id: offers.titleId,
-        provider_id: offers.providerId,
-        monetization_type: offers.monetizationType,
-        presentation_type: offers.presentationType,
-        price_value: offers.priceValue,
-        price_currency: offers.priceCurrency,
-        url: offers.url,
-        available_to: offers.availableTo,
-        provider_name: providers.name,
-        provider_technical_name: providers.technicalName,
-        provider_icon_url: providers.iconUrl,
-      })
+      .select(offerColumns)
       .from(offers)
       .innerJoin(providers, eq(offers.providerId, providers.id))
       .where(eq(offers.titleId, titleId))
@@ -33,24 +35,38 @@ export async function getOffersForTitles(titleIds: string[]) {
     if (titleIds.length === 0) return new Map<string, Awaited<ReturnType<typeof getOffersForTitle>>>();
     const db = getDb();
     const allOffers = await db
-      .select({
-        id: offers.id,
-        title_id: offers.titleId,
-        provider_id: offers.providerId,
-        monetization_type: offers.monetizationType,
-        presentation_type: offers.presentationType,
-        price_value: offers.priceValue,
-        price_currency: offers.priceCurrency,
-        url: offers.url,
-        available_to: offers.availableTo,
-        provider_name: providers.name,
-        provider_technical_name: providers.technicalName,
-        provider_icon_url: providers.iconUrl,
-      })
+      .select(offerColumns)
       .from(offers)
       .innerJoin(providers, eq(offers.providerId, providers.id))
       .where(inArray(offers.titleId, titleIds))
       .all();
     return Map.groupBy(allOffers, (o) => o.title_id);
+  });
+}
+
+/**
+ * Returns titles that need Streaming Availability enrichment.
+ * Prioritizes tracked titles, then sorts by most recent release date.
+ */
+export async function getTitlesNeedingSaEnrichment(limit: number) {
+  return traceDbQuery("getTitlesNeedingSaEnrichment", async () => {
+    const db = getDb();
+    return await db
+      .select({
+        id: titles.id,
+        tmdbId: titles.tmdbId,
+        objectType: titles.objectType,
+      })
+      .from(titles)
+      .leftJoin(tracked, eq(titles.id, tracked.titleId))
+      .where(
+        sql`${titles.tmdbId} IS NOT NULL AND ${titles.saFetchedAt} IS NULL`,
+      )
+      .orderBy(
+        desc(tracked.titleId),  // tracked titles first (non-null)
+        desc(titles.releaseDate),
+      )
+      .limit(limit)
+      .all();
   });
 }

--- a/server/db/repository/titles.ts
+++ b/server/db/repository/titles.ts
@@ -100,8 +100,22 @@ export async function upsertTitles(parsedTitles: ParsedTitle[]) {
 
       // Replace offers only when new data includes them (prevents sync fallback from wiping existing offers)
       if (t.offers.length > 0) {
+        // Preserve deep links: build a map of (providerId, monetizationType) → deepLink
+        const existingOffers = await db
+          .select({ providerId: offers.providerId, monetizationType: offers.monetizationType, deepLink: offers.deepLink })
+          .from(offers)
+          .where(eq(offers.titleId, t.id))
+          .all();
+        const deepLinkMap = new Map<string, string>();
+        for (const o of existingOffers) {
+          if (o.deepLink) {
+            deepLinkMap.set(`${o.providerId}:${o.monetizationType}`, o.deepLink);
+          }
+        }
+
         await db.delete(offers).where(eq(offers.titleId, t.id)).run();
         for (const o of t.offers) {
+          const preservedDeepLink = deepLinkMap.get(`${o.providerId}:${o.monetizationType}`) ?? null;
           await db.insert(offers)
             .values({
               titleId: o.titleId,
@@ -111,6 +125,7 @@ export async function upsertTitles(parsedTitles: ParsedTitle[]) {
               priceValue: o.priceValue,
               priceCurrency: o.priceCurrency,
               url: o.url,
+              deepLink: preservedDeepLink,
               availableTo: o.availableTo,
             })
             .run();

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -45,6 +45,7 @@ export const titles = sqliteTable(
     ageCertification: text("age_certification"),
     originalLanguage: text("original_language"),
     tmdbUrl: text("tmdb_url"),
+    saFetchedAt: text("sa_fetched_at"),
     updatedAt: text("updated_at").default(sql`(datetime('now'))`),
   },
   (table) => [
@@ -75,6 +76,7 @@ export const offers = sqliteTable(
     priceValue: real("price_value"),
     priceCurrency: text("price_currency"),
     url: text("url"),
+    deepLink: text("deep_link"),
     availableTo: text("available_to"),
   },
   (table) => [

--- a/server/jobs/processor.ts
+++ b/server/jobs/processor.ts
@@ -153,6 +153,41 @@ async function handleMigrateOffers(): Promise<void> {
   await migrateOffers();
 }
 
+async function handleSyncDeepLinks(): Promise<void> {
+  if (!CONFIG.STREAMING_AVAILABILITY_API_KEY) {
+    log.info("Skipping deep link sync", { reason: "STREAMING_AVAILABILITY_API_KEY not configured" });
+    return;
+  }
+  const { enrichTitleDeepLinks } = await import("../streaming-availability/enrich");
+  const { RateLimitError } = await import("../streaming-availability/types");
+  const { getTitlesNeedingSaEnrichment } = await import("../db/repository");
+
+  const titleRows = await getTitlesNeedingSaEnrichment(CONFIG.SA_DAILY_BUDGET);
+  if (titleRows.length === 0) return;
+
+  let enriched = 0;
+  let processed = 0;
+  for (const t of titleRows) {
+    try {
+      const count = await enrichTitleDeepLinks(
+        t.id,
+        Number(t.tmdbId),
+        t.objectType as "MOVIE" | "SHOW",
+      );
+      enriched += count;
+      processed++;
+    } catch (err) {
+      if (err instanceof RateLimitError) {
+        log.warn("SA rate limit hit, stopping early", { processed, enriched });
+        break;
+      }
+      log.error("SA enrichment failed", { titleId: t.id, err });
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  log.info("Deep link sync complete", { processed, enriched });
+}
+
 // ─── Job Dispatcher ────────────────────────────────────────────────────────
 
 const handlers: Record<string, (data: string | null) => Promise<void>> = {
@@ -162,6 +197,7 @@ const handlers: Record<string, (data: string | null) => Promise<void>> = {
   "send-notifications": () => handleSendNotifications(),
   "backfill-title-offers": (data) => handleBackfillTitleOffers(data),
   "migrate-offers": () => handleMigrateOffers(),
+  "sync-deep-links": () => handleSyncDeepLinks(),
 };
 
 interface JobRow {

--- a/server/jobs/sync.ts
+++ b/server/jobs/sync.ts
@@ -12,6 +12,9 @@ import { parseMovieDetails, parseTvDetails } from "../tmdb/parser";
 import { migrateTitles } from "./migrate-titles";
 import { migrateBackdrops } from "./migrate-backdrops";
 import { migrateOffers } from "./migrate-offers";
+import { enrichTitleDeepLinks } from "../streaming-availability/enrich";
+import { RateLimitError } from "../streaming-availability/types";
+import { getTitlesNeedingSaEnrichment } from "../db/repository";
 
 export function registerSyncJobs() {
   // ─── Handlers ───────────────────────────────────────────────────────────
@@ -90,10 +93,48 @@ export function registerSyncJobs() {
     await migrateOffers();
   });
 
+  registerHandler("sync-deep-links", async () => {
+    if (!CONFIG.STREAMING_AVAILABILITY_API_KEY) {
+      log.info("Skipping deep link sync", { reason: "STREAMING_AVAILABILITY_API_KEY not configured" });
+      return;
+    }
+    const titleRows = await getTitlesNeedingSaEnrichment(CONFIG.SA_DAILY_BUDGET);
+    if (titleRows.length === 0) {
+      log.info("No titles need deep link enrichment");
+      return;
+    }
+    log.info("Starting deep link sync", { count: titleRows.length });
+    let enriched = 0;
+    let processed = 0;
+    for (const t of titleRows) {
+      try {
+        const count = await enrichTitleDeepLinks(
+          t.id,
+          Number(t.tmdbId),
+          t.objectType as "MOVIE" | "SHOW",
+        );
+        enriched += count;
+        processed++;
+      } catch (err) {
+        if (err instanceof RateLimitError) {
+          log.warn("SA rate limit hit, stopping early", { processed, enriched });
+          break;
+        }
+        log.error("SA enrichment failed", { titleId: t.id, err });
+      }
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+    log.info("Deep link sync complete", { processed, enriched });
+  });
+
   // ─── Cron Schedules ────────────────────────────────────────────────────
 
   registerCron("sync-titles", CONFIG.SYNC_TITLES_CRON);
   registerCron("sync-episodes", CONFIG.SYNC_EPISODES_CRON);
+
+  if (CONFIG.STREAMING_AVAILABILITY_API_KEY) {
+    registerCron("sync-deep-links", CONFIG.SYNC_DEEP_LINKS_CRON);
+  }
 
   // Enqueue one-time title migration (will no-op if all titles already have original_title)
   enqueueJob("migrate-titles", undefined, { maxAttempts: 1 });
@@ -103,4 +144,9 @@ export function registerSyncJobs() {
 
   // Enqueue one-time offers backfill (will no-op if all titles already have offers)
   enqueueJob("migrate-offers", undefined, { maxAttempts: 1 });
+
+  // Enqueue one-time deep link backfill for existing titles
+  if (CONFIG.STREAMING_AVAILABILITY_API_KEY) {
+    enqueueJob("sync-deep-links", undefined, { maxAttempts: 1 });
+  }
 }

--- a/server/streaming-availability/client.test.ts
+++ b/server/streaming-availability/client.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, spyOn, beforeEach, afterEach } from "bun:test";
+import Sentry from "../sentry";
+import { CONFIG } from "../config";
+import { RateLimitError } from "./types";
+
+// Mock Sentry tracing
+let sentrySpy: ReturnType<typeof spyOn>;
+let fetchSpy: ReturnType<typeof spyOn>;
+
+const originalApiKey = CONFIG.STREAMING_AVAILABILITY_API_KEY;
+
+beforeEach(() => {
+  sentrySpy = spyOn(Sentry, "startSpan").mockImplementation((_opts: any, fn: any) => fn({}));
+  fetchSpy = spyOn(globalThis, "fetch");
+  CONFIG.STREAMING_AVAILABILITY_API_KEY = "test-api-key";
+});
+
+afterEach(() => {
+  sentrySpy?.mockRestore();
+  fetchSpy?.mockRestore();
+  CONFIG.STREAMING_AVAILABILITY_API_KEY = originalApiKey;
+});
+
+import { fetchStreamingOptions } from "./client";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("fetchStreamingOptions", () => {
+  it("fetches streaming options for a movie", async () => {
+    const mockResponse = {
+      streamingOptions: {
+        us: [
+          {
+            service: { id: "netflix", name: "Netflix", homePage: "", themeColorCode: "", imageSet: {} },
+            type: "subscription",
+            link: "https://www.netflix.com/watch/12345",
+            quality: "hd",
+          },
+        ],
+      },
+    };
+    fetchSpy.mockResolvedValue(jsonResponse(mockResponse));
+
+    const result = await fetchStreamingOptions(550, "MOVIE", "US");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].link).toBe("https://www.netflix.com/watch/12345");
+    expect(result[0].service.id).toBe("netflix");
+
+    const fetchCall = fetchSpy.mock.calls[0];
+    expect(fetchCall[0]).toContain("/shows/movie/550");
+    expect(fetchCall[0]).toContain("country=us");
+  });
+
+  it("fetches streaming options for a TV show", async () => {
+    const mockResponse = {
+      streamingOptions: {
+        us: [
+          {
+            service: { id: "disney", name: "Disney+", homePage: "", themeColorCode: "", imageSet: {} },
+            type: "subscription",
+            link: "https://www.disneyplus.com/series/123",
+          },
+        ],
+      },
+    };
+    fetchSpy.mockResolvedValue(jsonResponse(mockResponse));
+
+    const result = await fetchStreamingOptions(1396, "SHOW", "US");
+
+    expect(result).toHaveLength(1);
+    const fetchCall = fetchSpy.mock.calls[0];
+    expect(fetchCall[0]).toContain("/shows/tv/1396");
+  });
+
+  it("returns empty array on 404", async () => {
+    fetchSpy.mockResolvedValue(new Response("Not Found", { status: 404 }));
+
+    const result = await fetchStreamingOptions(999999, "MOVIE", "US");
+    expect(result).toEqual([]);
+  });
+
+  it("throws RateLimitError on 429", async () => {
+    fetchSpy.mockResolvedValue(new Response("Too Many Requests", { status: 429 }));
+
+    await expect(fetchStreamingOptions(550, "MOVIE", "US")).rejects.toBeInstanceOf(RateLimitError);
+  });
+
+  it("throws on other HTTP errors", async () => {
+    fetchSpy.mockResolvedValue(new Response("Server Error", { status: 500, statusText: "Internal Server Error" }));
+
+    await expect(fetchStreamingOptions(550, "MOVIE", "US")).rejects.toThrow("SA API error: 500");
+  });
+
+  it("returns empty array when country has no options", async () => {
+    const mockResponse = {
+      streamingOptions: {
+        gb: [{ service: { id: "netflix" }, type: "subscription", link: "https://netflix.com/1" }],
+      },
+    };
+    fetchSpy.mockResolvedValue(jsonResponse(mockResponse));
+
+    const result = await fetchStreamingOptions(550, "MOVIE", "US");
+    expect(result).toEqual([]);
+  });
+
+  it("sends correct headers", async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ streamingOptions: {} }));
+
+    await fetchStreamingOptions(550, "MOVIE", "US");
+
+    const headers = fetchSpy.mock.calls[0][1].headers;
+    expect(headers["X-RapidAPI-Key"]).toBe("test-api-key");
+    expect(headers["X-RapidAPI-Host"]).toBe("streaming-availability.p.rapidapi.com");
+  });
+});

--- a/server/streaming-availability/client.ts
+++ b/server/streaming-availability/client.ts
@@ -1,0 +1,58 @@
+import { CONFIG } from "../config";
+import { traceHttp } from "../tracing";
+import { logger } from "../logger";
+import type { SAShow, SAStreamingOption } from "./types";
+import { RateLimitError } from "./types";
+
+const log = logger.child({ module: "streaming-availability" });
+
+const SA_BASE_URL = "https://streaming-availability.p.rapidapi.com";
+
+/**
+ * Fetch streaming options from the Streaming Availability API for a single title.
+ * Returns streaming options for the configured country, or empty array if not found.
+ */
+export async function fetchStreamingOptions(
+  tmdbId: number,
+  objectType: "MOVIE" | "SHOW",
+  country: string,
+): Promise<SAStreamingOption[]> {
+  const showType = objectType === "MOVIE" ? "movie" : "tv";
+  const showId = `${showType}/${tmdbId}`;
+  const url = new URL(`${SA_BASE_URL}/shows/${showId}`);
+  url.searchParams.set("country", country.toLowerCase());
+  url.searchParams.set("series_granularity", "show");
+
+  return traceHttp("GET", url.toString(), async () => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), CONFIG.TMDB_API_TIMEOUT_MS);
+    try {
+      const res = await fetch(url.toString(), {
+        headers: {
+          "X-RapidAPI-Key": CONFIG.STREAMING_AVAILABILITY_API_KEY,
+          "X-RapidAPI-Host": "streaming-availability.p.rapidapi.com",
+        },
+        signal: controller.signal,
+      });
+
+      if (res.status === 404) {
+        log.debug("Title not found on SA", { tmdbId, objectType });
+        return [];
+      }
+
+      if (res.status === 429) {
+        throw new RateLimitError();
+      }
+
+      if (!res.ok) {
+        throw new Error(`SA API error: ${res.status} ${res.statusText}`);
+      }
+
+      const data = (await res.json()) as SAShow;
+      const countryKey = country.toLowerCase();
+      return data.streamingOptions?.[countryKey] ?? [];
+    } finally {
+      clearTimeout(timeout);
+    }
+  });
+}

--- a/server/streaming-availability/enrich.test.ts
+++ b/server/streaming-availability/enrich.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach, afterAll, spyOn } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { getRawDb } from "../db/bun-db";
+import { CONFIG } from "../config";
+
+// Mock Sentry
+import Sentry from "../sentry";
+spyOn(Sentry, "startSpan").mockImplementation((_opts: any, fn: any) => fn({}));
+
+// Mock SA client
+import * as saClient from "./client";
+const mockFetchStreamingOptions = spyOn(saClient, "fetchStreamingOptions");
+
+import { enrichTitleDeepLinks } from "./enrich";
+
+const originalCountry = CONFIG.COUNTRY;
+
+function insertTitle(id: string, objectType: string, tmdbId: string) {
+  const db = getRawDb();
+  db.prepare(
+    `INSERT INTO titles (id, object_type, tmdb_id, title, release_date) VALUES (?, ?, ?, ?, '2024-01-01')`,
+  ).run(id, objectType, tmdbId, `Title ${id}`);
+}
+
+function insertProvider(id: number, name: string, technicalName: string) {
+  const db = getRawDb();
+  db.prepare(
+    `INSERT OR IGNORE INTO providers (id, name, technical_name) VALUES (?, ?, ?)`,
+  ).run(id, name, technicalName);
+}
+
+function insertOffer(titleId: string, providerId: number, monetizationType: string, url: string) {
+  const db = getRawDb();
+  db.prepare(
+    `INSERT INTO offers (title_id, provider_id, monetization_type, url) VALUES (?, ?, ?, ?)`,
+  ).run(titleId, providerId, monetizationType, url);
+}
+
+function getOfferDeepLink(titleId: string, providerId: number): string | null {
+  const db = getRawDb();
+  const row = db
+    .prepare("SELECT deep_link FROM offers WHERE title_id = ? AND provider_id = ?")
+    .get(titleId, providerId) as { deep_link: string | null } | null;
+  return row?.deep_link ?? null;
+}
+
+function getSaFetchedAt(titleId: string): string | null {
+  const db = getRawDb();
+  const row = db
+    .prepare("SELECT sa_fetched_at FROM titles WHERE id = ?")
+    .get(titleId) as { sa_fetched_at: string | null } | null;
+  return row?.sa_fetched_at ?? null;
+}
+
+beforeEach(() => {
+  setupTestDb();
+  mockFetchStreamingOptions.mockClear();
+  CONFIG.COUNTRY = "US";
+});
+
+afterAll(() => {
+  CONFIG.COUNTRY = originalCountry;
+  mockFetchStreamingOptions.mockRestore();
+  teardownTestDb();
+});
+
+describe("enrichTitleDeepLinks", () => {
+  it("updates deep_link for matching offers", async () => {
+    insertTitle("movie-550", "MOVIE", "550");
+    insertProvider(8, "Netflix", "netflix");
+    insertOffer("movie-550", 8, "FLATRATE", "https://www.themoviedb.org/movie/550");
+
+    mockFetchStreamingOptions.mockResolvedValue([
+      {
+        service: { id: "netflix", name: "Netflix", homePage: "", themeColorCode: "", imageSet: {} },
+        type: "subscription",
+        link: "https://www.netflix.com/watch/12345",
+      },
+    ] as any);
+
+    const count = await enrichTitleDeepLinks("movie-550", 550, "MOVIE");
+
+    expect(count).toBe(1);
+    expect(getOfferDeepLink("movie-550", 8)).toBe("https://www.netflix.com/watch/12345");
+  });
+
+  it("marks sa_fetched_at even when no offers match", async () => {
+    insertTitle("movie-100", "MOVIE", "100");
+
+    mockFetchStreamingOptions.mockResolvedValue([]);
+
+    const count = await enrichTitleDeepLinks("movie-100", 100, "MOVIE");
+
+    expect(count).toBe(0);
+    expect(getSaFetchedAt("movie-100")).not.toBeNull();
+  });
+
+  it("marks sa_fetched_at when title has no existing offers", async () => {
+    insertTitle("movie-200", "MOVIE", "200");
+
+    mockFetchStreamingOptions.mockResolvedValue([
+      {
+        service: { id: "netflix", name: "Netflix", homePage: "", themeColorCode: "", imageSet: {} },
+        type: "subscription",
+        link: "https://www.netflix.com/watch/999",
+      },
+    ] as any);
+
+    const count = await enrichTitleDeepLinks("movie-200", 200, "MOVIE");
+
+    expect(count).toBe(0);
+    expect(getSaFetchedAt("movie-200")).not.toBeNull();
+  });
+
+  it("matches by provider only when monetization type differs", async () => {
+    insertTitle("movie-300", "MOVIE", "300");
+    insertProvider(8, "Netflix", "netflix");
+    insertOffer("movie-300", 8, "FLATRATE", "https://tmdb.org/movie/300");
+
+    mockFetchStreamingOptions.mockResolvedValue([
+      {
+        service: { id: "netflix", name: "Netflix", homePage: "", themeColorCode: "", imageSet: {} },
+        type: "addon",
+        link: "https://www.netflix.com/watch/addon/300",
+      },
+    ] as any);
+
+    const count = await enrichTitleDeepLinks("movie-300", 300, "MOVIE");
+
+    expect(count).toBe(1);
+    expect(getOfferDeepLink("movie-300", 8)).toBe("https://www.netflix.com/watch/addon/300");
+  });
+
+  it("handles multiple providers", async () => {
+    insertTitle("movie-400", "MOVIE", "400");
+    insertProvider(8, "Netflix", "netflix");
+    insertProvider(337, "Disney Plus", "disney_plus");
+    insertOffer("movie-400", 8, "FLATRATE", "https://tmdb.org/movie/400");
+    insertOffer("movie-400", 337, "FLATRATE", "https://tmdb.org/movie/400");
+
+    mockFetchStreamingOptions.mockResolvedValue([
+      {
+        service: { id: "netflix", name: "Netflix", homePage: "", themeColorCode: "", imageSet: {} },
+        type: "subscription",
+        link: "https://www.netflix.com/watch/400",
+      },
+      {
+        service: { id: "disney", name: "Disney+", homePage: "", themeColorCode: "", imageSet: {} },
+        type: "subscription",
+        link: "https://www.disneyplus.com/movies/400",
+      },
+    ] as any);
+
+    const count = await enrichTitleDeepLinks("movie-400", 400, "MOVIE");
+
+    expect(count).toBe(2);
+    expect(getOfferDeepLink("movie-400", 8)).toBe("https://www.netflix.com/watch/400");
+    expect(getOfferDeepLink("movie-400", 337)).toBe("https://www.disneyplus.com/movies/400");
+  });
+
+  it("skips unmapped providers gracefully", async () => {
+    insertTitle("movie-500", "MOVIE", "500");
+    insertProvider(8, "Netflix", "netflix");
+    insertOffer("movie-500", 8, "FLATRATE", "https://tmdb.org/movie/500");
+
+    mockFetchStreamingOptions.mockResolvedValue([
+      {
+        service: { id: "unknown_service_xyz", name: "Unknown Service", homePage: "", themeColorCode: "", imageSet: {} },
+        type: "subscription",
+        link: "https://unknown.com/watch/500",
+      },
+    ] as any);
+
+    const count = await enrichTitleDeepLinks("movie-500", 500, "MOVIE");
+
+    expect(count).toBe(0);
+    expect(getSaFetchedAt("movie-500")).not.toBeNull();
+  });
+
+  it("falls back to technical_name matching for unmapped providers", async () => {
+    insertTitle("movie-600", "MOVIE", "600");
+    insertProvider(999, "Custom Service", "custom_service");
+    insertOffer("movie-600", 999, "FLATRATE", "https://tmdb.org/movie/600");
+
+    mockFetchStreamingOptions.mockResolvedValue([
+      {
+        service: { id: "custom_service", name: "Custom Service", homePage: "", themeColorCode: "", imageSet: {} },
+        type: "subscription",
+        link: "https://custom-service.com/watch/600",
+      },
+    ] as any);
+
+    const count = await enrichTitleDeepLinks("movie-600", 600, "MOVIE");
+
+    expect(count).toBe(1);
+    expect(getOfferDeepLink("movie-600", 999)).toBe("https://custom-service.com/watch/600");
+  });
+});

--- a/server/streaming-availability/enrich.ts
+++ b/server/streaming-availability/enrich.ts
@@ -1,0 +1,136 @@
+import { eq, sql } from "drizzle-orm";
+import { getDb, offers, titles, providers } from "../db/schema";
+import { logger } from "../logger";
+import { CONFIG } from "../config";
+import { fetchStreamingOptions } from "./client";
+import { SA_TO_TMDB_PROVIDER, mapSAMonetizationType } from "./provider-map";
+import type { SAStreamingOption } from "./types";
+import { traceDbQuery } from "../tracing";
+
+const log = logger.child({ module: "sa-enrich" });
+
+/**
+ * Resolve a SA service ID to a TMDB provider ID.
+ * First checks the static map, then falls back to matching against providers.technical_name.
+ */
+async function resolveProviderId(
+  serviceId: string,
+  providerCache: Map<string, number>,
+): Promise<number | null> {
+  const staticId = SA_TO_TMDB_PROVIDER.get(serviceId);
+  if (staticId !== undefined) return staticId;
+
+  if (providerCache.has(serviceId)) return providerCache.get(serviceId)!;
+
+  const db = getDb();
+  const normalized = serviceId.toLowerCase().replace(/[^a-z0-9]+/g, "_");
+  const row = await db
+    .select({ id: providers.id })
+    .from(providers)
+    .where(eq(providers.technicalName, normalized))
+    .get();
+
+  if (row) {
+    providerCache.set(serviceId, row.id);
+    return row.id;
+  }
+
+  providerCache.set(serviceId, -1);
+  return null;
+}
+
+/**
+ * Enrich a single title's offers with deep links from the Streaming Availability API.
+ * Returns the number of offers updated.
+ */
+export async function enrichTitleDeepLinks(
+  titleId: string,
+  tmdbId: number,
+  objectType: "MOVIE" | "SHOW",
+): Promise<number> {
+  const country = CONFIG.COUNTRY;
+  const saOptions = await fetchStreamingOptions(tmdbId, objectType, country);
+
+  if (saOptions.length === 0) {
+    await markSaFetched(titleId);
+    return 0;
+  }
+
+  const db = getDb();
+  const existingOffers = await traceDbQuery("getOffersForEnrich", () =>
+    db
+      .select({
+        id: offers.id,
+        providerId: offers.providerId,
+        monetizationType: offers.monetizationType,
+      })
+      .from(offers)
+      .where(eq(offers.titleId, titleId))
+      .all(),
+  );
+
+  if (existingOffers.length === 0) {
+    await markSaFetched(titleId);
+    return 0;
+  }
+
+  const providerCache = new Map<string, number>();
+  let updated = 0;
+
+  for (const saOption of saOptions) {
+    const providerId = await resolveProviderId(saOption.service.id, providerCache);
+    if (providerId === null) {
+      log.debug("Unmapped SA provider", {
+        serviceId: saOption.service.id,
+        serviceName: saOption.service.name,
+        titleId,
+      });
+      continue;
+    }
+
+    const monetizationType = mapSAMonetizationType(saOption.type);
+
+    const matchingOffer = existingOffers.find(
+      (o) => o.providerId === providerId && o.monetizationType === monetizationType,
+    );
+
+    if (!matchingOffer) {
+      // Try matching by provider only (ignore monetization type)
+      const providerMatch = existingOffers.find((o) => o.providerId === providerId);
+      if (providerMatch) {
+        await updateOfferDeepLink(providerMatch.id, saOption.link);
+        updated++;
+      }
+      continue;
+    }
+
+    await updateOfferDeepLink(matchingOffer.id, saOption.link);
+    updated++;
+  }
+
+  await markSaFetched(titleId);
+  log.debug("Enriched title deep links", { titleId, updated, saOptions: saOptions.length });
+  return updated;
+}
+
+async function updateOfferDeepLink(offerId: number, deepLink: string): Promise<void> {
+  return traceDbQuery("updateOfferDeepLink", async () => {
+    const db = getDb();
+    await db
+      .update(offers)
+      .set({ deepLink })
+      .where(eq(offers.id, offerId))
+      .run();
+  });
+}
+
+async function markSaFetched(titleId: string): Promise<void> {
+  return traceDbQuery("markSaFetched", async () => {
+    const db = getDb();
+    await db
+      .update(titles)
+      .set({ saFetchedAt: sql`datetime('now')` })
+      .where(eq(titles.id, titleId))
+      .run();
+  });
+}

--- a/server/streaming-availability/provider-map.test.ts
+++ b/server/streaming-availability/provider-map.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "bun:test";
+import { SA_TO_TMDB_PROVIDER, mapSAMonetizationType } from "./provider-map";
+
+describe("SA_TO_TMDB_PROVIDER", () => {
+  it("maps common streaming services", () => {
+    expect(SA_TO_TMDB_PROVIDER.get("netflix")).toBe(8);
+    expect(SA_TO_TMDB_PROVIDER.get("disney")).toBe(337);
+    expect(SA_TO_TMDB_PROVIDER.get("hbo")).toBe(384);
+    expect(SA_TO_TMDB_PROVIDER.get("prime")).toBe(9);
+    expect(SA_TO_TMDB_PROVIDER.get("apple")).toBe(350);
+  });
+
+  it("returns undefined for unknown services", () => {
+    expect(SA_TO_TMDB_PROVIDER.get("unknown_service")).toBeUndefined();
+  });
+});
+
+describe("mapSAMonetizationType", () => {
+  it("maps subscription to FLATRATE", () => {
+    expect(mapSAMonetizationType("subscription")).toBe("FLATRATE");
+  });
+
+  it("maps free to FREE", () => {
+    expect(mapSAMonetizationType("free")).toBe("FREE");
+  });
+
+  it("maps addon to ADS", () => {
+    expect(mapSAMonetizationType("addon")).toBe("ADS");
+  });
+
+  it("maps rent to RENT", () => {
+    expect(mapSAMonetizationType("rent")).toBe("RENT");
+  });
+
+  it("maps buy to BUY", () => {
+    expect(mapSAMonetizationType("buy")).toBe("BUY");
+  });
+
+  it("defaults to FLATRATE for unknown types", () => {
+    expect(mapSAMonetizationType("whatever")).toBe("FLATRATE");
+  });
+});

--- a/server/streaming-availability/provider-map.ts
+++ b/server/streaming-availability/provider-map.ts
@@ -1,0 +1,50 @@
+/**
+ * Maps Streaming Availability service IDs to TMDB provider IDs.
+ * Extend this map as new providers are encountered.
+ */
+export const SA_TO_TMDB_PROVIDER: Map<string, number> = new Map([
+  ["netflix", 8],
+  ["prime", 9],
+  ["disney", 337],
+  ["hbo", 384],
+  ["apple", 350],
+  ["paramount", 531],
+  ["peacock", 386],
+  ["hulu", 15],
+  ["mubi", 11],
+  ["curiosity", 190],
+  ["stan", 21],
+  ["now", 39],
+  ["wow", 30],
+  ["crave", 230],
+  ["all4", 103],
+  ["iplayer", 38],
+  ["britbox", 380],
+  ["hotstar", 122],
+  ["zee5", 232],
+  ["starz", 43],
+  ["showtime", 37],
+  ["crunchyroll", 283],
+  ["tubi", 73],
+  ["plutotv", 300],
+]);
+
+/**
+ * Maps SA offer types to the monetization types used in our database.
+ */
+export function mapSAMonetizationType(saType: string): string {
+  switch (saType) {
+    case "subscription":
+      return "FLATRATE";
+    case "free":
+      return "FREE";
+    case "addon":
+      return "ADS";
+    case "rent":
+      return "RENT";
+    case "buy":
+      return "BUY";
+    default:
+      return "FLATRATE";
+  }
+}

--- a/server/streaming-availability/types.ts
+++ b/server/streaming-availability/types.ts
@@ -1,0 +1,44 @@
+export interface SAService {
+  id: string;
+  name: string;
+  homePage: string;
+  themeColorCode: string;
+  imageSet: {
+    lightThemeImage: string;
+    darkThemeImage: string;
+    whiteImage: string;
+  };
+}
+
+export interface SAPrice {
+  amount: string;
+  currency: string;
+  formatted: string;
+}
+
+export interface SAStreamingOption {
+  service: SAService;
+  type: "subscription" | "rent" | "buy" | "addon" | "free";
+  link: string;
+  quality?: "sd" | "hd" | "qhd" | "uhd";
+  price?: SAPrice;
+  expiresSoon?: boolean;
+  expiresOn?: number;
+  availableSince?: number;
+}
+
+export interface SAShow {
+  itemType: "show" | "movie";
+  showType?: "movie" | "series";
+  imdbId?: string;
+  tmdbId?: string;
+  title: string;
+  streamingOptions: Record<string, SAStreamingOption[]>;
+}
+
+export class RateLimitError extends Error {
+  constructor(message = "Streaming Availability API rate limit exceeded") {
+    super(message);
+    this.name = "RateLimitError";
+  }
+}


### PR DESCRIPTION
## Summary
- Integrates the [Streaming Availability API](https://docs.movieofthenight.com/) to enrich existing TMDB offers with actual deep links to streaming services (Netflix, Disney+, etc.) instead of JustWatch redirect links
- Feature is opt-in via `STREAMING_AVAILABILITY_API_KEY` env var — zero impact when not configured
- Uses `COALESCE(deep_link, url)` in offer queries so the frontend automatically gets the best available link with no frontend changes needed

## How it works
- New `server/streaming-availability/` module: API client, provider ID mapping (24 services), and enrichment logic
- Daily cron (`sync-deep-links`, default 4 AM) processes up to 95 titles/day (free plan allows 100 req/day), prioritizing tracked titles
- One-time backfill job runs on first startup to begin enriching existing titles
- TMDB sync preserves existing deep links when re-inserting offers
- Handles rate limits gracefully (stops early on 429, resumes next day)

## New env vars
| Variable | Default | Description |
|----------|---------|-------------|
| `STREAMING_AVAILABILITY_API_KEY` | `""` | RapidAPI key for SA API. Empty = feature disabled |
| `SYNC_DEEP_LINKS_CRON` | `0 4 * * *` | Cron schedule for deep link enrichment |
| `SA_DAILY_BUDGET` | `95` | Max SA API calls per cron run |

## Test plan
- [x] `bun run check` passes (928 tests, 0 failures)
- [ ] Set `STREAMING_AVAILABILITY_API_KEY` and run `POST /api/jobs/sync-deep-links` to trigger manually
- [ ] Verify `GET /api/details/movie/<id>` returns deep links in the `url` field
- [ ] Verify offers without SA data still show TMDB fallback links
- [ ] Verify cron appears in `GET /api/jobs` when API key is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)