### PR TITLE
Update WatchButton full variant to show icon only without provider name

### DIFF
--- a/frontend/src/components/TitleCard.test.tsx
+++ b/frontend/src/components/TitleCard.test.tsx
@@ -177,9 +177,10 @@ describe("TitleCard", () => {
     });
     render(<TitleCard title={title} />, { wrapper: NoUserWrapper });
 
-    // Full variant renders provider name as text and "Stream" label
-    expect(screen.getByText("Netflix")).toBeDefined();
+    // Full variant renders "Stream" label and provider icon (no provider name text)
     expect(screen.getByText("Stream")).toBeDefined();
+    const img = screen.getByAltText("Netflix");
+    expect(img).toBeDefined();
   });
 
   it("deduplicates providers and shows only first", () => {

--- a/frontend/src/components/TrackButton.tsx
+++ b/frontend/src/components/TrackButton.tsx
@@ -47,7 +47,7 @@ export default function TrackButton({ titleId, isTracked, onToggle, titleData }:
       onClick={toggle}
       disabled={loading}
       aria-pressed={tracked}
-      className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors cursor-pointer ${
+      className={`w-full px-3 py-1.5 rounded-md text-xs font-medium transition-colors cursor-pointer ${
         tracked
           ? "bg-amber-500 text-zinc-950 hover:bg-red-500"
           : "bg-zinc-800 text-zinc-400 hover:bg-amber-500 hover:text-zinc-950"

--- a/frontend/src/components/WatchButton.test.tsx
+++ b/frontend/src/components/WatchButton.test.tsx
@@ -19,12 +19,14 @@ describe("WatchButton", () => {
     expect(link!.getAttribute("title")).toBe("Netflix");
   });
 
-  it("renders full variant with provider name", () => {
+  it("renders full variant with provider icon only (no name text)", () => {
     const { container } = render(<WatchButton {...defaultProps} variant="full" />);
     const link = container.querySelector("a");
     expect(link).toBeTruthy();
-    expect(link!.textContent).toContain("Netflix");
+    expect(link!.textContent).not.toContain("Netflix");
     expect(link!.getAttribute("href")).toBe("https://example.com/watch");
+    const img = link!.querySelector("img");
+    expect(img!.getAttribute("alt")).toBe("Netflix");
   });
 
   it("renders compact variant by default", () => {
@@ -50,7 +52,7 @@ describe("WatchButton", () => {
     );
     const link = container.querySelector("a");
     expect(link!.textContent).toContain("Stream");
-    expect(link!.textContent).toContain("Netflix");
+    expect(link!.textContent).not.toContain("Netflix");
   });
 
   it("renders Rent label for RENT monetization type", () => {

--- a/frontend/src/components/WatchButton.tsx
+++ b/frontend/src/components/WatchButton.tsx
@@ -79,11 +79,10 @@ export default function WatchButton({
       {label && <span className="opacity-75">{label}</span>}
       <img
         src={providerIconUrl}
-        alt=""
+        alt={providerName}
         className="w-5 h-5 rounded"
         loading="lazy"
       />
-      {providerName}
       <ExternalLink size={14} className="opacity-60" />
     </a>
   );


### PR DESCRIPTION
## Summary
This PR updates the WatchButton component's full variant to display only the provider icon without the provider name text, improving the UI layout while maintaining accessibility through the image alt text.

## Key Changes
- **WatchButton.tsx**: Removed provider name text from full variant and added `alt={providerName}` to the provider icon image for accessibility
- **WatchButton.test.tsx**: Updated test expectations to verify icon-only display and confirm alt text contains provider name
- **TitleCard.test.tsx**: Updated test comment and assertions to reflect that full variant now shows icon instead of provider name text
- **TrackButton.tsx**: Added `w-full` class to button for full-width styling

## Implementation Details
- The provider icon now serves as the primary visual identifier with proper alt text for screen readers
- The "Stream" label and external link icon remain visible in the full variant
- All tests updated to verify the new behavior while maintaining accessibility standards

https://claude.ai/code/session_01Qs7eTnTf8ebC6j1pUhwsz2