### PR TITLE
Add social DB schema for follows, ratings, recommendations, invitations

### DIFF
--- a/drizzle/0011_add_social_tables.sql
+++ b/drizzle/0011_add_social_tables.sql
@@ -1,0 +1,55 @@
+CREATE TABLE IF NOT EXISTS `follows` (
+	`follower_id` text NOT NULL,
+	`following_id` text NOT NULL,
+	`created_at` text DEFAULT (datetime('now')),
+	PRIMARY KEY(`follower_id`, `following_id`),
+	FOREIGN KEY (`follower_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`following_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_follows_following` ON `follows` (`following_id`);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `ratings` (
+	`user_id` text NOT NULL,
+	`title_id` text NOT NULL,
+	`rating` text NOT NULL,
+	`created_at` text DEFAULT (datetime('now')),
+	PRIMARY KEY(`user_id`, `title_id`),
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`title_id`) REFERENCES `titles`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_ratings_title` ON `ratings` (`title_id`);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `recommendations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`from_user_id` text NOT NULL,
+	`to_user_id` text NOT NULL,
+	`title_id` text NOT NULL,
+	`message` text,
+	`created_at` text DEFAULT (datetime('now')),
+	`read_at` text,
+	FOREIGN KEY (`from_user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`to_user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`title_id`) REFERENCES `titles`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_recommendations_to_user` ON `recommendations` (`to_user_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_recommendations_from_user` ON `recommendations` (`from_user_id`);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `invitations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`code` text NOT NULL,
+	`created_by_id` text NOT NULL,
+	`used_by_id` text,
+	`created_at` text DEFAULT (datetime('now')),
+	`used_at` text,
+	`expires_at` text NOT NULL,
+	FOREIGN KEY (`created_by_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`used_by_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `invitations_code_unique` ON `invitations` (`code`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_invitations_code` ON `invitations` (`code`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1774952400000,
       "tag": "0010_add_profile_visibility",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1775052400000,
+      "tag": "0011_add_social_tables",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -129,10 +129,10 @@ describe("fixSkippedMigrations", () => {
     }>;
     expect(titleCols.some((c) => c.name === "genres")).toBe(false);
 
-    // All 11 migrations should be recorded
+    // All 12 migrations should be recorded
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(11);
+    expect(migrations.cnt).toBe(12);
   });
 });

--- a/server/db/repository/follows.test.ts
+++ b/server/db/repository/follows.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
+import { createUser } from "../repository";
+import {
+  follow,
+  unfollow,
+  getFollowers,
+  getFollowing,
+  isFollowing,
+  areMutualFollowers,
+  getFollowerCount,
+  getFollowingCount,
+} from "./follows";
+
+let userA: string;
+let userB: string;
+let userC: string;
+
+beforeEach(async () => {
+  setupTestDb();
+  userA = await createUser("alice", "hash");
+  userB = await createUser("bob", "hash");
+  userC = await createUser("carol", "hash");
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+describe("follow", () => {
+  it("creates a follow relationship", async () => {
+    await follow(userA, userB);
+    expect(await isFollowing(userA, userB)).toBe(true);
+  });
+
+  it("is idempotent — following twice does not error", async () => {
+    await follow(userA, userB);
+    await follow(userA, userB);
+    expect(await isFollowing(userA, userB)).toBe(true);
+    expect(await getFollowerCount(userB)).toBe(1);
+  });
+
+  it("throws when trying to follow yourself", async () => {
+    await expect(follow(userA, userA)).rejects.toThrow("Cannot follow yourself");
+  });
+});
+
+describe("unfollow", () => {
+  it("removes a follow relationship", async () => {
+    await follow(userA, userB);
+    await unfollow(userA, userB);
+    expect(await isFollowing(userA, userB)).toBe(false);
+  });
+
+  it("is a no-op when not following", async () => {
+    await unfollow(userA, userB);
+    expect(await isFollowing(userA, userB)).toBe(false);
+  });
+});
+
+describe("getFollowers", () => {
+  it("returns users following a given user", async () => {
+    await follow(userA, userC);
+    await follow(userB, userC);
+
+    const followers = await getFollowers(userC);
+    expect(followers).toHaveLength(2);
+    const usernames = followers.map((f) => f.username);
+    expect(usernames).toContain("alice");
+    expect(usernames).toContain("bob");
+  });
+
+  it("returns empty list when no followers", async () => {
+    const followers = await getFollowers(userA);
+    expect(followers).toHaveLength(0);
+  });
+});
+
+describe("getFollowing", () => {
+  it("returns users that a given user follows", async () => {
+    await follow(userA, userB);
+    await follow(userA, userC);
+
+    const following = await getFollowing(userA);
+    expect(following).toHaveLength(2);
+    const usernames = following.map((f) => f.username);
+    expect(usernames).toContain("bob");
+    expect(usernames).toContain("carol");
+  });
+
+  it("returns empty list when not following anyone", async () => {
+    const following = await getFollowing(userA);
+    expect(following).toHaveLength(0);
+  });
+});
+
+describe("isFollowing", () => {
+  it("returns true when following", async () => {
+    await follow(userA, userB);
+    expect(await isFollowing(userA, userB)).toBe(true);
+  });
+
+  it("returns false when not following", async () => {
+    expect(await isFollowing(userA, userB)).toBe(false);
+  });
+
+  it("is directional — A follows B does not mean B follows A", async () => {
+    await follow(userA, userB);
+    expect(await isFollowing(userA, userB)).toBe(true);
+    expect(await isFollowing(userB, userA)).toBe(false);
+  });
+});
+
+describe("areMutualFollowers", () => {
+  it("returns true when both users follow each other", async () => {
+    await follow(userA, userB);
+    await follow(userB, userA);
+    expect(await areMutualFollowers(userA, userB)).toBe(true);
+  });
+
+  it("returns false when only one follows the other", async () => {
+    await follow(userA, userB);
+    expect(await areMutualFollowers(userA, userB)).toBe(false);
+  });
+
+  it("returns false when neither follows the other", async () => {
+    expect(await areMutualFollowers(userA, userB)).toBe(false);
+  });
+});
+
+describe("getFollowerCount / getFollowingCount", () => {
+  it("returns correct follower count", async () => {
+    await follow(userA, userC);
+    await follow(userB, userC);
+    expect(await getFollowerCount(userC)).toBe(2);
+  });
+
+  it("returns correct following count", async () => {
+    await follow(userA, userB);
+    await follow(userA, userC);
+    expect(await getFollowingCount(userA)).toBe(2);
+  });
+
+  it("returns 0 for no followers/following", async () => {
+    expect(await getFollowerCount(userA)).toBe(0);
+    expect(await getFollowingCount(userA)).toBe(0);
+  });
+});

--- a/server/db/repository/follows.ts
+++ b/server/db/repository/follows.ts
@@ -1,0 +1,106 @@
+import { eq, and, sql, count } from "drizzle-orm";
+import { getDb } from "../schema";
+import { follows, users } from "../schema";
+import { traceDbQuery } from "../../tracing";
+
+export async function follow(followerId: string, followingId: string) {
+  return traceDbQuery("follow", async () => {
+    if (followerId === followingId) {
+      throw new Error("Cannot follow yourself");
+    }
+    const db = getDb();
+    await db.insert(follows)
+      .values({ followerId, followingId })
+      .onConflictDoNothing()
+      .run();
+  });
+}
+
+export async function unfollow(followerId: string, followingId: string) {
+  return traceDbQuery("unfollow", async () => {
+    const db = getDb();
+    await db.delete(follows)
+      .where(and(eq(follows.followerId, followerId), eq(follows.followingId, followingId)))
+      .run();
+  });
+}
+
+export async function getFollowers(userId: string) {
+  return traceDbQuery("getFollowers", async () => {
+    const db = getDb();
+    return await db
+      .select({
+        id: users.id,
+        username: users.username,
+        displayName: users.name,
+        followedAt: follows.createdAt,
+      })
+      .from(follows)
+      .innerJoin(users, eq(users.id, follows.followerId))
+      .where(eq(follows.followingId, userId))
+      .all();
+  });
+}
+
+export async function getFollowing(userId: string) {
+  return traceDbQuery("getFollowing", async () => {
+    const db = getDb();
+    return await db
+      .select({
+        id: users.id,
+        username: users.username,
+        displayName: users.name,
+        followedAt: follows.createdAt,
+      })
+      .from(follows)
+      .innerJoin(users, eq(users.id, follows.followingId))
+      .where(eq(follows.followerId, userId))
+      .all();
+  });
+}
+
+export async function isFollowing(followerId: string, followingId: string): Promise<boolean> {
+  return traceDbQuery("isFollowing", async () => {
+    const db = getDb();
+    const row = await db
+      .select({ followerId: follows.followerId })
+      .from(follows)
+      .where(and(eq(follows.followerId, followerId), eq(follows.followingId, followingId)))
+      .get();
+    return row !== undefined;
+  });
+}
+
+export async function areMutualFollowers(userId1: string, userId2: string): Promise<boolean> {
+  return traceDbQuery("areMutualFollowers", async () => {
+    const [a, b] = await Promise.all([
+      isFollowing(userId1, userId2),
+      isFollowing(userId2, userId1),
+    ]);
+    return a && b;
+  });
+}
+
+export async function getFollowerCount(userId: string): Promise<number> {
+  return traceDbQuery("getFollowerCount", async () => {
+    const db = getDb();
+    const row = await db
+      .select({ count: count() })
+      .from(follows)
+      .where(eq(follows.followingId, userId))
+      .get();
+    return row?.count ?? 0;
+  });
+}
+
+export async function getFollowingCount(userId: string): Promise<number> {
+  return traceDbQuery("getFollowingCount", async () => {
+    const db = getDb();
+    const row = await db
+      .select({ count: count() })
+      .from(follows)
+      .where(eq(follows.followerId, userId))
+      .get();
+    return row?.count ?? 0;
+  });
+}

--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -91,3 +91,40 @@ export {
   getDistinctNotifierTimezones,
   getEnabledNotifierSchedules,
 } from "./notifiers";
+
+export {
+  follow,
+  unfollow,
+  getFollowers,
+  getFollowing,
+  isFollowing,
+  areMutualFollowers,
+  getFollowerCount,
+  getFollowingCount,
+} from "./follows";
+
+export {
+  rateTitle,
+  unrateTitle,
+  getUserRating,
+  getTitleRatings,
+  getFriendsRatings,
+} from "./ratings";
+export type { RatingValue } from "./ratings";
+
+export {
+  createRecommendation,
+  getReceivedRecommendations,
+  getSentRecommendations,
+  markAsRead,
+  deleteRecommendation,
+  getUnreadCount,
+} from "./recommendations";
+
+export {
+  createInvitation,
+  getInvitation,
+  redeemInvitation,
+  getUserInvitations,
+  revokeInvitation,
+} from "./invitations";

--- a/server/db/repository/invitations.test.ts
+++ b/server/db/repository/invitations.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
+import { createUser } from "../repository";
+import { getDb, invitations } from "../schema";
+import { eq } from "drizzle-orm";
+import {
+  createInvitation,
+  getInvitation,
+  redeemInvitation,
+  getUserInvitations,
+  revokeInvitation,
+} from "./invitations";
+
+let userA: string;
+let userB: string;
+
+beforeEach(async () => {
+  setupTestDb();
+  userA = await createUser("alice", "hash");
+  userB = await createUser("bob", "hash");
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+describe("createInvitation", () => {
+  it("creates an invitation with id, code, and expiry", async () => {
+    const inv = await createInvitation(userA);
+    expect(inv.id).toBeDefined();
+    expect(inv.code).toBeDefined();
+    expect(inv.expiresAt).toBeDefined();
+    // Expiry should be ~7 days from now
+    const expiry = new Date(inv.expiresAt);
+    const now = new Date();
+    const daysDiff = (expiry.getTime() - now.getTime()) / (1000 * 60 * 60 * 24);
+    expect(daysDiff).toBeGreaterThan(6);
+    expect(daysDiff).toBeLessThanOrEqual(7);
+  });
+});
+
+describe("getInvitation", () => {
+  it("finds an invitation by code", async () => {
+    const inv = await createInvitation(userA);
+    const found = await getInvitation(inv.code);
+    expect(found).not.toBeNull();
+    expect(found!.id).toBe(inv.id);
+    expect(found!.createdByUsername).toBe("alice");
+  });
+
+  it("returns null for unknown code", async () => {
+    const found = await getInvitation("nonexistent-code");
+    expect(found).toBeNull();
+  });
+});
+
+describe("redeemInvitation", () => {
+  it("redeems a valid invitation", async () => {
+    const inv = await createInvitation(userA);
+    const result = await redeemInvitation(inv.code, userB);
+    expect(result).toBe(true);
+
+    const found = await getInvitation(inv.code);
+    expect(found!.usedById).toBe(userB);
+    expect(found!.usedAt).not.toBeNull();
+  });
+
+  it("returns false for already used invitation", async () => {
+    const inv = await createInvitation(userA);
+    await redeemInvitation(inv.code, userB);
+
+    const secondUser = await createUser("charlie", "hash");
+    const result = await redeemInvitation(inv.code, secondUser);
+    expect(result).toBe(false);
+  });
+
+  it("returns false for expired invitation", async () => {
+    const inv = await createInvitation(userA);
+
+    // Manually set the expiry to the past
+    const db = getDb();
+    await db.update(invitations)
+      .set({ expiresAt: "2020-01-01T00:00:00.000Z" })
+      .where(eq(invitations.id, inv.id))
+      .run();
+
+    const result = await redeemInvitation(inv.code, userB);
+    expect(result).toBe(false);
+  });
+
+  it("returns false for unknown code", async () => {
+    const result = await redeemInvitation("nonexistent-code", userB);
+    expect(result).toBe(false);
+  });
+});
+
+describe("getUserInvitations", () => {
+  it("returns all invitations created by a user", async () => {
+    await createInvitation(userA);
+    await createInvitation(userA);
+
+    const invs = await getUserInvitations(userA);
+    expect(invs).toHaveLength(2);
+  });
+
+  it("returns empty list when no invitations", async () => {
+    const invs = await getUserInvitations(userA);
+    expect(invs).toHaveLength(0);
+  });
+
+  it("does not return invitations from other users", async () => {
+    await createInvitation(userA);
+    await createInvitation(userB);
+
+    const invs = await getUserInvitations(userA);
+    expect(invs).toHaveLength(1);
+  });
+});
+
+describe("revokeInvitation", () => {
+  it("deletes an invitation owned by the user", async () => {
+    const inv = await createInvitation(userA);
+    await revokeInvitation(inv.id, userA);
+
+    const invs = await getUserInvitations(userA);
+    expect(invs).toHaveLength(0);
+  });
+
+  it("does not delete another user's invitation", async () => {
+    const inv = await createInvitation(userA);
+    await revokeInvitation(inv.id, userB); // userB did not create it
+
+    const invs = await getUserInvitations(userA);
+    expect(invs).toHaveLength(1);
+  });
+});

--- a/server/db/repository/invitations.ts
+++ b/server/db/repository/invitations.ts
@@ -1,0 +1,94 @@
+import { eq, and, sql, desc, isNull } from "drizzle-orm";
+import { getDb } from "../schema";
+import { invitations, users } from "../schema";
+import { traceDbQuery } from "../../tracing";
+
+export async function createInvitation(createdById: string): Promise<{ id: string; code: string; expiresAt: string }> {
+  return traceDbQuery("createInvitation", async () => {
+    const db = getDb();
+    const id = crypto.randomUUID();
+    const code = crypto.randomUUID();
+    const expiresAt = new Date(Date.now() + 7 * 24 * 3600 * 1000).toISOString();
+    await db.insert(invitations)
+      .values({ id, code, createdById, expiresAt })
+      .run();
+    return { id, code, expiresAt };
+  });
+}
+
+export async function getInvitation(code: string) {
+  return traceDbQuery("getInvitation", async () => {
+    const db = getDb();
+    return await db
+      .select({
+        id: invitations.id,
+        code: invitations.code,
+        createdById: invitations.createdById,
+        createdByUsername: users.username,
+        usedById: invitations.usedById,
+        createdAt: invitations.createdAt,
+        usedAt: invitations.usedAt,
+        expiresAt: invitations.expiresAt,
+      })
+      .from(invitations)
+      .innerJoin(users, eq(users.id, invitations.createdById))
+      .where(eq(invitations.code, code))
+      .get() ?? null;
+  });
+}
+
+export async function redeemInvitation(code: string, usedById: string): Promise<boolean> {
+  return traceDbQuery("redeemInvitation", async () => {
+    const db = getDb();
+
+    // Find the invitation
+    const invitation = await db
+      .select({
+        id: invitations.id,
+        usedById: invitations.usedById,
+        expiresAt: invitations.expiresAt,
+      })
+      .from(invitations)
+      .where(eq(invitations.code, code))
+      .get();
+
+    if (!invitation) return false;
+    if (invitation.usedById !== null) return false;
+    if (new Date(invitation.expiresAt) < new Date()) return false;
+
+    await db.update(invitations)
+      .set({ usedById, usedAt: sql`(datetime('now'))` })
+      .where(eq(invitations.id, invitation.id))
+      .run();
+
+    return true;
+  });
+}
+
+export async function getUserInvitations(userId: string) {
+  return traceDbQuery("getUserInvitations", async () => {
+    const db = getDb();
+    return await db
+      .select({
+        id: invitations.id,
+        code: invitations.code,
+        usedById: invitations.usedById,
+        createdAt: invitations.createdAt,
+        usedAt: invitations.usedAt,
+        expiresAt: invitations.expiresAt,
+      })
+      .from(invitations)
+      .where(eq(invitations.createdById, userId))
+      .orderBy(desc(invitations.createdAt))
+      .all();
+  });
+}
+
+export async function revokeInvitation(id: string, userId: string) {
+  return traceDbQuery("revokeInvitation", async () => {
+    const db = getDb();
+    await db.delete(invitations)
+      .where(and(eq(invitations.id, id), eq(invitations.createdById, userId)))
+      .run();
+  });
+}

--- a/server/db/repository/ratings.test.ts
+++ b/server/db/repository/ratings.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
+import { makeParsedTitle } from "../../test-utils/fixtures";
+import { upsertTitles, createUser } from "../repository";
+import { follow } from "./follows";
+import {
+  rateTitle,
+  unrateTitle,
+  getUserRating,
+  getTitleRatings,
+  getFriendsRatings,
+} from "./ratings";
+
+let userA: string;
+let userB: string;
+let userC: string;
+
+beforeEach(async () => {
+  setupTestDb();
+  userA = await createUser("alice", "hash");
+  userB = await createUser("bob", "hash");
+  userC = await createUser("carol", "hash");
+  await upsertTitles([
+    makeParsedTitle({ id: "movie-1", title: "Test Movie" }),
+    makeParsedTitle({ id: "movie-2", title: "Another Movie" }),
+  ]);
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+describe("rateTitle", () => {
+  it("inserts a new rating", async () => {
+    await rateTitle(userA, "movie-1", "LOVE");
+    const rating = await getUserRating(userA, "movie-1");
+    expect(rating).toBe("LOVE");
+  });
+
+  it("updates an existing rating (upsert)", async () => {
+    await rateTitle(userA, "movie-1", "LIKE");
+    await rateTitle(userA, "movie-1", "LOVE");
+    const rating = await getUserRating(userA, "movie-1");
+    expect(rating).toBe("LOVE");
+  });
+});
+
+describe("unrateTitle", () => {
+  it("removes a rating", async () => {
+    await rateTitle(userA, "movie-1", "LIKE");
+    await unrateTitle(userA, "movie-1");
+    const rating = await getUserRating(userA, "movie-1");
+    expect(rating).toBeNull();
+  });
+
+  it("is a no-op when no rating exists", async () => {
+    await unrateTitle(userA, "movie-1");
+    const rating = await getUserRating(userA, "movie-1");
+    expect(rating).toBeNull();
+  });
+});
+
+describe("getUserRating", () => {
+  it("returns the rating for a user+title", async () => {
+    await rateTitle(userA, "movie-1", "DISLIKE");
+    expect(await getUserRating(userA, "movie-1")).toBe("DISLIKE");
+  });
+
+  it("returns null when no rating exists", async () => {
+    expect(await getUserRating(userA, "movie-1")).toBeNull();
+  });
+});
+
+describe("getTitleRatings", () => {
+  it("returns aggregated counts per rating type", async () => {
+    await rateTitle(userA, "movie-1", "LOVE");
+    await rateTitle(userB, "movie-1", "LOVE");
+    await rateTitle(userC, "movie-1", "LIKE");
+
+    const result = await getTitleRatings("movie-1");
+    expect(result.LOVE).toBe(2);
+    expect(result.LIKE).toBe(1);
+    expect(result.DISLIKE).toBe(0);
+    expect(result.HATE).toBe(0);
+  });
+
+  it("returns all zeros for an unrated title", async () => {
+    const result = await getTitleRatings("movie-2");
+    expect(result.LOVE).toBe(0);
+    expect(result.LIKE).toBe(0);
+    expect(result.DISLIKE).toBe(0);
+    expect(result.HATE).toBe(0);
+  });
+});
+
+describe("getFriendsRatings", () => {
+  it("returns ratings from users the current user follows", async () => {
+    await follow(userA, userB);
+    await follow(userA, userC);
+    await rateTitle(userB, "movie-1", "LOVE");
+    await rateTitle(userC, "movie-1", "LIKE");
+
+    const result = await getFriendsRatings(userA, "movie-1");
+    expect(result).toHaveLength(2);
+    const usernames = result.map((r) => r.username);
+    expect(usernames).toContain("bob");
+    expect(usernames).toContain("carol");
+  });
+
+  it("does not include ratings from unfollowed users", async () => {
+    await follow(userA, userB);
+    await rateTitle(userB, "movie-1", "LOVE");
+    await rateTitle(userC, "movie-1", "LIKE"); // not followed by userA
+
+    const result = await getFriendsRatings(userA, "movie-1");
+    expect(result).toHaveLength(1);
+    expect(result[0].username).toBe("bob");
+  });
+
+  it("returns empty list when no friends have rated", async () => {
+    await follow(userA, userB);
+    const result = await getFriendsRatings(userA, "movie-1");
+    expect(result).toHaveLength(0);
+  });
+});

--- a/server/db/repository/ratings.ts
+++ b/server/db/repository/ratings.ts
@@ -1,0 +1,78 @@
+import { eq, and, sql, inArray, count } from "drizzle-orm";
+import { getDb } from "../schema";
+import { ratings, follows, users } from "../schema";
+import { traceDbQuery } from "../../tracing";
+
+export type RatingValue = "HATE" | "DISLIKE" | "LIKE" | "LOVE";
+
+export async function rateTitle(userId: string, titleId: string, rating: RatingValue) {
+  return traceDbQuery("rateTitle", async () => {
+    const db = getDb();
+    await db.insert(ratings)
+      .values({ userId, titleId, rating })
+      .onConflictDoUpdate({
+        target: [ratings.userId, ratings.titleId],
+        set: { rating, createdAt: sql`(datetime('now'))` },
+      })
+      .run();
+  });
+}
+
+export async function unrateTitle(userId: string, titleId: string) {
+  return traceDbQuery("unrateTitle", async () => {
+    const db = getDb();
+    await db.delete(ratings)
+      .where(and(eq(ratings.userId, userId), eq(ratings.titleId, titleId)))
+      .run();
+  });
+}
+
+export async function getUserRating(userId: string, titleId: string): Promise<RatingValue | null> {
+  return traceDbQuery("getUserRating", async () => {
+    const db = getDb();
+    const row = await db
+      .select({ rating: ratings.rating })
+      .from(ratings)
+      .where(and(eq(ratings.userId, userId), eq(ratings.titleId, titleId)))
+      .get();
+    return (row?.rating as RatingValue) ?? null;
+  });
+}
+
+export async function getTitleRatings(titleId: string): Promise<Record<RatingValue, number>> {
+  return traceDbQuery("getTitleRatings", async () => {
+    const db = getDb();
+    const rows = await db
+      .select({
+        rating: ratings.rating,
+        count: count(),
+      })
+      .from(ratings)
+      .where(eq(ratings.titleId, titleId))
+      .groupBy(ratings.rating)
+      .all();
+    const result: Record<RatingValue, number> = { HATE: 0, DISLIKE: 0, LIKE: 0, LOVE: 0 };
+    for (const row of rows) {
+      result[row.rating as RatingValue] = row.count;
+    }
+    return result;
+  });
+}
+
+export async function getFriendsRatings(userId: string, titleId: string) {
+  return traceDbQuery("getFriendsRatings", async () => {
+    const db = getDb();
+    return await db
+      .select({
+        userId: ratings.userId,
+        username: users.username,
+        displayName: users.name,
+        rating: ratings.rating,
+      })
+      .from(ratings)
+      .innerJoin(users, eq(users.id, ratings.userId))
+      .innerJoin(follows, and(eq(follows.followerId, userId), eq(follows.followingId, ratings.userId)))
+      .where(eq(ratings.titleId, titleId))
+      .all();
+  });
+}

--- a/server/db/repository/recommendations.test.ts
+++ b/server/db/repository/recommendations.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
+import { makeParsedTitle } from "../../test-utils/fixtures";
+import { upsertTitles, createUser } from "../repository";
+import {
+  createRecommendation,
+  getReceivedRecommendations,
+  getSentRecommendations,
+  markAsRead,
+  deleteRecommendation,
+  getUnreadCount,
+} from "./recommendations";
+
+let userA: string;
+let userB: string;
+let userC: string;
+
+beforeEach(async () => {
+  setupTestDb();
+  userA = await createUser("alice", "hash");
+  userB = await createUser("bob", "hash");
+  userC = await createUser("carol", "hash");
+  await upsertTitles([
+    makeParsedTitle({ id: "movie-1", title: "Test Movie" }),
+    makeParsedTitle({ id: "movie-2", title: "Another Movie" }),
+  ]);
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+describe("createRecommendation", () => {
+  it("creates a recommendation and returns an id", async () => {
+    const id = await createRecommendation(userA, userB, "movie-1", "You should watch this!");
+    expect(id).toBeDefined();
+    expect(typeof id).toBe("string");
+  });
+
+  it("creates a recommendation without a message", async () => {
+    const id = await createRecommendation(userA, userB, "movie-1");
+    expect(id).toBeDefined();
+  });
+});
+
+describe("getReceivedRecommendations", () => {
+  it("returns received recommendations with user and title info", async () => {
+    await createRecommendation(userA, userB, "movie-1", "Check this out");
+    await createRecommendation(userC, userB, "movie-2");
+
+    const recs = await getReceivedRecommendations(userB);
+    expect(recs).toHaveLength(2);
+    expect(recs[0].fromUsername).toBeDefined();
+    expect(recs[0].titleName).toBeDefined();
+  });
+
+  it("returns empty list when no recommendations", async () => {
+    const recs = await getReceivedRecommendations(userA);
+    expect(recs).toHaveLength(0);
+  });
+
+  it("supports pagination with limit and offset", async () => {
+    await createRecommendation(userA, userB, "movie-1");
+    await createRecommendation(userC, userB, "movie-2");
+
+    const page1 = await getReceivedRecommendations(userB, 1, 0);
+    expect(page1).toHaveLength(1);
+
+    const page2 = await getReceivedRecommendations(userB, 1, 1);
+    expect(page2).toHaveLength(1);
+    expect(page1[0].id).not.toBe(page2[0].id);
+  });
+});
+
+describe("getSentRecommendations", () => {
+  it("returns sent recommendations", async () => {
+    await createRecommendation(userA, userB, "movie-1");
+    await createRecommendation(userA, userC, "movie-2");
+
+    const recs = await getSentRecommendations(userA);
+    expect(recs).toHaveLength(2);
+  });
+
+  it("returns empty list when no recommendations sent", async () => {
+    const recs = await getSentRecommendations(userA);
+    expect(recs).toHaveLength(0);
+  });
+});
+
+describe("markAsRead", () => {
+  it("sets readAt on a received recommendation", async () => {
+    const id = await createRecommendation(userA, userB, "movie-1");
+
+    await markAsRead(id, userB);
+
+    const recs = await getReceivedRecommendations(userB);
+    expect(recs[0].readAt).not.toBeNull();
+  });
+
+  it("does not mark if user is not the recipient", async () => {
+    const id = await createRecommendation(userA, userB, "movie-1");
+
+    await markAsRead(id, userC); // userC is not the recipient
+
+    const recs = await getReceivedRecommendations(userB);
+    expect(recs[0].readAt).toBeNull();
+  });
+});
+
+describe("deleteRecommendation", () => {
+  it("deletes a recommendation the user received", async () => {
+    const id = await createRecommendation(userA, userB, "movie-1");
+
+    await deleteRecommendation(id, userB);
+
+    const recs = await getReceivedRecommendations(userB);
+    expect(recs).toHaveLength(0);
+  });
+
+  it("deletes a recommendation the user sent", async () => {
+    const id = await createRecommendation(userA, userB, "movie-1");
+
+    await deleteRecommendation(id, userA);
+
+    const recs = await getSentRecommendations(userA);
+    expect(recs).toHaveLength(0);
+  });
+
+  it("does not delete if user is neither sender nor recipient", async () => {
+    const id = await createRecommendation(userA, userB, "movie-1");
+
+    await deleteRecommendation(id, userC);
+
+    const recs = await getReceivedRecommendations(userB);
+    expect(recs).toHaveLength(1);
+  });
+});
+
+describe("getUnreadCount", () => {
+  it("returns count of unread recommendations", async () => {
+    await createRecommendation(userA, userB, "movie-1");
+    await createRecommendation(userC, userB, "movie-2");
+
+    expect(await getUnreadCount(userB)).toBe(2);
+  });
+
+  it("decreases after marking as read", async () => {
+    const id = await createRecommendation(userA, userB, "movie-1");
+    await createRecommendation(userC, userB, "movie-2");
+
+    await markAsRead(id, userB);
+
+    expect(await getUnreadCount(userB)).toBe(1);
+  });
+
+  it("returns 0 when no unread recommendations", async () => {
+    expect(await getUnreadCount(userA)).toBe(0);
+  });
+});

--- a/server/db/repository/recommendations.ts
+++ b/server/db/repository/recommendations.ts
@@ -1,0 +1,114 @@
+import { eq, and, sql, or, desc, count, isNull } from "drizzle-orm";
+import { getDb } from "../schema";
+import { recommendations, users, titles } from "../schema";
+import { traceDbQuery } from "../../tracing";
+
+export async function createRecommendation(
+  fromUserId: string,
+  toUserId: string,
+  titleId: string,
+  message?: string,
+): Promise<string> {
+  return traceDbQuery("createRecommendation", async () => {
+    const db = getDb();
+    const id = crypto.randomUUID();
+    await db.insert(recommendations)
+      .values({
+        id,
+        fromUserId,
+        toUserId,
+        titleId,
+        message: message ?? null,
+      })
+      .run();
+    return id;
+  });
+}
+
+export async function getReceivedRecommendations(userId: string, limit = 20, offset = 0) {
+  return traceDbQuery("getReceivedRecommendations", async () => {
+    const db = getDb();
+    return await db
+      .select({
+        id: recommendations.id,
+        fromUserId: recommendations.fromUserId,
+        fromUsername: users.username,
+        fromDisplayName: users.name,
+        titleId: recommendations.titleId,
+        titleName: titles.title,
+        posterUrl: titles.posterUrl,
+        message: recommendations.message,
+        createdAt: recommendations.createdAt,
+        readAt: recommendations.readAt,
+      })
+      .from(recommendations)
+      .innerJoin(users, eq(users.id, recommendations.fromUserId))
+      .innerJoin(titles, eq(titles.id, recommendations.titleId))
+      .where(eq(recommendations.toUserId, userId))
+      .orderBy(desc(recommendations.createdAt))
+      .limit(limit)
+      .offset(offset)
+      .all();
+  });
+}
+
+export async function getSentRecommendations(userId: string) {
+  return traceDbQuery("getSentRecommendations", async () => {
+    const db = getDb();
+    return await db
+      .select({
+        id: recommendations.id,
+        toUserId: recommendations.toUserId,
+        toUsername: users.username,
+        toDisplayName: users.name,
+        titleId: recommendations.titleId,
+        titleName: titles.title,
+        posterUrl: titles.posterUrl,
+        message: recommendations.message,
+        createdAt: recommendations.createdAt,
+        readAt: recommendations.readAt,
+      })
+      .from(recommendations)
+      .innerJoin(users, eq(users.id, recommendations.toUserId))
+      .innerJoin(titles, eq(titles.id, recommendations.titleId))
+      .where(eq(recommendations.fromUserId, userId))
+      .orderBy(desc(recommendations.createdAt))
+      .all();
+  });
+}
+
+export async function markAsRead(id: string, userId: string) {
+  return traceDbQuery("markRecommendationAsRead", async () => {
+    const db = getDb();
+    await db.update(recommendations)
+      .set({ readAt: sql`(datetime('now'))` })
+      .where(and(eq(recommendations.id, id), eq(recommendations.toUserId, userId)))
+      .run();
+  });
+}
+
+export async function deleteRecommendation(id: string, userId: string) {
+  return traceDbQuery("deleteRecommendation", async () => {
+    const db = getDb();
+    await db.delete(recommendations)
+      .where(
+        and(
+          eq(recommendations.id, id),
+          or(eq(recommendations.fromUserId, userId), eq(recommendations.toUserId, userId)),
+        )
+      )
+      .run();
+  });
+}
+
+export async function getUnreadCount(userId: string): Promise<number> {
+  return traceDbQuery("getUnreadRecommendationCount", async () => {
+    const db = getDb();
+    const row = await db
+      .select({ count: count() })
+      .from(recommendations)
+      .where(and(eq(recommendations.toUserId, userId), isNull(recommendations.readAt)))
+      .get();
+    return row?.count ?? 0;
+  });
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -314,6 +314,66 @@ export const oidcStates = sqliteTable("oidc_states", {
   createdAt: integer("created_at").notNull(),
 });
 
+export const follows = sqliteTable(
+  "follows",
+  {
+    followerId: text("follower_id").notNull().references(() => users.id, { onDelete: "cascade" }),
+    followingId: text("following_id").notNull().references(() => users.id, { onDelete: "cascade" }),
+    createdAt: text("created_at").default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.followerId, table.followingId] }),
+    index("idx_follows_following").on(table.followingId),
+  ]
+);
+
+export const ratings = sqliteTable(
+  "ratings",
+  {
+    userId: text("user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
+    titleId: text("title_id").notNull().references(() => titles.id),
+    rating: text("rating").notNull(), // 'HATE', 'DISLIKE', 'LIKE', 'LOVE'
+    createdAt: text("created_at").default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.titleId] }),
+    index("idx_ratings_title").on(table.titleId),
+  ]
+);
+
+export const recommendations = sqliteTable(
+  "recommendations",
+  {
+    id: text("id").primaryKey(),
+    fromUserId: text("from_user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
+    toUserId: text("to_user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
+    titleId: text("title_id").notNull().references(() => titles.id),
+    message: text("message"),
+    createdAt: text("created_at").default(sql`(datetime('now'))`),
+    readAt: text("read_at"),
+  },
+  (table) => [
+    index("idx_recommendations_to_user").on(table.toUserId),
+    index("idx_recommendations_from_user").on(table.fromUserId),
+  ]
+);
+
+export const invitations = sqliteTable(
+  "invitations",
+  {
+    id: text("id").primaryKey(),
+    code: text("code").notNull().unique(),
+    createdById: text("created_by_id").notNull().references(() => users.id, { onDelete: "cascade" }),
+    usedById: text("used_by_id").references(() => users.id),
+    createdAt: text("created_at").default(sql`(datetime('now'))`),
+    usedAt: text("used_at"),
+    expiresAt: text("expires_at").notNull(),
+  },
+  (table) => [
+    index("idx_invitations_code").on(table.code),
+  ]
+);
+
 export const jobs = sqliteTable(
   "jobs",
   {
@@ -351,6 +411,8 @@ export const titlesRelations = relations(titles, ({ many, one }) => ({
   episodes: many(episodes),
   tracked: many(tracked),
   genres: many(titleGenres),
+  ratings: many(ratings),
+  recommendations: many(recommendations),
 }));
 
 export const titleGenresRelations = relations(titleGenres, ({ one }) => ({
@@ -381,6 +443,12 @@ export const usersRelations = relations(users, ({ many }) => ({
   sessions: many(sessions),
   accounts: many(account),
   tracked: many(tracked),
+  ratings: many(ratings),
+  followers: many(follows, { relationName: "following" }),
+  following: many(follows, { relationName: "follower" }),
+  sentRecommendations: many(recommendations, { relationName: "fromUser" }),
+  receivedRecommendations: many(recommendations, { relationName: "toUser" }),
+  createdInvitations: many(invitations, { relationName: "createdBy" }),
 }));
 
 export const sessionsRelations = relations(sessions, ({ one }) => ({
@@ -410,6 +478,27 @@ export const notifiersRelations = relations(notifiers, ({ one }) => ({
   user: one(users, { fields: [notifiers.userId], references: [users.id] }),
 }));
 
+export const followsRelations = relations(follows, ({ one }) => ({
+  follower: one(users, { fields: [follows.followerId], references: [users.id], relationName: "follower" }),
+  following: one(users, { fields: [follows.followingId], references: [users.id], relationName: "following" }),
+}));
+
+export const ratingsRelations = relations(ratings, ({ one }) => ({
+  user: one(users, { fields: [ratings.userId], references: [users.id] }),
+  title: one(titles, { fields: [ratings.titleId], references: [titles.id] }),
+}));
+
+export const recommendationsRelations = relations(recommendations, ({ one }) => ({
+  fromUser: one(users, { fields: [recommendations.fromUserId], references: [users.id], relationName: "fromUser" }),
+  toUser: one(users, { fields: [recommendations.toUserId], references: [users.id], relationName: "toUser" }),
+  title: one(titles, { fields: [recommendations.titleId], references: [titles.id] }),
+}));
+
+export const invitationsRelations = relations(invitations, ({ one }) => ({
+  createdBy: one(users, { fields: [invitations.createdById], references: [users.id], relationName: "createdBy" }),
+  usedBy: one(users, { fields: [invitations.usedById], references: [users.id] }),
+}));
+
 // ─── Database Instance ──────────────────────────────────────────────────────
 
 export const passkeyRelations = relations(passkey, ({ one }) => ({
@@ -418,9 +507,11 @@ export const passkeyRelations = relations(passkey, ({ one }) => ({
 
 export const schemaExports = {
   titles, providers, offers, scores, titleGenres, episodes, users, sessions, account, verification, passkey, settings, tracked, watchedEpisodes, watchedTitles, notifiers, oidcStates, jobs, cronJobs,
+  follows, ratings, recommendations, invitations,
   titlesRelations, providersRelations, offersRelations, scoresRelations, titleGenresRelations, episodesRelations,
   passkeyRelations,
   usersRelations, sessionsRelations, accountRelations, trackedRelations, watchedEpisodesRelations, watchedTitlesRelations, notifiersRelations,
+  followsRelations, ratingsRelations, recommendationsRelations, invitationsRelations,
 };
 
 // Re-export the union type from platform for convenience


### PR DESCRIPTION
## Summary
- Add 4 new SQLite tables (`follows`, `ratings`, `recommendations`, `invitations`) with Drizzle ORM schema definitions, relations, and migration
- Add 4 new repository modules with full CRUD operations: follow/unfollow with mutual detection, 4-tier ratings with friend aggregation, recommendations with read tracking, and invite codes with 7-day expiry
- Add 56 colocated tests covering all operations and edge cases (self-follow prevention, expired invitations, unauthorized deletes, etc.)

## Test plan
- [x] All 56 new repository tests pass (`bun test server/db/repository/{follows,ratings,recommendations,invitations}.test.ts`)
- [x] All 772 server tests pass with zero failures (`bun test server/`)
- [x] Server TypeScript compiles cleanly (`bunx tsc --noEmit` exits 0)
- [x] Migration `0011_add_social_tables.sql` applies correctly on fresh in-memory DB
- [x] Existing `bun-db.test.ts` updated for new migration count (11 -> 12)

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)