### PR TITLE
Add compactOnMobile prop to WatchedToggleButton

### DIFF
--- a/frontend/src/components/EpisodeComponents.tsx
+++ b/frontend/src/components/EpisodeComponents.tsx
@@ -55,8 +55,8 @@ export function isEpisodeReleased(ep: Episode): boolean {
   return ep.air_date <= today;
 }
 
-export function WatchedIcon({ watched, onClick, disabled, size = "sm" }: { watched: boolean; onClick: () => void; disabled?: boolean; size?: "sm" | "md" }) {
-  return <WatchedToggleButton watched={watched} onClick={onClick} disabled={disabled} size={size} />;
+export function WatchedIcon({ watched, onClick, disabled, size = "sm", compactOnMobile }: { watched: boolean; onClick: () => void; disabled?: boolean; size?: "sm" | "md"; compactOnMobile?: boolean }) {
+  return <WatchedToggleButton watched={watched} onClick={onClick} disabled={disabled} size={size} compactOnMobile={compactOnMobile} />;
 }
 
 export function EpisodeCard({ episode, compact, onToggleWatched }: { episode: Episode; compact?: boolean; onToggleWatched: (id: number, current: boolean) => void }) {

--- a/frontend/src/components/WatchedToggleButton.test.tsx
+++ b/frontend/src/components/WatchedToggleButton.test.tsx
@@ -84,4 +84,29 @@ describe("WatchedToggleButton", () => {
     const button = screen.getByRole("button");
     expect(button.className).toContain("text-zinc-400");
   });
+
+  it("hides label on mobile when compactOnMobile is true", () => {
+    render(<WatchedToggleButton watched={true} onClick={() => {}} size="md" compactOnMobile />);
+    const button = screen.getByRole("button");
+    const labelSpan = button.querySelector("span.hidden.sm\\:inline");
+    expect(labelSpan).toBeTruthy();
+    expect(labelSpan!.textContent).toBe("Watched");
+  });
+
+  it("hides label on mobile for disabled state when compactOnMobile is true", () => {
+    const { container } = render(
+      <WatchedToggleButton watched={false} onClick={() => {}} disabled compactOnMobile />,
+    );
+    const span = container.querySelector("span");
+    expect(span).toBeTruthy();
+    const labelSpan = span!.querySelector("span.hidden.sm\\:inline");
+    expect(labelSpan).toBeTruthy();
+  });
+
+  it("uses compact padding when compactOnMobile is true (md size)", () => {
+    render(<WatchedToggleButton watched={false} onClick={() => {}} size="md" compactOnMobile />);
+    const button = screen.getByRole("button");
+    expect(button.className).toContain("px-1.5");
+    expect(button.className).toContain("sm:px-2.5");
+  });
 });

--- a/frontend/src/components/WatchedToggleButton.tsx
+++ b/frontend/src/components/WatchedToggleButton.tsx
@@ -6,6 +6,7 @@ interface WatchedToggleButtonProps {
   onClick: () => void;
   disabled?: boolean;
   size?: "sm" | "md";
+  compactOnMobile?: boolean;
 }
 
 export default function WatchedToggleButton({
@@ -13,6 +14,7 @@ export default function WatchedToggleButton({
   onClick,
   disabled = false,
   size = "sm",
+  compactOnMobile = false,
 }: WatchedToggleButtonProps) {
   const { t } = useTranslation();
 
@@ -30,13 +32,15 @@ export default function WatchedToggleButton({
         className={`inline-flex items-center flex-shrink-0 border cursor-not-allowed opacity-50 bg-zinc-800/50 text-zinc-600 border-zinc-800 ${
           size === "sm"
             ? "px-2 py-0.5 text-xs rounded-full gap-1"
-            : "px-2.5 py-1 text-xs rounded-lg gap-1.5"
+            : compactOnMobile
+              ? "px-1.5 sm:px-2.5 py-1 text-xs rounded-lg gap-1.5"
+              : "px-2.5 py-1 text-xs rounded-lg gap-1.5"
         }`}
         aria-label={t("episodes.notYetReleased")}
         role="img"
       >
         <Circle size={iconSize} aria-hidden="true" />
-        {label}
+        {compactOnMobile ? <span className="hidden sm:inline">{label}</span> : label}
       </span>
     );
   }
@@ -56,7 +60,9 @@ export default function WatchedToggleButton({
       } ${
         size === "sm"
           ? "px-2 py-0.5 text-xs rounded-full gap-1"
-          : "px-2.5 py-1 text-xs rounded-lg gap-1.5"
+          : compactOnMobile
+            ? "px-1.5 sm:px-2.5 py-1 text-xs rounded-lg gap-1.5"
+            : "px-2.5 py-1 text-xs rounded-lg gap-1.5"
       }`}
     >
       {watched ? (
@@ -64,7 +70,7 @@ export default function WatchedToggleButton({
       ) : (
         <Circle size={iconSize} aria-hidden="true" />
       )}
-      {label}
+      {compactOnMobile ? <span className="hidden sm:inline">{label}</span> : label}
     </button>
   );
 }

--- a/frontend/src/pages/SeasonDetailPage.tsx
+++ b/frontend/src/pages/SeasonDetailPage.tsx
@@ -216,6 +216,7 @@ export default function SeasonDetailPage() {
                       onClick={() => toggleWatched(ep.episode_number)}
                       disabled={!released || !status}
                       size="md"
+                      compactOnMobile
                     />
                   )}
 


### PR DESCRIPTION
## Summary
Added a new `compactOnMobile` prop to the `WatchedToggleButton` component that hides the label text on mobile devices and reduces horizontal padding, improving the mobile UI experience for compact layouts.

## Key Changes
- Added `compactOnMobile` optional prop to `WatchedToggleButton` component interface
- When `compactOnMobile` is true:
  - Label text is hidden on mobile and shown only on small screens and up using Tailwind's `hidden sm:inline` classes
  - Horizontal padding is reduced on mobile (`px-1.5`) and restored on larger screens (`sm:px-2.5`) for md size buttons
- Updated `WatchedIcon` wrapper component in `EpisodeComponents.tsx` to accept and forward the `compactOnMobile` prop
- Applied `compactOnMobile` to the season detail page's episode list for improved mobile layout
- Added comprehensive test coverage for the new functionality

## Implementation Details
- The compact styling only applies to `md` size buttons; `sm` size buttons remain unchanged
- Both disabled and active button states support the compact mobile behavior
- Uses Tailwind CSS responsive utilities (`sm:`) to conditionally show/hide content and adjust padding based on screen size

https://claude.ai/code/session_01B2AWbsRdjqov4xErqVTLnr