### PR TITLE
Add profile banner with recently watched show backdrops

### DIFF
--- a/frontend/src/components/ProfileBanner.test.tsx
+++ b/frontend/src/components/ProfileBanner.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { render, screen, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import ProfileBanner from "./ProfileBanner";
+import type { ProfileBackdrop } from "../types";
+
+afterEach(cleanup);
+
+function renderBanner(backdrops: ProfileBackdrop[]) {
+  return render(
+    <MemoryRouter>
+      <ProfileBanner backdrops={backdrops} />
+    </MemoryRouter>,
+  );
+}
+
+describe("ProfileBanner", () => {
+  it("renders nothing when backdrops array is empty", () => {
+    const { container } = renderBanner([]);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders a single backdrop image", () => {
+    const backdrops = [{ id: "show-1", title: "Test Show", backdrop_url: "https://example.com/backdrop.jpg" }];
+    renderBanner(backdrops);
+
+    const img = screen.getByAltText("Test Show");
+    expect(img).toBeDefined();
+    expect(img.getAttribute("src")).toBe("https://example.com/backdrop.jpg");
+  });
+
+  it("renders multiple backdrop images", () => {
+    const backdrops = [
+      { id: "show-1", title: "Show One", backdrop_url: "https://example.com/1.jpg" },
+      { id: "show-2", title: "Show Two", backdrop_url: "https://example.com/2.jpg" },
+      { id: "show-3", title: "Show Three", backdrop_url: "https://example.com/3.jpg" },
+    ];
+    renderBanner(backdrops);
+
+    expect(screen.getByAltText("Show One")).toBeDefined();
+    expect(screen.getByAltText("Show Two")).toBeDefined();
+    expect(screen.getByAltText("Show Three")).toBeDefined();
+  });
+
+  it("links backdrop images to title detail pages", () => {
+    const backdrops = [{ id: "show-42", title: "Test Show", backdrop_url: "https://example.com/backdrop.jpg" }];
+    renderBanner(backdrops);
+
+    const link = screen.getByRole("link");
+    expect(link.getAttribute("href")).toBe("/title/show-42");
+  });
+});

--- a/frontend/src/components/ProfileBanner.tsx
+++ b/frontend/src/components/ProfileBanner.tsx
@@ -1,0 +1,62 @@
+import { Link } from "react-router";
+import type { ProfileBackdrop } from "../types";
+
+interface Props {
+  backdrops: ProfileBackdrop[];
+}
+
+export default function ProfileBanner({ backdrops }: Props) {
+  if (backdrops.length === 0) return null;
+
+  return (
+    <div className="w-[100vw] relative left-[50%] ml-[-50vw] overflow-hidden h-48 sm:h-56">
+      {/* Image grid */}
+      <div className="absolute inset-0 flex">
+        {backdrops.length === 1 && (
+          <Link to={`/title/${backdrops[0].id}`} className="relative w-full h-full">
+            <img
+              src={backdrops[0].backdrop_url}
+              alt={backdrops[0].title}
+              className="w-full h-full object-cover"
+            />
+          </Link>
+        )}
+        {backdrops.length === 2 && backdrops.map((b) => (
+          <Link key={b.id} to={`/title/${b.id}`} className="relative w-1/2 h-full">
+            <img
+              src={b.backdrop_url}
+              alt={b.title}
+              className="w-full h-full object-cover"
+            />
+          </Link>
+        ))}
+        {backdrops.length >= 3 && (
+          <>
+            <Link to={`/title/${backdrops[0].id}`} className="relative w-1/2 h-full">
+              <img
+                src={backdrops[0].backdrop_url}
+                alt={backdrops[0].title}
+                className="w-full h-full object-cover"
+              />
+            </Link>
+            <div className="w-1/2 h-full flex flex-col">
+              {backdrops.slice(1, 3).map((b) => (
+                <Link key={b.id} to={`/title/${b.id}`} className="relative w-full h-1/2">
+                  <img
+                    src={b.backdrop_url}
+                    alt={b.title}
+                    className="w-full h-full object-cover"
+                  />
+                </Link>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+      {/* Bottom gradient fade */}
+      <div className="absolute inset-0 bg-gradient-to-t from-zinc-950 via-zinc-950/40 to-transparent pointer-events-none" />
+      {/* Subtle overlay for contrast */}
+      <div className="absolute inset-0 bg-black/20 pointer-events-none" />
+    </div>
+  );
+}

--- a/frontend/src/components/TitleCard.test.tsx
+++ b/frontend/src/components/TitleCard.test.tsx
@@ -224,6 +224,51 @@ describe("TitleCard", () => {
     expect(detailLinks.length).toBeGreaterThan(0);
   });
 
+  it("hides TV badge when hideTypeBadge is true", () => {
+    const title = makeTitle({ object_type: "SHOW" });
+    render(<TitleCard title={title} hideTypeBadge />, { wrapper: NoUserWrapper });
+
+    expect(screen.queryByText("TV")).toBeNull();
+  });
+
+  it("shows progress bar when showProgressBar is true for shows with episodes", () => {
+    const title = makeTitle({
+      object_type: "SHOW",
+      total_episodes: 10,
+      watched_episodes_count: 3,
+      is_watched: false,
+    });
+    const { container } = render(<TitleCard title={title} showProgressBar />, { wrapper: NoUserWrapper });
+
+    const progressTrack = container.querySelector(".bg-zinc-700");
+    expect(progressTrack).not.toBeNull();
+    const progressFill = progressTrack!.querySelector(".bg-amber-500");
+    expect(progressFill).not.toBeNull();
+  });
+
+  it("shows text badge instead of progress bar when showProgressBar is false", () => {
+    const title = makeTitle({
+      object_type: "SHOW",
+      total_episodes: 10,
+      watched_episodes_count: 3,
+      is_watched: false,
+    });
+    render(<TitleCard title={title} />, { wrapper: NoUserWrapper });
+
+    expect(screen.getByText("3/10 ep")).toBeDefined();
+  });
+
+  it("does not show progress bar for movies", () => {
+    const title = makeTitle({
+      object_type: "MOVIE",
+      is_watched: false,
+    });
+    const { container } = render(<TitleCard title={title} showProgressBar />, { wrapper: NoUserWrapper });
+
+    const progressBar = container.querySelector(".bg-amber-500");
+    expect(progressBar).toBeNull();
+  });
+
   it("renders track button with correct state", () => {
     const title = makeTitle({ id: "movie-99", is_tracked: true });
     render(<TitleCard title={title} />, { wrapper: Wrapper });

--- a/frontend/src/components/TitleCard.tsx
+++ b/frontend/src/components/TitleCard.tsx
@@ -10,9 +10,11 @@ interface Props {
   onTrackToggle?: () => void;
   showVisibilityToggle?: boolean;
   onVisibilityToggle?: (titleId: string, isPublic: boolean) => void;
+  hideTypeBadge?: boolean;
+  showProgressBar?: boolean;
 }
 
-const TitleCard = memo(function TitleCard({ title, onTrackToggle, showVisibilityToggle, onVisibilityToggle }: Props) {
+const TitleCard = memo(function TitleCard({ title, onTrackToggle, showVisibilityToggle, onVisibilityToggle, hideTypeBadge, showProgressBar }: Props) {
   // Deduplicate offers by provider (keep best quality)
   const uniqueProviders = new Map<number, Title["offers"][0]>();
   for (const offer of title.offers) {
@@ -42,7 +44,7 @@ const TitleCard = memo(function TitleCard({ title, onTrackToggle, showVisibility
             </div>
           )}
         </Link>
-        {title.object_type === "SHOW" && (
+        {!hideTypeBadge && title.object_type === "SHOW" && (
           <span className="absolute top-2 left-2 bg-amber-500 text-black text-[10px] font-bold px-1.5 py-0.5 rounded">
             TV
           </span>
@@ -55,10 +57,18 @@ const TitleCard = memo(function TitleCard({ title, onTrackToggle, showVisibility
             Watched
           </span>
         )}
-        {!title.is_watched && title.object_type === "SHOW" && title.total_episodes != null && title.total_episodes > 0 && (
+        {!title.is_watched && !showProgressBar && title.object_type === "SHOW" && title.total_episodes != null && title.total_episodes > 0 && (
           <span className="absolute bottom-2 left-2 bg-zinc-800/90 text-white text-[10px] font-bold px-1.5 py-0.5 rounded">
             {title.watched_episodes_count ?? 0}/{title.total_episodes} ep
           </span>
+        )}
+        {!title.is_watched && showProgressBar && title.object_type === "SHOW" && title.total_episodes != null && title.total_episodes > 0 && (
+          <div className="absolute bottom-0 left-0 right-0 h-1 bg-zinc-700">
+            <div
+              className="h-full bg-amber-500 transition-all duration-300"
+              style={{ width: `${((title.watched_episodes_count ?? 0) / title.total_episodes) * 100}%` }}
+            />
+          </div>
         )}
         {title.imdb_score && !showVisibilityToggle && (
           <span className="absolute top-2 right-2 bg-yellow-500 text-black text-[11px] font-bold px-1.5 py-0.5 rounded">

--- a/frontend/src/components/TitleList.tsx
+++ b/frontend/src/components/TitleList.tsx
@@ -7,9 +7,11 @@ interface Props {
   emptyMessage?: string;
   showVisibilityToggle?: boolean;
   onVisibilityToggle?: (titleId: string, isPublic: boolean) => void;
+  hideTypeBadge?: boolean;
+  showProgressBar?: boolean;
 }
 
-export default function TitleList({ titles, onTrackToggle, emptyMessage = "No titles found", showVisibilityToggle, onVisibilityToggle }: Props) {
+export default function TitleList({ titles, onTrackToggle, emptyMessage = "No titles found", showVisibilityToggle, onVisibilityToggle, hideTypeBadge, showProgressBar }: Props) {
   if (titles.length === 0) {
     return (
       <div className="text-center py-12 text-zinc-500">
@@ -21,7 +23,7 @@ export default function TitleList({ titles, onTrackToggle, emptyMessage = "No ti
   return (
     <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
       {titles.map((title) => (
-        <TitleCard key={title.id} title={title} onTrackToggle={onTrackToggle} showVisibilityToggle={showVisibilityToggle} onVisibilityToggle={onVisibilityToggle} />
+        <TitleCard key={title.id} title={title} onTrackToggle={onTrackToggle} showVisibilityToggle={showVisibilityToggle} onVisibilityToggle={onVisibilityToggle} hideTypeBadge={hideTypeBadge} showProgressBar={showProgressBar} />
       ))}
     </div>
   );

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -4,6 +4,7 @@ import { Settings } from "lucide-react";
 import { toast } from "sonner";
 import * as api from "../api";
 import TitleList from "../components/TitleList";
+import ProfileBanner from "../components/ProfileBanner";
 import { TitleGridSkeleton } from "../components/SkeletonComponents";
 import { useApiCall } from "../hooks/useApiCall";
 
@@ -40,7 +41,7 @@ export default function UserProfilePage() {
     );
   }
 
-  const { user, stats, movies, shows, is_own_profile, show_watchlist } = data;
+  const { user, stats, movies, shows, is_own_profile, show_watchlist, backdrops } = data;
   const displayName = user.display_name || user.username;
 
   async function handleVisibilityToggle(titleId: string, isPublic: boolean) {
@@ -55,6 +56,9 @@ export default function UserProfilePage() {
 
   return (
     <div className="max-w-4xl mx-auto space-y-8">
+      {/* Banner */}
+      <ProfileBanner backdrops={backdrops} />
+
       {/* Header */}
       <div className="flex items-start justify-between">
         <div>
@@ -103,20 +107,20 @@ export default function UserProfilePage() {
       {/* Watchlist */}
       {show_watchlist && (movies.length > 0 || shows.length > 0) && (
         <div className="space-y-8">
+          {shows.length > 0 && (
+            <div>
+              <h2 className="text-lg font-semibold text-white mb-4">
+                {t("userProfile.tvShows")} <span className="text-zinc-500 font-normal text-base">({shows.length})</span>
+              </h2>
+              <TitleList titles={shows} onTrackToggle={refetch} showVisibilityToggle={is_own_profile} onVisibilityToggle={handleVisibilityToggle} hideTypeBadge showProgressBar />
+            </div>
+          )}
           {movies.length > 0 && (
             <div>
               <h2 className="text-lg font-semibold text-white mb-4">
                 {t("userProfile.movies")} <span className="text-zinc-500 font-normal text-base">({movies.length})</span>
               </h2>
               <TitleList titles={movies} onTrackToggle={refetch} showVisibilityToggle={is_own_profile} onVisibilityToggle={handleVisibilityToggle} />
-            </div>
-          )}
-          {shows.length > 0 && (
-            <div>
-              <h2 className="text-lg font-semibold text-white mb-4">
-                {t("userProfile.tvShows")} <span className="text-zinc-500 font-normal text-base">({shows.length})</span>
-              </h2>
-              <TitleList titles={shows} onTrackToggle={refetch} showVisibilityToggle={is_own_profile} onVisibilityToggle={handleVisibilityToggle} />
             </div>
           )}
         </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -410,6 +410,12 @@ export interface UserProfileStats {
   watched_episodes: number;
 }
 
+export interface ProfileBackdrop {
+  id: string;
+  title: string;
+  backdrop_url: string;
+}
+
 export interface UserProfileResponse {
   user: UserProfileUser;
   stats: UserProfileStats;
@@ -417,6 +423,7 @@ export interface UserProfileResponse {
   shows: Title[];
   show_watchlist: boolean;
   is_own_profile: boolean;
+  backdrops: ProfileBackdrop[];
 }
 
 // Normalize search results to same shape as DB titles

--- a/server/db/repository/profile.ts
+++ b/server/db/repository/profile.ts
@@ -1,6 +1,6 @@
 import { eq, sql } from "drizzle-orm";
 import { getDb } from "../schema";
-import { users, watchedTitles, watchedEpisodes } from "../schema";
+import { users, watchedTitles, watchedEpisodes, episodes, titles } from "../schema";
 import { traceDbQuery } from "../../tracing";
 import { getPublicTrackedTitles, getPublicTrackedCount, getTrackedTitles } from "./tracked";
 
@@ -25,7 +25,7 @@ export async function getUserPublicProfile(username: string, isOwnProfile = fals
 
     const showWatchlist = isOwnProfile || Boolean(user.profile_public);
 
-    const [trackedCount, watchedMoviesRow, watchedEpisodesRow, allTitles] = await Promise.all([
+    const [trackedCount, watchedMoviesRow, watchedEpisodesRow, allTitles, backdrops] = await Promise.all([
       showWatchlist ? getPublicTrackedCount(user.id) : Promise.resolve(0),
       db
         .select({ count: sql<number>`COUNT(*)` })
@@ -38,10 +38,13 @@ export async function getUserPublicProfile(username: string, isOwnProfile = fals
         .where(eq(watchedEpisodes.userId, user.id))
         .get(),
       isOwnProfile
-        ? getTrackedTitles(user.id).then(titles => titles.map(t => ({ ...t, is_public: t.public })))
+        ? getTrackedTitles(user.id).then(t => t.map(r => ({ ...r, is_public: r.public })))
         : showWatchlist
-          ? getPublicTrackedTitles(user.id).then(titles => titles.map(t => ({ ...t, is_public: true })))
+          ? getPublicTrackedTitles(user.id).then(t => t.map(r => ({ ...r, is_public: true })))
           : Promise.resolve([]),
+      showWatchlist
+        ? getRecentlyWatchedBackdrops(db, user.id)
+        : Promise.resolve([]),
     ]);
 
     const movies = allTitles.filter(t => t.object_type === "MOVIE");
@@ -62,8 +65,28 @@ export async function getUserPublicProfile(username: string, isOwnProfile = fals
       show_watchlist: showWatchlist,
       movies,
       shows,
+      backdrops,
     };
   });
+}
+
+async function getRecentlyWatchedBackdrops(db: ReturnType<typeof getDb>, userId: string, limit = 5) {
+  const rows = await db
+    .select({
+      id: titles.id,
+      title: titles.title,
+      backdrop_url: titles.backdropUrl,
+    })
+    .from(watchedEpisodes)
+    .innerJoin(episodes, eq(episodes.id, watchedEpisodes.episodeId))
+    .innerJoin(titles, eq(titles.id, episodes.titleId))
+    .where(sql`${watchedEpisodes.userId} = ${userId} AND ${titles.backdropUrl} IS NOT NULL`)
+    .groupBy(titles.id)
+    .orderBy(sql`MAX(${watchedEpisodes.watchedAt}) DESC`)
+    .limit(limit)
+    .all();
+
+  return rows as { id: string; title: string; backdrop_url: string }[];
 }
 
 export async function updateProfilePublic(userId: string, isPublic: boolean) {

--- a/server/db/repository/tracked.ts
+++ b/server/db/repository/tracked.ts
@@ -83,6 +83,8 @@ export async function getTrackedTitles(userId: string) {
         public: tracked.public,
         is_tracked: sql<number>`1`,
         is_watched: sql<number>`EXISTS(SELECT 1 FROM watched_titles wt WHERE wt.title_id = ${titles.id} AND wt.user_id = ${userId})`,
+        total_episodes: sql<number>`(SELECT COUNT(*) FROM episodes e WHERE e.title_id = ${titles.id})`,
+        watched_episodes_count: sql<number>`(SELECT COUNT(*) FROM watched_episodes we INNER JOIN episodes e ON e.id = we.episode_id WHERE e.title_id = ${titles.id} AND we.user_id = ${userId})`,
       })
       .from(tracked)
       .innerJoin(titles, eq(titles.id, tracked.titleId))

--- a/server/routes/profile.test.ts
+++ b/server/routes/profile.test.ts
@@ -274,6 +274,62 @@ describe("GET /user/:username", () => {
     expect(body.movies[0].id).toBe("movie-1");
   });
 
+  it("includes episode progress for shows on own profile", async () => {
+    await upsertTitles([
+      makeParsedTitle({ id: "show-1", objectType: "SHOW", title: "Test Show" }),
+    ]);
+    await trackTitle("show-1", userId);
+
+    await upsertEpisodes([
+      { title_id: "show-1", season_number: 1, episode_number: 1, name: "Ep 1", overview: null, air_date: "2024-01-01", still_path: null },
+      { title_id: "show-1", season_number: 1, episode_number: 2, name: "Ep 2", overview: null, air_date: "2024-01-08", still_path: null },
+      { title_id: "show-1", season_number: 1, episode_number: 3, name: "Ep 3", overview: null, air_date: "2024-01-15", still_path: null },
+    ]);
+
+    const { getDb } = await import("../db/schema");
+    const db = getDb();
+    const eps = await db.query.episodes.findMany({ where: (e, { eq }) => eq(e.titleId, "show-1") });
+    await watchEpisode(eps[0].id, userId);
+
+    const res = await app.request("/user/testuser", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.is_own_profile).toBe(true);
+    expect(body.shows).toHaveLength(1);
+    expect(body.shows[0].total_episodes).toBe(3);
+    expect(body.shows[0].watched_episodes_count).toBe(1);
+  });
+
+  it("includes backdrops for recently watched shows", async () => {
+    await upsertTitles([
+      makeParsedTitle({ id: "show-1", objectType: "SHOW", title: "Test Show", backdropUrl: "https://example.com/backdrop.jpg" }),
+    ]);
+    await trackTitle("show-1", userId);
+
+    await upsertEpisodes([
+      { title_id: "show-1", season_number: 1, episode_number: 1, name: "Ep 1", overview: null, air_date: "2024-01-01", still_path: null },
+    ]);
+
+    const { getDb } = await import("../db/schema");
+    const db = getDb();
+    const eps = await db.query.episodes.findMany({ where: (e, { eq }) => eq(e.titleId, "show-1") });
+    await watchEpisode(eps[0].id, userId);
+
+    const res = await app.request("/user/testuser", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.backdrops).toHaveLength(1);
+    expect(body.backdrops[0].id).toBe("show-1");
+    expect(body.backdrops[0].backdrop_url).toBe("https://example.com/backdrop.jpg");
+  });
+
+  it("returns empty backdrops when no watched shows", async () => {
+    const res = await app.request("/user/testuser", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.backdrops).toHaveLength(0);
+  });
+
   it("includes episode progress for shows", async () => {
     await updateProfilePublic(userId, true);
     await upsertTitles([


### PR DESCRIPTION
## Summary
This PR adds a visual profile banner component that displays backdrop images from recently watched shows on user profile pages. It also includes improvements to the TV show display in watchlists with progress bars and better visual hierarchy.

## Key Changes

**Backend (Server)**
- Added `getRecentlyWatchedBackdrops()` function to fetch up to 5 most recently watched shows with backdrop images
- Modified `getUserPublicProfile()` to include backdrop data in the profile response
- Added tests for backdrop retrieval and episode progress tracking

**Frontend (Components)**
- Created new `ProfileBanner` component that displays backdrop images in a responsive grid layout:
  - Single backdrop: full width
  - Two backdrops: side-by-side split
  - Three+ backdrops: large left image with two stacked right images
  - Includes gradient fade and overlay for visual polish
  - All images link to their respective title detail pages
- Enhanced `TitleCard` component with:
  - `hideTypeBadge` prop to optionally hide the "TV" badge
  - `showProgressBar` prop to display a progress bar instead of text badge for show episodes
- Updated `TitleList` component to pass through new props to `TitleCard`
- Modified `UserProfilePage` to render the banner and reordered watchlist sections (shows before movies)

**Types**
- Added `ProfileBackdrop` interface for backdrop data structure
- Updated `UserProfileResponse` to include `backdrops` array

**Tests**
- Added comprehensive test suite for `ProfileBanner` component covering empty state, single/multiple backdrops, and link navigation
- Added tests for new `TitleCard` props (`hideTypeBadge`, `showProgressBar`)
- Added backend tests for backdrop retrieval and episode progress

## Implementation Details
- The banner uses full viewport width with negative margin technique to break out of container constraints
- Responsive height: 192px on mobile, 224px on tablet and up
- Backdrops are fetched based on most recent episode watch timestamps
- Progress bar width is calculated as a percentage of watched episodes

https://claude.ai/code/session_01AWqXSnrzUfUQt3wbes9FAK