### PR TITLE
Add Discovery page for received recommendations

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,7 @@ const EpisodeDetailPage = lazyWithRetry(() => import("./pages/EpisodeDetailPage"
 const PersonPage = lazyWithRetry(() => import("./pages/PersonPage"));
 const ReelsPage = lazyWithRetry(() => import("./pages/ReelsPage"));
 const UpcomingPage = lazyWithRetry(() => import("./pages/UpcomingPage"));
+const DiscoveryPage = lazyWithRetry(() => import("./pages/DiscoveryPage"));
 
 function MobileHomeRedirect() {
   const { user, loading } = useAuth();
@@ -150,6 +151,7 @@ export default function App() {
             <Route path="/calendar" element={<RequireAuth><CalendarPage /></RequireAuth>} />
             <Route path="/reels" element={<RequireAuth><ReelsPage /></RequireAuth>} />
             <Route path="/upcoming" element={<RequireAuth><UpcomingPage /></RequireAuth>} />
+            <Route path="/discovery" element={<RequireAuth><DiscoveryPage /></RequireAuth>} />
             <Route path="/user/:username" element={<UserProfilePage />} />
             <Route path="/settings" element={<RequireAuth><SettingsPage /></RequireAuth>} />
             <Route path="/profile" element={<ProfilePage />} />

--- a/frontend/src/components/BottomTabBar.test.tsx
+++ b/frontend/src/components/BottomTabBar.test.tsx
@@ -2,6 +2,15 @@ import { describe, it, expect, mock, afterEach } from "bun:test";
 import { render, screen, cleanup } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import type { ReactNode } from "react";
+
+// Initialize i18n
+import "../i18n";
+
+// Mock the API module before importing BottomTabBar
+mock.module("../api", () => ({
+  getUnreadRecommendationCount: mock(() => Promise.resolve({ count: 0 })),
+}));
+
 import BottomTabBar from "./BottomTabBar";
 import { AuthContext } from "../context/AuthContext";
 
@@ -34,8 +43,8 @@ describe("BottomTabBar", () => {
 
     expect(screen.getByText("Watch")).toBeDefined();
     expect(screen.getByText("Upcoming")).toBeDefined();
+    expect(screen.getByText("Discovery")).toBeDefined();
     expect(screen.getByText("Browse")).toBeDefined();
-    expect(screen.getByText("Calendar")).toBeDefined();
     expect(screen.getByText("Profile")).toBeDefined();
   });
 
@@ -53,7 +62,7 @@ describe("BottomTabBar", () => {
     expect(screen.getByText("Sign In")).toBeDefined();
     expect(screen.queryByText("Watch")).toBeNull();
     expect(screen.queryByText("Upcoming")).toBeNull();
-    expect(screen.queryByText("Calendar")).toBeNull();
+    expect(screen.queryByText("Discovery")).toBeNull();
     expect(screen.queryByText("Profile")).toBeNull();
   });
 
@@ -83,8 +92,8 @@ describe("BottomTabBar", () => {
     const hrefs = links.map((link) => link.getAttribute("href"));
     expect(hrefs).toContain("/reels");
     expect(hrefs).toContain("/upcoming");
+    expect(hrefs).toContain("/discovery");
     expect(hrefs).toContain("/browse");
-    expect(hrefs).toContain("/calendar");
     expect(hrefs).toContain("/user/test");
   });
 

--- a/frontend/src/components/BottomTabBar.tsx
+++ b/frontend/src/components/BottomTabBar.tsx
@@ -1,14 +1,23 @@
 import { NavLink } from "react-router";
-import { Clapperboard, Clock, Search, CalendarDays, User, LogIn } from "lucide-react";
+import { Clapperboard, Clock, Search, Sparkles, User, LogIn } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../context/AuthContext";
 import { bottomTabClass } from "../nav-utils";
+import { useApiCall } from "../hooks/useApiCall";
+import * as api from "../api";
 
 const ICON_SIZE = 20;
 
 export default function BottomTabBar() {
   const { user, loading } = useAuth();
   const { t } = useTranslation();
+
+  const { data: countData } = useApiCall(
+    () => (user ? api.getUnreadRecommendationCount() : Promise.resolve({ count: 0 })),
+    [user?.id],
+  );
+
+  const unreadCount = countData?.count ?? 0;
 
   if (loading) return null;
 
@@ -27,14 +36,24 @@ export default function BottomTabBar() {
               <span className="text-[10px] mt-0.5">{t("bottomNav.upcoming")}</span>
             </NavLink>
 
+            <NavLink to="/discovery" className={({ isActive }) => bottomTabClass(isActive)}>
+              <div className="relative">
+                <Sparkles size={ICON_SIZE} aria-hidden="true" />
+                {unreadCount > 0 && (
+                  <span
+                    data-testid="unread-badge"
+                    className="absolute -top-1 -right-2 min-w-4 h-4 px-1 flex items-center justify-center rounded-full bg-amber-500 text-zinc-950 text-[9px] font-bold leading-none"
+                  >
+                    {unreadCount > 99 ? "99+" : unreadCount}
+                  </span>
+                )}
+              </div>
+              <span className="text-[10px] mt-0.5">{t("bottomNav.discovery")}</span>
+            </NavLink>
+
             <NavLink to="/browse" className={({ isActive }) => bottomTabClass(isActive)}>
               <Search size={ICON_SIZE} aria-hidden="true" />
               <span className="text-[10px] mt-0.5">{t("bottomNav.browse")}</span>
-            </NavLink>
-
-            <NavLink to="/calendar" className={({ isActive }) => bottomTabClass(isActive)}>
-              <CalendarDays size={ICON_SIZE} aria-hidden="true" />
-              <span className="text-[10px] mt-0.5">{t("bottomNav.calendar")}</span>
             </NavLink>
 
             <NavLink to={`/user/${user.username}`} className={({ isActive }) => bottomTabClass(isActive)}>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -14,6 +14,7 @@
     "upcoming": "Upcoming",
     "browse": "Browse",
     "calendar": "Calendar",
+    "discovery": "Discovery",
     "profile": "Profile",
     "signIn": "Sign In"
   },
@@ -233,6 +234,17 @@
     "enable": "Enable",
     "enabling": "Enabling...",
     "dismiss": "Dismiss notification prompt"
+  },
+  "discovery": {
+    "title": "Discovery",
+    "empty": "No recommendations yet. Follow people to get recommendations!",
+    "movie": "Movie",
+    "tv": "TV Show",
+    "track": "Track",
+    "dismiss": "Dismiss",
+    "tracked": "\"{{title}}\" added to your watchlist",
+    "trackFailed": "Failed to track title",
+    "dismissFailed": "Failed to dismiss recommendation"
   },
   "common": {
     "loading": "Loading...",

--- a/frontend/src/pages/DiscoveryPage.test.tsx
+++ b/frontend/src/pages/DiscoveryPage.test.tsx
@@ -1,0 +1,267 @@
+import { describe, it, expect, mock, afterEach } from "bun:test";
+import { render, screen, waitFor, cleanup, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import type { ReactNode } from "react";
+
+// Initialize i18n before anything else
+import "../i18n";
+
+// Mock auth context
+mock.module("../context/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: "u1", username: "testuser", display_name: null, auth_provider: "local", is_admin: false },
+    providers: { local: true, oidc: null },
+    loading: false,
+    login: mock(() => Promise.resolve()),
+    signup: mock(() => Promise.resolve()),
+    logout: mock(() => Promise.resolve()),
+    refresh: mock(() => Promise.resolve()),
+  }),
+  AuthContext: {
+    Provider: ({ children }: { children: ReactNode }) => children,
+  },
+}));
+
+// Mock IntersectionObserver
+class MockIntersectionObserver {
+  callback: IntersectionObserverCallback;
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+Object.defineProperty(globalThis, "IntersectionObserver", {
+  value: MockIntersectionObserver,
+  writable: true,
+  configurable: true,
+});
+
+const mockGetRecommendations = mock(() =>
+  Promise.resolve({ recommendations: [], count: 0 })
+);
+const mockGetUnreadCount = mock(() =>
+  Promise.resolve({ count: 0 })
+);
+const mockTrackTitle = mock(() => Promise.resolve());
+const mockMarkRecommendationRead = mock(() => Promise.resolve());
+const mockDeleteRecommendation = mock(() => Promise.resolve());
+
+mock.module("../api", () => ({
+  getRecommendations: mockGetRecommendations,
+  getUnreadRecommendationCount: mockGetUnreadCount,
+  trackTitle: mockTrackTitle,
+  markRecommendationRead: mockMarkRecommendationRead,
+  deleteRecommendation: mockDeleteRecommendation,
+}));
+
+const { default: DiscoveryPage } = await import("./DiscoveryPage");
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
+
+function makeRecommendation(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    from_user: {
+      id: "sender1",
+      username: "alice",
+      name: "Alice",
+      display_name: "Alice",
+      image: null,
+    },
+    title: {
+      id: `title-${id}`,
+      title: `Movie ${id}`,
+      object_type: "MOVIE",
+      poster_url: null,
+    },
+    message: null,
+    created_at: new Date().toISOString(),
+    read_at: null,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  mockGetRecommendations.mockReset();
+  mockGetUnreadCount.mockReset();
+  mockTrackTitle.mockReset();
+  mockMarkRecommendationRead.mockReset();
+  mockDeleteRecommendation.mockReset();
+
+  // Reset defaults
+  mockGetRecommendations.mockImplementation(() =>
+    Promise.resolve({ recommendations: [], count: 0 })
+  );
+  mockGetUnreadCount.mockImplementation(() =>
+    Promise.resolve({ count: 0 })
+  );
+});
+
+describe("DiscoveryPage", () => {
+  it("shows empty state when no recommendations", async () => {
+    mockGetRecommendations.mockImplementation(() =>
+      Promise.resolve({ recommendations: [], count: 0 })
+    );
+    mockGetUnreadCount.mockImplementation(() =>
+      Promise.resolve({ count: 0 })
+    );
+
+    render(<DiscoveryPage />, { wrapper: Wrapper });
+
+    await waitFor(() =>
+      expect(screen.getByText(/No recommendations yet/)).toBeDefined()
+    );
+  });
+
+  it("renders recommendations list", async () => {
+    const recs = [
+      makeRecommendation("r1"),
+      makeRecommendation("r2", {
+        from_user: { id: "sender2", username: "bob", name: "Bob", display_name: "Bob", image: null },
+        title: { id: "title-r2", title: "Show R2", object_type: "SHOW", poster_url: null },
+        message: "You should watch this!",
+      }),
+    ];
+    mockGetRecommendations.mockImplementation(() =>
+      Promise.resolve({ recommendations: recs, count: 2 })
+    );
+    mockGetUnreadCount.mockImplementation(() =>
+      Promise.resolve({ count: 2 })
+    );
+
+    render(<DiscoveryPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Movie r1")).toBeDefined();
+      expect(screen.getByText("Show R2")).toBeDefined();
+      expect(screen.getByText(/You should watch this!/)).toBeDefined();
+    });
+  });
+
+  it("shows unread count badge", async () => {
+    mockGetRecommendations.mockImplementation(() =>
+      Promise.resolve({ recommendations: [], count: 0 })
+    );
+    mockGetUnreadCount.mockImplementation(() =>
+      Promise.resolve({ count: 5 })
+    );
+
+    render(<DiscoveryPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("5")).toBeDefined();
+    });
+  });
+
+  it("track button calls trackTitle and removes the card", async () => {
+    const rec = makeRecommendation("r1");
+    mockGetRecommendations.mockImplementation(() =>
+      Promise.resolve({ recommendations: [rec], count: 1 })
+    );
+    mockGetUnreadCount.mockImplementation(() =>
+      Promise.resolve({ count: 1 })
+    );
+    mockTrackTitle.mockImplementation(() => Promise.resolve());
+    mockMarkRecommendationRead.mockImplementation(() => Promise.resolve());
+
+    render(<DiscoveryPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Movie r1")).toBeDefined();
+    });
+
+    const trackButtons = screen.getAllByText("Track");
+    fireEvent.click(trackButtons[0]);
+
+    await waitFor(() => {
+      expect(mockTrackTitle).toHaveBeenCalledWith("title-r1");
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Movie r1")).toBeNull();
+    });
+  });
+
+  it("dismiss button calls deleteRecommendation and removes the card", async () => {
+    const rec = makeRecommendation("r1");
+    mockGetRecommendations.mockImplementation(() =>
+      Promise.resolve({ recommendations: [rec], count: 1 })
+    );
+    mockGetUnreadCount.mockImplementation(() =>
+      Promise.resolve({ count: 0 })
+    );
+    mockDeleteRecommendation.mockImplementation(() => Promise.resolve());
+
+    render(<DiscoveryPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Movie r1")).toBeDefined();
+    });
+
+    const dismissButtons = screen.getAllByText("Dismiss");
+    fireEvent.click(dismissButtons[0]);
+
+    await waitFor(() => {
+      expect(mockDeleteRecommendation).toHaveBeenCalledWith("r1");
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Movie r1")).toBeNull();
+    });
+  });
+
+  it("shows sender name and optional message", async () => {
+    const rec = makeRecommendation("r1", {
+      from_user: { id: "s1", username: "charlie", name: "Charlie D", display_name: "Charlie D", image: null },
+      message: "Great film!",
+    });
+    mockGetRecommendations.mockImplementation(() =>
+      Promise.resolve({ recommendations: [rec], count: 1 })
+    );
+    mockGetUnreadCount.mockImplementation(() =>
+      Promise.resolve({ count: 0 })
+    );
+
+    render(<DiscoveryPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Charlie D")).toBeDefined();
+      expect(screen.getByText(/Great film!/)).toBeDefined();
+    });
+  });
+
+  it("distinguishes movie and TV type labels", async () => {
+    const recs = [
+      makeRecommendation("r1", {
+        title: { id: "t1", title: "A Movie", object_type: "MOVIE", poster_url: null },
+      }),
+      makeRecommendation("r2", {
+        title: { id: "t2", title: "A Show", object_type: "SHOW", poster_url: null },
+      }),
+    ];
+    mockGetRecommendations.mockImplementation(() =>
+      Promise.resolve({ recommendations: recs, count: 2 })
+    );
+    mockGetUnreadCount.mockImplementation(() =>
+      Promise.resolve({ count: 0 })
+    );
+
+    render(<DiscoveryPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("A Movie")).toBeDefined();
+      expect(screen.getByText("A Show")).toBeDefined();
+    });
+
+    // Check type badges
+    const movieBadges = screen.getAllByText("Movie");
+    const tvBadges = screen.getAllByText("TV Show");
+    expect(movieBadges.length).toBeGreaterThanOrEqual(1);
+    expect(tvBadges.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/frontend/src/pages/DiscoveryPage.tsx
+++ b/frontend/src/pages/DiscoveryPage.tsx
@@ -1,0 +1,261 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { Link } from "react-router";
+import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
+import * as api from "../api";
+import type { Recommendation } from "../types";
+import { useApiCall } from "../hooks/useApiCall";
+import { Skeleton } from "../components/ui/skeleton";
+
+function formatRelativeTime(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diffMs = now - then;
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHr = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHr / 24);
+
+  if (diffSec < 60) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHr < 24) return `${diffHr}h ago`;
+  if (diffDay < 30) return `${diffDay}d ago`;
+  return new Date(dateStr).toLocaleDateString();
+}
+
+function DiscoverySkeleton() {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="bg-zinc-900 rounded-lg p-4">
+          <div className="flex gap-3">
+            <Skeleton className="w-8 h-8 rounded-full flex-shrink-0" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <div className="flex gap-3">
+                <Skeleton className="w-12 h-18 rounded flex-shrink-0" />
+                <div className="flex-1 space-y-1.5">
+                  <Skeleton className="h-4 w-48" />
+                  <Skeleton className="h-3 w-20" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function RecommendationCard({
+  rec,
+  onTrack,
+  onDismiss,
+  onMarkRead,
+}: {
+  rec: Recommendation;
+  onTrack: (rec: Recommendation) => void;
+  onDismiss: (rec: Recommendation) => void;
+  onMarkRead: (rec: Recommendation) => void;
+}) {
+  const { t } = useTranslation();
+  const cardRef = useRef<HTMLDivElement>(null);
+  const markedRef = useRef(false);
+
+  useEffect(() => {
+    if (rec.read_at || markedRef.current) return;
+
+    const el = cardRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && !markedRef.current) {
+          markedRef.current = true;
+          onMarkRead(rec);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.5 },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [rec, onMarkRead]);
+
+  const isUnread = !rec.read_at;
+  const posterSrc = rec.title.poster_url
+    ? `https://image.tmdb.org/t/p/w92${rec.title.poster_url}`
+    : null;
+
+  const senderName = rec.from_user.name ?? rec.from_user.display_name ?? rec.from_user.username;
+  const senderInitial = (senderName || "?")[0].toUpperCase();
+
+  return (
+    <div
+      ref={cardRef}
+      className={`bg-zinc-900 rounded-lg p-4 transition-colors ${isUnread ? "border-l-2 border-l-amber-500" : ""}`}
+    >
+      {/* Sender row */}
+      <div className="flex items-center gap-2 mb-3">
+        {rec.from_user.image ? (
+          <img
+            src={rec.from_user.image}
+            alt=""
+            className="w-7 h-7 rounded-full object-cover flex-shrink-0"
+          />
+        ) : (
+          <div className="w-7 h-7 rounded-full bg-zinc-700 flex items-center justify-center text-xs font-medium text-zinc-300 flex-shrink-0">
+            {senderInitial}
+          </div>
+        )}
+        <span className="text-sm text-zinc-300 font-medium">{senderName}</span>
+        <span className="text-xs text-zinc-500 ml-auto">{formatRelativeTime(rec.created_at)}</span>
+      </div>
+
+      {/* Title info */}
+      <div className="flex gap-3 mb-3">
+        <Link to={`/title/${rec.title.id}`} className="flex-shrink-0">
+          {posterSrc ? (
+            <img
+              src={posterSrc}
+              alt={rec.title.title}
+              className="w-12 h-18 rounded object-cover"
+              loading="lazy"
+            />
+          ) : (
+            <div className="w-12 h-18 rounded bg-zinc-800 flex items-center justify-center text-zinc-600 text-xs">
+              N/A
+            </div>
+          )}
+        </Link>
+        <div className="flex-1 min-w-0">
+          <Link
+            to={`/title/${rec.title.id}`}
+            className="text-sm font-medium text-white hover:text-amber-400 transition-colors line-clamp-2"
+          >
+            {rec.title.title}
+          </Link>
+          <p className="text-xs text-zinc-500 mt-0.5">
+            {rec.title.object_type === "MOVIE" ? t("discovery.movie") : t("discovery.tv")}
+          </p>
+        </div>
+      </div>
+
+      {/* Optional message */}
+      {rec.message && (
+        <p className="text-sm text-zinc-400 mb-3 italic">&ldquo;{rec.message}&rdquo;</p>
+      )}
+
+      {/* Actions */}
+      <div className="flex gap-2">
+        <button
+          onClick={() => onTrack(rec)}
+          className="inline-flex items-center justify-center px-3 py-1.5 rounded-md text-xs font-medium bg-amber-500 text-zinc-950 hover:bg-amber-400 transition-colors cursor-pointer"
+        >
+          {t("discovery.track")}
+        </button>
+        <button
+          onClick={() => onDismiss(rec)}
+          className="inline-flex items-center justify-center px-3 py-1.5 rounded-md text-xs font-medium bg-zinc-700 text-zinc-300 hover:bg-zinc-600 transition-colors cursor-pointer"
+        >
+          {t("discovery.dismiss")}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function DiscoveryPage() {
+  const { t } = useTranslation();
+  const [recommendations, setRecommendations] = useState<Recommendation[]>([]);
+
+  const { loading, error } = useApiCall(
+    () => api.getRecommendations(),
+    [],
+    {
+      onSuccess: (data) => {
+        setRecommendations(data.recommendations);
+      },
+    },
+  );
+
+  const { data: countData } = useApiCall(
+    () => api.getUnreadRecommendationCount(),
+    [],
+  );
+
+  const unreadCount = countData?.count ?? 0;
+
+  const handleMarkRead = useCallback(async (rec: Recommendation) => {
+    try {
+      await api.markRecommendationRead(rec.id);
+      setRecommendations((prev) =>
+        prev.map((r) =>
+          r.id === rec.id ? { ...r, read_at: new Date().toISOString() } : r,
+        ),
+      );
+    } catch {
+      // Silent failure for mark-read
+    }
+  }, []);
+
+  const handleTrack = useCallback(async (rec: Recommendation) => {
+    try {
+      await api.trackTitle(rec.title.id);
+      if (!rec.read_at) {
+        await api.markRecommendationRead(rec.id);
+      }
+      setRecommendations((prev) => prev.filter((r) => r.id !== rec.id));
+      toast.success(t("discovery.tracked", { title: rec.title.title }));
+    } catch {
+      toast.error(t("discovery.trackFailed"));
+    }
+  }, [t]);
+
+  const handleDismiss = useCallback(async (rec: Recommendation) => {
+    try {
+      await api.deleteRecommendation(rec.id);
+      setRecommendations((prev) => prev.filter((r) => r.id !== rec.id));
+    } catch {
+      toast.error(t("discovery.dismissFailed"));
+    }
+  }, [t]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <h2 className="text-lg font-semibold">{t("discovery.title")}</h2>
+        {unreadCount > 0 && (
+          <span className="inline-flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full bg-amber-500 text-zinc-950 text-xs font-bold">
+            {unreadCount}
+          </span>
+        )}
+      </div>
+
+      {loading ? (
+        <DiscoverySkeleton />
+      ) : error ? (
+        <div className="bg-red-900/50 border border-red-800 text-red-200 px-4 py-2 rounded-lg text-sm">
+          {error}
+        </div>
+      ) : recommendations.length === 0 ? (
+        <p className="text-zinc-500 text-sm py-8 text-center">
+          {t("discovery.empty")}
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {recommendations.map((rec) => (
+            <RecommendationCard
+              key={rec.id}
+              rec={rec}
+              onTrack={handleTrack}
+              onDismiss={handleDismiss}
+              onMarkRead={handleMarkRead}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `DiscoveryPage` at `/discovery` for viewing received recommendations with track/dismiss actions
- Replace Calendar tab in mobile bottom nav with Discovery tab, including unread count badge
- Mark recommendations as read automatically via IntersectionObserver when cards become visible

## Test plan
- [x] All 1281 tests pass (`bun run check`)
- [x] DiscoveryPage tests: empty state, recommendation list rendering, track/dismiss actions, unread badge, sender info, type labels
- [x] BottomTabBar tests updated for Discovery tab replacing Calendar tab
- [ ] Manual: verify Discovery page loads at `/discovery` with auth required
- [ ] Manual: verify bottom tab bar shows Discovery tab with unread badge on mobile
- [ ] Manual: verify track button adds title to watchlist and removes card
- [ ] Manual: verify dismiss button removes recommendation

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)