### PR TITLE
Group tracked shows by status on Tracked and Profile pages

### DIFF
--- a/frontend/src/lib/groupShows.test.ts
+++ b/frontend/src/lib/groupShows.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "bun:test";
+import { groupShowsByStatus } from "./groupShows";
+import type { Title } from "../types";
+
+function makeShow(overrides: Partial<Title> = {}): Title {
+  return {
+    id: "show-1",
+    object_type: "SHOW",
+    title: "Test Show",
+    original_title: null,
+    release_year: 2024,
+    release_date: "2024-01-01",
+    runtime_minutes: null,
+    short_description: null,
+    genres: [],
+    imdb_id: null,
+    tmdb_id: null,
+    poster_url: null,
+    age_certification: null,
+    original_language: null,
+    tmdb_url: null,
+    imdb_score: null,
+    imdb_votes: null,
+    tmdb_score: null,
+    is_tracked: true,
+    offers: [],
+    ...overrides,
+  };
+}
+
+describe("groupShowsByStatus", () => {
+  it("returns empty array for no shows", () => {
+    expect(groupShowsByStatus([])).toEqual([]);
+  });
+
+  it("groups shows by status in correct order", () => {
+    const shows = [
+      makeShow({ id: "s1", show_status: "completed" }),
+      makeShow({ id: "s2", show_status: "watching" }),
+      makeShow({ id: "s3", show_status: "caught_up" }),
+      makeShow({ id: "s4", show_status: "not_started" }),
+      makeShow({ id: "s5", show_status: "unreleased" }),
+    ];
+
+    const groups = groupShowsByStatus(shows);
+    expect(groups).toHaveLength(5);
+    expect(groups[0].key).toBe("watching");
+    expect(groups[1].key).toBe("caught_up");
+    expect(groups[2].key).toBe("not_started");
+    expect(groups[3].key).toBe("unreleased");
+    expect(groups[4].key).toBe("completed");
+  });
+
+  it("omits empty groups", () => {
+    const shows = [
+      makeShow({ id: "s1", show_status: "watching" }),
+      makeShow({ id: "s2", show_status: "completed" }),
+    ];
+
+    const groups = groupShowsByStatus(shows);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].key).toBe("watching");
+    expect(groups[1].key).toBe("completed");
+  });
+
+  it("treats null status as not_started", () => {
+    const shows = [makeShow({ id: "s1", show_status: null })];
+    const groups = groupShowsByStatus(shows);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe("not_started");
+    expect(groups[0].titles[0].id).toBe("s1");
+  });
+
+  it("treats undefined status as not_started", () => {
+    const shows = [makeShow({ id: "s1" })];
+    const groups = groupShowsByStatus(shows);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe("not_started");
+  });
+
+  it("sorts watching by latest_released_air_date DESC", () => {
+    const shows = [
+      makeShow({ id: "s1", show_status: "watching", latest_released_air_date: "2024-01-01" }),
+      makeShow({ id: "s2", show_status: "watching", latest_released_air_date: "2024-06-15" }),
+      makeShow({ id: "s3", show_status: "watching", latest_released_air_date: "2024-03-10" }),
+    ];
+
+    const groups = groupShowsByStatus(shows);
+    expect(groups[0].titles.map((t) => t.id)).toEqual(["s2", "s3", "s1"]);
+  });
+
+  it("sorts caught_up by next_episode_air_date ASC", () => {
+    const shows = [
+      makeShow({ id: "s1", show_status: "caught_up", next_episode_air_date: "2025-03-01" }),
+      makeShow({ id: "s2", show_status: "caught_up", next_episode_air_date: "2025-01-15" }),
+      makeShow({ id: "s3", show_status: "caught_up", next_episode_air_date: "2025-06-01" }),
+    ];
+
+    const groups = groupShowsByStatus(shows);
+    expect(groups[0].titles.map((t) => t.id)).toEqual(["s2", "s1", "s3"]);
+  });
+
+  it("sorts not_started by latest_released_air_date DESC", () => {
+    const shows = [
+      makeShow({ id: "s1", show_status: "not_started", latest_released_air_date: "2024-01-01" }),
+      makeShow({ id: "s2", show_status: "not_started", latest_released_air_date: "2024-12-01" }),
+    ];
+
+    const groups = groupShowsByStatus(shows);
+    expect(groups[0].titles.map((t) => t.id)).toEqual(["s2", "s1"]);
+  });
+
+  it("sorts unreleased by release_date ASC", () => {
+    const shows = [
+      makeShow({ id: "s1", show_status: "unreleased", release_date: "2025-12-01" }),
+      makeShow({ id: "s2", show_status: "unreleased", release_date: "2025-06-01" }),
+    ];
+
+    const groups = groupShowsByStatus(shows);
+    expect(groups[0].titles.map((t) => t.id)).toEqual(["s2", "s1"]);
+  });
+
+  it("sorts completed by tracked_at DESC", () => {
+    const shows = [
+      makeShow({ id: "s1", show_status: "completed", tracked_at: "2024-01-01T00:00:00Z" }),
+      makeShow({ id: "s2", show_status: "completed", tracked_at: "2024-06-01T00:00:00Z" }),
+    ];
+
+    const groups = groupShowsByStatus(shows);
+    expect(groups[0].titles.map((t) => t.id)).toEqual(["s2", "s1"]);
+  });
+
+  it("pushes null dates to the end in date-sorted groups", () => {
+    const shows = [
+      makeShow({ id: "s1", show_status: "watching", latest_released_air_date: null }),
+      makeShow({ id: "s2", show_status: "watching", latest_released_air_date: "2024-06-15" }),
+    ];
+
+    const groups = groupShowsByStatus(shows);
+    expect(groups[0].titles.map((t) => t.id)).toEqual(["s2", "s1"]);
+  });
+
+  it("includes correct labelKey for each group", () => {
+    const shows = [
+      makeShow({ id: "s1", show_status: "watching" }),
+      makeShow({ id: "s2", show_status: "caught_up" }),
+    ];
+
+    const groups = groupShowsByStatus(shows);
+    expect(groups[0].labelKey).toBe("tracked.sections.watching");
+    expect(groups[1].labelKey).toBe("tracked.sections.caughtUp");
+  });
+});

--- a/frontend/src/lib/groupShows.ts
+++ b/frontend/src/lib/groupShows.ts
@@ -1,0 +1,97 @@
+import type { Title } from "../types";
+
+export interface ShowGroup {
+  key: string;
+  labelKey: string;
+  titles: Title[];
+}
+
+const STATUS_ORDER = ["watching", "caught_up", "not_started", "unreleased", "completed"] as const;
+
+const LABEL_KEYS: Record<string, string> = {
+  watching: "tracked.sections.watching",
+  caught_up: "tracked.sections.caughtUp",
+  not_started: "tracked.sections.notStarted",
+  unreleased: "tracked.sections.unreleased",
+  completed: "tracked.sections.completed",
+};
+
+function compareDatesDesc(a: string | null | undefined, b: string | null | undefined): number {
+  if (!a && !b) return 0;
+  if (!a) return 1;
+  if (!b) return -1;
+  return b.localeCompare(a);
+}
+
+function compareDatesAsc(a: string | null | undefined, b: string | null | undefined): number {
+  if (!a && !b) return 0;
+  if (!a) return 1;
+  if (!b) return -1;
+  return a.localeCompare(b);
+}
+
+function sortByTrackedAtDesc(a: Title, b: Title): number {
+  return compareDatesDesc(a.tracked_at, b.tracked_at);
+}
+
+function sortGroup(key: string, titles: Title[]): Title[] {
+  switch (key) {
+    case "watching":
+      return [...titles].sort((a, b) =>
+        compareDatesDesc(a.latest_released_air_date, b.latest_released_air_date)
+      );
+    case "caught_up":
+      return [...titles].sort((a, b) =>
+        compareDatesAsc(a.next_episode_air_date, b.next_episode_air_date)
+      );
+    case "not_started":
+      return [...titles].sort((a, b) =>
+        compareDatesDesc(a.latest_released_air_date, b.latest_released_air_date)
+      );
+    case "unreleased":
+      return [...titles].sort((a, b) =>
+        compareDatesAsc(a.release_date, b.release_date)
+      );
+    case "completed":
+      return [...titles].sort(sortByTrackedAtDesc);
+    default:
+      return titles;
+  }
+}
+
+/**
+ * Groups shows by their show_status into sorted sections.
+ * Returns only non-empty groups in the defined order.
+ */
+export function groupShowsByStatus(shows: Title[]): ShowGroup[] {
+  const buckets: Record<string, Title[]> = {};
+
+  for (const status of STATUS_ORDER) {
+    buckets[status] = [];
+  }
+
+  for (const show of shows) {
+    const status = show.show_status ?? "not_started";
+    const bucket = buckets[status];
+    if (bucket) {
+      bucket.push(show);
+    } else {
+      // Fallback for unexpected status values
+      buckets["not_started"].push(show);
+    }
+  }
+
+  const groups: ShowGroup[] = [];
+  for (const status of STATUS_ORDER) {
+    const titles = buckets[status];
+    if (titles.length > 0) {
+      groups.push({
+        key: status,
+        labelKey: LABEL_KEYS[status],
+        titles: sortGroup(status, titles),
+      });
+    }
+  }
+
+  return groups;
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -35,7 +35,15 @@
   },
   "tracked": {
     "title": "Tracked Titles ({{count}})",
-    "empty": "No tracked titles yet. Search for titles and click 'Track' to add them here."
+    "empty": "No tracked titles yet. Search for titles and click 'Track' to add them here.",
+    "sections": {
+      "watching": "Currently Watching",
+      "caughtUp": "Caught Up",
+      "notStarted": "Not Started",
+      "unreleased": "Unreleased",
+      "completed": "Completed",
+      "movies": "Movies"
+    }
   },
   "upcoming": {
     "today": "Today",

--- a/frontend/src/pages/TrackedPage.test.tsx
+++ b/frontend/src/pages/TrackedPage.test.tsx
@@ -1,0 +1,227 @@
+import { describe, it, expect, mock, afterEach } from "bun:test";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import type { ReactNode } from "react";
+
+// Initialize i18n before anything else
+import "../i18n";
+
+// Mock auth context
+mock.module("../context/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: "u1", username: "testuser", display_name: null, auth_provider: "local", is_admin: false },
+    providers: { local: true, oidc: null },
+    loading: false,
+    login: mock(() => Promise.resolve()),
+    signup: mock(() => Promise.resolve()),
+    logout: mock(() => Promise.resolve()),
+    refresh: mock(() => Promise.resolve()),
+  }),
+  AuthContext: {
+    Provider: ({ children }: { children: ReactNode }) => children,
+  },
+}));
+
+const mockGetTrackedTitles = mock(() =>
+  Promise.resolve({ titles: [], count: 0, profile_public: false })
+);
+
+mock.module("../api", () => ({
+  getTrackedTitles: mockGetTrackedTitles,
+  trackTitle: mock(() => Promise.resolve()),
+  untrackTitle: mock(() => Promise.resolve()),
+}));
+
+const { default: TrackedPage } = await import("./TrackedPage");
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
+
+afterEach(() => {
+  cleanup();
+  mockGetTrackedTitles.mockReset();
+});
+
+function makeShow(id: string, status: string | null, overrides = {}) {
+  return {
+    id,
+    object_type: "SHOW",
+    title: `Show ${id}`,
+    original_title: null,
+    release_year: 2024,
+    release_date: "2024-01-01",
+    runtime_minutes: null,
+    short_description: null,
+    genres: [],
+    imdb_id: null,
+    tmdb_id: null,
+    poster_url: null,
+    age_certification: null,
+    original_language: null,
+    tmdb_url: null,
+    imdb_score: null,
+    imdb_votes: null,
+    tmdb_score: null,
+    is_tracked: true,
+    offers: [],
+    show_status: status,
+    tracked_at: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeMovie(id: string) {
+  return {
+    id,
+    object_type: "MOVIE",
+    title: `Movie ${id}`,
+    original_title: null,
+    release_year: 2024,
+    release_date: "2024-01-01",
+    runtime_minutes: 120,
+    short_description: null,
+    genres: [],
+    imdb_id: null,
+    tmdb_id: null,
+    poster_url: null,
+    age_certification: null,
+    original_language: null,
+    tmdb_url: null,
+    imdb_score: null,
+    imdb_votes: null,
+    tmdb_score: null,
+    is_tracked: true,
+    offers: [],
+    tracked_at: "2024-01-01T00:00:00Z",
+  };
+}
+
+describe("TrackedPage", () => {
+  it("shows loading state initially", () => {
+    mockGetTrackedTitles.mockImplementation(() => new Promise(() => {}));
+    const { container } = render(<TrackedPage />, { wrapper: Wrapper });
+    expect(container.querySelector(".animate-pulse")).toBeDefined();
+  });
+
+  it("shows empty message when no tracked titles", async () => {
+    mockGetTrackedTitles.mockImplementation(() =>
+      Promise.resolve({ titles: [], count: 0, profile_public: false })
+    );
+    render(<TrackedPage />, { wrapper: Wrapper });
+    await waitFor(() =>
+      expect(screen.getByText(/No tracked titles yet/)).toBeDefined()
+    );
+  });
+
+  it("groups shows by status with section headers", async () => {
+    const titles = [
+      makeShow("s1", "watching"),
+      makeShow("s2", "caught_up"),
+      makeShow("s3", "not_started"),
+      makeShow("s4", "completed"),
+      makeMovie("m1"),
+    ];
+    mockGetTrackedTitles.mockImplementation(() =>
+      Promise.resolve({ titles, count: titles.length, profile_public: false })
+    );
+
+    render(<TrackedPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Currently Watching (1)")).toBeDefined();
+      expect(screen.getByText("Caught Up (1)")).toBeDefined();
+      expect(screen.getByText("Not Started (1)")).toBeDefined();
+      expect(screen.getByText("Completed (1)")).toBeDefined();
+      expect(screen.getByText("Movies (1)")).toBeDefined();
+    });
+  });
+
+  it("does not render empty groups", async () => {
+    const titles = [
+      makeShow("s1", "watching"),
+      makeMovie("m1"),
+    ];
+    mockGetTrackedTitles.mockImplementation(() =>
+      Promise.resolve({ titles, count: titles.length, profile_public: false })
+    );
+
+    render(<TrackedPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Currently Watching (1)")).toBeDefined();
+    });
+
+    // These sections should not exist
+    expect(screen.queryByText(/Caught Up/)).toBeNull();
+    expect(screen.queryByText(/Not Started/)).toBeNull();
+    expect(screen.queryByText(/Unreleased/)).toBeNull();
+    expect(screen.queryByText(/Completed/)).toBeNull();
+  });
+
+  it("shows movies in their own section after shows", async () => {
+    const titles = [
+      makeShow("s1", "watching"),
+      makeMovie("m1"),
+      makeMovie("m2"),
+    ];
+    mockGetTrackedTitles.mockImplementation(() =>
+      Promise.resolve({ titles, count: titles.length, profile_public: false })
+    );
+
+    render(<TrackedPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Movies (2)")).toBeDefined();
+    });
+  });
+
+  it("shows total count in header", async () => {
+    const titles = [
+      makeShow("s1", "watching"),
+      makeShow("s2", "completed"),
+      makeMovie("m1"),
+    ];
+    mockGetTrackedTitles.mockImplementation(() =>
+      Promise.resolve({ titles, count: titles.length, profile_public: false })
+    );
+
+    render(<TrackedPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Tracked Titles (3)")).toBeDefined();
+    });
+  });
+
+  it("renders unreleased section when shows have unreleased status", async () => {
+    const titles = [
+      makeShow("s1", "unreleased"),
+    ];
+    mockGetTrackedTitles.mockImplementation(() =>
+      Promise.resolve({ titles, count: titles.length, profile_public: false })
+    );
+
+    render(<TrackedPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Unreleased (1)")).toBeDefined();
+    });
+  });
+
+  it("does not show movies section when there are no movies", async () => {
+    const titles = [
+      makeShow("s1", "watching"),
+    ];
+    mockGetTrackedTitles.mockImplementation(() =>
+      Promise.resolve({ titles, count: titles.length, profile_public: false })
+    );
+
+    render(<TrackedPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Currently Watching (1)")).toBeDefined();
+    });
+
+    expect(screen.queryByText(/^Movies/)).toBeNull();
+  });
+});

--- a/frontend/src/pages/TrackedPage.tsx
+++ b/frontend/src/pages/TrackedPage.tsx
@@ -1,26 +1,56 @@
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import * as api from "../api";
 import type { Title } from "../types";
 import TitleList from "../components/TitleList";
 import { TitleGridSkeleton } from "../components/SkeletonComponents";
 import { useApiCall } from "../hooks/useApiCall";
+import { groupShowsByStatus } from "../lib/groupShows";
 
 export default function TrackedPage() {
   const { data, loading, refetch } = useApiCall(() => api.getTrackedTitles(), []);
-  const titles: Title[] = data?.titles ?? [];
+  const titles: Title[] = useMemo(() => data?.titles ?? [], [data]);
   const { t } = useTranslation();
+
+  const { showGroups, movies } = useMemo(() => {
+    const shows = titles.filter((t) => t.object_type === "SHOW");
+    const movieList = titles
+      .filter((t) => t.object_type === "MOVIE")
+      .sort((a, b) => {
+        if (!a.tracked_at && !b.tracked_at) return 0;
+        if (!a.tracked_at) return 1;
+        if (!b.tracked_at) return -1;
+        return b.tracked_at.localeCompare(a.tracked_at);
+      });
+    return { showGroups: groupShowsByStatus(shows), movies: movieList };
+  }, [titles]);
 
   return (
     <div className="space-y-4">
       <h2 className="text-lg font-semibold">{t("tracked.title", { count: titles.length })}</h2>
       {loading ? (
         <TitleGridSkeleton />
+      ) : titles.length === 0 ? (
+        <TitleList titles={[]} onTrackToggle={refetch} emptyMessage={t("tracked.empty")} />
       ) : (
-        <TitleList
-          titles={titles}
-          onTrackToggle={refetch}
-          emptyMessage={t("tracked.empty")}
-        />
+        <div className="space-y-6">
+          {showGroups.map((group) => (
+            <div key={group.key}>
+              <h3 className="text-sm font-semibold text-zinc-400 mb-3">
+                {t(group.labelKey)} ({group.titles.length})
+              </h3>
+              <TitleList titles={group.titles} onTrackToggle={refetch} hideTypeBadge showProgressBar />
+            </div>
+          ))}
+          {movies.length > 0 && (
+            <div>
+              <h3 className="text-sm font-semibold text-zinc-400 mb-3">
+                {t("tracked.sections.movies")} ({movies.length})
+              </h3>
+              <TitleList titles={movies} onTrackToggle={refetch} />
+            </div>
+          )}
+        </div>
       )}
     </div>
   );

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Link, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import { Settings } from "lucide-react";
@@ -8,6 +9,7 @@ import ProfileBanner from "../components/ProfileBanner";
 import ShareButton from "../components/ShareButton";
 import { TitleGridSkeleton } from "../components/SkeletonComponents";
 import { useApiCall } from "../hooks/useApiCall";
+import { groupShowsByStatus } from "../lib/groupShows";
 
 export default function UserProfilePage() {
   const { username } = useParams<{ username: string }>();
@@ -16,6 +18,9 @@ export default function UserProfilePage() {
     () => api.getUserProfile(username!),
     [username],
   );
+
+  const shows = useMemo(() => data?.shows ?? [], [data]);
+  const showGroups = useMemo(() => groupShowsByStatus(shows), [shows]);
 
   if (loading) {
     return (
@@ -42,7 +47,7 @@ export default function UserProfilePage() {
     );
   }
 
-  const { user, stats, movies, shows, is_own_profile, show_watchlist, backdrops } = data;
+  const { user, stats, movies, is_own_profile, show_watchlist, backdrops } = data;
   const displayName = user.display_name || user.username;
 
   async function handleVisibilityToggle(titleId: string, isPublic: boolean) {
@@ -112,11 +117,18 @@ export default function UserProfilePage() {
       {show_watchlist && (movies.length > 0 || shows.length > 0) && (
         <div className="space-y-8">
           {shows.length > 0 && (
-            <div>
-              <h2 className="text-lg font-semibold text-white mb-4">
+            <div className="space-y-6">
+              <h2 className="text-lg font-semibold text-white">
                 {t("userProfile.tvShows")} <span className="text-zinc-500 font-normal text-base">({shows.length})</span>
               </h2>
-              <TitleList titles={shows} onTrackToggle={refetch} showVisibilityToggle={is_own_profile} onVisibilityToggle={handleVisibilityToggle} hideTypeBadge showProgressBar />
+              {showGroups.map((group) => (
+                <div key={group.key}>
+                  <h3 className="text-sm font-semibold text-zinc-400 mb-3">
+                    {t(group.labelKey)} ({group.titles.length})
+                  </h3>
+                  <TitleList titles={group.titles} onTrackToggle={refetch} showVisibilityToggle={is_own_profile} onVisibilityToggle={handleVisibilityToggle} hideTypeBadge showProgressBar />
+                </div>
+              ))}
             </div>
           )}
           {movies.length > 0 && (


### PR DESCRIPTION
## Summary
- Add `groupShowsByStatus` utility that groups shows into 5 categories: Currently Watching, Caught Up, Not Started, Unreleased, Completed
- Each group is sorted by a status-appropriate field (e.g., latest_released_air_date DESC for Watching, next_episode_air_date ASC for Caught Up)
- TrackedPage now renders shows in grouped sections with headers, movies in a separate section at the end
- UserProfilePage applies the same grouping under the TV Shows heading
- Add i18n translation keys for all section headers

## Test plan
- [x] `groupShows.test.ts`: 12 tests covering grouping, sorting, empty groups, null/undefined status fallback
- [x] `TrackedPage.test.tsx`: 8 tests covering loading state, empty state, grouped sections, missing groups, movie section, total count
- [x] `bun run check` passes (tsc + lint + 1078 tests)

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)