### PR TITLE
Add invitations API with mutual follow on redeem

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -16,6 +16,7 @@ import type {
   TitleRatingResponse,
   SentRecommendation,
   RecommendationsResponse,
+  InvitationItem,
 } from "./types";
 
 const BASE = "/api";
@@ -471,4 +472,22 @@ export async function deleteRecommendation(id: string): Promise<void> {
 
 export async function getUnreadRecommendationCount(): Promise<{ count: number }> {
   return fetchJson("/recommendations/count");
+}
+
+// ─── Invitations ──────────────────────────────────────────────────────────
+
+export async function createInvitation(): Promise<{ id: string; code: string; expires_at: string }> {
+  return fetchJson("/invitations", { method: "POST" });
+}
+
+export async function getInvitations(): Promise<{ invitations: InvitationItem[] }> {
+  return fetchJson("/invitations");
+}
+
+export async function redeemInvitation(code: string): Promise<{ success: boolean; inviter: UserSummary }> {
+  return fetchJson(`/invitations/redeem/${encodeURIComponent(code)}`, { method: "POST" });
+}
+
+export async function revokeInvitation(id: string): Promise<void> {
+  await fetchJson(`/invitations/${encodeURIComponent(id)}`, { method: "DELETE" });
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -497,6 +497,17 @@ export interface UserSummary {
   image: string | null;
 }
 
+// ─── Invitation Types ─────────────────────────────────────────────────────
+
+export interface InvitationItem {
+  id: string;
+  code: string;
+  created_at: string;
+  expires_at: string;
+  used_at: string | null;
+  used_by: UserSummary | null;
+}
+
 // Normalize search results to same shape as DB titles
 export function normalizeSearchTitle(t: SearchTitle): Title {
   return {

--- a/server/index.ts
+++ b/server/index.ts
@@ -26,6 +26,7 @@ import profileRoutes from "./routes/profile";
 import socialRoutes from "./routes/social";
 import ratingsRoutes from "./routes/ratings";
 import recommendationsRoutes from "./routes/recommendations";
+import invitationsRoutes from "./routes/invitations";
 import healthRoutes from "./routes/health";
 import metricsRoutes from "./routes/metrics";
 import type { AppEnv } from "./types";
@@ -177,6 +178,11 @@ app.route("/api/ratings", ratingsRoutes);
 app.use("/api/recommendations/*", requireAuth);
 app.use("/api/recommendations", requireAuth);
 app.route("/api/recommendations", recommendationsRoutes);
+
+// Invitations routes
+app.use("/api/invitations/*", requireAuth);
+app.use("/api/invitations", requireAuth);
+app.route("/api/invitations", invitationsRoutes);
 
 // Protected routes
 app.use("/api/track/*", requireAuth);

--- a/server/routes/invitations.test.ts
+++ b/server/routes/invitations.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { createUser, createSession, getSessionWithUser, isFollowing } from "../db/repository";
+import { getRawDb } from "../db/bun-db";
+import { requireAuth } from "../middleware/auth";
+import invitationsApp from "./invitations";
+import type { AppEnv } from "../types";
+
+function createMockAuth() {
+  return {
+    api: {
+      getSession: async ({ headers }: { headers: Headers }) => {
+        const cookieHeader = headers.get("cookie") || "";
+        const match = cookieHeader.match(/better-auth\.session_token=([^;]+)/);
+        const token = match?.[1];
+        if (!token) return null;
+        const user = await getSessionWithUser(token);
+        if (!user) return null;
+        return {
+          session: { id: "session-id", userId: user.id },
+          user: {
+            id: user.id,
+            name: user.display_name,
+            username: user.username,
+            role: user.role || (user.is_admin ? "admin" : "user"),
+          },
+        };
+      },
+    },
+  };
+}
+
+let app: Hono<AppEnv>;
+let userAId: string;
+let userAToken: string;
+let userBId: string;
+let userBToken: string;
+
+beforeEach(async () => {
+  setupTestDb();
+
+  userAId = await createUser("alice", "hash", "Alice");
+  userAToken = await createSession(userAId);
+  userBId = await createUser("bob", "hash", "Bob");
+  userBToken = await createSession(userBId);
+
+  app = new Hono<AppEnv>();
+  app.use("*", async (c, next) => {
+    c.set("auth", createMockAuth() as any);
+    await next();
+  });
+  app.use("/invitations/*", requireAuth);
+  app.use("/invitations", requireAuth);
+  app.route("/invitations", invitationsApp);
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+function authHeaders(token: string) {
+  return { Cookie: `better-auth.session_token=${token}` };
+}
+
+describe("POST /invitations", () => {
+  it("generates an invitation", async () => {
+    const res = await app.request("/invitations", {
+      method: "POST",
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.id).toBeDefined();
+    expect(body.code).toBeDefined();
+    expect(body.expires_at).toBeDefined();
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await app.request("/invitations", { method: "POST" });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /invitations", () => {
+  it("lists user invitations", async () => {
+    // Create two invitations
+    await app.request("/invitations", {
+      method: "POST",
+      headers: authHeaders(userAToken),
+    });
+    await app.request("/invitations", {
+      method: "POST",
+      headers: authHeaders(userAToken),
+    });
+
+    const res = await app.request("/invitations", {
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.invitations).toHaveLength(2);
+    expect(body.invitations[0].id).toBeDefined();
+    expect(body.invitations[0].code).toBeDefined();
+    expect(body.invitations[0].created_at).toBeDefined();
+    expect(body.invitations[0].expires_at).toBeDefined();
+    expect(body.invitations[0].used_at).toBeNull();
+    expect(body.invitations[0].used_by).toBeNull();
+  });
+
+  it("returns empty list when no invitations", async () => {
+    const res = await app.request("/invitations", {
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.invitations).toHaveLength(0);
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await app.request("/invitations");
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /invitations/redeem/:code", () => {
+  it("redeems an invitation and creates mutual follows", async () => {
+    // Alice creates an invitation
+    const createRes = await app.request("/invitations", {
+      method: "POST",
+      headers: authHeaders(userAToken),
+    });
+    const { code } = await createRes.json();
+
+    // Bob redeems it
+    const res = await app.request(`/invitations/redeem/${code}`, {
+      method: "POST",
+      headers: authHeaders(userBToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.inviter.id).toBe(userAId);
+    expect(body.inviter.username).toBe("alice");
+
+    // Verify mutual follows
+    const aliceFollowsBob = await isFollowing(userAId, userBId);
+    const bobFollowsAlice = await isFollowing(userBId, userAId);
+    expect(aliceFollowsBob).toBe(true);
+    expect(bobFollowsAlice).toBe(true);
+  });
+
+  it("returns 400 when redeeming own invitation", async () => {
+    const createRes = await app.request("/invitations", {
+      method: "POST",
+      headers: authHeaders(userAToken),
+    });
+    const { code } = await createRes.json();
+
+    const res = await app.request(`/invitations/redeem/${code}`, {
+      method: "POST",
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("own invitation");
+  });
+
+  it("returns 410 when invitation is expired", async () => {
+    const createRes = await app.request("/invitations", {
+      method: "POST",
+      headers: authHeaders(userAToken),
+    });
+    const { code } = await createRes.json();
+
+    // Manually expire the invitation in the DB
+    const db = getRawDb();
+    db.prepare("UPDATE invitations SET expires_at = '2020-01-01T00:00:00.000Z' WHERE code = ?").run(code);
+
+    const res = await app.request(`/invitations/redeem/${code}`, {
+      method: "POST",
+      headers: authHeaders(userBToken),
+    });
+    expect(res.status).toBe(410);
+    const body = await res.json();
+    expect(body.error).toContain("expired");
+  });
+
+  it("returns 409 when invitation is already used", async () => {
+    const createRes = await app.request("/invitations", {
+      method: "POST",
+      headers: authHeaders(userAToken),
+    });
+    const { code } = await createRes.json();
+
+    // Bob redeems it
+    await app.request(`/invitations/redeem/${code}`, {
+      method: "POST",
+      headers: authHeaders(userBToken),
+    });
+
+    // Create another user to try redeeming the same code
+    const userCId = await createUser("carol", "hash", "Carol");
+    const userCToken = await createSession(userCId);
+
+    const res = await app.request(`/invitations/redeem/${code}`, {
+      method: "POST",
+      headers: authHeaders(userCToken),
+    });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toContain("already been used");
+  });
+
+  it("returns 404 when invitation code does not exist", async () => {
+    const res = await app.request("/invitations/redeem/nonexistent-code", {
+      method: "POST",
+      headers: authHeaders(userBToken),
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toContain("not found");
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await app.request("/invitations/redeem/some-code", {
+      method: "POST",
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("DELETE /invitations/:id", () => {
+  it("revokes own invitation", async () => {
+    const createRes = await app.request("/invitations", {
+      method: "POST",
+      headers: authHeaders(userAToken),
+    });
+    const { id } = await createRes.json();
+
+    const res = await app.request(`/invitations/${id}`, {
+      method: "DELETE",
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    // Verify it's gone
+    const listRes = await app.request("/invitations", {
+      headers: authHeaders(userAToken),
+    });
+    const listBody = await listRes.json();
+    expect(listBody.invitations).toHaveLength(0);
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await app.request("/invitations/some-id", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/server/routes/invitations.ts
+++ b/server/routes/invitations.ts
@@ -1,0 +1,134 @@
+import { Hono } from "hono";
+import {
+  createInvitation,
+  getInvitation,
+  redeemInvitation,
+  getUserInvitations,
+  revokeInvitation,
+  follow,
+  getUserById,
+} from "../db/repository";
+import type { AppEnv } from "../types";
+import { logger } from "../logger";
+import { ok, err } from "./response";
+
+const log = logger.child({ module: "invitations" });
+
+const app = new Hono<AppEnv>();
+
+// POST / — Generate an invitation
+app.post("/", async (c) => {
+  const user = c.get("user");
+  if (!user) {
+    return err(c, "Authentication required", 401);
+  }
+
+  const invitation = await createInvitation(user.id);
+  log.info("Invitation created", { userId: user.id, invitationId: invitation.id });
+  return c.json({
+    id: invitation.id,
+    code: invitation.code,
+    expires_at: invitation.expiresAt,
+  }, 201);
+});
+
+// GET / — List user's invitations
+app.get("/", async (c) => {
+  const user = c.get("user");
+  if (!user) {
+    return err(c, "Authentication required", 401);
+  }
+
+  const rows = await getUserInvitations(user.id);
+  const invitations = await Promise.all(
+    rows.map(async (row) => {
+      let usedBy = null;
+      if (row.usedById) {
+        const usedByUser = await getUserById(row.usedById);
+        if (usedByUser) {
+          usedBy = {
+            id: usedByUser.id,
+            username: usedByUser.username,
+            name: usedByUser.display_name,
+            image: null,
+          };
+        }
+      }
+      return {
+        id: row.id,
+        code: row.code,
+        created_at: row.createdAt,
+        expires_at: row.expiresAt,
+        used_at: row.usedAt,
+        used_by: usedBy,
+      };
+    })
+  );
+
+  return ok(c, { invitations });
+});
+
+// POST /redeem/:code — Redeem an invitation
+app.post("/redeem/:code", async (c) => {
+  const user = c.get("user");
+  if (!user) {
+    return err(c, "Authentication required", 401);
+  }
+
+  const code = c.req.param("code");
+  const invitation = await getInvitation(code);
+
+  if (!invitation) {
+    return err(c, "Invitation not found", 404);
+  }
+
+  if (invitation.createdById === user.id) {
+    return err(c, "Cannot redeem your own invitation", 400);
+  }
+
+  if (invitation.usedById !== null) {
+    return err(c, "Invitation has already been used", 409);
+  }
+
+  if (new Date(invitation.expiresAt) < new Date()) {
+    return err(c, "Invitation has expired", 410);
+  }
+
+  const success = await redeemInvitation(code, user.id);
+  if (!success) {
+    return err(c, "Failed to redeem invitation", 400);
+  }
+
+  // Create mutual follows
+  await follow(invitation.createdById, user.id);
+  await follow(user.id, invitation.createdById);
+
+  log.info("Invitation redeemed with mutual follow", {
+    code,
+    redeemerId: user.id,
+    inviterId: invitation.createdById,
+  });
+
+  return ok(c, {
+    success: true,
+    inviter: {
+      id: invitation.createdById,
+      username: invitation.createdByUsername,
+    },
+  });
+});
+
+// DELETE /:id — Revoke an invitation
+app.delete("/:id", async (c) => {
+  const user = c.get("user");
+  if (!user) {
+    return err(c, "Authentication required", 401);
+  }
+
+  const id = c.req.param("id");
+  await revokeInvitation(id, user.id);
+  log.info("Invitation revoked", { invitationId: id, userId: user.id });
+  return ok(c, { success: true });
+});
+
+export default app;

--- a/server/routes/response.ts
+++ b/server/routes/response.ts
@@ -10,6 +10,6 @@ export function ok<T extends Record<string, unknown>>(c: Context, data: T) {
 /**
  * Standard error response helper. Always returns `{ error: message }` with the given status code.
  */
-export function err(c: Context, message: string, status: 400 | 401 | 403 | 404 | 409 | 500 | 503 = 400) {
+export function err(c: Context, message: string, status: 400 | 401 | 403 | 404 | 409 | 410 | 500 | 503 = 400) {
   return c.json({ error: message }, status);
 }


### PR DESCRIPTION
## Summary
- Add `POST/GET /api/invitations` for creating and listing invitation links
- Add `POST /api/invitations/redeem/:code` that validates and redeems invitations, creating mutual follows between inviter and redeemer
- Add `DELETE /api/invitations/:id` for revoking own invitations
- Proper error handling: 400 (own invitation), 404 (not found), 409 (already used), 410 (expired)
- Frontend API client functions and `InvitationItem` type added
- Add 410 status code support to the shared `err()` response helper

## Test plan
- [x] Generate invitation returns 201 with id, code, expires_at
- [x] List invitations returns user's invitations
- [x] Redeem creates mutual follows between inviter and redeemer
- [x] Cannot redeem own invitation (400)
- [x] Cannot redeem expired invitation (410)
- [x] Cannot redeem already used invitation (409)
- [x] Cannot redeem nonexistent code (404)
- [x] Revoke own invitation
- [x] Unauthenticated access returns 401

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)