### PR TITLE
Add ratings API routes

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -13,6 +13,7 @@ import type {
   AdminSettingsUpdateResponse,
   UserProfileResponse,
   UserSummary,
+  TitleRatingResponse,
 } from "./types";
 
 const BASE = "/api";
@@ -408,4 +409,23 @@ export async function getFollowing(userId?: string): Promise<{ following: UserSu
     ? `/social/following/${encodeURIComponent(userId)}`
     : "/social/following";
   return fetchJson(path);
+}
+
+// ─── Ratings ─────────────────────────────────────────────────────────────────
+
+export async function rateTitle(titleId: string, rating: string): Promise<void> {
+  await fetchJson(`/ratings/${encodeURIComponent(titleId)}`, {
+    method: "POST",
+    body: JSON.stringify({ rating }),
+  });
+}
+
+export async function unrateTitle(titleId: string): Promise<void> {
+  await fetchJson(`/ratings/${encodeURIComponent(titleId)}`, {
+    method: "DELETE",
+  });
+}
+
+export async function getTitleRating(titleId: string): Promise<TitleRatingResponse> {
+  return fetchJson(`/ratings/${encodeURIComponent(titleId)}`);
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -443,6 +443,21 @@ export interface UserProfileResponse {
   backdrops: ProfileBackdrop[];
 }
 
+// ─── Rating Types ────────────────────────────────────────────────────────────
+
+export type RatingValue = "HATE" | "DISLIKE" | "LIKE" | "LOVE";
+
+export interface FriendRating {
+  user: UserSummary;
+  rating: RatingValue;
+}
+
+export interface TitleRatingResponse {
+  user_rating: RatingValue | null;
+  aggregated: Record<RatingValue, number>;
+  friends_ratings: FriendRating[];
+}
+
 // ─── Social Types ────────────────────────────────────────────────────────────
 
 export interface UserSummary {

--- a/server/db/repository/ratings.ts
+++ b/server/db/repository/ratings.ts
@@ -67,6 +67,7 @@ export async function getFriendsRatings(userId: string, titleId: string) {
         userId: ratings.userId,
         username: users.username,
         displayName: users.name,
+        image: users.image,
         rating: ratings.rating,
       })
       .from(ratings)

--- a/server/index.ts
+++ b/server/index.ts
@@ -24,6 +24,7 @@ import detailsRoutes from "./routes/details";
 import notifierRoutes from "./routes/notifiers";
 import profileRoutes from "./routes/profile";
 import socialRoutes from "./routes/social";
+import ratingsRoutes from "./routes/ratings";
 import healthRoutes from "./routes/health";
 import metricsRoutes from "./routes/metrics";
 import type { AppEnv } from "./types";
@@ -165,6 +166,11 @@ app.use("/api/social/followers", optionalAuth);
 app.use("/api/social/following/*", optionalAuth);
 app.use("/api/social/following", optionalAuth);
 app.route("/api/social", socialRoutes);
+
+// Ratings routes — optionalAuth base, POST/DELETE check auth internally
+app.use("/api/ratings/*", optionalAuth);
+app.use("/api/ratings", optionalAuth);
+app.route("/api/ratings", ratingsRoutes);
 
 // Protected routes
 app.use("/api/track/*", requireAuth);

--- a/server/routes/ratings.test.ts
+++ b/server/routes/ratings.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { createUser, createSession, getSessionWithUser, follow } from "../db/repository";
+import { getRawDb } from "../db/bun-db";
+import { optionalAuth } from "../middleware/auth";
+import ratingsApp from "./ratings";
+import type { AppEnv } from "../types";
+
+function createMockAuth() {
+  return {
+    api: {
+      getSession: async ({ headers }: { headers: Headers }) => {
+        const cookieHeader = headers.get("cookie") || "";
+        const match = cookieHeader.match(/better-auth\.session_token=([^;]+)/);
+        const token = match?.[1];
+        if (!token) return null;
+        const user = await getSessionWithUser(token);
+        if (!user) return null;
+        return {
+          session: { id: "session-id", userId: user.id },
+          user: {
+            id: user.id,
+            name: user.display_name,
+            username: user.username,
+            role: user.role || (user.is_admin ? "admin" : "user"),
+          },
+        };
+      },
+    },
+  };
+}
+
+let app: Hono<AppEnv>;
+let userAId: string;
+let userAToken: string;
+let userBId: string;
+let userBToken: string;
+
+beforeEach(async () => {
+  setupTestDb();
+
+  userAId = await createUser("alice", "hash", "Alice");
+  userAToken = await createSession(userAId);
+  userBId = await createUser("bob", "hash", "Bob");
+  userBToken = await createSession(userBId);
+
+  // Insert test titles for FK constraint
+  insertTitle("movie-123");
+  insertTitle("movie-999");
+
+  app = new Hono<AppEnv>();
+  app.use("*", async (c, next) => {
+    c.set("auth", createMockAuth() as any);
+    await next();
+  });
+  app.use("/ratings/*", optionalAuth);
+  app.use("/ratings", optionalAuth);
+  app.route("/ratings", ratingsApp);
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+function authHeaders(token: string) {
+  return { Cookie: `better-auth.session_token=${token}` };
+}
+
+function insertTitle(id: string) {
+  const db = getRawDb();
+  db.prepare(
+    `INSERT INTO titles (id, object_type, title, release_date) VALUES (?, 'MOVIE', ?, '2024-01-01')`
+  ).run(id, `Title ${id}`);
+}
+
+describe("POST /ratings/:titleId", () => {
+  it("rates a title successfully", async () => {
+    const res = await app.request("/ratings/movie-123", {
+      method: "POST",
+      headers: {
+        ...authHeaders(userAToken),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ rating: "LOVE" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.rating).toBe("LOVE");
+  });
+
+  it("updates an existing rating", async () => {
+    // Rate first
+    await app.request("/ratings/movie-123", {
+      method: "POST",
+      headers: {
+        ...authHeaders(userAToken),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ rating: "LIKE" }),
+    });
+
+    // Update rating
+    const res = await app.request("/ratings/movie-123", {
+      method: "POST",
+      headers: {
+        ...authHeaders(userAToken),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ rating: "LOVE" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.rating).toBe("LOVE");
+
+    // Verify the rating was updated
+    const getRes = await app.request("/ratings/movie-123", {
+      headers: authHeaders(userAToken),
+    });
+    const getBody = await getRes.json();
+    expect(getBody.user_rating).toBe("LOVE");
+  });
+
+  it("returns 400 for invalid rating value", async () => {
+    const res = await app.request("/ratings/movie-123", {
+      method: "POST",
+      headers: {
+        ...authHeaders(userAToken),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ rating: "INVALID" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Invalid rating value");
+  });
+
+  it("returns 400 for missing rating value", async () => {
+    const res = await app.request("/ratings/movie-123", {
+      method: "POST",
+      headers: {
+        ...authHeaders(userAToken),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Invalid rating value");
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await app.request("/ratings/movie-123", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ rating: "LOVE" }),
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("DELETE /ratings/:titleId", () => {
+  it("removes a rating successfully", async () => {
+    // Rate first
+    await app.request("/ratings/movie-123", {
+      method: "POST",
+      headers: {
+        ...authHeaders(userAToken),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ rating: "LIKE" }),
+    });
+
+    // Delete rating
+    const res = await app.request("/ratings/movie-123", {
+      method: "DELETE",
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    // Verify rating was removed
+    const getRes = await app.request("/ratings/movie-123", {
+      headers: authHeaders(userAToken),
+    });
+    const getBody = await getRes.json();
+    expect(getBody.user_rating).toBeNull();
+  });
+
+  it("returns 200 when removing a non-existent rating", async () => {
+    const res = await app.request("/ratings/movie-123", {
+      method: "DELETE",
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await app.request("/ratings/movie-123", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /ratings/:titleId", () => {
+  it("returns aggregated ratings and user rating when authenticated", async () => {
+    // Alice rates LOVE
+    await app.request("/ratings/movie-123", {
+      method: "POST",
+      headers: {
+        ...authHeaders(userAToken),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ rating: "LOVE" }),
+    });
+
+    // Bob rates LIKE
+    await app.request("/ratings/movie-123", {
+      method: "POST",
+      headers: {
+        ...authHeaders(userBToken),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ rating: "LIKE" }),
+    });
+
+    const res = await app.request("/ratings/movie-123", {
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.user_rating).toBe("LOVE");
+    expect(body.aggregated.LOVE).toBe(1);
+    expect(body.aggregated.LIKE).toBe(1);
+    expect(body.aggregated.HATE).toBe(0);
+    expect(body.aggregated.DISLIKE).toBe(0);
+  });
+
+  it("returns null user_rating when not authenticated", async () => {
+    // Alice rates
+    await app.request("/ratings/movie-123", {
+      method: "POST",
+      headers: {
+        ...authHeaders(userAToken),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ rating: "LOVE" }),
+    });
+
+    const res = await app.request("/ratings/movie-123");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.user_rating).toBeNull();
+    expect(body.aggregated.LOVE).toBe(1);
+    expect(body.friends_ratings).toHaveLength(0);
+  });
+
+  it("returns friends ratings from followed users", async () => {
+    // Alice follows Bob
+    await follow(userAId, userBId);
+
+    // Bob rates the title
+    await app.request("/ratings/movie-123", {
+      method: "POST",
+      headers: {
+        ...authHeaders(userBToken),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ rating: "LIKE" }),
+    });
+
+    // Alice gets ratings — should see Bob's rating as friend
+    const res = await app.request("/ratings/movie-123", {
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.friends_ratings).toHaveLength(1);
+    expect(body.friends_ratings[0].rating).toBe("LIKE");
+    expect(body.friends_ratings[0].user.username).toBe("bob");
+    expect(body.friends_ratings[0].user.display_name).toBe("Bob");
+    expect(body.friends_ratings[0].user.id).toBe(userBId);
+  });
+
+  it("returns empty friends ratings when not following anyone", async () => {
+    // Bob rates the title
+    await app.request("/ratings/movie-123", {
+      method: "POST",
+      headers: {
+        ...authHeaders(userBToken),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ rating: "LIKE" }),
+    });
+
+    // Alice gets ratings — should not see Bob since not following
+    const res = await app.request("/ratings/movie-123", {
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.friends_ratings).toHaveLength(0);
+  });
+
+  it("returns zero counts for unrated title", async () => {
+    const res = await app.request("/ratings/movie-999");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.user_rating).toBeNull();
+    expect(body.aggregated).toEqual({ HATE: 0, DISLIKE: 0, LIKE: 0, LOVE: 0 });
+    expect(body.friends_ratings).toHaveLength(0);
+  });
+});

--- a/server/routes/ratings.ts
+++ b/server/routes/ratings.ts
@@ -1,0 +1,79 @@
+import { Hono } from "hono";
+import {
+  rateTitle,
+  unrateTitle,
+  getUserRating,
+  getTitleRatings,
+  getFriendsRatings,
+} from "../db/repository";
+import type { RatingValue } from "../db/repository";
+import type { AppEnv } from "../types";
+import { logger } from "../logger";
+import { ok, err } from "./response";
+
+const log = logger.child({ module: "ratings" });
+
+const VALID_RATINGS: RatingValue[] = ["HATE", "DISLIKE", "LIKE", "LOVE"];
+
+const app = new Hono<AppEnv>();
+
+// POST /:titleId — Rate a title
+app.post("/:titleId", async (c) => {
+  const user = c.get("user");
+  if (!user) {
+    return err(c, "Authentication required", 401);
+  }
+
+  const titleId = c.req.param("titleId");
+  const body = await c.req.json<{ rating: string }>();
+
+  if (!body.rating || !VALID_RATINGS.includes(body.rating as RatingValue)) {
+    return err(c, "Invalid rating value. Must be one of: HATE, DISLIKE, LIKE, LOVE", 400);
+  }
+
+  const rating = body.rating as RatingValue;
+  await rateTitle(user.id, titleId, rating);
+  log.info("Title rated", { userId: user.id, titleId, rating });
+  return ok(c, { success: true, rating });
+});
+
+// DELETE /:titleId — Remove rating
+app.delete("/:titleId", async (c) => {
+  const user = c.get("user");
+  if (!user) {
+    return err(c, "Authentication required", 401);
+  }
+
+  const titleId = c.req.param("titleId");
+  await unrateTitle(user.id, titleId);
+  log.info("Title unrated", { userId: user.id, titleId });
+  return ok(c, { success: true });
+});
+
+// GET /:titleId — Get rating info
+app.get("/:titleId", async (c) => {
+  const user = c.get("user");
+  const titleId = c.req.param("titleId");
+
+  const userRating = user ? await getUserRating(user.id, titleId) : null;
+  const aggregated = await getTitleRatings(titleId);
+  const friendsRaw = user ? await getFriendsRatings(user.id, titleId) : [];
+
+  const friendsRatings = friendsRaw.map((f) => ({
+    user: {
+      id: f.userId,
+      username: f.username,
+      display_name: f.displayName,
+      image: f.image,
+    },
+    rating: f.rating,
+  }));
+
+  return ok(c, {
+    user_rating: userRating,
+    aggregated,
+    friends_ratings: friendsRatings,
+  });
+});
+
+export default app;


### PR DESCRIPTION
## Summary
- Add `server/routes/ratings.ts` with POST (rate), DELETE (unrate), and GET (rating info) endpoints for `/api/ratings/:titleId`
- Mount ratings routes in `server/index.ts` with `optionalAuth` base middleware
- Add `RatingValue`, `FriendRating`, and `TitleRatingResponse` types to `frontend/src/types.ts`
- Add `rateTitle`, `unrateTitle`, and `getTitleRating` API functions to `frontend/src/api.ts`
- Add `image` field to `getFriendsRatings` repository query for friend user info
- 13 tests covering rate, update, delete, validation, auth, aggregation, and friends data

Closes #285

## Test plan
- [x] All 13 new ratings route tests pass
- [x] Full test suite (1223 tests) passes with zero failures
- [x] Server TypeScript type check passes
- [x] Frontend ESLint passes (zero errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)