### PR TITLE
Add untrack confirmation dialog

### DIFF
--- a/frontend/src/components/TrackButton.test.tsx
+++ b/frontend/src/components/TrackButton.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, mock, afterEach, beforeEach, spyOn } from "bun:test";
 import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
 import type { ReactNode } from "react";
+// Initialize i18n before anything else
+import "../i18n";
 import TrackButton from "./TrackButton";
 import * as api from "../api";
 import * as sonner from "sonner";
@@ -74,21 +76,6 @@ describe("TrackButton", () => {
     expect(onToggle).toHaveBeenCalledWith(true);
   });
 
-  it("calls untrackTitle and updates to 'Track' on click", async () => {
-    const onToggle = mock(() => {});
-    render(<TrackButton titleId="456" isTracked={true} onToggle={onToggle} />, { wrapper: Wrapper });
-
-    const button = screen.getByRole("button", { name: "Tracked" });
-    fireEvent.click(button);
-
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Track" })).toBeDefined();
-    });
-
-    expect(api.untrackTitle).toHaveBeenCalledWith("456");
-    expect(onToggle).toHaveBeenCalledWith(false);
-  });
-
   it("has aria-pressed=false when not tracked", () => {
     render(<TrackButton titleId="123" isTracked={false} />, { wrapper: Wrapper });
     expect(screen.getByRole("button", { name: "Track" }).getAttribute("aria-pressed")).toBe("false");
@@ -109,16 +96,6 @@ describe("TrackButton", () => {
     });
   });
 
-  it("shows success toast when untracking a title", async () => {
-    render(<TrackButton titleId="456" isTracked={true} />, { wrapper: Wrapper });
-
-    fireEvent.click(screen.getByRole("button", { name: "Tracked" }));
-
-    await waitFor(() => {
-      expect(sonner.toast.success).toHaveBeenCalledWith("Removed from tracked");
-    });
-  });
-
   it("shows error toast when tracking fails", async () => {
     (api.trackTitle as any).mockRejectedValueOnce(new Error("Network error"));
 
@@ -128,18 +105,6 @@ describe("TrackButton", () => {
 
     await waitFor(() => {
       expect(sonner.toast.error).toHaveBeenCalledWith("Failed to track — please try again");
-    });
-  });
-
-  it("shows error toast when untracking fails", async () => {
-    (api.untrackTitle as any).mockRejectedValueOnce(new Error("Network error"));
-
-    render(<TrackButton titleId="456" isTracked={true} />, { wrapper: Wrapper });
-
-    fireEvent.click(screen.getByRole("button", { name: "Tracked" }));
-
-    await waitFor(() => {
-      expect(sonner.toast.error).toHaveBeenCalledWith("Failed to untrack — please try again");
     });
   });
 
@@ -166,6 +131,156 @@ describe("TrackButton", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Tracked" })).toBeDefined();
+    });
+  });
+
+  describe("untrack confirmation dialog", () => {
+    it("shows confirmation dialog when clicking untrack", async () => {
+      render(
+        <TrackButton
+          titleId="456"
+          isTracked={true}
+          titleData={{ title: "Breaking Bad" } as any}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Tracked" }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Stop tracking Breaking Bad?")).toBeDefined();
+      });
+
+      // untrackTitle should NOT have been called yet
+      expect(api.untrackTitle).not.toHaveBeenCalled();
+    });
+
+    it("does not untrack when cancel is clicked", async () => {
+      render(
+        <TrackButton
+          titleId="456"
+          isTracked={true}
+          titleData={{ title: "Breaking Bad" } as any}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Tracked" }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Stop tracking Breaking Bad?")).toBeDefined();
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+      // Dialog should close
+      await waitFor(() => {
+        expect(screen.queryByText("Stop tracking Breaking Bad?")).toBeNull();
+      });
+
+      // untrackTitle should not have been called
+      expect(api.untrackTitle).not.toHaveBeenCalled();
+
+      // Button should still show "Tracked"
+      expect(screen.getByRole("button", { name: "Tracked" })).toBeDefined();
+    });
+
+    it("proceeds with untrack when confirm is clicked", async () => {
+      const onToggle = mock(() => {});
+      render(
+        <TrackButton
+          titleId="456"
+          isTracked={true}
+          onToggle={onToggle}
+          titleData={{ title: "Breaking Bad" } as any}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Tracked" }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Stop tracking Breaking Bad?")).toBeDefined();
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Track" })).toBeDefined();
+      });
+
+      expect(api.untrackTitle).toHaveBeenCalledWith("456");
+      expect(onToggle).toHaveBeenCalledWith(false);
+    });
+
+    it("shows success toast after confirming untrack", async () => {
+      render(
+        <TrackButton
+          titleId="456"
+          isTracked={true}
+          titleData={{ title: "Breaking Bad" } as any}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Tracked" }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Stop tracking Breaking Bad?")).toBeDefined();
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+      await waitFor(() => {
+        expect(sonner.toast.success).toHaveBeenCalledWith("Removed from tracked");
+      });
+    });
+
+    it("shows error toast when untrack fails after confirmation", async () => {
+      (api.untrackTitle as any).mockRejectedValueOnce(new Error("Network error"));
+
+      render(
+        <TrackButton
+          titleId="456"
+          isTracked={true}
+          titleData={{ title: "Breaking Bad" } as any}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Tracked" }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Stop tracking Breaking Bad?")).toBeDefined();
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+      await waitFor(() => {
+        expect(sonner.toast.error).toHaveBeenCalledWith("Failed to untrack — please try again");
+      });
+    });
+
+    it("uses fallback title in dialog when titleData is not provided", async () => {
+      render(
+        <TrackButton titleId="456" isTracked={true} />,
+        { wrapper: Wrapper },
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Tracked" }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Stop tracking Track?")).toBeDefined();
+      });
+    });
+
+    it("does not show confirmation dialog when tracking", () => {
+      render(<TrackButton titleId="123" isTracked={false} />, { wrapper: Wrapper });
+
+      fireEvent.click(screen.getByRole("button", { name: "Track" }));
+
+      // No dialog should appear
+      expect(screen.queryByText(/Stop tracking/)).toBeNull();
     });
   });
 });

--- a/frontend/src/components/TrackButton.tsx
+++ b/frontend/src/components/TrackButton.tsx
@@ -4,6 +4,13 @@ import { useTranslation } from "react-i18next";
 import * as api from "../api";
 import type { Title } from "../types";
 import { useAuth } from "../context/AuthContext";
+import {
+  AlertDialog,
+  AlertDialogPopup,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogClose,
+} from "./ui/alert-dialog";
 
 interface Props {
   titleId: string;
@@ -17,43 +24,89 @@ export default function TrackButton({ titleId, isTracked, onToggle, titleData }:
   const { t } = useTranslation();
   const [tracked, setTracked] = useState(isTracked);
   const [loading, setLoading] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   if (!user) return null;
 
-  async function toggle() {
+  async function handleTrack() {
     setLoading(true);
     try {
-      if (tracked) {
-        await api.untrackTitle(titleId);
-        setTracked(false);
-        onToggle?.(false);
-        toast.success("Removed from tracked");
-      } else {
-        await api.trackTitle(titleId, undefined, titleData);
-        setTracked(true);
-        onToggle?.(true);
-        toast.success("Title tracked");
-      }
+      await api.trackTitle(titleId, undefined, titleData);
+      setTracked(true);
+      onToggle?.(true);
+      toast.success("Title tracked");
     } catch (err) {
       console.error("Track toggle failed:", err);
-      toast.error(tracked ? "Failed to untrack — please try again" : "Failed to track — please try again");
+      toast.error("Failed to track — please try again");
     } finally {
       setLoading(false);
     }
   }
 
+  async function handleUntrack() {
+    setConfirmOpen(false);
+    setLoading(true);
+    try {
+      await api.untrackTitle(titleId);
+      setTracked(false);
+      onToggle?.(false);
+      toast.success("Removed from tracked");
+    } catch (err) {
+      console.error("Track toggle failed:", err);
+      toast.error("Failed to untrack — please try again");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleClick() {
+    if (tracked) {
+      setConfirmOpen(true);
+    } else {
+      handleTrack();
+    }
+  }
+
+  const titleName = titleData?.title ?? t("track.track");
+
   return (
-    <button
-      onClick={toggle}
-      disabled={loading}
-      aria-pressed={tracked}
-      className={`min-h-8 inline-flex items-center justify-center px-3 py-1.5 rounded-md text-xs font-medium transition-colors cursor-pointer ${
-        tracked
-          ? "bg-amber-500 text-zinc-950 hover:bg-red-500"
-          : "bg-zinc-800 text-zinc-400 hover:bg-amber-500 hover:text-zinc-950"
-      } disabled:opacity-50`}
-    >
-      {loading ? "..." : tracked ? t("track.tracked") : t("track.track")}
-    </button>
+    <>
+      <button
+        onClick={handleClick}
+        disabled={loading}
+        aria-pressed={tracked}
+        className={`min-h-8 inline-flex items-center justify-center px-3 py-1.5 rounded-md text-xs font-medium transition-colors cursor-pointer ${
+          tracked
+            ? "bg-amber-500 text-zinc-950 hover:bg-red-500"
+            : "bg-zinc-800 text-zinc-400 hover:bg-amber-500 hover:text-zinc-950"
+        } disabled:opacity-50`}
+      >
+        {loading ? "..." : tracked ? t("track.tracked") : t("track.track")}
+      </button>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogPopup>
+          <AlertDialogTitle>
+            {t("track.confirmUntrack", { title: titleName })}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {t("track.confirmUntrackDescription")}
+          </AlertDialogDescription>
+          <div className="mt-4 flex justify-end gap-2">
+            <AlertDialogClose
+              className="inline-flex items-center justify-center rounded-md px-3 py-1.5 text-xs font-medium bg-zinc-800 text-zinc-400 hover:bg-zinc-700 cursor-pointer transition-colors"
+            >
+              {t("common.cancel")}
+            </AlertDialogClose>
+            <button
+              onClick={handleUntrack}
+              className="inline-flex items-center justify-center rounded-md px-3 py-1.5 text-xs font-medium bg-red-600 text-white hover:bg-red-700 cursor-pointer transition-colors"
+            >
+              {t("track.confirm")}
+            </button>
+          </div>
+        </AlertDialogPopup>
+      </AlertDialog>
+    </>
   );
 }

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,94 @@
+import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog"
+import type { ComponentProps } from "react"
+
+import { cn } from "@/lib/utils"
+
+function AlertDialog(props: ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root {...props} />
+}
+
+function AlertDialogTrigger(props: ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return <AlertDialogPrimitive.Trigger {...props} />
+}
+
+function AlertDialogPortal(props: ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return <AlertDialogPrimitive.Portal {...props} />
+}
+
+function AlertDialogBackdrop({
+  className,
+  ...props
+}: ComponentProps<typeof AlertDialogPrimitive.Backdrop>) {
+  return (
+    <AlertDialogPrimitive.Backdrop
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 transition-opacity",
+        "data-[ending-style]:opacity-0 data-[starting-style]:opacity-0",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogPopup({
+  className,
+  children,
+  ...props
+}: ComponentProps<typeof AlertDialogPrimitive.Popup>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogBackdrop />
+      <AlertDialogPrimitive.Popup
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-lg border border-zinc-800 bg-zinc-950 p-6 shadow-lg transition-all",
+          "data-[ending-style]:scale-95 data-[ending-style]:opacity-0",
+          "data-[starting-style]:scale-95 data-[starting-style]:opacity-0",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </AlertDialogPrimitive.Popup>
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      className={cn("text-lg font-semibold text-zinc-100", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      className={cn("mt-2 text-sm text-zinc-400", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogClose(props: ComponentProps<typeof AlertDialogPrimitive.Close>) {
+  return <AlertDialogPrimitive.Close {...props} />
+}
+
+export {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogPortal,
+  AlertDialogBackdrop,
+  AlertDialogPopup,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogClose,
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -153,7 +153,10 @@
   },
   "track": {
     "track": "Track",
-    "tracked": "Tracked"
+    "tracked": "Tracked",
+    "confirmUntrack": "Stop tracking {{title}}?",
+    "confirmUntrackDescription": "This title will be removed from your watchlist.",
+    "confirm": "Confirm"
   },
   "episodes": {
     "tomorrow": "Tomorrow",


### PR DESCRIPTION
## Summary
- When a user clicks to untrack a title, an AlertDialog now asks for confirmation before proceeding
- Tracking a new title still works with a single click (no confirmation needed)
- Added `alert-dialog.tsx` shadcn UI component built on `@base-ui/react/alert-dialog`
- Added i18n translation keys for the dialog text
- Updated tests to cover dialog show, cancel, and confirm flows

Closes #270

## Test plan
- [ ] Click "Tracked" on a tracked title and verify the confirmation dialog appears
- [ ] Click "Cancel" in the dialog and verify the title remains tracked
- [ ] Click "Confirm" in the dialog and verify the title is untracked
- [ ] Click "Track" on an untracked title and verify it tracks immediately (no dialog)
- [ ] Verify all 16 TrackButton tests pass (`bun test frontend/src/components/TrackButton.test.tsx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)