### PR TITLE
Add Recommended for You section on Home page

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -32,7 +32,9 @@
     "today": "Today",
     "noEpisodes": "No upcoming episodes for your tracked shows.",
     "noEpisodesToday": "No episodes airing today.",
-    "comingUp": "Coming Up"
+    "comingUp": "Coming Up",
+    "recommendedForYou": "Recommended for You",
+    "seeAll": "See all"
   },
   "tracked": {
     "title": "Tracked Titles ({{count}})",

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -14,6 +14,34 @@ mock.module("../context/AuthContext", () => ({
   AuthContext: { Provider: ({ children }: any) => children },
 }));
 
+// Mock IntersectionObserver
+class MockIntersectionObserver {
+  callback: IntersectionObserverCallback;
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+Object.defineProperty(globalThis, "IntersectionObserver", {
+  value: MockIntersectionObserver,
+  writable: true,
+  configurable: true,
+});
+
+// Mock ResizeObserver
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+Object.defineProperty(globalThis, "ResizeObserver", {
+  value: MockResizeObserver,
+  writable: true,
+  configurable: true,
+});
+
 function makeSearchTitle(i: number) {
   return {
     id: `t${i}`,
@@ -37,6 +65,29 @@ function makeSearchTitle(i: number) {
   };
 }
 
+function makeRecommendation(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    from_user: {
+      id: "sender1",
+      username: "alice",
+      name: "Alice",
+      display_name: "Alice",
+      image: null,
+    },
+    title: {
+      id: `title-${id}`,
+      title: `Rec Movie ${id}`,
+      object_type: "MOVIE",
+      poster_url: null,
+    },
+    message: null,
+    created_at: new Date().toISOString(),
+    read_at: null,
+    ...overrides,
+  };
+}
+
 const mockBrowseTitles = mock(() =>
   Promise.resolve({
     titles: Array.from({ length: 20 }, (_, i) => makeSearchTitle(i + 1)),
@@ -46,11 +97,18 @@ const mockBrowseTitles = mock(() =>
   })
 );
 
+const mockGetUpcomingEpisodes = mock(() =>
+  Promise.resolve({ today: [], upcoming: [], unwatched: [] })
+);
+
+const mockGetRecommendations = mock(() =>
+  Promise.resolve({ recommendations: [], count: 0 })
+);
+
 mock.module("../api", () => ({
   browseTitles: mockBrowseTitles,
-  getUpcomingEpisodes: mock(() =>
-    Promise.resolve({ today: [], upcoming: [], unwatched: [] })
-  ),
+  getUpcomingEpisodes: mockGetUpcomingEpisodes,
+  getRecommendations: mockGetRecommendations,
 }));
 
 const { default: HomePage } = await import("./HomePage");
@@ -64,6 +122,16 @@ afterEach(() => {
   mockUser = null;
   mockAuthLoading = false;
   mockBrowseTitles.mockClear();
+  mockGetUpcomingEpisodes.mockClear();
+  mockGetRecommendations.mockClear();
+
+  // Reset defaults
+  mockGetUpcomingEpisodes.mockImplementation(() =>
+    Promise.resolve({ today: [], upcoming: [], unwatched: [] })
+  );
+  mockGetRecommendations.mockImplementation(() =>
+    Promise.resolve({ recommendations: [], count: 0 })
+  );
 });
 
 describe("HomePage — unauthenticated landing", () => {
@@ -131,5 +199,119 @@ describe("HomePage — unauthenticated landing", () => {
 
     const link = screen.getByText(/Discover More/).closest("a");
     expect(link?.getAttribute("href")).toBe("/browse");
+  });
+
+  it("does not show recommendations section when unauthenticated", async () => {
+    render(<HomePage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Track movies & TV shows you love")).toBeDefined();
+    });
+
+    expect(screen.queryByText("Recommended for You")).toBeNull();
+    expect(mockGetRecommendations).not.toHaveBeenCalled();
+  });
+});
+
+describe("HomePage — authenticated recommendations", () => {
+  it("shows recommendations section when recommendations exist", async () => {
+    mockUser = { id: "u1", username: "testuser", display_name: null, auth_provider: "local", is_admin: false };
+    const recs = [
+      makeRecommendation("r1"),
+      makeRecommendation("r2", {
+        from_user: { id: "s2", username: "bob", name: "Bob", display_name: "Bob", image: null },
+        title: { id: "title-r2", title: "Rec Movie r2", object_type: "SHOW", poster_url: null },
+      }),
+    ];
+    mockGetRecommendations.mockImplementation(() =>
+      Promise.resolve({ recommendations: recs, count: 2 })
+    );
+
+    render(<HomePage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Recommended for You")).toBeDefined();
+    });
+
+    expect(screen.getByText("Rec Movie r1")).toBeDefined();
+    expect(screen.getByText("Rec Movie r2")).toBeDefined();
+    expect(screen.getByText("from @alice")).toBeDefined();
+    expect(screen.getByText("from @bob")).toBeDefined();
+  });
+
+  it("hides recommendations section when no recommendations", async () => {
+    mockUser = { id: "u1", username: "testuser", display_name: null, auth_provider: "local", is_admin: false };
+    mockGetRecommendations.mockImplementation(() =>
+      Promise.resolve({ recommendations: [], count: 0 })
+    );
+
+    render(<HomePage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Today")).toBeDefined();
+    });
+
+    expect(screen.queryByText("Recommended for You")).toBeNull();
+  });
+
+  it("fetches recommendations with limit of 6", async () => {
+    mockUser = { id: "u1", username: "testuser", display_name: null, auth_provider: "local", is_admin: false };
+
+    render(<HomePage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(mockGetRecommendations).toHaveBeenCalledWith(6);
+    });
+  });
+
+  it("shows 'See all' link to /discovery", async () => {
+    mockUser = { id: "u1", username: "testuser", display_name: null, auth_provider: "local", is_admin: false };
+    const recs = [makeRecommendation("r1")];
+    mockGetRecommendations.mockImplementation(() =>
+      Promise.resolve({ recommendations: recs, count: 1 })
+    );
+
+    render(<HomePage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Recommended for You")).toBeDefined();
+    });
+
+    const seeAllLink = screen.getByText(/See all/).closest("a");
+    expect(seeAllLink?.getAttribute("href")).toBe("/discovery");
+  });
+
+  it("links recommendation cards to title detail page", async () => {
+    mockUser = { id: "u1", username: "testuser", display_name: null, auth_provider: "local", is_admin: false };
+    const recs = [makeRecommendation("r1")];
+    mockGetRecommendations.mockImplementation(() =>
+      Promise.resolve({ recommendations: recs, count: 1 })
+    );
+
+    render(<HomePage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Rec Movie r1")).toBeDefined();
+    });
+
+    // The card is a link to the title detail page
+    const titleLink = screen.getByText("Rec Movie r1").closest("a");
+    expect(titleLink?.getAttribute("href")).toBe("/title/title-r1");
+  });
+
+  it("still shows today section even when recommendations API fails", async () => {
+    mockUser = { id: "u1", username: "testuser", display_name: null, auth_provider: "local", is_admin: false };
+    mockGetRecommendations.mockImplementation(() =>
+      Promise.reject(new Error("network error"))
+    );
+
+    render(<HomePage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Today")).toBeDefined();
+    });
+
+    // Recommendations section should not appear
+    expect(screen.queryByText("Recommended for You")).toBeNull();
   });
 });

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../context/AuthContext";
 import * as api from "../api";
-import type { Episode, Title } from "../types";
+import type { Episode, Title, Recommendation } from "../types";
 import { normalizeSearchTitle } from "../types";
 import TitleList from "../components/TitleList";
 import { TitleGridSkeleton, EpisodeListSkeleton } from "../components/SkeletonComponents";
@@ -77,6 +77,7 @@ export default function HomePage() {
   const [upcoming, setUpcoming] = useState<Episode[]>([]);
   const [unwatched, setUnwatched] = useState<Episode[]>([]);
   const [popularTitles, setPopularTitles] = useState<Title[]>([]);
+  const [recommendations, setRecommendations] = useState<Recommendation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [confirmingTitleId, setConfirmingTitleId] = useState<string | null>(null);
@@ -94,10 +95,14 @@ export default function HomePage() {
 
     async function load() {
       try {
-        const data = await api.getUpcomingEpisodes();
-        setToday(data.today);
-        setUpcoming(data.upcoming);
-        setUnwatched(data.unwatched);
+        const [episodeData, recData] = await Promise.all([
+          api.getUpcomingEpisodes(),
+          api.getRecommendations(6).catch(() => ({ recommendations: [], count: 0 })),
+        ]);
+        setToday(episodeData.today);
+        setUpcoming(episodeData.upcoming);
+        setUnwatched(episodeData.unwatched);
+        setRecommendations(recData.recommendations);
       } catch (err: unknown) {
         setError(err instanceof Error ? err.message : String(err));
       } finally {
@@ -282,6 +287,58 @@ export default function HomePage() {
                 </DeckCardWrapper>
               </div>
             ))}
+          </UnwatchedCarousel>
+        </section>
+      )}
+
+      {/* Recommended for You */}
+      {recommendations.length > 0 && (
+        <section>
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-xl font-bold text-white">{t("home.recommendedForYou")}</h2>
+            <Link to="/discovery" className="text-sm text-amber-400 hover:text-amber-300 transition-colors">
+              {t("home.seeAll")} →
+            </Link>
+          </div>
+          <UnwatchedCarousel>
+            {recommendations.map((rec) => {
+              const posterSrc = rec.title.poster_url
+                ? `https://image.tmdb.org/t/p/w185${rec.title.poster_url}`
+                : null;
+              const isUnread = !rec.read_at;
+              return (
+                <Link
+                  key={rec.id}
+                  to={`/title/${rec.title.id}`}
+                  className="w-32 flex-shrink-0 group"
+                  style={{ scrollSnapAlign: "start" }}
+                >
+                  <div className={`relative aspect-[2/3] rounded-lg overflow-hidden bg-zinc-800 ${isUnread ? "ring-2 ring-amber-500/60" : ""}`}>
+                    {posterSrc ? (
+                      <img
+                        src={posterSrc}
+                        alt={rec.title.title}
+                        className="w-full h-full object-cover group-hover:scale-105 transition-transform"
+                        loading="lazy"
+                      />
+                    ) : (
+                      <div className="w-full h-full flex items-center justify-center text-zinc-600 text-xs">
+                        N/A
+                      </div>
+                    )}
+                    {isUnread && (
+                      <div className="absolute top-1.5 right-1.5 w-2 h-2 rounded-full bg-amber-500" />
+                    )}
+                  </div>
+                  <p className="text-sm text-white mt-1.5 line-clamp-2 group-hover:text-amber-400 transition-colors">
+                    {rec.title.title}
+                  </p>
+                  <p className="text-xs text-zinc-400 truncate">
+                    from @{rec.from_user.username}
+                  </p>
+                </Link>
+              );
+            })}
           </UnwatchedCarousel>
         </section>
       )}


### PR DESCRIPTION
## Summary
- Add a "Recommended for You" horizontal carousel on the authenticated Home page, positioned after the Unwatched episodes and before Today
- Fetch up to 6 recent recommendations via `getRecommendations(6)` in parallel with episode data
- Each card shows poster thumbnail (w-32, 2:3 aspect ratio), title name, and "from @username" text
- Unread recommendations show an amber ring highlight and dot indicator
- Cards link to `/title/:id`; a "See all" link goes to `/discovery`
- Section is completely hidden when unauthenticated or when there are no recommendations
- Recommendation API failures are caught silently so the rest of the page still loads

## Test plan
- [x] Section renders with title, cards, and "See all" link when recommendations exist
- [x] Section hidden when no recommendations are returned
- [x] Section hidden when user is not authenticated (API not called)
- [x] Recommendations fetched with limit of 6
- [x] Card links point to correct title detail pages
- [x] "See all" link points to `/discovery`
- [x] Page still renders Today section even when recommendations API fails
- [x] All 1309 existing tests pass
- [x] ESLint passes with 0 errors

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)