### PR TITLE
Add released episodes count and show status classification

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -44,6 +44,10 @@ export interface Title {
   is_watched?: boolean;
   total_episodes?: number;
   watched_episodes_count?: number;
+  released_episodes_count?: number;
+  show_status?: "watching" | "caught_up" | "completed" | "not_started" | "unreleased" | null;
+  latest_released_air_date?: string | null;
+  next_episode_air_date?: string | null;
   offers: Offer[];
   tracked_at?: string;
   notes?: string;

--- a/server/db/repository/tracked.test.ts
+++ b/server/db/repository/tracked.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
+import { makeParsedTitle } from "../../test-utils/fixtures";
+import {
+  upsertTitles,
+  createUser,
+  trackTitle,
+  upsertEpisodes,
+  watchEpisode,
+  watchEpisodesBulk,
+} from "../repository";
+import { getTrackedTitles } from "./tracked";
+import { getRawDb } from "../bun-db";
+
+let userId: string;
+
+beforeEach(async () => {
+  setupTestDb();
+  userId = await createUser("testuser", "hash");
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+// Helper: insert episodes for a title and return their DB ids
+async function insertEpisodes(
+  titleId: string,
+  eps: { season: number; episode: number; airDate: string | null }[],
+): Promise<number[]> {
+  await upsertEpisodes(
+    eps.map((e) => ({
+      title_id: titleId,
+      season_number: e.season,
+      episode_number: e.episode,
+      name: `S${e.season}E${e.episode}`,
+      overview: null,
+      air_date: e.airDate,
+      still_path: null,
+    })),
+  );
+
+  // Retrieve inserted episode ids
+  const db = getRawDb();
+  const rows = db
+    .prepare(
+      `SELECT id, season_number, episode_number FROM episodes WHERE title_id = ? ORDER BY season_number, episode_number`,
+    )
+    .all(titleId) as { id: number; season_number: number; episode_number: number }[];
+  return rows.map((r) => r.id);
+}
+
+describe("getTrackedTitles show_status", () => {
+  it("returns 'completed' when all episodes released and watched", async () => {
+    await upsertTitles([
+      makeParsedTitle({ id: "show-1", objectType: "SHOW", title: "Completed Show" }),
+    ]);
+    await trackTitle("show-1", userId);
+
+    // All episodes have past air dates
+    const epIds = await insertEpisodes("show-1", [
+      { season: 1, episode: 1, airDate: "2020-01-01" },
+      { season: 1, episode: 2, airDate: "2020-01-08" },
+      { season: 1, episode: 3, airDate: "2020-01-15" },
+    ]);
+
+    // Watch all episodes
+    await watchEpisodesBulk(epIds, userId);
+
+    const titles = await getTrackedTitles(userId);
+    const show = titles.find((t) => t.id === "show-1");
+    expect(show).toBeDefined();
+    expect(show!.show_status).toBe("completed");
+    expect(show!.released_episodes_count).toBe(3);
+    expect(show!.latest_released_air_date).toBe("2020-01-15");
+    expect(show!.next_episode_air_date).toBeNull();
+  });
+
+  it("returns 'caught_up' when all released episodes watched but more coming", async () => {
+    await upsertTitles([
+      makeParsedTitle({ id: "show-2", objectType: "SHOW", title: "Caught Up Show" }),
+    ]);
+    await trackTitle("show-2", userId);
+
+    // 2 released episodes + 1 future episode
+    const epIds = await insertEpisodes("show-2", [
+      { season: 1, episode: 1, airDate: "2020-01-01" },
+      { season: 1, episode: 2, airDate: "2020-01-08" },
+      { season: 1, episode: 3, airDate: "2099-12-31" },
+    ]);
+
+    // Watch only the released ones
+    await watchEpisodesBulk([epIds[0], epIds[1]], userId);
+
+    const titles = await getTrackedTitles(userId);
+    const show = titles.find((t) => t.id === "show-2");
+    expect(show).toBeDefined();
+    expect(show!.show_status).toBe("caught_up");
+    expect(show!.released_episodes_count).toBe(2);
+    expect(show!.total_episodes).toBe(3);
+    expect(show!.watched_episodes_count).toBe(2);
+    expect(show!.next_episode_air_date).toBe("2099-12-31");
+  });
+
+  it("returns 'watching' when released episodes exist but not all watched", async () => {
+    await upsertTitles([
+      makeParsedTitle({ id: "show-3", objectType: "SHOW", title: "Watching Show" }),
+    ]);
+    await trackTitle("show-3", userId);
+
+    const epIds = await insertEpisodes("show-3", [
+      { season: 1, episode: 1, airDate: "2020-01-01" },
+      { season: 1, episode: 2, airDate: "2020-01-08" },
+      { season: 1, episode: 3, airDate: "2020-01-15" },
+    ]);
+
+    // Watch only the first episode
+    await watchEpisode(epIds[0], userId);
+
+    const titles = await getTrackedTitles(userId);
+    const show = titles.find((t) => t.id === "show-3");
+    expect(show).toBeDefined();
+    expect(show!.show_status).toBe("watching");
+    expect(show!.released_episodes_count).toBe(3);
+    expect(show!.watched_episodes_count).toBe(1);
+  });
+
+  it("returns 'not_started' when episodes released but none watched", async () => {
+    await upsertTitles([
+      makeParsedTitle({ id: "show-4", objectType: "SHOW", title: "Not Started Show" }),
+    ]);
+    await trackTitle("show-4", userId);
+
+    await insertEpisodes("show-4", [
+      { season: 1, episode: 1, airDate: "2020-01-01" },
+      { season: 1, episode: 2, airDate: "2020-01-08" },
+    ]);
+
+    const titles = await getTrackedTitles(userId);
+    const show = titles.find((t) => t.id === "show-4");
+    expect(show).toBeDefined();
+    expect(show!.show_status).toBe("not_started");
+    expect(show!.released_episodes_count).toBe(2);
+    expect(show!.watched_episodes_count).toBe(0);
+  });
+
+  it("returns 'unreleased' when no episodes have been released yet", async () => {
+    await upsertTitles([
+      makeParsedTitle({ id: "show-5", objectType: "SHOW", title: "Unreleased Show" }),
+    ]);
+    await trackTitle("show-5", userId);
+
+    // All episodes in the future
+    await insertEpisodes("show-5", [
+      { season: 1, episode: 1, airDate: "2099-01-01" },
+      { season: 1, episode: 2, airDate: "2099-01-08" },
+    ]);
+
+    const titles = await getTrackedTitles(userId);
+    const show = titles.find((t) => t.id === "show-5");
+    expect(show).toBeDefined();
+    expect(show!.show_status).toBe("unreleased");
+    expect(show!.released_episodes_count).toBe(0);
+    expect(show!.next_episode_air_date).toBe("2099-01-01");
+  });
+
+  it("returns null show_status for movies", async () => {
+    await upsertTitles([
+      makeParsedTitle({ id: "movie-1", objectType: "MOVIE", title: "Test Movie" }),
+    ]);
+    await trackTitle("movie-1", userId);
+
+    const titles = await getTrackedTitles(userId);
+    const movie = titles.find((t) => t.id === "movie-1");
+    expect(movie).toBeDefined();
+    expect(movie!.show_status).toBeNull();
+    expect(movie!.released_episodes_count).toBe(0);
+  });
+
+  it("returns 'unreleased' for show with no episodes at all", async () => {
+    await upsertTitles([
+      makeParsedTitle({ id: "show-6", objectType: "SHOW", title: "Empty Show" }),
+    ]);
+    await trackTitle("show-6", userId);
+
+    const titles = await getTrackedTitles(userId);
+    const show = titles.find((t) => t.id === "show-6");
+    expect(show).toBeDefined();
+    expect(show!.show_status).toBe("unreleased");
+    expect(show!.released_episodes_count).toBe(0);
+    expect(show!.total_episodes).toBe(0);
+  });
+});

--- a/server/db/repository/tracked.ts
+++ b/server/db/repository/tracked.ts
@@ -4,6 +4,23 @@ import { titles, scores, tracked, titleGenres, watchedTitles } from "../schema";
 import { traceDbQuery } from "../../tracing";
 import { getOffersForTitles } from "./offers";
 
+type ShowStatus = "watching" | "caught_up" | "completed" | "not_started" | "unreleased" | null;
+
+function computeShowStatus(
+  objectType: string,
+  releasedEpisodesCount: number,
+  watchedEpisodesCount: number,
+  totalEpisodes: number,
+): ShowStatus {
+  if (objectType !== "SHOW") return null;
+  if (releasedEpisodesCount === 0) return "unreleased";
+  if (watchedEpisodesCount === 0) return "not_started";
+  if (totalEpisodes > 0 && totalEpisodes === watchedEpisodesCount && totalEpisodes === releasedEpisodesCount) return "completed";
+  if (releasedEpisodesCount > 0 && releasedEpisodesCount === watchedEpisodesCount && totalEpisodes > releasedEpisodesCount) return "caught_up";
+  if (releasedEpisodesCount > watchedEpisodesCount) return "watching";
+  return null;
+}
+
 async function getGenresForTitles(titleIds: string[]): Promise<Map<string, string[]>> {
   if (titleIds.length === 0) return new Map();
   const db = getDb();
@@ -85,6 +102,9 @@ export async function getTrackedTitles(userId: string) {
         is_watched: sql<number>`EXISTS(SELECT 1 FROM watched_titles wt WHERE wt.title_id = ${titles.id} AND wt.user_id = ${userId})`,
         total_episodes: sql<number>`(SELECT COUNT(*) FROM episodes e WHERE e.title_id = ${titles.id})`,
         watched_episodes_count: sql<number>`(SELECT COUNT(*) FROM watched_episodes we INNER JOIN episodes e ON e.id = we.episode_id WHERE e.title_id = ${titles.id} AND we.user_id = ${userId})`,
+        released_episodes_count: sql<number>`(SELECT COUNT(*) FROM episodes e WHERE e.title_id = ${titles.id} AND e.air_date <= date('now'))`,
+        latest_released_air_date: sql<string | null>`(SELECT MAX(e.air_date) FROM episodes e WHERE e.title_id = ${titles.id} AND e.air_date <= date('now'))`,
+        next_episode_air_date: sql<string | null>`(SELECT MIN(e.air_date) FROM episodes e WHERE e.title_id = ${titles.id} AND e.air_date > date('now'))`,
       })
       .from(tracked)
       .innerJoin(titles, eq(titles.id, tracked.titleId))
@@ -105,6 +125,7 @@ export async function getTrackedTitles(userId: string) {
       is_watched: Boolean(row.is_watched),
       public: Boolean(row.public),
       offers: offersByTitle.get(row.id) ?? [],
+      show_status: computeShowStatus(row.object_type, row.released_episodes_count, row.watched_episodes_count, row.total_episodes),
     }));
   });
 }
@@ -137,6 +158,9 @@ export async function getPublicTrackedTitles(userId: string) {
         is_watched: sql<number>`EXISTS(SELECT 1 FROM watched_titles wt WHERE wt.title_id = ${titles.id} AND wt.user_id = ${userId})`,
         total_episodes: sql<number>`(SELECT COUNT(*) FROM episodes e WHERE e.title_id = ${titles.id})`,
         watched_episodes_count: sql<number>`(SELECT COUNT(*) FROM watched_episodes we INNER JOIN episodes e ON e.id = we.episode_id WHERE e.title_id = ${titles.id} AND we.user_id = ${userId})`,
+        released_episodes_count: sql<number>`(SELECT COUNT(*) FROM episodes e WHERE e.title_id = ${titles.id} AND e.air_date <= date('now'))`,
+        latest_released_air_date: sql<string | null>`(SELECT MAX(e.air_date) FROM episodes e WHERE e.title_id = ${titles.id} AND e.air_date <= date('now'))`,
+        next_episode_air_date: sql<string | null>`(SELECT MIN(e.air_date) FROM episodes e WHERE e.title_id = ${titles.id} AND e.air_date > date('now'))`,
       })
       .from(tracked)
       .innerJoin(titles, eq(titles.id, tracked.titleId))
@@ -156,6 +180,7 @@ export async function getPublicTrackedTitles(userId: string) {
       is_tracked: true,
       is_watched: Boolean(row.is_watched),
       offers: offersByTitle.get(row.id) ?? [],
+      show_status: computeShowStatus(row.object_type, row.released_episodes_count, row.watched_episodes_count, row.total_episodes),
     }));
   });
 }


### PR DESCRIPTION
## Summary
- Add `released_episodes_count`, `show_status`, `latest_released_air_date`, and `next_episode_air_date` fields to `getTrackedTitles()` and `getPublicTrackedTitles()` queries
- Compute `show_status` from episode data: `watching`, `caught_up`, `completed`, `not_started`, `unreleased` (null for movies)
- Add corresponding fields to the frontend `Title` interface

## Test plan
- [x] Show with all episodes released and watched returns `completed`
- [x] Show with released episodes all watched but more coming returns `caught_up`
- [x] Show with unwatched released episodes returns `watching`
- [x] Show with released episodes but none watched returns `not_started`
- [x] Show with no released episodes returns `unreleased`
- [x] Show with no episodes at all returns `unreleased`
- [x] Movie returns null `show_status`
- [x] All 1058 tests pass (server + frontend)

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)