### PR TITLE
Add profile progress metrics for shows and episodes

### DIFF
--- a/frontend/src/components/ProfileBanner.test.tsx
+++ b/frontend/src/components/ProfileBanner.test.tsx
@@ -18,6 +18,10 @@ const mockStats: UserProfileStats = {
   tracked_count: 12,
   watched_movies: 5,
   watched_episodes: 42,
+  shows_completed: 2,
+  shows_total: 5,
+  total_watched_episodes: 30,
+  total_released_episodes: 50,
 };
 
 function renderBanner(
@@ -107,6 +111,72 @@ describe("ProfileBanner", () => {
       renderBanner();
       const statsEl = screen.getByTestId("profile-stats");
       expect(statsEl.textContent).toContain("42");
+    });
+  });
+
+  describe("progress bars", () => {
+    it("renders progress section when shows_total > 0", () => {
+      renderBanner();
+      expect(screen.getByTestId("progress-section")).toBeDefined();
+    });
+
+    it("does not render progress section when shows_total is 0", () => {
+      renderBanner({
+        stats: { ...mockStats, shows_total: 0, shows_completed: 0, total_watched_episodes: 0, total_released_episodes: 0 },
+      });
+      expect(screen.queryByTestId("progress-section")).toBeNull();
+    });
+
+    it("renders show progress bar with correct width", () => {
+      renderBanner();
+      const fill = screen.getByTestId("shows-progress-fill");
+      // 2/5 = 40%
+      expect(fill.style.width).toBe("40%");
+    });
+
+    it("renders episode progress bar with correct width", () => {
+      renderBanner();
+      const fill = screen.getByTestId("episodes-progress-fill");
+      // 30/50 = 60%
+      expect(fill.style.width).toBe("60%");
+    });
+
+    it("shows correct show progress text", () => {
+      renderBanner();
+      const section = screen.getByTestId("progress-section");
+      expect(section.textContent).toContain("2/5");
+    });
+
+    it("shows correct episode progress text", () => {
+      renderBanner();
+      const section = screen.getByTestId("progress-section");
+      expect(section.textContent).toContain("30/50");
+    });
+
+    it("hides episode progress bar when total_released_episodes is 0", () => {
+      renderBanner({
+        stats: { ...mockStats, total_released_episodes: 0, total_watched_episodes: 0 },
+      });
+      expect(screen.getByTestId("progress-section")).toBeDefined();
+      expect(screen.queryByTestId("episodes-progress-bar")).toBeNull();
+    });
+
+    it("renders 0% width when no shows completed", () => {
+      renderBanner({
+        stats: { ...mockStats, shows_completed: 0 },
+      });
+      const fill = screen.getByTestId("shows-progress-fill");
+      expect(fill.style.width).toBe("0%");
+    });
+
+    it("renders 100% width when all shows completed", () => {
+      renderBanner({
+        stats: { ...mockStats, shows_completed: 5, shows_total: 5, total_watched_episodes: 50, total_released_episodes: 50 },
+      });
+      const showFill = screen.getByTestId("shows-progress-fill");
+      expect(showFill.style.width).toBe("100%");
+      const epFill = screen.getByTestId("episodes-progress-fill");
+      expect(epFill.style.width).toBe("100%");
     });
   });
 

--- a/frontend/src/components/ProfileBanner.tsx
+++ b/frontend/src/components/ProfileBanner.tsx
@@ -110,22 +110,56 @@ export default function ProfileBanner({ backdrops, user, stats, isOwnProfile, au
           </div>
 
           {/* Stats */}
-          <div className="pointer-events-auto flex gap-2 sm:gap-3 shrink-0" data-testid="profile-stats">
-            <div className="bg-zinc-900/70 backdrop-blur-sm rounded-lg px-3 py-2 text-center min-w-[4.5rem]">
-              <Bookmark className="size-4 text-zinc-400 mx-auto mb-1" />
-              <p className="text-lg font-bold text-white leading-tight">{stats.tracked_count}</p>
-              <p className="text-[10px] text-zinc-400 mt-0.5">{t("userProfile.trackedTitles")}</p>
+          <div className="pointer-events-auto shrink-0 flex flex-col items-end gap-2" data-testid="profile-stats">
+            <div className="flex gap-2 sm:gap-3">
+              <div className="bg-zinc-900/70 backdrop-blur-sm rounded-lg px-3 py-2 text-center min-w-[4.5rem]">
+                <Bookmark className="size-4 text-zinc-400 mx-auto mb-1" />
+                <p className="text-lg font-bold text-white leading-tight">{stats.tracked_count}</p>
+                <p className="text-[10px] text-zinc-400 mt-0.5">{t("userProfile.trackedTitles")}</p>
+              </div>
+              <div className="bg-zinc-900/70 backdrop-blur-sm rounded-lg px-3 py-2 text-center min-w-[4.5rem]">
+                <Film className="size-4 text-zinc-400 mx-auto mb-1" />
+                <p className="text-lg font-bold text-white leading-tight">{stats.watched_movies}</p>
+                <p className="text-[10px] text-zinc-400 mt-0.5">{t("userProfile.watchedMovies")}</p>
+              </div>
+              <div className="bg-zinc-900/70 backdrop-blur-sm rounded-lg px-3 py-2 text-center min-w-[4.5rem]">
+                <Tv className="size-4 text-zinc-400 mx-auto mb-1" />
+                <p className="text-lg font-bold text-white leading-tight">{stats.watched_episodes}</p>
+                <p className="text-[10px] text-zinc-400 mt-0.5">{t("userProfile.watchedEpisodes")}</p>
+              </div>
             </div>
-            <div className="bg-zinc-900/70 backdrop-blur-sm rounded-lg px-3 py-2 text-center min-w-[4.5rem]">
-              <Film className="size-4 text-zinc-400 mx-auto mb-1" />
-              <p className="text-lg font-bold text-white leading-tight">{stats.watched_movies}</p>
-              <p className="text-[10px] text-zinc-400 mt-0.5">{t("userProfile.watchedMovies")}</p>
-            </div>
-            <div className="bg-zinc-900/70 backdrop-blur-sm rounded-lg px-3 py-2 text-center min-w-[4.5rem]">
-              <Tv className="size-4 text-zinc-400 mx-auto mb-1" />
-              <p className="text-lg font-bold text-white leading-tight">{stats.watched_episodes}</p>
-              <p className="text-[10px] text-zinc-400 mt-0.5">{t("userProfile.watchedEpisodes")}</p>
-            </div>
+            {stats.shows_total > 0 && (
+              <div className="bg-zinc-900/70 backdrop-blur-sm rounded-lg px-3 py-2 w-full space-y-1.5" data-testid="progress-section">
+                <div>
+                  <div className="flex justify-between items-baseline mb-0.5">
+                    <p className="text-[10px] text-zinc-400">{t("userProfile.showsCompleted")}</p>
+                    <p className="text-[10px] text-zinc-300 font-medium">{stats.shows_completed}/{stats.shows_total}</p>
+                  </div>
+                  <div className="h-1.5 rounded-full bg-zinc-700 overflow-hidden" data-testid="shows-progress-bar">
+                    <div
+                      className="h-full rounded-full bg-amber-400 transition-all"
+                      style={{ width: `${Math.round((stats.shows_completed / stats.shows_total) * 100)}%` }}
+                      data-testid="shows-progress-fill"
+                    />
+                  </div>
+                </div>
+                {stats.total_released_episodes > 0 && (
+                  <div>
+                    <div className="flex justify-between items-baseline mb-0.5">
+                      <p className="text-[10px] text-zinc-400">{t("userProfile.episodesWatched")}</p>
+                      <p className="text-[10px] text-zinc-300 font-medium">{stats.total_watched_episodes}/{stats.total_released_episodes}</p>
+                    </div>
+                    <div className="h-1.5 rounded-full bg-zinc-700 overflow-hidden" data-testid="episodes-progress-bar">
+                      <div
+                        className="h-full rounded-full bg-amber-400 transition-all"
+                        style={{ width: `${Math.round((stats.total_watched_episodes / stats.total_released_episodes) * 100)}%` }}
+                        data-testid="episodes-progress-fill"
+                      />
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -205,7 +205,9 @@
     "watchlist": "Watchlist",
     "watchlistHidden": "This user's watchlist is private.",
     "watchlistHiddenOwn": "Your watchlist is hidden from your public profile.",
-    "enableInSettings": "Enable in settings"
+    "enableInSettings": "Enable in settings",
+    "showsCompleted": "Shows Completed",
+    "episodesWatched": "Episodes Watched"
   },
   "settings": {
     "title": "Settings",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -412,6 +412,10 @@ export interface UserProfileStats {
   tracked_count: number;
   watched_movies: number;
   watched_episodes: number;
+  shows_completed: number;
+  shows_total: number;
+  total_watched_episodes: number;
+  total_released_episodes: number;
 }
 
 export interface ProfileBackdrop {

--- a/server/db/repository/profile.test.ts
+++ b/server/db/repository/profile.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterAll } from "bun:test";
 import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
 import { makeParsedTitle } from "../../test-utils/fixtures";
-import { upsertTitles, createUser, trackTitle, updateProfilePublic, watchTitle } from "../repository";
+import { upsertTitles, createUser, trackTitle, updateProfilePublic, watchTitle, upsertEpisodes, watchEpisode } from "../repository";
 import { getDb, watchedTitles } from "../schema";
 import { getUserPublicProfile } from "./profile";
 import { sql } from "drizzle-orm";
@@ -96,5 +96,119 @@ describe("getUserPublicProfile movie sort order", () => {
     expect(result).not.toBeNull();
     expect(result!.movies).toHaveLength(2);
     // Both unwatched, so order is stable (original order preserved)
+  });
+});
+
+describe("getUserPublicProfile progress metrics", () => {
+  it("returns zero progress when no shows are tracked", async () => {
+    const result = await getUserPublicProfile("testuser", true);
+    expect(result).not.toBeNull();
+    expect(result!.stats.shows_completed).toBe(0);
+    expect(result!.stats.shows_total).toBe(0);
+    expect(result!.stats.total_watched_episodes).toBe(0);
+    expect(result!.stats.total_released_episodes).toBe(0);
+  });
+
+  it("counts shows_total correctly", async () => {
+    await upsertTitles([
+      makeParsedTitle({ id: "show-a", objectType: "SHOW", title: "Show A" }),
+      makeParsedTitle({ id: "show-b", objectType: "SHOW", title: "Show B" }),
+      makeParsedTitle({ id: "movie-1", objectType: "MOVIE", title: "Movie 1" }),
+    ]);
+    await trackTitle("show-a", userId);
+    await trackTitle("show-b", userId);
+    await trackTitle("movie-1", userId);
+
+    const result = await getUserPublicProfile("testuser", true);
+    expect(result).not.toBeNull();
+    expect(result!.stats.shows_total).toBe(2);
+  });
+
+  it("counts shows_completed when all episodes watched and released", async () => {
+    await upsertTitles([
+      makeParsedTitle({ id: "show-done", objectType: "SHOW", title: "Completed Show" }),
+    ]);
+    await trackTitle("show-done", userId);
+    await upsertEpisodes([
+      { title_id: "show-done", season_number: 1, episode_number: 1, name: "Ep 1", overview: null, air_date: "2024-01-01", still_path: null },
+      { title_id: "show-done", season_number: 1, episode_number: 2, name: "Ep 2", overview: null, air_date: "2024-01-08", still_path: null },
+    ]);
+
+    const db = getDb();
+    const eps = await db.query.episodes.findMany({ where: (e, { eq }) => eq(e.titleId, "show-done") });
+    for (const ep of eps) {
+      await watchEpisode(ep.id, userId);
+    }
+
+    const result = await getUserPublicProfile("testuser", true);
+    expect(result).not.toBeNull();
+    expect(result!.stats.shows_completed).toBe(1);
+    expect(result!.stats.shows_total).toBe(1);
+  });
+
+  it("does not count show as completed when not all episodes are watched", async () => {
+    await upsertTitles([
+      makeParsedTitle({ id: "show-partial", objectType: "SHOW", title: "Partial Show" }),
+    ]);
+    await trackTitle("show-partial", userId);
+    await upsertEpisodes([
+      { title_id: "show-partial", season_number: 1, episode_number: 1, name: "Ep 1", overview: null, air_date: "2024-01-01", still_path: null },
+      { title_id: "show-partial", season_number: 1, episode_number: 2, name: "Ep 2", overview: null, air_date: "2024-01-08", still_path: null },
+    ]);
+
+    const db = getDb();
+    const eps = await db.query.episodes.findMany({ where: (e, { eq }) => eq(e.titleId, "show-partial") });
+    await watchEpisode(eps[0].id, userId);
+
+    const result = await getUserPublicProfile("testuser", true);
+    expect(result).not.toBeNull();
+    expect(result!.stats.shows_completed).toBe(0);
+    expect(result!.stats.total_watched_episodes).toBe(1);
+    expect(result!.stats.total_released_episodes).toBe(2);
+  });
+
+  it("aggregates episodes across multiple shows", async () => {
+    await upsertTitles([
+      makeParsedTitle({ id: "show-x", objectType: "SHOW", title: "Show X" }),
+      makeParsedTitle({ id: "show-y", objectType: "SHOW", title: "Show Y" }),
+    ]);
+    await trackTitle("show-x", userId);
+    await trackTitle("show-y", userId);
+    await upsertEpisodes([
+      { title_id: "show-x", season_number: 1, episode_number: 1, name: "X Ep 1", overview: null, air_date: "2024-01-01", still_path: null },
+      { title_id: "show-x", season_number: 1, episode_number: 2, name: "X Ep 2", overview: null, air_date: "2024-01-08", still_path: null },
+      { title_id: "show-y", season_number: 1, episode_number: 1, name: "Y Ep 1", overview: null, air_date: "2024-02-01", still_path: null },
+    ]);
+
+    const db = getDb();
+    const xEps = await db.query.episodes.findMany({ where: (e, { eq }) => eq(e.titleId, "show-x") });
+    await watchEpisode(xEps[0].id, userId);
+
+    const result = await getUserPublicProfile("testuser", true);
+    expect(result).not.toBeNull();
+    expect(result!.stats.total_watched_episodes).toBe(1);
+    expect(result!.stats.total_released_episodes).toBe(3);
+  });
+
+  it("does not count show as completed when unreleased episodes exist", async () => {
+    await upsertTitles([
+      makeParsedTitle({ id: "show-future", objectType: "SHOW", title: "Future Show" }),
+    ]);
+    await trackTitle("show-future", userId);
+    await upsertEpisodes([
+      { title_id: "show-future", season_number: 1, episode_number: 1, name: "Ep 1", overview: null, air_date: "2024-01-01", still_path: null },
+      { title_id: "show-future", season_number: 1, episode_number: 2, name: "Ep 2", overview: null, air_date: "2099-12-31", still_path: null },
+    ]);
+
+    const db = getDb();
+    const eps = await db.query.episodes.findMany({ where: (e, { eq }) => eq(e.titleId, "show-future") });
+    // Watch the one released episode
+    const releasedEp = eps.find(e => e.airDate === "2024-01-01")!;
+    await watchEpisode(releasedEp.id, userId);
+
+    const result = await getUserPublicProfile("testuser", true);
+    expect(result).not.toBeNull();
+    // total_episodes=2, watched=1, released=1 -> not completed (total != watched)
+    expect(result!.stats.shows_completed).toBe(0);
   });
 });

--- a/server/db/repository/profile.ts
+++ b/server/db/repository/profile.ts
@@ -49,6 +49,22 @@ export async function getUserPublicProfile(username: string, isOwnProfile = fals
 
     const shows = allTitles.filter(t => t.object_type === "SHOW");
 
+    // Compute show progress metrics
+    let showsCompleted = 0;
+    let showsTotal = shows.length;
+    let totalWatchedEpisodes = 0;
+    let totalReleasedEpisodes = 0;
+    for (const show of shows) {
+      const total = show.total_episodes ?? 0;
+      const watched = show.watched_episodes_count ?? 0;
+      const released = show.released_episodes_count ?? 0;
+      totalWatchedEpisodes += watched;
+      totalReleasedEpisodes += released;
+      if (total > 0 && total === watched && total === released) {
+        showsCompleted++;
+      }
+    }
+
     // Sort movies by most recently watched first, unwatched movies last
     const movieTitles = allTitles.filter(t => t.object_type === "MOVIE");
     const movieIds = movieTitles.map(t => t.id);
@@ -83,6 +99,10 @@ export async function getUserPublicProfile(username: string, isOwnProfile = fals
         tracked_count: trackedCount,
         watched_movies: watchedMoviesRow?.count ?? 0,
         watched_episodes: watchedEpisodesRow?.count ?? 0,
+        shows_completed: showsCompleted,
+        shows_total: showsTotal,
+        total_watched_episodes: totalWatchedEpisodes,
+        total_released_episodes: totalReleasedEpisodes,
       },
       show_watchlist: showWatchlist,
       movies,

--- a/server/routes/profile.test.ts
+++ b/server/routes/profile.test.ts
@@ -71,6 +71,10 @@ describe("GET /user/:username", () => {
     expect(body.stats.tracked_count).toBe(0);
     expect(body.stats.watched_movies).toBe(0);
     expect(body.stats.watched_episodes).toBe(0);
+    expect(body.stats.shows_completed).toBe(0);
+    expect(body.stats.shows_total).toBe(0);
+    expect(body.stats.total_watched_episodes).toBe(0);
+    expect(body.stats.total_released_episodes).toBe(0);
     expect(body.movies).toHaveLength(0);
     expect(body.shows).toHaveLength(0);
     expect(body.show_watchlist).toBe(false);
@@ -355,5 +359,41 @@ describe("GET /user/:username", () => {
     expect(body.shows).toHaveLength(1);
     expect(body.shows[0].total_episodes).toBe(3);
     expect(body.shows[0].watched_episodes_count).toBe(1);
+  });
+
+  it("includes progress metrics in API response", async () => {
+    await updateProfilePublic(userId, true);
+    await upsertTitles([
+      makeParsedTitle({ id: "show-1", objectType: "SHOW", title: "Completed Show" }),
+      makeParsedTitle({ id: "show-2", objectType: "SHOW", title: "Partial Show" }),
+    ]);
+    await trackTitle("show-1", userId);
+    await trackTitle("show-2", userId);
+
+    await upsertEpisodes([
+      { title_id: "show-1", season_number: 1, episode_number: 1, name: "Ep 1", overview: null, air_date: "2024-01-01", still_path: null },
+      { title_id: "show-1", season_number: 1, episode_number: 2, name: "Ep 2", overview: null, air_date: "2024-01-08", still_path: null },
+      { title_id: "show-2", season_number: 1, episode_number: 1, name: "Ep 1", overview: null, air_date: "2024-02-01", still_path: null },
+      { title_id: "show-2", season_number: 1, episode_number: 2, name: "Ep 2", overview: null, air_date: "2024-02-08", still_path: null },
+      { title_id: "show-2", season_number: 1, episode_number: 3, name: "Ep 3", overview: null, air_date: "2024-02-15", still_path: null },
+    ]);
+
+    // Watch all episodes of show-1 (completed) and 1 of show-2 (partial)
+    const { getDb } = await import("../db/schema");
+    const db = getDb();
+    const show1Eps = await db.query.episodes.findMany({ where: (e, { eq }) => eq(e.titleId, "show-1") });
+    const show2Eps = await db.query.episodes.findMany({ where: (e, { eq }) => eq(e.titleId, "show-2") });
+    for (const ep of show1Eps) {
+      await watchEpisode(ep.id, userId);
+    }
+    await watchEpisode(show2Eps[0].id, userId);
+
+    const res = await app.request("/user/testuser");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.stats.shows_completed).toBe(1);
+    expect(body.stats.shows_total).toBe(2);
+    expect(body.stats.total_watched_episodes).toBe(3); // 2 from show-1 + 1 from show-2
+    expect(body.stats.total_released_episodes).toBe(5); // 2 from show-1 + 3 from show-2
   });
 });


### PR DESCRIPTION
## Summary
- Add show completion and episode watch progress aggregation to the profile API (shows_completed, shows_total, total_watched_episodes, total_released_episodes)
- Display progress bars on the profile banner below the existing stat cards, with amber fill on zinc-700 background
- Progress section only renders when the user has tracked shows; episode bar only renders when released episodes exist

## Test plan
- [x] Server repository test: verify aggregation returns correct counts for zero shows, completed shows, partial shows, multi-show aggregation, and unreleased episode edge cases
- [x] Server route test: verify new fields present in API response with correct values
- [x] Frontend test: verify progress bars render with correct widths (0%, 40%, 60%, 100%), correct text labels, and conditional visibility
- [x] `bun run check` passes (1130 tests, 0 failures)

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)