### PR TITLE
Add RatingButtons UI component for title detail pages

### DIFF
--- a/frontend/src/components/RatingButtons.test.tsx
+++ b/frontend/src/components/RatingButtons.test.tsx
@@ -1,0 +1,259 @@
+import { describe, it, expect, mock, afterEach, beforeEach, spyOn } from "bun:test";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import type { ReactNode } from "react";
+import "../i18n";
+import RatingButtons from "./RatingButtons";
+import * as api from "../api";
+import * as sonner from "sonner";
+import { AuthContext } from "../context/AuthContext";
+import type { TitleRatingResponse } from "../types";
+
+const mockUser = { id: "1", username: "test", display_name: null, auth_provider: "local", is_admin: false };
+
+const mockAuthValue = {
+  user: mockUser,
+  providers: null,
+  loading: false,
+  login: mock(() => Promise.resolve()),
+  signup: mock(() => Promise.resolve()),
+  logout: mock(() => Promise.resolve()),
+  refresh: mock(() => Promise.resolve()),
+};
+
+function Wrapper({ children, authValue }: { children: ReactNode; authValue?: typeof mockAuthValue }) {
+  return <AuthContext value={(authValue ?? mockAuthValue) as any}>{children}</AuthContext>;
+}
+
+const emptyRatingResponse: TitleRatingResponse = {
+  user_rating: null,
+  aggregated: { HATE: 0, DISLIKE: 0, LIKE: 0, LOVE: 0 },
+  friends_ratings: [],
+};
+
+const ratedResponse: TitleRatingResponse = {
+  user_rating: "LIKE",
+  aggregated: { HATE: 1, DISLIKE: 0, LIKE: 3, LOVE: 2 },
+  friends_ratings: [],
+};
+
+const friendsResponse: TitleRatingResponse = {
+  user_rating: null,
+  aggregated: { HATE: 0, DISLIKE: 1, LIKE: 2, LOVE: 1 },
+  friends_ratings: [
+    { user: { id: "u2", username: "alice" }, rating: "LIKE" },
+    { user: { id: "u3", username: "bob" }, rating: "LOVE" },
+  ],
+};
+
+let spies: ReturnType<typeof spyOn>[] = [];
+
+beforeEach(() => {
+  spies = [
+    spyOn(api, "getTitleRating").mockResolvedValue(emptyRatingResponse),
+    spyOn(api, "rateTitle").mockResolvedValue(undefined),
+    spyOn(api, "unrateTitle").mockResolvedValue(undefined),
+    spyOn(sonner.toast, "success").mockImplementation(() => "1" as any),
+    spyOn(sonner.toast, "error").mockImplementation(() => "1" as any),
+  ];
+});
+
+afterEach(() => {
+  cleanup();
+  for (const spy of spies) spy.mockRestore();
+  spies = [];
+});
+
+describe("RatingButtons", () => {
+  it("renders 4 rating buttons", async () => {
+    render(<RatingButtons titleId="title-1" />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Hate" })).toBeDefined();
+    });
+
+    expect(screen.getByRole("button", { name: "Dislike" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Like" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Love" })).toBeDefined();
+  });
+
+  it("shows loading skeleton on mount", () => {
+    // Make getTitleRating hang
+    (api.getTitleRating as any).mockImplementation(
+      () => new Promise<TitleRatingResponse>(() => {})
+    );
+
+    render(<RatingButtons titleId="title-1" />, { wrapper: Wrapper });
+
+    expect(screen.getByTestId("rating-loading")).toBeDefined();
+  });
+
+  it("clicking a rating calls rateTitle API", async () => {
+    // After rating, the refresh call returns the new state
+    (api.getTitleRating as any)
+      .mockResolvedValueOnce(emptyRatingResponse)
+      .mockResolvedValueOnce({ ...emptyRatingResponse, user_rating: "LIKE", aggregated: { ...emptyRatingResponse.aggregated, LIKE: 1 } });
+
+    render(<RatingButtons titleId="title-1" />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Like" })).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Like" }));
+
+    await waitFor(() => {
+      expect(api.rateTitle).toHaveBeenCalledWith("title-1", "LIKE");
+    });
+
+    expect(sonner.toast.success).toHaveBeenCalledWith("Rating saved");
+  });
+
+  it("clicking active rating calls unrateTitle API", async () => {
+    (api.getTitleRating as any)
+      .mockResolvedValueOnce(ratedResponse)
+      .mockResolvedValueOnce({ ...ratedResponse, user_rating: null, aggregated: { ...ratedResponse.aggregated, LIKE: 2 } });
+
+    render(<RatingButtons titleId="title-1" />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Like" })).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Like" }));
+
+    await waitFor(() => {
+      expect(api.unrateTitle).toHaveBeenCalledWith("title-1");
+    });
+
+    expect(sonner.toast.success).toHaveBeenCalledWith("Rating removed");
+  });
+
+  it("active rating button has aria-pressed=true", async () => {
+    (api.getTitleRating as any).mockResolvedValue(ratedResponse);
+
+    render(<RatingButtons titleId="title-1" />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Like" }).getAttribute("aria-pressed")).toBe("true");
+    });
+
+    // Others should be false
+    expect(screen.getByRole("button", { name: "Hate" }).getAttribute("aria-pressed")).toBe("false");
+    expect(screen.getByRole("button", { name: "Dislike" }).getAttribute("aria-pressed")).toBe("false");
+    expect(screen.getByRole("button", { name: "Love" }).getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("shows aggregated counts when > 0", async () => {
+    (api.getTitleRating as any).mockResolvedValue(ratedResponse);
+
+    render(<RatingButtons titleId="title-1" />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Like" })).toBeDefined();
+    });
+
+    // ratedResponse has HATE: 1, LIKE: 3, LOVE: 2 — those should be visible
+    const hateBtn = screen.getByRole("button", { name: "Hate" });
+    expect(hateBtn.textContent).toContain("1");
+
+    const likeBtn = screen.getByRole("button", { name: "Like" });
+    expect(likeBtn.textContent).toContain("3");
+
+    const loveBtn = screen.getByRole("button", { name: "Love" });
+    expect(loveBtn.textContent).toContain("2");
+  });
+
+  it("buttons are disabled during API call", async () => {
+    let resolveRate: () => void;
+    (api.rateTitle as any).mockImplementationOnce(
+      () => new Promise<void>((resolve) => { resolveRate = resolve; })
+    );
+
+    render(<RatingButtons titleId="title-1" />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Like" })).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Like" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Like" }).hasAttribute("disabled")).toBe(true);
+    });
+
+    // All buttons should be disabled
+    expect(screen.getByRole("button", { name: "Hate" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "Dislike" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "Love" }).hasAttribute("disabled")).toBe(true);
+
+    resolveRate!();
+  });
+
+  it("shows error toast when rating fails", async () => {
+    (api.rateTitle as any).mockRejectedValueOnce(new Error("Network error"));
+
+    render(<RatingButtons titleId="title-1" />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Love" })).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Love" }));
+
+    await waitFor(() => {
+      expect(sonner.toast.error).toHaveBeenCalledWith("Failed to update rating");
+    });
+  });
+
+  it("shows read-only buttons when not authenticated", async () => {
+    const noUserAuth = { ...mockAuthValue, user: null };
+
+    render(
+      <AuthContext value={noUserAuth as any}>
+        <RatingButtons titleId="title-1" />
+      </AuthContext>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Like" })).toBeDefined();
+    });
+
+    // All buttons should be disabled
+    expect(screen.getByRole("button", { name: "Hate" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "Dislike" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "Like" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "Love" }).hasAttribute("disabled")).toBe(true);
+  });
+
+  it("displays friends' ratings summary", async () => {
+    (api.getTitleRating as any).mockResolvedValue(friendsResponse);
+
+    render(<RatingButtons titleId="title-1" />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("friends-ratings")).toBeDefined();
+    });
+
+    const friendsText = screen.getByTestId("friends-ratings").textContent;
+    expect(friendsText).toContain("alice liked");
+    expect(friendsText).toContain("bob loved");
+  });
+
+  it("does not show friends section when there are no friends' ratings", async () => {
+    render(<RatingButtons titleId="title-1" />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Like" })).toBeDefined();
+    });
+
+    expect(screen.queryByTestId("friends-ratings")).toBeNull();
+  });
+
+  it("fetches rating data on mount", async () => {
+    render(<RatingButtons titleId="title-42" />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(api.getTitleRating).toHaveBeenCalledWith("title-42");
+    });
+  });
+});

--- a/frontend/src/components/RatingButtons.tsx
+++ b/frontend/src/components/RatingButtons.tsx
@@ -1,0 +1,178 @@
+import { useState, useEffect, useCallback } from "react";
+import { ThumbsDown, ThumbsUp, Heart } from "lucide-react";
+import { toast } from "sonner";
+import * as api from "../api";
+import type { RatingValue, TitleRatingResponse } from "../types";
+import { useAuth } from "../context/AuthContext";
+
+interface RatingButtonsProps {
+  titleId: string;
+}
+
+const RATING_CONFIG: {
+  value: RatingValue;
+  Icon: typeof ThumbsDown;
+  label: string;
+  activeColor: string;
+  activeBg: string;
+  filled?: boolean;
+}[] = [
+  {
+    value: "HATE",
+    Icon: ThumbsDown,
+    label: "Hate",
+    activeColor: "text-white",
+    activeBg: "bg-red-500",
+    filled: true,
+  },
+  {
+    value: "DISLIKE",
+    Icon: ThumbsDown,
+    label: "Dislike",
+    activeColor: "text-white",
+    activeBg: "bg-orange-500",
+  },
+  {
+    value: "LIKE",
+    Icon: ThumbsUp,
+    label: "Like",
+    activeColor: "text-white",
+    activeBg: "bg-blue-500",
+  },
+  {
+    value: "LOVE",
+    Icon: Heart,
+    label: "Love",
+    activeColor: "text-white",
+    activeBg: "bg-pink-500",
+    filled: true,
+  },
+];
+
+export default function RatingButtons({ titleId }: RatingButtonsProps) {
+  const { user } = useAuth();
+  const [ratingData, setRatingData] = useState<TitleRatingResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+
+  const fetchRating = useCallback(async () => {
+    try {
+      const data = await api.getTitleRating(titleId);
+      setRatingData(data);
+    } catch {
+      // Silently handle — rating data is non-critical
+    } finally {
+      setLoading(false);
+    }
+  }, [titleId]);
+
+  useEffect(() => {
+    fetchRating();
+  }, [fetchRating]);
+
+  async function handleRate(value: RatingValue) {
+    if (submitting || !user) return;
+
+    const isActive = ratingData?.user_rating === value;
+    setSubmitting(true);
+
+    try {
+      if (isActive) {
+        await api.unrateTitle(titleId);
+        setRatingData((prev) =>
+          prev ? { ...prev, user_rating: null } : prev
+        );
+        toast.success("Rating removed");
+      } else {
+        await api.rateTitle(titleId, value);
+        setRatingData((prev) =>
+          prev ? { ...prev, user_rating: value } : prev
+        );
+        toast.success("Rating saved");
+      }
+      // Refresh to get updated aggregated counts
+      const updated = await api.getTitleRating(titleId);
+      setRatingData(updated);
+    } catch {
+      toast.error("Failed to update rating");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2" data-testid="rating-loading">
+        {RATING_CONFIG.map(({ value }) => (
+          <div key={value} className="h-9 w-16 rounded-lg bg-zinc-800 animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!ratingData) return null;
+
+  const isReadOnly = !user;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        {RATING_CONFIG.map(({ value, Icon, label, activeColor, activeBg, filled }) => {
+          const isActive = ratingData.user_rating === value;
+          const count = ratingData.aggregated[value] || 0;
+
+          return (
+            <button
+              key={value}
+              onClick={() => handleRate(value)}
+              disabled={submitting || isReadOnly}
+              aria-label={label}
+              aria-pressed={isActive}
+              className={`inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
+                isActive
+                  ? `${activeBg} ${activeColor}`
+                  : "bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-300"
+              } disabled:cursor-default ${isReadOnly ? "" : "disabled:opacity-50"}`}
+            >
+              <Icon
+                className="w-4 h-4"
+                fill={isActive && filled ? "currentColor" : "none"}
+                strokeWidth={value === "HATE" ? 2.5 : 2}
+              />
+              {count > 0 && <span className="text-xs">{count}</span>}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Friends' Ratings */}
+      {ratingData.friends_ratings.length > 0 && (
+        <FriendsRatings ratings={ratingData.friends_ratings} />
+      )}
+    </div>
+  );
+}
+
+function FriendsRatings({ ratings }: { ratings: TitleRatingResponse["friends_ratings"] }) {
+  const ratingLabels: Record<RatingValue, string> = {
+    HATE: "hated",
+    DISLIKE: "disliked",
+    LIKE: "liked",
+    LOVE: "loved",
+  };
+
+  const parts = ratings.map(
+    (fr) => `${fr.user.username} ${ratingLabels[fr.rating]}`
+  );
+
+  // Show up to 3 friends inline, then "+N more"
+  const visible = parts.slice(0, 3);
+  const remaining = parts.length - visible.length;
+
+  return (
+    <p className="text-xs text-zinc-400" data-testid="friends-ratings">
+      Friends: {visible.join(", ")}
+      {remaining > 0 && ` +${remaining} more`}
+    </p>
+  );
+}

--- a/frontend/src/pages/TitleDetailPage.tsx
+++ b/frontend/src/pages/TitleDetailPage.tsx
@@ -13,6 +13,7 @@ import type {
   SeasonSummary,
 } from "../types";
 import TrackButton from "../components/TrackButton";
+import RatingButtons from "../components/RatingButtons";
 import PersonCard from "../components/PersonCard";
 import { DetailPageSkeleton } from "../components/SkeletonComponents";
 import ExternalLinks from "../components/ExternalLinks";
@@ -358,6 +359,8 @@ function MovieDetail({ data }: { data: MovieDetailsResponse }) {
               })()}
               <ShareButton title={tmdb?.title || title.title} />
             </div>
+
+            <RatingButtons titleId={title.id} />
           </div>
         </div>
       </div>
@@ -654,6 +657,8 @@ function ShowDetail({ data }: { data: ShowDetailsResponse }) {
               })()}
               <ShareButton title={tmdb?.name || title.title} />
             </div>
+
+            <RatingButtons titleId={title.id} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add `RatingButtons` component with HATE/DISLIKE/LIKE/LOVE buttons using lucide-react icons (ThumbsDown, ThumbsUp, Heart)
- Integrate with existing ratings API (`rateTitle`, `unrateTitle`, `getTitleRating`)
- Display aggregated counts per rating, friends' ratings summary, loading/error states
- Read-only mode for unauthenticated users
- Add RatingButtons to both MovieDetail and ShowDetail sections in TitleDetailPage
- Add 12 tests covering rendering, API interactions, loading states, auth behavior, and friends display

## Test plan
- [x] All 12 new RatingButtons tests pass
- [x] All 439 frontend tests pass (0 failures)
- [x] All 814 server tests pass (0 failures)
- [x] ESLint passes with 0 errors
- [ ] Verify rating buttons render on movie detail pages
- [ ] Verify rating buttons render on show detail pages
- [ ] Verify clicking a rating calls the API and updates the UI
- [ ] Verify clicking an active rating removes it
- [ ] Verify friends' ratings appear when present

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)