### PR TITLE
Add FollowButton component and profile integration

### DIFF
--- a/frontend/src/components/FollowButton.test.tsx
+++ b/frontend/src/components/FollowButton.test.tsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, mock, afterEach, beforeEach, spyOn } from "bun:test";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import type { ReactNode } from "react";
+import "../i18n";
+import FollowButton from "./FollowButton";
+import * as api from "../api";
+import * as sonner from "sonner";
+import { AuthContext } from "../context/AuthContext";
+
+const mockUser = { id: "user-1", username: "test", display_name: null, auth_provider: "local", is_admin: false };
+
+const mockAuthValue = {
+  user: mockUser,
+  providers: null,
+  loading: false,
+  login: mock(() => Promise.resolve()),
+  logout: mock(() => Promise.resolve()),
+  refresh: mock(() => Promise.resolve()),
+};
+
+function Wrapper({ children, authValue }: { children: ReactNode; authValue?: typeof mockAuthValue }) {
+  return <AuthContext value={(authValue ?? mockAuthValue) as any}>{children}</AuthContext>;
+}
+
+let spies: ReturnType<typeof spyOn>[] = [];
+
+beforeEach(() => {
+  spies = [
+    spyOn(api, "followUser").mockResolvedValue(undefined as any),
+    spyOn(api, "unfollowUser").mockResolvedValue(undefined as any),
+    spyOn(sonner.toast, "success").mockImplementation(() => "1" as any),
+    spyOn(sonner.toast, "error").mockImplementation(() => "1" as any),
+  ];
+});
+
+afterEach(() => {
+  cleanup();
+  for (const spy of spies) spy.mockRestore();
+  spies = [];
+});
+
+describe("FollowButton", () => {
+  it("renders 'Follow' when not following", () => {
+    render(<FollowButton userId="user-2" initialIsFollowing={false} />, { wrapper: Wrapper });
+    expect(screen.getByRole("button", { name: "Follow" })).toBeDefined();
+  });
+
+  it("renders 'Following' when following", () => {
+    render(<FollowButton userId="user-2" initialIsFollowing={true} />, { wrapper: Wrapper });
+    expect(screen.getByRole("button", { name: "Following" })).toBeDefined();
+  });
+
+  it("returns null when user is not logged in", () => {
+    const noUserAuth = { ...mockAuthValue, user: null };
+    const { container } = render(
+      <AuthContext value={noUserAuth as any}>
+        <FollowButton userId="user-2" initialIsFollowing={false} />
+      </AuthContext>
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("does not render on own profile", () => {
+    const { container } = render(
+      <FollowButton userId="user-1" initialIsFollowing={false} />,
+      { wrapper: Wrapper },
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("calls followUser and updates to 'Following' on click", async () => {
+    const onToggle = mock(() => {});
+    render(<FollowButton userId="user-2" initialIsFollowing={false} onToggle={onToggle} />, { wrapper: Wrapper });
+
+    const button = screen.getByRole("button", { name: "Follow" });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Following" })).toBeDefined();
+    });
+
+    expect(api.followUser).toHaveBeenCalledWith("user-2");
+    expect(onToggle).toHaveBeenCalledWith(true);
+  });
+
+  it("calls unfollowUser and updates to 'Follow' on click", async () => {
+    const onToggle = mock(() => {});
+    render(<FollowButton userId="user-2" initialIsFollowing={true} onToggle={onToggle} />, { wrapper: Wrapper });
+
+    const button = screen.getByRole("button", { name: "Following" });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Follow" })).toBeDefined();
+    });
+
+    expect(api.unfollowUser).toHaveBeenCalledWith("user-2");
+    expect(onToggle).toHaveBeenCalledWith(false);
+  });
+
+  it("shows 'Unfollow' on hover when following", () => {
+    render(<FollowButton userId="user-2" initialIsFollowing={true} />, { wrapper: Wrapper });
+
+    const button = screen.getByRole("button", { name: "Following" });
+    fireEvent.mouseEnter(button);
+
+    expect(screen.getByRole("button", { name: "Unfollow" })).toBeDefined();
+  });
+
+  it("reverts to 'Following' on mouse leave", () => {
+    render(<FollowButton userId="user-2" initialIsFollowing={true} />, { wrapper: Wrapper });
+
+    const button = screen.getByRole("button", { name: "Following" });
+    fireEvent.mouseEnter(button);
+    expect(screen.getByRole("button", { name: "Unfollow" })).toBeDefined();
+
+    fireEvent.mouseLeave(button);
+    expect(screen.getByRole("button", { name: "Following" })).toBeDefined();
+  });
+
+  it("shows loading indicator during API call", async () => {
+    let resolveFollow: () => void;
+    (api.followUser as any).mockImplementationOnce(
+      () => new Promise<void>((resolve) => { resolveFollow = resolve; })
+    );
+
+    render(<FollowButton userId="user-2" initialIsFollowing={false} />, { wrapper: Wrapper });
+
+    const button = screen.getByRole("button", { name: "Follow" });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "..." })).toBeDefined();
+    });
+
+    expect(screen.getByRole("button", { name: "..." }).hasAttribute("disabled")).toBe(true);
+
+    resolveFollow!();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Following" })).toBeDefined();
+    });
+  });
+
+  it("shows success toast when following", async () => {
+    render(<FollowButton userId="user-2" initialIsFollowing={false} />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByRole("button", { name: "Follow" }));
+
+    await waitFor(() => {
+      expect(sonner.toast.success).toHaveBeenCalledWith("Following");
+    });
+  });
+
+  it("shows success toast when unfollowing", async () => {
+    render(<FollowButton userId="user-2" initialIsFollowing={true} />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByRole("button", { name: "Following" }));
+
+    await waitFor(() => {
+      expect(sonner.toast.success).toHaveBeenCalledWith("Unfollowed");
+    });
+  });
+
+  it("shows error toast when follow fails", async () => {
+    (api.followUser as any).mockRejectedValueOnce(new Error("Network error"));
+
+    render(<FollowButton userId="user-2" initialIsFollowing={false} />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByRole("button", { name: "Follow" }));
+
+    await waitFor(() => {
+      expect(sonner.toast.error).toHaveBeenCalledWith("Failed to update follow status");
+    });
+  });
+
+  it("shows error toast when unfollow fails", async () => {
+    (api.unfollowUser as any).mockRejectedValueOnce(new Error("Network error"));
+
+    render(<FollowButton userId="user-2" initialIsFollowing={true} />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByRole("button", { name: "Following" }));
+
+    await waitFor(() => {
+      expect(sonner.toast.error).toHaveBeenCalledWith("Failed to update follow status");
+    });
+  });
+});

--- a/frontend/src/components/FollowButton.tsx
+++ b/frontend/src/components/FollowButton.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import * as api from "../api";
+import { useAuth } from "../context/AuthContext";
+
+interface Props {
+  userId: string;
+  initialIsFollowing: boolean;
+  onToggle?: (isFollowing: boolean) => void;
+}
+
+export default function FollowButton({ userId, initialIsFollowing, onToggle }: Props) {
+  const { user } = useAuth();
+  const [following, setFollowing] = useState(initialIsFollowing);
+  const [loading, setLoading] = useState(false);
+  const [hovered, setHovered] = useState(false);
+
+  // Don't render if not authenticated or viewing own profile
+  if (!user || user.id === userId) return null;
+
+  async function handleClick() {
+    setLoading(true);
+    try {
+      if (following) {
+        await api.unfollowUser(userId);
+        setFollowing(false);
+        onToggle?.(false);
+        toast.success("Unfollowed");
+      } else {
+        await api.followUser(userId);
+        setFollowing(true);
+        onToggle?.(true);
+        toast.success("Following");
+      }
+    } catch (err: unknown) {
+      console.error("Follow toggle failed:", err);
+      toast.error("Failed to update follow status");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const showUnfollow = following && hovered;
+
+  let label: string;
+  if (loading) {
+    label = "...";
+  } else if (showUnfollow) {
+    label = "Unfollow";
+  } else if (following) {
+    label = "Following";
+  } else {
+    label = "Follow";
+  }
+
+  let className: string;
+  if (showUnfollow) {
+    className = "bg-red-500 text-white";
+  } else if (following) {
+    className = "bg-amber-500 text-zinc-950";
+  } else {
+    className = "bg-zinc-800 text-zinc-400 hover:bg-amber-500 hover:text-zinc-950";
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={loading}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      className={`min-h-8 inline-flex items-center justify-center px-3 py-1.5 rounded-md text-xs font-medium transition-colors cursor-pointer ${className} disabled:opacity-50`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/frontend/src/components/ProfileBanner.test.tsx
+++ b/frontend/src/components/ProfileBanner.test.tsx
@@ -8,6 +8,7 @@ import type { ProfileBackdrop, UserProfileUser, UserProfileStats } from "../type
 afterEach(cleanup);
 
 const mockUser: UserProfileUser = {
+  id: "user-1",
   username: "testuser",
   display_name: "Test User",
   image: null,

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -207,7 +207,9 @@
     "watchlistHiddenOwn": "Your watchlist is hidden from your public profile.",
     "enableInSettings": "Enable in settings",
     "showsCompleted": "Shows Completed",
-    "episodesWatched": "Episodes Watched"
+    "episodesWatched": "Episodes Watched",
+    "followers": "followers",
+    "following": "following"
   },
   "settings": {
     "title": "Settings",

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -1,10 +1,11 @@
-import { useMemo } from "react";
+import { useMemo, useState, useCallback } from "react";
 import { Link, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import * as api from "../api";
 import TitleList from "../components/TitleList";
 import ProfileBanner from "../components/ProfileBanner";
+import FollowButton from "../components/FollowButton";
 import { TitleGridSkeleton } from "../components/SkeletonComponents";
 import { useApiCall } from "../hooks/useApiCall";
 import { groupShowsByStatus } from "../lib/groupShows";
@@ -19,6 +20,15 @@ export default function UserProfilePage() {
 
   const shows = useMemo(() => data?.shows ?? [], [data]);
   const showGroups = useMemo(() => groupShowsByStatus(shows), [shows]);
+
+  // Track optimistic adjustment to follower count (resets on refetch)
+  const [followerAdjust, setFollowerAdjust] = useState(0);
+
+  const handleFollowToggle = useCallback((isNowFollowing: boolean) => {
+    setFollowerAdjust((prev) => prev + (isNowFollowing ? 1 : -1));
+  }, []);
+
+  const followerCount = (data?.follower_count ?? 0) + followerAdjust;
 
   if (loading) {
     return (
@@ -45,7 +55,7 @@ export default function UserProfilePage() {
     );
   }
 
-  const { user, stats, movies, is_own_profile, show_watchlist, backdrops } = data;
+  const { user, stats, movies, is_own_profile, show_watchlist, backdrops, following_count, is_following } = data;
 
   async function handleVisibilityToggle(titleId: string, isPublic: boolean) {
     try {
@@ -61,6 +71,20 @@ export default function UserProfilePage() {
     <div className="max-w-7xl mx-auto space-y-8">
       {/* Banner with overlaid user info and stats */}
       <ProfileBanner backdrops={backdrops} user={user} stats={stats} isOwnProfile={is_own_profile} />
+
+      {/* Social bar: follower/following counts + follow button */}
+      <div className="flex items-center gap-3" data-testid="social-bar">
+        <span className="text-zinc-400 text-sm">
+          <span className="text-white font-medium">{followerCount}</span> {t("userProfile.followers")}
+        </span>
+        <span className="text-zinc-600">&middot;</span>
+        <span className="text-zinc-400 text-sm">
+          <span className="text-white font-medium">{following_count}</span> {t("userProfile.following")}
+        </span>
+        {!is_own_profile && (
+          <FollowButton userId={user.id} initialIsFollowing={is_following} onToggle={handleFollowToggle} />
+        )}
+      </div>
 
       {/* Watchlist */}
       {show_watchlist && (movies.length > 0 || shows.length > 0) && (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -411,6 +411,7 @@ export interface UserSummary {
 // ─── User Profile Types ─────────────────────────────────────────────────────
 
 export interface UserProfileUser {
+  id: string;
   username: string;
   display_name: string | null;
   image: string | null;
@@ -441,6 +442,9 @@ export interface UserProfileResponse {
   show_watchlist: boolean;
   is_own_profile: boolean;
   backdrops: ProfileBackdrop[];
+  follower_count: number;
+  following_count: number;
+  is_following: boolean;
 }
 
 // ─── Rating Types ────────────────────────────────────────────────────────────

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "5.0",
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2022",
     "useDefineForClassFields": true,

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]

--- a/server/db/repository/profile.ts
+++ b/server/db/repository/profile.ts
@@ -3,8 +3,9 @@ import { getDb } from "../schema";
 import { users, watchedTitles, watchedEpisodes, episodes, titles } from "../schema";
 import { traceDbQuery } from "../../tracing";
 import { getPublicTrackedTitles, getPublicTrackedCount, getTrackedTitles } from "./tracked";
+import { getFollowerCount, getFollowingCount, isFollowing } from "./follows";
 
-export async function getUserPublicProfile(username: string, isOwnProfile = false) {
+export async function getUserPublicProfile(username: string, isOwnProfile = false, viewerId?: string | null) {
   return traceDbQuery("getUserPublicProfile", async () => {
     const db = getDb();
 
@@ -25,7 +26,7 @@ export async function getUserPublicProfile(username: string, isOwnProfile = fals
 
     const showWatchlist = isOwnProfile || Boolean(user.profile_public);
 
-    const [trackedCount, watchedMoviesRow, watchedEpisodesRow, allTitles, backdrops] = await Promise.all([
+    const [trackedCount, watchedMoviesRow, watchedEpisodesRow, allTitles, backdrops, followerCount, followingCount, viewerIsFollowing] = await Promise.all([
       showWatchlist ? getPublicTrackedCount(user.id) : Promise.resolve(0),
       db
         .select({ count: sql<number>`COUNT(*)` })
@@ -45,6 +46,9 @@ export async function getUserPublicProfile(username: string, isOwnProfile = fals
       showWatchlist
         ? getRecentlyWatchedBackdrops(db, user.id)
         : Promise.resolve([]),
+      getFollowerCount(user.id),
+      getFollowingCount(user.id),
+      viewerId && !isOwnProfile ? isFollowing(viewerId, user.id) : Promise.resolve(false),
     ]);
 
     const shows = allTitles.filter(t => t.object_type === "SHOW");
@@ -90,6 +94,7 @@ export async function getUserPublicProfile(username: string, isOwnProfile = fals
 
     return {
       user: {
+        id: user.id,
         username: user.username,
         display_name: user.display_name,
         image: user.image,
@@ -105,6 +110,9 @@ export async function getUserPublicProfile(username: string, isOwnProfile = fals
         total_released_episodes: totalReleasedEpisodes,
       },
       show_watchlist: showWatchlist,
+      follower_count: followerCount,
+      following_count: followingCount,
+      is_following: viewerIsFollowing,
       movies,
       shows,
       backdrops,

--- a/server/routes/profile.test.ts
+++ b/server/routes/profile.test.ts
@@ -5,6 +5,7 @@ import { makeParsedTitle } from "../test-utils/fixtures";
 import { upsertTitles, createUser, createSession, getSessionWithUser, trackTitle, updateProfilePublic, updateTrackedVisibility } from "../db/repository";
 import { watchTitle } from "../db/repository";
 import { upsertEpisodes, watchEpisode } from "../db/repository";
+import { follow } from "../db/repository";
 import { optionalAuth } from "../middleware/auth";
 import { getDb, users } from "../db/schema";
 import { eq } from "drizzle-orm";
@@ -81,6 +82,9 @@ describe("GET /user/:username", () => {
     expect(body.shows).toHaveLength(0);
     expect(body.show_watchlist).toBe(false);
     expect(body.is_own_profile).toBe(false);
+    expect(body.follower_count).toBe(0);
+    expect(body.following_count).toBe(0);
+    expect(body.is_following).toBe(false);
   });
 
   it("returns 404 for nonexistent username", async () => {
@@ -124,7 +128,8 @@ describe("GET /user/:username", () => {
     expect(body.user.password_hash).toBeUndefined();
     expect(body.user.is_admin).toBeUndefined();
     expect(body.user.role).toBeUndefined();
-    expect(body.user.id).toBeUndefined();
+    // id is intentionally exposed for the FollowButton
+    expect(body.user.id).toBeTruthy();
   });
 
   it("hides watchlist when profile_public is false (default)", async () => {
@@ -397,6 +402,62 @@ describe("GET /user/:username", () => {
     expect(body.stats.shows_total).toBe(2);
     expect(body.stats.total_watched_episodes).toBe(3); // 2 from show-1 + 1 from show-2
     expect(body.stats.total_released_episodes).toBe(5); // 2 from show-1 + 3 from show-2
+  });
+
+  it("includes follower and following counts", async () => {
+    const otherUserId1 = await createUser("follower1", "hash", "Follower One");
+    const otherUserId2 = await createUser("follower2", "hash", "Follower Two");
+    const followingUserId = await createUser("followee", "hash", "Followee");
+
+    await follow(otherUserId1, userId);
+    await follow(otherUserId2, userId);
+    await follow(userId, followingUserId);
+
+    const res = await app.request("/user/testuser");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.follower_count).toBe(2);
+    expect(body.following_count).toBe(1);
+  });
+
+  it("is_following is true when viewer follows the profile user", async () => {
+    const viewerId = await createUser("viewer", "hash", "Viewer");
+    const viewerToken = await createSession(viewerId);
+
+    await follow(viewerId, userId);
+
+    const res = await app.request("/user/testuser", {
+      headers: { Cookie: `better-auth.session_token=${viewerToken}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.is_following).toBe(true);
+  });
+
+  it("is_following is false when viewer does not follow the profile user", async () => {
+    const viewerId = await createUser("viewer", "hash", "Viewer");
+    const viewerToken = await createSession(viewerId);
+
+    const res = await app.request("/user/testuser", {
+      headers: { Cookie: `better-auth.session_token=${viewerToken}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.is_following).toBe(false);
+  });
+
+  it("is_following is false on own profile", async () => {
+    const res = await app.request("/user/testuser", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.is_following).toBe(false);
+  });
+
+  it("is_following is false when not authenticated", async () => {
+    const res = await app.request("/user/testuser");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.is_following).toBe(false);
   });
 });
 

--- a/server/routes/profile.ts
+++ b/server/routes/profile.ts
@@ -25,7 +25,8 @@ app.get("/:username", async (c) => {
   const viewer = c.get("user");
   const isOwnProfile = viewer?.username?.toLowerCase() === username.toLowerCase();
 
-  const profile = await getUserPublicProfile(username, isOwnProfile);
+  const viewerId = viewer?.id ?? null;
+  const profile = await getUserPublicProfile(username, isOwnProfile, viewerId);
 
   if (!profile) {
     return err(c, "User not found", 404);


### PR DESCRIPTION
## Summary
- Create `FollowButton` component with follow/unfollow toggle, hover "Unfollow" state, loading indicator, and auth-gated visibility (hidden for unauthenticated users and on own profile)
- Extend profile API response with `follower_count`, `following_count`, and `is_following` fields
- Add social bar to `UserProfilePage` displaying follower/following counts with optimistic UI updates
- Fix pre-existing TypeScript 6.0 `baseUrl` deprecation warnings in frontend tsconfigs

## Test plan
- [x] FollowButton renders "Follow" when not following, "Following" when following
- [x] FollowButton hidden when not authenticated or viewing own profile
- [x] Follow/unfollow toggles call correct API and update button state
- [x] Hover state changes "Following" to "Unfollow" with red styling
- [x] Loading state shows "..." and disables button during API call
- [x] Success/error toasts on follow/unfollow actions
- [x] Profile API returns follower_count, following_count, is_following
- [x] is_following is true/false based on viewer authentication and follow status
- [x] is_following is always false on own profile and when unauthenticated
- [x] All 1228 tests pass, 0 lint errors

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)