### PR TITLE
Refactor TitleCard button layout to anchor buttons at bottom

### DIFF
--- a/frontend/src/components/TitleCard.tsx
+++ b/frontend/src/components/TitleCard.tsx
@@ -72,9 +72,9 @@ const TitleCard = memo(function TitleCard({ title, onTrackToggle }: Props) {
           </p>
         </div>
 
-        {/* Streaming provider */}
-        {streamingOffers.length > 0 && (
-          <div>
+        {/* Buttons — always anchored at bottom */}
+        <div className="mt-auto flex flex-col gap-2">
+          {streamingOffers.length > 0 && (
             <WatchButton
               url={streamingOffers[0].url}
               providerId={streamingOffers[0].provider_id}
@@ -83,10 +83,7 @@ const TitleCard = memo(function TitleCard({ title, onTrackToggle }: Props) {
               monetizationType={streamingOffers[0].monetization_type}
               variant="full"
             />
-          </div>
-        )}
-
-        <div className="mt-auto pt-1">
+          )}
           <TrackButton
             titleId={title.id}
             isTracked={title.is_tracked}


### PR DESCRIPTION
## Summary
Restructured the TitleCard component's button layout to ensure buttons are consistently anchored at the bottom of the card, improving visual consistency and layout stability.

## Key Changes
- Consolidated the streaming provider button and track button into a single flex container with `mt-auto` to push buttons to the bottom
- Removed the conditional wrapper div around the WatchButton, keeping the conditional logic but simplifying the DOM structure
- Applied flexbox layout (`flex flex-col gap-2`) to the button container for consistent spacing and alignment
- Updated comments to reflect the new button layout strategy

## Implementation Details
The refactoring maintains the same conditional rendering of the WatchButton (only shown when streaming offers are available) while improving the overall layout structure. The `mt-auto` utility class ensures that regardless of content height above, both buttons will be anchored at the bottom of the card container.

https://claude.ai/code/session_01BxBmZaYehaE4isQ16tNNFs