### PR TITLE
Increase max-width constraint on profile and settings pages

### DIFF
--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -16,7 +16,7 @@ export default function SettingsPage() {
   if (!user) return null;
 
   return (
-    <div className="max-w-2xl mx-auto space-y-8">
+    <div className="max-w-7xl mx-auto space-y-8">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold text-white">{t("settings.title")}</h1>
         <Link to={`/user/${user.username}`} className="text-sm text-amber-500 hover:text-amber-400 transition-colors">

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -18,7 +18,7 @@ export default function UserProfilePage() {
 
   if (loading) {
     return (
-      <div className="max-w-4xl mx-auto space-y-8">
+      <div className="max-w-7xl mx-auto space-y-8">
         <div className="animate-pulse space-y-4">
           <div className="h-8 w-48 bg-zinc-800 rounded" />
           <div className="h-4 w-32 bg-zinc-800 rounded" />
@@ -35,7 +35,7 @@ export default function UserProfilePage() {
 
   if (error || !data) {
     return (
-      <div className="max-w-4xl mx-auto py-12 text-center">
+      <div className="max-w-7xl mx-auto py-12 text-center">
         <p className="text-zinc-400 text-lg">{t("userProfile.userNotFound")}</p>
       </div>
     );
@@ -55,7 +55,7 @@ export default function UserProfilePage() {
   }
 
   return (
-    <div className="max-w-4xl mx-auto space-y-8">
+    <div className="max-w-7xl mx-auto space-y-8">
       {/* Banner */}
       <ProfileBanner backdrops={backdrops} />
 


### PR DESCRIPTION
## Summary
Updated the maximum width constraints on the UserProfilePage and SettingsPage to use a wider layout (`max-w-7xl` instead of `max-w-4xl` and `max-w-2xl`), allowing these pages to utilize more screen real estate on larger displays.

## Changes
- **UserProfilePage**: Changed `max-w-4xl` to `max-w-7xl` in three locations (loading state, error state, and main content)
- **SettingsPage**: Changed `max-w-2xl` to `max-w-7xl` in the main container

## Details
These changes standardize the maximum width across both pages to `max-w-7xl`, providing a more consistent and spacious layout experience for users on wider screens while maintaining responsive behavior on smaller viewports.

https://claude.ai/code/session_01FUHeahVyVZNCE9QUwCsGaA