### PR TITLE
Extract WebAuthn rpID derivation logic into reusable function

### DIFF
--- a/server/auth/better-auth-passkey.test.ts
+++ b/server/auth/better-auth-passkey.test.ts
@@ -145,6 +145,17 @@ describe("passkey support", () => {
       expect(auth).toBeDefined();
     });
 
+    it("strips www. from rpID when BASE_URL has www prefix", () => {
+      CONFIG.BASE_URL = "https://www.remindarr.app";
+      CONFIG.PASSKEY_RP_ID = "";
+      CONFIG.PASSKEY_ORIGIN = "";
+
+      const db = getDb();
+      const auth = createAuth(db, new BunPlatform());
+      expect(auth).toBeDefined();
+      // rpID is "remindarr.app" (stripped www.), valid for both www and non-www origins
+    });
+
     it("falls back to localhost when BASE_URL is not set", () => {
       CONFIG.BASE_URL = "";
       CONFIG.PASSKEY_RP_ID = "";

--- a/server/auth/better-auth.test.ts
+++ b/server/auth/better-auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { checkAdminClaim, buildPasskeyOrigins } from "./better-auth";
+import { checkAdminClaim, buildPasskeyOrigins, getPasskeyRpId } from "./better-auth";
 
 describe("checkAdminClaim", () => {
   test("returns false when claimName is empty", () => {
@@ -40,6 +40,32 @@ describe("checkAdminClaim", () => {
 
   test("coerces array elements to string for comparison", () => {
     expect(checkAdminClaim({ flags: [1, 2, 3] }, "flags", "2")).toBe(true);
+  });
+});
+
+describe("getPasskeyRpId", () => {
+  test("strips www. prefix from hostname", () => {
+    expect(getPasskeyRpId("https://www.remindarr.app")).toBe("remindarr.app");
+  });
+
+  test("returns bare hostname as-is", () => {
+    expect(getPasskeyRpId("https://remindarr.app")).toBe("remindarr.app");
+  });
+
+  test("returns undefined for empty string", () => {
+    expect(getPasskeyRpId("")).toBeUndefined();
+  });
+
+  test("returns undefined for invalid URL", () => {
+    expect(getPasskeyRpId("not-a-url")).toBeUndefined();
+  });
+
+  test("preserves subdomain that is not www", () => {
+    expect(getPasskeyRpId("https://app.remindarr.app")).toBe("app.remindarr.app");
+  });
+
+  test("returns localhost for localhost URL", () => {
+    expect(getPasskeyRpId("http://localhost:3000")).toBe("localhost");
   });
 });
 

--- a/server/auth/better-auth.ts
+++ b/server/auth/better-auth.ts
@@ -15,6 +15,24 @@ import type { DrizzleDb } from "../platform/types";
 const log = logger.child({ module: "auth" });
 
 /**
+ * Derive the WebAuthn Relying Party ID from a base URL.
+ * Strips the "www." prefix so the rpID is the registrable domain,
+ * which is valid for both www and non-www origins per WebAuthn spec.
+ */
+export function getPasskeyRpId(baseUrl: string): string | undefined {
+  if (!baseUrl) return undefined;
+  try {
+    let hostname = new URL(baseUrl).hostname;
+    if (hostname.startsWith("www.")) {
+      hostname = hostname.slice(4);
+    }
+    return hostname;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Given a base URL, return an array of origins for WebAuthn validation.
  * Includes both www and non-www variants so passkeys work on either domain.
  */
@@ -75,7 +93,7 @@ export function createAuth(db: DrizzleDb, platform: Platform, oidcConfig?: {
     }),
     admin(),
     passkeyPlugin({
-      rpID: CONFIG.PASSKEY_RP_ID || (CONFIG.BASE_URL ? new URL(CONFIG.BASE_URL).hostname : undefined),
+      rpID: CONFIG.PASSKEY_RP_ID || getPasskeyRpId(CONFIG.BASE_URL),
       rpName: CONFIG.PASSKEY_RP_NAME || "Remindarr",
       origin: CONFIG.PASSKEY_ORIGIN
         ? CONFIG.PASSKEY_ORIGIN.split(",").map((o) => o.trim()).filter(Boolean)
@@ -176,7 +194,7 @@ export function createAuth(db: DrizzleDb, platform: Platform, oidcConfig?: {
     basePath: "/api/auth",
     trustedOrigins: [
       ...(CONFIG.CORS_ORIGIN
-        ? CONFIG.CORS_ORIGIN.split(",").map((o) => o.trim()).filter(Boolean)
+        ? CONFIG.CORS_ORIGIN.split(",").map((o) => o.trim()).filter(Boolean).flatMap(buildPasskeyOrigins)
         : []),
       ...(CONFIG.BASE_URL ? buildPasskeyOrigins(CONFIG.BASE_URL) : []),
     ].filter((v, i, a) => a.indexOf(v) === i),


### PR DESCRIPTION
## Summary
Refactored WebAuthn Relying Party ID (rpID) derivation logic into a dedicated `getPasskeyRpId()` function to improve code reusability and testability. This function properly handles the "www." prefix stripping per WebAuthn specification.

## Key Changes
- **New function `getPasskeyRpId()`**: Extracts hostname from a base URL and strips the "www." prefix to derive a valid rpID that works for both www and non-www origins
  - Returns `undefined` for empty strings or invalid URLs
  - Handles edge cases like localhost and subdomains correctly
  - Includes comprehensive JSDoc explaining the WebAuthn spec compliance

- **Updated `createAuth()` passkey configuration**: Replaced inline URL parsing with the new `getPasskeyRpId()` function for cleaner, more maintainable code

- **Enhanced CORS origin handling**: Extended `trustedOrigins` to apply `buildPasskeyOrigins()` to all configured CORS origins, not just the base URL, ensuring consistent passkey origin validation across all allowed origins

- **Added test coverage**: New test suite for `getPasskeyRpId()` with 6 test cases covering:
  - www prefix stripping
  - bare hostnames
  - invalid inputs
  - non-www subdomains
  - localhost handling

## Implementation Details
The `getPasskeyRpId()` function uses the URL API for robust parsing and gracefully handles errors by returning `undefined`. This approach is safer than the previous inline `new URL().hostname` call and centralizes the logic for easier maintenance and testing.

https://claude.ai/code/session_01XeS5UHrmy7V3qQAAo4ahDf