### PR TITLE
Improve HeroBanner text readability with dark scrim and shadows

### DIFF
--- a/frontend/src/components/HeroBanner.tsx
+++ b/frontend/src/components/HeroBanner.tsx
@@ -140,6 +140,15 @@ export default function HeroBanner({ episodes }: { episodes: Episode[] }) {
         );
       })}
 
+      {/* Dark scrim gradient for text contrast */}
+      <div
+        className="absolute inset-0 z-[5] pointer-events-none"
+        style={{
+          background:
+            "linear-gradient(to right, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.4) 40%, transparent 70%)",
+        }}
+      />
+
       {/* Content overlay */}
       <div className="relative z-10 h-full max-w-[1920px] mx-auto flex">
         {/* Continue Watching card (left side) */}
@@ -208,7 +217,10 @@ export default function HeroBanner({ episodes }: { episodes: Episode[] }) {
           )}
 
           {/* Episode info */}
-          <div className="flex flex-col justify-center max-w-md">
+          <div
+            className="flex flex-col justify-center max-w-md"
+            style={{ textShadow: "0 1px 4px rgba(0,0,0,0.6)" }}
+          >
             <p className="text-xs uppercase tracking-widest text-amber-400 font-medium mb-2">
               Currently Watching
             </p>


### PR DESCRIPTION
## Summary
Enhanced the visual contrast and readability of text in the HeroBanner component by adding a dark gradient scrim overlay and text shadows to the episode information section.

## Key Changes
- Added a dark gradient scrim overlay that fades from left to right (70% opacity on left, transparent on right) to improve text contrast against background images
- Applied text shadow styling to the episode info text block for better legibility
- Positioned the scrim at z-index 5 with pointer-events-none to ensure it doesn't interfere with interactive elements

## Implementation Details
- The scrim uses a linear gradient (`rgba(0,0,0,0.7)` to `transparent`) positioned absolutely to cover the full banner area
- Text shadow uses `0 1px 4px rgba(0,0,0,0.6)` for subtle depth without being overly prominent
- The scrim is placed before the content overlay in the DOM to sit between the background and text layers

https://claude.ai/code/session_01PShDvfhjhuaAjaNSh8MHrV