### PR TITLE
Update WatchButton full variant styling and tests

### DIFF
--- a/frontend/src/components/WatchButton.test.tsx
+++ b/frontend/src/components/WatchButton.test.tsx
@@ -82,12 +82,20 @@ describe("WatchButton", () => {
     expect(container.textContent).not.toContain("Stream");
   });
 
-  it("applies custom className to full variant", () => {
+  it("full variant has full width and centered content by default", () => {
     const { container } = render(
-      <WatchButton {...defaultProps} variant="full" className="w-full justify-center" />
+      <WatchButton {...defaultProps} variant="full" />
     );
     const link = container.querySelector("a");
     expect(link!.className).toContain("w-full");
     expect(link!.className).toContain("justify-center");
+  });
+
+  it("applies custom className to full variant", () => {
+    const { container } = render(
+      <WatchButton {...defaultProps} variant="full" className="custom-class" />
+    );
+    const link = container.querySelector("a");
+    expect(link!.className).toContain("custom-class");
   });
 });

--- a/frontend/src/components/WatchButton.tsx
+++ b/frontend/src/components/WatchButton.tsx
@@ -68,7 +68,7 @@ export default function WatchButton({
       href={url}
       target="_blank"
       rel="noopener noreferrer"
-      className={`inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-200 ${className ?? ""}`}
+      className={`w-full flex items-center justify-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold transition-colors duration-200 ${className ?? ""}`}
       style={{
         backgroundColor: hovered ? color.hover : color.bg,
         color: color.text,


### PR DESCRIPTION
## Summary
Updated the WatchButton component's "full" variant to have full width and centered content by default, with improved styling consistency.

## Key Changes
- **Component styling**: Modified the full variant className to include `w-full` and `justify-center` by default, making it the standard behavior for this variant
- **Typography adjustments**: Updated text sizing from `text-sm` to `text-xs` and font weight from `font-medium` to `font-semibold`
- **Spacing refinement**: Changed gap from `gap-2` to `gap-1.5` for tighter spacing
- **Layout fix**: Changed from `inline-flex` to `flex` to properly support full width behavior
- **Test improvements**: 
  - Renamed existing test to clarify that full width and centered content are now default behaviors
  - Added new test to verify custom className prop still works correctly with the full variant

## Implementation Details
The full variant now applies `w-full flex items-center justify-center` as base styles, ensuring consistent layout behavior across all uses. Custom className props are still supported and will be appended to these base styles, allowing for further customization when needed.

https://claude.ai/code/session_017kgXg9hYU1sDSREXRKzTrA