### PR TITLE
Add footer with copyright and GitHub link

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { useIsMobile } from "./hooks/useIsMobile";
 import RequireAuth from "./components/RequireAuth";
 import BottomTabBar from "./components/BottomTabBar";
 import OfflineIndicator from "./components/OfflineIndicator";
+import { Github } from "lucide-react";
 import { navLinkClass } from "./nav-utils";
 
 // Retry dynamic imports once on failure (handles stale chunks after deploy)
@@ -144,6 +145,20 @@ export default function App() {
           </Routes>
         </Suspense>
       </main>
+      <footer className="hidden sm:block border-t border-white/[0.06] py-6 mt-8">
+        <div className="max-w-7xl mx-auto px-4 flex items-center justify-between text-sm text-zinc-500">
+          <span>&copy; {new Date().getFullYear()} Remindarr</span>
+          <a
+            href="https://github.com/MatijaMaric/remindarr"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1.5 text-zinc-500 hover:text-white transition-colors"
+          >
+            <Github className="size-4" />
+            GitHub
+          </a>
+        </div>
+      </footer>
       <BottomTabBar />
       <OfflineIndicator />
       <Toaster theme="dark" position="bottom-center" richColors />


### PR DESCRIPTION
## Summary
Added a footer component to the application displaying copyright information and a link to the GitHub repository.

## Key Changes
- Imported `Github` icon from lucide-react
- Added a new footer section below the main content with:
  - Copyright notice with dynamic year
  - GitHub repository link with icon
  - Responsive design (hidden on mobile, visible on sm+ screens)
  - Styled with consistent color scheme and hover effects

## Implementation Details
- Footer is positioned after the main routes but before the BottomTabBar component
- Uses Tailwind CSS for styling with a subtle top border and zinc color palette
- GitHub link opens in a new tab with proper security attributes (`target="_blank"` and `rel="noopener noreferrer"`)
- Maintains visual consistency with the rest of the application using existing color tokens

https://claude.ai/code/session_01BqWa13MatuMcURxVakF9Vn