### PR TITLE
Add follow/unfollow API routes

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -381,3 +381,31 @@ export async function testNotifier(
     method: "POST",
   });
 }
+
+// ─── Social (Follow/Unfollow) ────────────────────────────────────────────────
+
+export async function followUser(userId: string): Promise<void> {
+  await fetchJson(`/social/follow/${encodeURIComponent(userId)}`, {
+    method: "POST",
+  });
+}
+
+export async function unfollowUser(userId: string): Promise<void> {
+  await fetchJson(`/social/follow/${encodeURIComponent(userId)}`, {
+    method: "DELETE",
+  });
+}
+
+export async function getFollowers(userId?: string): Promise<{ followers: UserSummary[]; count: number }> {
+  const path = userId
+    ? `/social/followers/${encodeURIComponent(userId)}`
+    : "/social/followers";
+  return fetchJson(path);
+}
+
+export async function getFollowing(userId?: string): Promise<{ following: UserSummary[]; count: number }> {
+  const path = userId
+    ? `/social/following/${encodeURIComponent(userId)}`
+    : "/social/following";
+  return fetchJson(path);
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -443,6 +443,15 @@ export interface UserProfileResponse {
   backdrops: ProfileBackdrop[];
 }
 
+// ─── Social Types ────────────────────────────────────────────────────────────
+
+export interface UserSummary {
+  id: string;
+  username: string;
+  display_name: string | null;
+  image: string | null;
+}
+
 // Normalize search results to same shape as DB titles
 export function normalizeSearchTitle(t: SearchTitle): Title {
   return {

--- a/server/db/repository/follows.ts
+++ b/server/db/repository/follows.ts
@@ -32,7 +32,8 @@ export async function getFollowers(userId: string) {
       .select({
         id: users.id,
         username: users.username,
-        displayName: users.name,
+        display_name: users.name,
+        image: users.image,
         followedAt: follows.createdAt,
       })
       .from(follows)
@@ -49,7 +50,8 @@ export async function getFollowing(userId: string) {
       .select({
         id: users.id,
         username: users.username,
-        displayName: users.name,
+        display_name: users.name,
+        image: users.image,
         followedAt: follows.createdAt,
       })
       .from(follows)

--- a/server/index.ts
+++ b/server/index.ts
@@ -23,6 +23,7 @@ import browseRoutes from "./routes/browse";
 import detailsRoutes from "./routes/details";
 import notifierRoutes from "./routes/notifiers";
 import profileRoutes from "./routes/profile";
+import socialRoutes from "./routes/social";
 import healthRoutes from "./routes/health";
 import metricsRoutes from "./routes/metrics";
 import type { AppEnv } from "./types";
@@ -155,6 +156,15 @@ app.route("/api/calendar", calendarRoutes);
 app.use("/api/user/*", optionalAuth);
 app.use("/api/user", optionalAuth);
 app.route("/api/user", profileRoutes);
+
+// Social routes — follow/unfollow (auth), follower/following lists (public)
+app.use("/api/social/follow/*", requireAuth);
+app.use("/api/social/follow", requireAuth);
+app.use("/api/social/followers/*", optionalAuth);
+app.use("/api/social/followers", optionalAuth);
+app.use("/api/social/following/*", optionalAuth);
+app.use("/api/social/following", optionalAuth);
+app.route("/api/social", socialRoutes);
 
 // Protected routes
 app.use("/api/track/*", requireAuth);

--- a/server/routes/social.test.ts
+++ b/server/routes/social.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { createUser, createSession, getSessionWithUser } from "../db/repository";
+import { requireAuth, optionalAuth } from "../middleware/auth";
+import socialApp from "./social";
+import type { AppEnv } from "../types";
+
+function createMockAuth() {
+  return {
+    api: {
+      getSession: async ({ headers }: { headers: Headers }) => {
+        const cookieHeader = headers.get("cookie") || "";
+        const match = cookieHeader.match(/better-auth\.session_token=([^;]+)/);
+        const token = match?.[1];
+        if (!token) return null;
+        const user = await getSessionWithUser(token);
+        if (!user) return null;
+        return {
+          session: { id: "session-id", userId: user.id },
+          user: {
+            id: user.id,
+            name: user.display_name,
+            username: user.username,
+            role: user.role || (user.is_admin ? "admin" : "user"),
+          },
+        };
+      },
+    },
+  };
+}
+
+let app: Hono<AppEnv>;
+let userAId: string;
+let userAToken: string;
+let userBId: string;
+let userBToken: string;
+
+beforeEach(async () => {
+  setupTestDb();
+
+  userAId = await createUser("alice", "hash", "Alice");
+  userAToken = await createSession(userAId);
+  userBId = await createUser("bob", "hash", "Bob");
+  userBToken = await createSession(userBId);
+
+  app = new Hono<AppEnv>();
+  app.use("*", async (c, next) => {
+    c.set("auth", createMockAuth() as any);
+    await next();
+  });
+  app.use("/social/follow/*", requireAuth);
+  app.use("/social/follow", requireAuth);
+  app.use("/social/followers/*", optionalAuth);
+  app.use("/social/followers", optionalAuth);
+  app.use("/social/following/*", optionalAuth);
+  app.use("/social/following", optionalAuth);
+  app.route("/social", socialApp);
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+function authHeaders(token: string) {
+  return { Cookie: `better-auth.session_token=${token}` };
+}
+
+describe("POST /social/follow/:userId", () => {
+  it("follows a user successfully", async () => {
+    const res = await app.request(`/social/follow/${userBId}`, {
+      method: "POST",
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  it("returns 400 when trying to follow yourself", async () => {
+    const res = await app.request(`/social/follow/${userAId}`, {
+      method: "POST",
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Cannot follow yourself");
+  });
+
+  it("returns 404 when target user does not exist", async () => {
+    const res = await app.request("/social/follow/nonexistent-id", {
+      method: "POST",
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("User not found");
+  });
+
+  it("is idempotent — following twice returns 200", async () => {
+    await app.request(`/social/follow/${userBId}`, {
+      method: "POST",
+      headers: authHeaders(userAToken),
+    });
+    const res = await app.request(`/social/follow/${userBId}`, {
+      method: "POST",
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await app.request(`/social/follow/${userBId}`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("DELETE /social/follow/:userId", () => {
+  it("unfollows a user successfully", async () => {
+    // Follow first
+    await app.request(`/social/follow/${userBId}`, {
+      method: "POST",
+      headers: authHeaders(userAToken),
+    });
+
+    const res = await app.request(`/social/follow/${userBId}`, {
+      method: "DELETE",
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    // Verify unfollowed
+    const followersRes = await app.request(`/social/followers/${userBId}`);
+    const followersBody = await followersRes.json();
+    expect(followersBody.followers).toHaveLength(0);
+  });
+
+  it("returns 200 when unfollowing a user not being followed", async () => {
+    const res = await app.request(`/social/follow/${userBId}`, {
+      method: "DELETE",
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await app.request(`/social/follow/${userBId}`, {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /social/followers", () => {
+  it("returns current user's followers", async () => {
+    // B follows A
+    await app.request(`/social/follow/${userAId}`, {
+      method: "POST",
+      headers: authHeaders(userBToken),
+    });
+
+    const res = await app.request("/social/followers", {
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.followers).toHaveLength(1);
+    expect(body.count).toBe(1);
+    expect(body.followers[0].username).toBe("bob");
+    expect(body.followers[0].display_name).toBe("Bob");
+    expect(body.followers[0].id).toBe(userBId);
+  });
+
+  it("returns empty list when no followers", async () => {
+    const res = await app.request("/social/followers", {
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.followers).toHaveLength(0);
+    expect(body.count).toBe(0);
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await app.request("/social/followers");
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Authentication required");
+  });
+});
+
+describe("GET /social/following", () => {
+  it("returns current user's following list", async () => {
+    // A follows B
+    await app.request(`/social/follow/${userBId}`, {
+      method: "POST",
+      headers: authHeaders(userAToken),
+    });
+
+    const res = await app.request("/social/following", {
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.following).toHaveLength(1);
+    expect(body.count).toBe(1);
+    expect(body.following[0].username).toBe("bob");
+    expect(body.following[0].id).toBe(userBId);
+  });
+
+  it("returns empty list when not following anyone", async () => {
+    const res = await app.request("/social/following", {
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.following).toHaveLength(0);
+    expect(body.count).toBe(0);
+  });
+});
+
+describe("GET /social/followers/:userId", () => {
+  it("returns followers for a specific user (public)", async () => {
+    // A follows B
+    await app.request(`/social/follow/${userBId}`, {
+      method: "POST",
+      headers: authHeaders(userAToken),
+    });
+
+    const res = await app.request(`/social/followers/${userBId}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.followers).toHaveLength(1);
+    expect(body.count).toBe(1);
+    expect(body.followers[0].username).toBe("alice");
+    expect(body.followers[0].id).toBe(userAId);
+    expect(body.followers[0].display_name).toBe("Alice");
+    expect(body.followers[0]).toHaveProperty("image");
+  });
+
+  it("returns empty list for user with no followers", async () => {
+    const res = await app.request(`/social/followers/${userAId}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.followers).toHaveLength(0);
+    expect(body.count).toBe(0);
+  });
+});
+
+describe("GET /social/following/:userId", () => {
+  it("returns following list for a specific user (public)", async () => {
+    // A follows B
+    await app.request(`/social/follow/${userBId}`, {
+      method: "POST",
+      headers: authHeaders(userAToken),
+    });
+
+    const res = await app.request(`/social/following/${userAId}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.following).toHaveLength(1);
+    expect(body.count).toBe(1);
+    expect(body.following[0].username).toBe("bob");
+    expect(body.following[0].id).toBe(userBId);
+    expect(body.following[0]).toHaveProperty("image");
+  });
+
+  it("returns empty list for user following nobody", async () => {
+    const res = await app.request(`/social/following/${userAId}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.following).toHaveLength(0);
+    expect(body.count).toBe(0);
+  });
+});

--- a/server/routes/social.ts
+++ b/server/routes/social.ts
@@ -1,0 +1,102 @@
+import { Hono } from "hono";
+import { follow, unfollow, getFollowers, getFollowing, getUserById } from "../db/repository";
+import type { AppEnv } from "../types";
+import { logger } from "../logger";
+import { ok, err } from "./response";
+
+const log = logger.child({ module: "social" });
+
+const app = new Hono<AppEnv>();
+
+// POST /follow/:userId — Follow a user
+app.post("/follow/:userId", async (c) => {
+  const currentUser = c.get("user")!;
+  const targetUserId = c.req.param("userId");
+
+  if (currentUser.id === targetUserId) {
+    return err(c, "Cannot follow yourself", 400);
+  }
+
+  const targetUser = await getUserById(targetUserId);
+  if (!targetUser) {
+    return err(c, "User not found", 404);
+  }
+
+  await follow(currentUser.id, targetUserId);
+  log.info("User followed", { followerId: currentUser.id, followingId: targetUserId });
+  return ok(c, { success: true });
+});
+
+// DELETE /follow/:userId — Unfollow a user
+app.delete("/follow/:userId", async (c) => {
+  const currentUser = c.get("user")!;
+  const targetUserId = c.req.param("userId");
+
+  await unfollow(currentUser.id, targetUserId);
+  log.info("User unfollowed", { followerId: currentUser.id, followingId: targetUserId });
+  return ok(c, { success: true });
+});
+
+// GET /followers — List current user's followers
+app.get("/followers", async (c) => {
+  const user = c.get("user");
+  if (!user) {
+    return err(c, "Authentication required", 401);
+  }
+
+  const followers = await getFollowers(user.id);
+  const summary = followers.map(({ id, username, display_name, image }) => ({
+    id,
+    username,
+    display_name,
+    image,
+  }));
+  return ok(c, { followers: summary, count: summary.length });
+});
+
+// GET /following — List current user's following
+app.get("/following", async (c) => {
+  const user = c.get("user");
+  if (!user) {
+    return err(c, "Authentication required", 401);
+  }
+
+  const following = await getFollowing(user.id);
+  const summary = following.map(({ id, username, display_name, image }) => ({
+    id,
+    username,
+    display_name,
+    image,
+  }));
+  return ok(c, { following: summary, count: summary.length });
+});
+
+// GET /followers/:userId — List a user's followers (public)
+app.get("/followers/:userId", async (c) => {
+  const targetUserId = c.req.param("userId");
+
+  const followers = await getFollowers(targetUserId);
+  const summary = followers.map(({ id, username, display_name, image }) => ({
+    id,
+    username,
+    display_name,
+    image,
+  }));
+  return ok(c, { followers: summary, count: summary.length });
+});
+
+// GET /following/:userId — List a user's following (public)
+app.get("/following/:userId", async (c) => {
+  const targetUserId = c.req.param("userId");
+
+  const following = await getFollowing(targetUserId);
+  const summary = following.map(({ id, username, display_name, image }) => ({
+    id,
+    username,
+    display_name,
+    image,
+  }));
+  return ok(c, { following: summary, count: summary.length });
+});
+
+export default app;


### PR DESCRIPTION
## Summary
- Adds social API routes (`server/routes/social.ts`) with 6 endpoints for follow/unfollow, listing followers, and listing following
- Mounts routes in `server/index.ts` with `requireAuth` for mutations and `optionalAuth` for read endpoints
- Updates `server/db/repository/follows.ts` to return `display_name` and `image` fields in follower/following queries
- Adds `UserSummary` type and social API functions (`followUser`, `unfollowUser`, `getFollowers`, `getFollowing`) to the frontend

## Test plan
- [x] 17 new tests in `server/routes/social.test.ts` covering all 6 endpoints
- [x] Self-follow returns 400
- [x] Follow non-existent user returns 404
- [x] Idempotent follow (double-follow returns 200)
- [x] Unfollow without prior follow returns 200
- [x] Auth required for mutation and current-user list endpoints
- [x] Public endpoints return correct follower/following data
- [x] All 1203 existing tests continue to pass

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)