### PR TITLE
Add TitleCard progress visual states

### DIFF
--- a/frontend/src/components/TitleCard.test.tsx
+++ b/frontend/src/components/TitleCard.test.tsx
@@ -231,12 +231,135 @@ describe("TitleCard", () => {
     expect(screen.queryByText("TV")).toBeNull();
   });
 
-  it("shows progress bar when showProgressBar is true for shows with episodes", () => {
+  // ─── show_status visual states ────────────────────────────────────────────
+
+  it("shows green overlay, 'Completed' badge, and reduced opacity for completed shows", () => {
+    const title = makeTitle({
+      object_type: "SHOW",
+      show_status: "completed",
+      total_episodes: 24,
+      watched_episodes_count: 24,
+      released_episodes_count: 24,
+    });
+    const { container } = render(<TitleCard title={title} />, { wrapper: NoUserWrapper });
+
+    // Green overlay
+    const overlay = screen.getByTestId("completed-overlay");
+    expect(overlay).toBeDefined();
+    expect(overlay.className).toContain("bg-emerald-900/40");
+
+    // "Completed" badge text
+    expect(screen.getByText("Completed")).toBeDefined();
+
+    // Reduced opacity on the card wrapper
+    const card = container.firstElementChild as HTMLElement;
+    expect(card.className).toContain("opacity-75");
+  });
+
+  it("shows 'Caught Up' teal badge for caught_up shows", () => {
+    const title = makeTitle({
+      object_type: "SHOW",
+      show_status: "caught_up",
+      total_episodes: 20,
+      watched_episodes_count: 15,
+      released_episodes_count: 15,
+    });
+    const { container } = render(<TitleCard title={title} />, { wrapper: NoUserWrapper });
+
+    const badge = screen.getByText("Caught Up");
+    expect(badge).toBeDefined();
+    expect(badge.className).toContain("bg-teal-600");
+
+    // No reduced opacity
+    const card = container.firstElementChild as HTMLElement;
+    expect(card.className).not.toContain("opacity-75");
+  });
+
+  it("shows episode progress text badge for watching shows (no progress bar)", () => {
+    const title = makeTitle({
+      object_type: "SHOW",
+      show_status: "watching",
+      total_episodes: 24,
+      watched_episodes_count: 5,
+      released_episodes_count: 12,
+    });
+    render(<TitleCard title={title} />, { wrapper: NoUserWrapper });
+
+    // Uses released_episodes_count instead of total_episodes
+    expect(screen.getByText("5/12 ep")).toBeDefined();
+  });
+
+  it("shows progress bar for watching shows when showProgressBar is true", () => {
+    const title = makeTitle({
+      object_type: "SHOW",
+      show_status: "watching",
+      total_episodes: 24,
+      watched_episodes_count: 6,
+      released_episodes_count: 12,
+    });
+    const { container } = render(<TitleCard title={title} showProgressBar />, { wrapper: NoUserWrapper });
+
+    const progressTrack = container.querySelector(".bg-zinc-700");
+    expect(progressTrack).not.toBeNull();
+    const progressFill = progressTrack!.querySelector(".bg-amber-500") as HTMLElement;
+    expect(progressFill).not.toBeNull();
+    // 6/12 = 50%
+    expect(progressFill.style.width).toBe("50%");
+  });
+
+  it("shows no special badge for not_started shows with episodes", () => {
+    const title = makeTitle({
+      object_type: "SHOW",
+      show_status: "not_started",
+      total_episodes: 10,
+      watched_episodes_count: 0,
+      released_episodes_count: 10,
+    });
+    render(<TitleCard title={title} />, { wrapper: NoUserWrapper });
+
+    // No completed/caught_up/watching badge
+    expect(screen.queryByText("Completed")).toBeNull();
+    expect(screen.queryByText("Caught Up")).toBeNull();
+    // No episode count badge either (not_started has no fallback badge)
+    expect(screen.queryByText(/\/.*ep/)).toBeNull();
+  });
+
+  it("shows no special badge for unreleased shows", () => {
+    const title = makeTitle({
+      object_type: "SHOW",
+      show_status: "unreleased",
+      total_episodes: 0,
+      watched_episodes_count: 0,
+      released_episodes_count: 0,
+    });
+    render(<TitleCard title={title} />, { wrapper: NoUserWrapper });
+
+    expect(screen.queryByText("Completed")).toBeNull();
+    expect(screen.queryByText("Caught Up")).toBeNull();
+    expect(screen.queryByText(/\/.*ep/)).toBeNull();
+  });
+
+  it("shows 'Watched' badge for movies with is_watched (no show_status)", () => {
+    const title = makeTitle({
+      object_type: "MOVIE",
+      is_watched: true,
+      show_status: undefined,
+    });
+    render(<TitleCard title={title} />, { wrapper: NoUserWrapper });
+
+    expect(screen.getByText("Watched")).toBeDefined();
+    expect(screen.queryByText("Completed")).toBeNull();
+  });
+
+  // ─── Fallback behavior for titles without show_status ─────────────────────
+
+  it("shows progress bar when showProgressBar is true for shows without show_status", () => {
     const title = makeTitle({
       object_type: "SHOW",
       total_episodes: 10,
       watched_episodes_count: 3,
       is_watched: false,
+      show_status: undefined,
     });
     const { container } = render(<TitleCard title={title} showProgressBar />, { wrapper: NoUserWrapper });
 
@@ -246,16 +369,31 @@ describe("TitleCard", () => {
     expect(progressFill).not.toBeNull();
   });
 
-  it("shows text badge instead of progress bar when showProgressBar is false", () => {
+  it("shows text badge instead of progress bar when showProgressBar is false for shows without show_status", () => {
     const title = makeTitle({
       object_type: "SHOW",
       total_episodes: 10,
       watched_episodes_count: 3,
       is_watched: false,
+      show_status: undefined,
     });
     render(<TitleCard title={title} />, { wrapper: NoUserWrapper });
 
     expect(screen.getByText("3/10 ep")).toBeDefined();
+  });
+
+  it("uses released_episodes_count in fallback badge when available", () => {
+    const title = makeTitle({
+      object_type: "SHOW",
+      total_episodes: 24,
+      watched_episodes_count: 3,
+      released_episodes_count: 12,
+      is_watched: false,
+      show_status: undefined,
+    });
+    render(<TitleCard title={title} />, { wrapper: NoUserWrapper });
+
+    expect(screen.getByText("3/12 ep")).toBeDefined();
   });
 
   it("does not show progress bar for movies", () => {

--- a/frontend/src/components/TitleCard.tsx
+++ b/frontend/src/components/TitleCard.tsx
@@ -27,7 +27,7 @@ const TitleCard = memo(function TitleCard({ title, onTrackToggle, showVisibility
   const streamingOffers = Array.from(uniqueProviders.values());
 
   return (
-    <div className="bg-zinc-900 rounded-xl overflow-hidden hover:scale-[1.02] transition-transform duration-200 flex flex-col">
+    <div className={`bg-zinc-900 rounded-xl overflow-hidden hover:scale-[1.02] transition-transform duration-200 flex flex-col${title.show_status === "completed" ? " opacity-75" : ""}`}>
       {/* Poster — clickable link to detail page */}
       <div className="aspect-[2/3] bg-zinc-800 relative">
         <Link to={`/title/${title.id}`} className="block w-full h-full">
@@ -49,7 +49,39 @@ const TitleCard = memo(function TitleCard({ title, onTrackToggle, showVisibility
             TV
           </span>
         )}
-        {title.is_watched && (
+        {title.show_status === "completed" && (
+          <>
+            <div className="absolute inset-0 bg-emerald-900/40 pointer-events-none" data-testid="completed-overlay" />
+            <span className="absolute bottom-2 left-2 bg-emerald-600 text-white text-[10px] font-bold px-1.5 py-0.5 rounded flex items-center gap-0.5">
+              <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clipRule="evenodd" />
+              </svg>
+              Completed
+            </span>
+          </>
+        )}
+        {title.show_status === "caught_up" && (
+          <span className="absolute bottom-2 left-2 bg-teal-600 text-white text-[10px] font-bold px-1.5 py-0.5 rounded">
+            Caught Up
+          </span>
+        )}
+        {title.show_status === "watching" && title.object_type === "SHOW" && (
+          <>
+            {showProgressBar && (title.released_episodes_count ?? title.total_episodes ?? 0) > 0 ? (
+              <div className="absolute bottom-0 left-0 right-0 h-1 bg-zinc-700">
+                <div
+                  className="h-full bg-amber-500 transition-all duration-300"
+                  style={{ width: `${((title.watched_episodes_count ?? 0) / (title.released_episodes_count ?? title.total_episodes ?? 1)) * 100}%` }}
+                />
+              </div>
+            ) : (
+              <span className="absolute bottom-2 left-2 bg-zinc-800/90 text-white text-[10px] font-bold px-1.5 py-0.5 rounded">
+                {title.watched_episodes_count ?? 0}/{title.released_episodes_count ?? title.total_episodes ?? 0} ep
+              </span>
+            )}
+          </>
+        )}
+        {!title.show_status && title.is_watched && (
           <span className="absolute bottom-2 left-2 bg-emerald-500 text-white text-[10px] font-bold px-1.5 py-0.5 rounded flex items-center gap-0.5">
             <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
               <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clipRule="evenodd" />
@@ -57,16 +89,16 @@ const TitleCard = memo(function TitleCard({ title, onTrackToggle, showVisibility
             Watched
           </span>
         )}
-        {!title.is_watched && !showProgressBar && title.object_type === "SHOW" && title.total_episodes != null && title.total_episodes > 0 && (
+        {!title.show_status && !title.is_watched && !showProgressBar && title.object_type === "SHOW" && title.total_episodes != null && title.total_episodes > 0 && (
           <span className="absolute bottom-2 left-2 bg-zinc-800/90 text-white text-[10px] font-bold px-1.5 py-0.5 rounded">
-            {title.watched_episodes_count ?? 0}/{title.total_episodes} ep
+            {title.watched_episodes_count ?? 0}/{title.released_episodes_count ?? title.total_episodes} ep
           </span>
         )}
-        {!title.is_watched && showProgressBar && title.object_type === "SHOW" && title.total_episodes != null && title.total_episodes > 0 && (
+        {!title.show_status && !title.is_watched && showProgressBar && title.object_type === "SHOW" && title.total_episodes != null && title.total_episodes > 0 && (
           <div className="absolute bottom-0 left-0 right-0 h-1 bg-zinc-700">
             <div
               className="h-full bg-amber-500 transition-all duration-300"
-              style={{ width: `${((title.watched_episodes_count ?? 0) / title.total_episodes) * 100}%` }}
+              style={{ width: `${((title.watched_episodes_count ?? 0) / (title.released_episodes_count ?? title.total_episodes)) * 100}%` }}
             />
           </div>
         )}


### PR DESCRIPTION
## Summary
- Add visual treatments to TitleCard based on `show_status` field from PR #299
- **completed**: green semi-transparent overlay, emerald "Completed" badge with checkmark, reduced card opacity (75%)
- **caught_up**: teal "Caught Up" badge
- **watching**: progress bar or text badge using `released_episodes_count` for accurate progress
- **not_started / unreleased**: no special treatment
- **Movies** (null show_status): existing "Watched" badge behavior preserved
- Fallback logic for titles without `show_status` uses `released_episodes_count` when available

## Test plan
- [x] Tests for completed state: green overlay, "Completed" badge, reduced opacity
- [x] Tests for caught_up state: teal badge, normal opacity
- [x] Tests for watching state: text badge with released count, progress bar with correct width
- [x] Tests for not_started and unreleased: no special badges
- [x] Tests for movies with is_watched: "Watched" badge preserved
- [x] Tests for fallback behavior: shows without show_status use existing logic
- [x] Tests for released_episodes_count in fallback badge
- [x] `bun run check` passes (type check + lint + 1066 tests)

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)