### PR TITLE
Fix layout issues in profile visibility toggle section

### DIFF
--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -436,15 +436,15 @@ function ProfileVisibilitySection() {
 
       <div className="bg-zinc-900 rounded-lg p-5 space-y-4">
         {/* Global toggle */}
-        <div className="flex items-center justify-between">
-          <div>
+        <div className="flex items-center justify-between gap-4">
+          <div className="min-w-0">
             <p className="text-white font-medium">{t("settings.showWatchlistOnProfile")}</p>
             <p className="text-sm text-zinc-400 mt-1">{t("settings.showWatchlistDescription")}</p>
           </div>
           <button
             onClick={handleGlobalToggle}
             disabled={updatingGlobal}
-            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors cursor-pointer disabled:opacity-50 ${
+            className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors cursor-pointer disabled:opacity-50 ${
               profilePublic ? "bg-amber-500" : "bg-zinc-700"
             }`}
           >


### PR DESCRIPTION
## Summary
Improved the layout and responsiveness of the profile visibility toggle in the Settings page to prevent text overflow and ensure proper spacing.

## Key Changes
- Added `gap-4` to the flex container for consistent spacing between label and toggle button
- Added `min-w-0` to the label div to allow text truncation when space is constrained
- Added `shrink-0` to the toggle button to prevent it from shrinking and maintain its fixed dimensions

## Implementation Details
These changes follow flexbox best practices for handling mixed-width content:
- The `gap-4` ensures proper spacing between the label and button
- The `min-w-0` on the label allows the text to properly wrap/truncate instead of forcing the flex container to overflow
- The `shrink-0` on the button preserves its 44px width (h-6 w-11) and prevents it from being compressed by the flex layout

This prevents layout issues where long translated text could cause the toggle button to be pushed off-screen or the container to overflow.

https://claude.ai/code/session_01YAyqNefxc5dYe5hpEKQcmT