### PR TITLE
Add user search endpoint

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -12,6 +12,7 @@ import type {
   AdminSettingsUpdateRequest,
   AdminSettingsUpdateResponse,
   UserProfileResponse,
+  UserSummary,
 } from "./types";
 
 const BASE = "/api";
@@ -155,6 +156,10 @@ export async function updateAllTitleVisibility(isPublic: boolean): Promise<void>
     method: "PATCH",
     body: JSON.stringify({ public: isPublic }),
   });
+}
+
+export async function searchUsers(query: string): Promise<{ users: UserSummary[] }> {
+  return fetchJson(`/user/search?q=${encodeURIComponent(query)}`);
 }
 
 export async function resolveImdb(url: string): Promise<{ success: boolean; title: SearchTitle }> {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -399,6 +399,15 @@ export interface AdminSettingsUpdateResponse {
   oidc_configured: boolean;
 }
 
+// ─── User Summary Type ──────────────────────────────────────────────────────
+
+export interface UserSummary {
+  id: string;
+  username: string;
+  name: string | null;
+  image: string | null;
+}
+
 // ─── User Profile Types ─────────────────────────────────────────────────────
 
 export interface UserProfileUser {

--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -55,6 +55,7 @@ export {
   getUserCount,
   updateUserPassword,
   updateUserAdmin,
+  searchUsers,
   createSession,
   getSessionWithUser,
   deleteSession,

--- a/server/db/repository/users.ts
+++ b/server/db/repository/users.ts
@@ -143,6 +143,29 @@ export async function updateUserAdmin(userId: string, isAdmin: boolean) {
   });
 }
 
+export async function searchUsers(query: string, limit = 10) {
+  return traceDbQuery("searchUsers", async () => {
+    const db = getDb();
+    const pattern = `%${query}%`;
+    return await db
+      .select({
+        id: users.id,
+        username: users.username,
+        name: users.name,
+        image: users.image,
+      })
+      .from(users)
+      .where(
+        and(
+          sql`(${users.username} LIKE ${pattern} OR ${users.name} LIKE ${pattern})`,
+          sql`COALESCE(${users.banned}, 0) = 0`
+        )
+      )
+      .limit(limit)
+      .all();
+  });
+}
+
 // ─── Sessions ────────────────────────────────────────────────────────────────
 
 export async function createSession(userId: string): Promise<string> {

--- a/server/routes/profile.test.ts
+++ b/server/routes/profile.test.ts
@@ -6,6 +6,8 @@ import { upsertTitles, createUser, createSession, getSessionWithUser, trackTitle
 import { watchTitle } from "../db/repository";
 import { upsertEpisodes, watchEpisode } from "../db/repository";
 import { optionalAuth } from "../middleware/auth";
+import { getDb, users } from "../db/schema";
+import { eq } from "drizzle-orm";
 import profileApp from "./profile";
 import type { AppEnv } from "../types";
 
@@ -395,5 +397,80 @@ describe("GET /user/:username", () => {
     expect(body.stats.shows_total).toBe(2);
     expect(body.stats.total_watched_episodes).toBe(3); // 2 from show-1 + 1 from show-2
     expect(body.stats.total_released_episodes).toBe(5); // 2 from show-1 + 3 from show-2
+  });
+});
+
+describe("GET /user/search", () => {
+  it("returns matching users by username", async () => {
+    await createUser("alice", "hash", "Alice Smith");
+    await createUser("bob", "hash", "Bob Jones");
+
+    const res = await app.request("/user/search?q=alice", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.users).toHaveLength(1);
+    expect(body.users[0].username).toBe("alice");
+    expect(body.users[0].name).toBe("Alice Smith");
+  });
+
+  it("returns matching users by display name", async () => {
+    await createUser("user1", "hash", "Alice Smith");
+    await createUser("user2", "hash", "Bob Jones");
+
+    const res = await app.request("/user/search?q=Jones", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.users).toHaveLength(1);
+    expect(body.users[0].username).toBe("user2");
+  });
+
+  it("returns empty array when no users match", async () => {
+    const res = await app.request("/user/search?q=nonexistent", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.users).toHaveLength(0);
+  });
+
+  it("returns 401 without authentication", async () => {
+    const res = await app.request("/user/search?q=test");
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Authentication required");
+  });
+
+  it("returns 400 without query parameter", async () => {
+    const res = await app.request("/user/search", { headers: authHeaders() });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Query parameter 'q' is required");
+  });
+
+  it("excludes banned users from results", async () => {
+    const bannedId = await createUser("banneduser", "hash", "Banned User");
+    await createUser("normaluser", "hash", "Normal User");
+
+    const db = getDb();
+    await db.update(users).set({ banned: true }).where(eq(users.id, bannedId)).run();
+
+    const res = await app.request("/user/search?q=user", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const usernames = body.users.map((u: { username: string }) => u.username);
+    expect(usernames).toContain("normaluser");
+    expect(usernames).not.toContain("banneduser");
+  });
+
+  it("returns id, username, name, and image fields", async () => {
+    await createUser("searchable", "hash", "Searchable User");
+
+    const res = await app.request("/user/search?q=searchable", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.users).toHaveLength(1);
+    const user = body.users[0];
+    expect(user.id).toBeTruthy();
+    expect(user.username).toBe("searchable");
+    expect(user.name).toBe("Searchable User");
+    expect(user).toHaveProperty("image");
   });
 });

--- a/server/routes/profile.ts
+++ b/server/routes/profile.ts
@@ -1,9 +1,24 @@
 import { Hono } from "hono";
-import { getUserPublicProfile, updateProfilePublic } from "../db/repository";
+import { getUserPublicProfile, updateProfilePublic, searchUsers } from "../db/repository";
 import type { AppEnv } from "../types";
 import { ok, err } from "./response";
 
 const app = new Hono<AppEnv>();
+
+app.get("/search", async (c) => {
+  const user = c.get("user");
+  if (!user) {
+    return err(c, "Authentication required", 401);
+  }
+
+  const query = c.req.query("q");
+  if (!query || query.length < 1) {
+    return err(c, "Query parameter 'q' is required");
+  }
+
+  const users = await searchUsers(query, 10);
+  return ok(c, { users });
+});
 
 app.get("/:username", async (c) => {
   const username = c.req.param("username");


### PR DESCRIPTION
## Summary
- Add `searchUsers(query, limit)` DB function that searches users by username or display name using SQL LIKE, excluding banned users
- Add `GET /api/user/search?q=` route requiring authentication, with query parameter validation
- Add `UserSummary` type and `searchUsers()` frontend API client function
- Add 7 tests covering: username match, display name match, empty results, auth required (401), missing query param (400), banned user exclusion, and response shape validation

## Test plan
- [x] All 1193 tests pass (`bun test server/ frontend/src/`)
- [x] Server and frontend type check cleanly
- [x] ESLint passes with zero errors
- [ ] Verify search works via manual testing in dev

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)