### PR TITLE
Fix uneven button heights on title detail page

### DIFF
--- a/frontend/src/components/TrackButton.tsx
+++ b/frontend/src/components/TrackButton.tsx
@@ -47,7 +47,7 @@ export default function TrackButton({ titleId, isTracked, onToggle, titleData }:
       onClick={toggle}
       disabled={loading}
       aria-pressed={tracked}
-      className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors cursor-pointer ${
+      className={`min-h-8 inline-flex items-center justify-center px-3 py-1.5 rounded-md text-xs font-medium transition-colors cursor-pointer ${
         tracked
           ? "bg-amber-500 text-zinc-950 hover:bg-red-500"
           : "bg-zinc-800 text-zinc-400 hover:bg-amber-500 hover:text-zinc-950"

--- a/frontend/src/components/WatchButton.tsx
+++ b/frontend/src/components/WatchButton.tsx
@@ -68,7 +68,7 @@ export default function WatchButton({
       href={url}
       target="_blank"
       rel="noopener noreferrer"
-      className={`flex items-center justify-center gap-1.5 rounded-lg px-3 py-1.5 ${className?.match(/\btext-(xs|sm|base|lg|xl|\d)/) ? "" : "text-xs"} font-semibold transition-colors duration-200 ${className ?? ""}`}
+      className={`min-h-8 flex items-center justify-center gap-1.5 rounded-lg px-3 py-1.5 ${className?.match(/\btext-(xs|sm|base|lg|xl|\d)/) ? "" : "text-xs"} font-semibold transition-colors duration-200 ${className ?? ""}`}
       style={{
         backgroundColor: hovered ? color.hover : color.bg,
         color: color.text,

--- a/frontend/src/pages/TitleDetailPage.tsx
+++ b/frontend/src/pages/TitleDetailPage.tsx
@@ -329,7 +329,7 @@ function MovieDetail({ data }: { data: MovieDetailsResponse }) {
               <button
                 onClick={toggleWatched}
                 aria-pressed={watched}
-                className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors cursor-pointer ${
+                className={`min-h-8 inline-flex items-center justify-center px-3 py-1.5 rounded-md text-xs font-medium transition-colors cursor-pointer ${
                   watched
                     ? "bg-emerald-500 text-white hover:bg-red-500"
                     : "bg-zinc-800 text-zinc-400 hover:bg-emerald-500 hover:text-white"


### PR DESCRIPTION
Add min-h-8 and inline-flex centering to TrackButton, WatchButton (full
variant), and the inline "Mark as Watched" button so all three render at
a consistent 32px minimum height. Uses min-h instead of fixed h to avoid
breaking the larger ReelsCard variant which overrides padding via className.

https://claude.ai/code/session_013q7sfeJzvHNH7A84TK81bA