### PR TITLE
Add share buttons to detail and profile pages

### DIFF
--- a/frontend/src/components/ShareButton.test.tsx
+++ b/frontend/src/components/ShareButton.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, afterEach, beforeEach, spyOn } from "bun:test";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import ShareButton from "./ShareButton";
+import * as sonner from "sonner";
+
+let spies: ReturnType<typeof spyOn>[] = [];
+
+beforeEach(() => {
+  spies = [
+    spyOn(sonner.toast, "success").mockImplementation(() => "1" as any),
+    spyOn(sonner.toast, "error").mockImplementation(() => "1" as any),
+  ];
+});
+
+afterEach(() => {
+  cleanup();
+  for (const spy of spies) spy.mockRestore();
+  spies = [];
+  // Restore navigator.share if it was modified
+  if ("share" in navigator) {
+    Object.defineProperty(navigator, "share", { value: undefined, writable: true, configurable: true });
+  }
+});
+
+describe("ShareButton", () => {
+  it("renders with Share text and icon", () => {
+    render(<ShareButton />);
+    const button = screen.getByRole("button", { name: /share/i });
+    expect(button).toBeDefined();
+    expect(button.textContent).toContain("Share");
+  });
+
+  it("has correct styling classes", () => {
+    render(<ShareButton />);
+    const button = screen.getByRole("button", { name: /share/i });
+    expect(button.className).toContain("bg-zinc-800");
+    expect(button.className).toContain("text-zinc-400");
+  });
+
+  it("copies URL to clipboard when navigator.share is not available", async () => {
+    // Ensure navigator.share is undefined
+    Object.defineProperty(navigator, "share", { value: undefined, writable: true, configurable: true });
+
+    const writeText = spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
+    spies.push(writeText);
+
+    render(<ShareButton url="https://example.com/movie/123" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /share/i }));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith("https://example.com/movie/123");
+      expect(sonner.toast.success).toHaveBeenCalledWith("Link copied to clipboard");
+    });
+  });
+
+  it("falls back to window.location.href when no url prop provided", async () => {
+    Object.defineProperty(navigator, "share", { value: undefined, writable: true, configurable: true });
+
+    const writeText = spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
+    spies.push(writeText);
+
+    render(<ShareButton />);
+
+    fireEvent.click(screen.getByRole("button", { name: /share/i }));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(window.location.href);
+    });
+  });
+
+  it("shows error toast when clipboard write fails", async () => {
+    Object.defineProperty(navigator, "share", { value: undefined, writable: true, configurable: true });
+
+    const writeText = spyOn(navigator.clipboard, "writeText").mockRejectedValue(new Error("Clipboard failed"));
+    spies.push(writeText);
+
+    render(<ShareButton url="https://example.com/test" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /share/i }));
+
+    await waitFor(() => {
+      expect(sonner.toast.error).toHaveBeenCalledWith("Failed to copy link");
+    });
+  });
+
+  it("uses navigator.share when available", async () => {
+    const shareFn = spyOn(navigator, "share" as any).mockResolvedValue(undefined);
+    // Ensure share is defined as a function
+    Object.defineProperty(navigator, "share", { value: shareFn, writable: true, configurable: true });
+    spies.push(shareFn);
+
+    render(<ShareButton title="Test Movie" text="Check this out" url="https://example.com/movie/1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /share/i }));
+
+    await waitFor(() => {
+      expect(shareFn).toHaveBeenCalledWith({
+        title: "Test Movie",
+        text: "Check this out",
+        url: "https://example.com/movie/1",
+      });
+    });
+  });
+
+  it("silently handles user cancelling the share dialog", async () => {
+    const abortError = new DOMException("Share canceled", "AbortError");
+    const shareFn = () => Promise.reject(abortError);
+    Object.defineProperty(navigator, "share", { value: shareFn, writable: true, configurable: true });
+
+    render(<ShareButton url="https://example.com/test" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /share/i }));
+
+    // Should not show any toast on abort
+    await waitFor(() => {
+      expect(sonner.toast.success).not.toHaveBeenCalled();
+      expect(sonner.toast.error).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/components/ShareButton.tsx
+++ b/frontend/src/components/ShareButton.tsx
@@ -1,0 +1,45 @@
+import { Share2 } from "lucide-react";
+import { toast } from "sonner";
+
+interface Props {
+  title?: string;
+  text?: string;
+  url?: string;
+}
+
+export default function ShareButton({ title, text, url }: Props) {
+  async function handleShare() {
+    const shareUrl = url || window.location.href;
+
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title,
+          text,
+          url: shareUrl,
+        });
+      } catch (err: unknown) {
+        // User cancelled the share dialog — not an error
+        if (err instanceof Error && err.name === "AbortError") return;
+      }
+    } else {
+      try {
+        await navigator.clipboard.writeText(shareUrl);
+        toast.success("Link copied to clipboard");
+      } catch {
+        toast.error("Failed to copy link");
+      }
+    }
+  }
+
+  return (
+    <button
+      onClick={handleShare}
+      className="min-h-8 inline-flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors cursor-pointer bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-white"
+      title="Share"
+    >
+      <Share2 className="size-3.5" />
+      Share
+    </button>
+  );
+}

--- a/frontend/src/pages/EpisodeDetailPage.tsx
+++ b/frontend/src/pages/EpisodeDetailPage.tsx
@@ -9,6 +9,7 @@ import { DetailPageSkeleton } from "../components/SkeletonComponents";
 import { useApiCall } from "../hooks/useApiCall";
 import { useAuth } from "../context/AuthContext";
 import { WatchedIcon } from "../components/EpisodeComponents";
+import ShareButton from "../components/ShareButton";
 
 const TMDB_IMG = "https://image.tmdb.org/t/p";
 
@@ -134,6 +135,7 @@ export default function EpisodeDetailPage() {
               size="md"
             />
           )}
+          <ShareButton title={`${title.title} — ${tmdb?.name || `Episode ${episodeNumber}`}`} />
         </div>
 
         <div className="flex items-center gap-3 text-sm text-zinc-400">

--- a/frontend/src/pages/SeasonDetailPage.tsx
+++ b/frontend/src/pages/SeasonDetailPage.tsx
@@ -9,6 +9,7 @@ import { DetailPageSkeleton } from "../components/SkeletonComponents";
 import { useApiCall } from "../hooks/useApiCall";
 import { useAuth } from "../context/AuthContext";
 import { WatchedIcon } from "../components/EpisodeComponents";
+import ShareButton from "../components/ShareButton";
 
 const TMDB_IMG = "https://image.tmdb.org/t/p";
 
@@ -175,6 +176,10 @@ export default function SeasonDetailPage() {
           {tmdb?.overview && (
             <p className="text-zinc-300 leading-relaxed">{tmdb.overview}</p>
           )}
+
+          <div className="pt-2">
+            <ShareButton title={`${title.title} — ${tmdb?.name || `Season ${seasonNumber}`}`} />
+          </div>
         </div>
       </div>
 

--- a/frontend/src/pages/TitleDetailPage.tsx
+++ b/frontend/src/pages/TitleDetailPage.tsx
@@ -18,6 +18,7 @@ import { DetailPageSkeleton } from "../components/SkeletonComponents";
 import ExternalLinks from "../components/ExternalLinks";
 import WatchButton from "../components/WatchButton";
 import VisibilityButton from "../components/VisibilityButton";
+import ShareButton from "../components/ShareButton";
 import { getProviderColor } from "../data/providerColors";
 
 const TMDB_IMG = "https://image.tmdb.org/t/p";
@@ -355,6 +356,7 @@ function MovieDetail({ data }: { data: MovieDetailsResponse }) {
                   />
                 );
               })()}
+              <ShareButton title={tmdb?.title || title.title} />
             </div>
           </div>
         </div>
@@ -650,6 +652,7 @@ function ShowDetail({ data }: { data: ShowDetailsResponse }) {
                   />
                 );
               })()}
+              <ShareButton title={tmdb?.name || title.title} />
             </div>
           </div>
         </div>

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import * as api from "../api";
 import TitleList from "../components/TitleList";
 import ProfileBanner from "../components/ProfileBanner";
+import ShareButton from "../components/ShareButton";
 import { TitleGridSkeleton } from "../components/SkeletonComponents";
 import { useApiCall } from "../hooks/useApiCall";
 
@@ -77,15 +78,18 @@ export default function UserProfilePage() {
             </p>
           )}
         </div>
-        {is_own_profile && (
-          <Link
-            to="/settings"
-            className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-zinc-400 hover:text-white bg-zinc-800 hover:bg-zinc-700 rounded-lg transition-colors"
-          >
-            <Settings className="size-4" />
-            {t("userProfile.editSettings")}
-          </Link>
-        )}
+        <div className="flex items-center gap-2">
+          <ShareButton title={`${displayName}'s Profile`} />
+          {is_own_profile && (
+            <Link
+              to="/settings"
+              className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-zinc-400 hover:text-white bg-zinc-800 hover:bg-zinc-700 rounded-lg transition-colors"
+            >
+              <Settings className="size-4" />
+              {t("userProfile.editSettings")}
+            </Link>
+          )}
+        </div>
       </div>
 
       {/* Stats */}


### PR DESCRIPTION
## Summary
- Add `ShareButton` component using Web Share API (mobile) with clipboard fallback + toast notification
- Integrate share button into movie/show detail, season detail, episode detail, and user profile pages
- Style consistent with existing action buttons (zinc background, hover effects)

Closes #271

## Test plan
- [x] `ShareButton.test.tsx` with 7 tests covering: rendering, clipboard fallback, `navigator.share` usage, error handling, and abort/cancel handling
- [x] All 1022 existing tests pass
- [x] ESLint passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)