### PR TITLE
Fix uneven font sizes on Reels page buttons

### DIFF
--- a/frontend/src/components/WatchButton.test.tsx
+++ b/frontend/src/components/WatchButton.test.tsx
@@ -100,4 +100,21 @@ describe("WatchButton", () => {
     const link = container.querySelector("a");
     expect(link!.className).toContain("custom-class");
   });
+
+  it("uses text-xs by default in full variant", () => {
+    const { container } = render(
+      <WatchButton {...defaultProps} variant="full" />
+    );
+    const link = container.querySelector("a");
+    expect(link!.className).toContain("text-xs");
+  });
+
+  it("omits text-xs when className includes a font-size class", () => {
+    const { container } = render(
+      <WatchButton {...defaultProps} variant="full" className="text-base font-semibold" />
+    );
+    const link = container.querySelector("a");
+    expect(link!.className).not.toContain("text-xs");
+    expect(link!.className).toContain("text-base");
+  });
 });

--- a/frontend/src/components/WatchButton.tsx
+++ b/frontend/src/components/WatchButton.tsx
@@ -68,7 +68,7 @@ export default function WatchButton({
       href={url}
       target="_blank"
       rel="noopener noreferrer"
-      className={`w-full flex items-center justify-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold transition-colors duration-200 ${className ?? ""}`}
+      className={`w-full flex items-center justify-center gap-1.5 rounded-lg px-3 py-1.5 ${className?.match(/\btext-(xs|sm|base|lg|xl|\d)/) ? "" : "text-xs"} font-semibold transition-colors duration-200 ${className ?? ""}`}
       style={{
         backgroundColor: hovered ? color.hover : color.bg,
         color: color.text,


### PR DESCRIPTION
The WatchButton's full variant hardcoded text-xs, which in Tailwind v4
couldn't be overridden by text-base passed via className due to CSS
cascade order. Now text-xs is only applied when no font-size class is
provided, allowing ReelsCard to set both buttons to text-base.

https://claude.ai/code/session_0128TYetKSGD8xqHr3UA4Pnn