### PR TITLE
Add invite page UI for managing invitations

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,6 +40,7 @@ const PersonPage = lazyWithRetry(() => import("./pages/PersonPage"));
 const ReelsPage = lazyWithRetry(() => import("./pages/ReelsPage"));
 const UpcomingPage = lazyWithRetry(() => import("./pages/UpcomingPage"));
 const DiscoveryPage = lazyWithRetry(() => import("./pages/DiscoveryPage"));
+const InvitePage = lazyWithRetry(() => import("./pages/InvitePage"));
 
 function MobileHomeRedirect() {
   const { user, loading } = useAuth();
@@ -152,6 +153,7 @@ export default function App() {
             <Route path="/reels" element={<RequireAuth><ReelsPage /></RequireAuth>} />
             <Route path="/upcoming" element={<RequireAuth><UpcomingPage /></RequireAuth>} />
             <Route path="/discovery" element={<RequireAuth><DiscoveryPage /></RequireAuth>} />
+            <Route path="/invite" element={<RequireAuth><InvitePage /></RequireAuth>} />
             <Route path="/user/:username" element={<UserProfilePage />} />
             <Route path="/settings" element={<RequireAuth><SettingsPage /></RequireAuth>} />
             <Route path="/profile" element={<ProfilePage />} />

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -255,6 +255,27 @@
     "trackFailed": "Failed to track title",
     "dismissFailed": "Failed to dismiss recommendation"
   },
+  "invite": {
+    "title": "Invite Friends",
+    "createLink": "Create Invite Link",
+    "creating": "Creating...",
+    "created": "Invite link created",
+    "empty": "No invitations yet. Create one to invite your friends!",
+    "revoke": "Revoke",
+    "revoking": "Revoking...",
+    "revoked": "Invitation revoked",
+    "redeeming": "Redeeming invitation...",
+    "redeemSuccess": "You and @{{name}} are now following each other!",
+    "statusPending": "Pending",
+    "statusUsed": "Used by @{{username}}",
+    "statusExpired": "Expired",
+    "created_at": "Created",
+    "expires_at": "Expires",
+    "usedBy": "Used by",
+    "shareTitle": "Join me on Remindarr",
+    "shareText": "Use my invite link to join Remindarr!",
+    "settingsLink": "Invite Friends"
+  },
   "common": {
     "loading": "Loading...",
     "error": "An error occurred",

--- a/frontend/src/pages/InvitePage.test.tsx
+++ b/frontend/src/pages/InvitePage.test.tsx
@@ -1,0 +1,263 @@
+import { describe, it, expect, mock, afterEach, beforeEach } from "bun:test";
+import { render, screen, waitFor, cleanup, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import type { ReactNode } from "react";
+
+// Initialize i18n before anything else
+import "../i18n";
+
+// Mock auth context
+mock.module("../context/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: "u1", username: "testuser", display_name: "Test User", auth_provider: "local", is_admin: false },
+    providers: { local: true, oidc: null },
+    loading: false,
+    login: mock(() => Promise.resolve()),
+    signup: mock(() => Promise.resolve()),
+    logout: mock(() => Promise.resolve()),
+    refresh: mock(() => Promise.resolve()),
+  }),
+  AuthContext: {
+    Provider: ({ children }: { children: ReactNode }) => children,
+  },
+}));
+
+const mockGetInvitations = mock(() =>
+  Promise.resolve({ invitations: [] })
+);
+const mockCreateInvitation = mock(() =>
+  Promise.resolve({ id: "inv-new", code: "NEWCODE", expires_at: new Date(Date.now() + 7 * 86400000).toISOString() })
+);
+const mockRevokeInvitation = mock(() => Promise.resolve());
+const mockRedeemInvitation = mock(() =>
+  Promise.resolve({ success: true, inviter: { id: "u2", username: "alice", display_name: "Alice", image: null } })
+);
+
+mock.module("../api", () => ({
+  getInvitations: mockGetInvitations,
+  createInvitation: mockCreateInvitation,
+  revokeInvitation: mockRevokeInvitation,
+  redeemInvitation: mockRedeemInvitation,
+}));
+
+const { default: InvitePage } = await import("./InvitePage");
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
+
+function WrapperWithCode({ children }: { children: ReactNode }) {
+  return <MemoryRouter initialEntries={["/invite?code=TESTCODE"]}>{children}</MemoryRouter>;
+}
+
+function makeInvitation(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "inv-1",
+    code: "ABC123",
+    created_at: new Date().toISOString(),
+    expires_at: new Date(Date.now() + 7 * 86400000).toISOString(),
+    used_at: null,
+    used_by: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockGetInvitations.mockImplementation(() =>
+    Promise.resolve({ invitations: [] })
+  );
+  mockCreateInvitation.mockImplementation(() =>
+    Promise.resolve({ id: "inv-new", code: "NEWCODE", expires_at: new Date(Date.now() + 7 * 86400000).toISOString() })
+  );
+  mockRevokeInvitation.mockImplementation(() => Promise.resolve());
+  mockRedeemInvitation.mockImplementation(() =>
+    Promise.resolve({ success: true, inviter: { id: "u2", username: "alice", display_name: "Alice", image: null } })
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  mockGetInvitations.mockReset();
+  mockCreateInvitation.mockReset();
+  mockRevokeInvitation.mockReset();
+  mockRedeemInvitation.mockReset();
+});
+
+describe("InvitePage", () => {
+  it("renders invitation list", async () => {
+    const invitations = [
+      makeInvitation({ id: "inv-1", code: "CODE1" }),
+      makeInvitation({ id: "inv-2", code: "CODE2" }),
+    ];
+    mockGetInvitations.mockImplementation(() =>
+      Promise.resolve({ invitations })
+    );
+
+    render(<InvitePage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("CODE1")).toBeDefined();
+      expect(screen.getByText("CODE2")).toBeDefined();
+    });
+  });
+
+  it("generate button creates new invitation", async () => {
+    mockGetInvitations.mockImplementation(() =>
+      Promise.resolve({ invitations: [] })
+    );
+    // After creation, refresh will return the new invitation
+    let callCount = 0;
+    mockGetInvitations.mockImplementation(() => {
+      callCount++;
+      if (callCount > 1) {
+        return Promise.resolve({
+          invitations: [makeInvitation({ id: "inv-new", code: "NEWCODE" })],
+        });
+      }
+      return Promise.resolve({ invitations: [] });
+    });
+
+    render(<InvitePage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Create Invite Link")).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByText("Create Invite Link"));
+
+    await waitFor(() => {
+      expect(mockCreateInvitation).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("NEWCODE")).toBeDefined();
+    });
+  });
+
+  it("share button present for pending invitations", async () => {
+    const invitations = [makeInvitation()];
+    mockGetInvitations.mockImplementation(() =>
+      Promise.resolve({ invitations })
+    );
+
+    render(<InvitePage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Share")).toBeDefined();
+    });
+  });
+
+  it("revoke button works", async () => {
+    const invitations = [makeInvitation({ id: "inv-1", code: "REVOKEME" })];
+    mockGetInvitations.mockImplementation(() =>
+      Promise.resolve({ invitations })
+    );
+
+    render(<InvitePage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Revoke")).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByText("Revoke"));
+
+    await waitFor(() => {
+      expect(mockRevokeInvitation).toHaveBeenCalledWith("inv-1");
+    });
+
+    // Card should be removed after revoke
+    await waitFor(() => {
+      expect(screen.queryByText("REVOKEME")).toBeNull();
+    });
+  });
+
+  it("expired invitations show correct status", async () => {
+    const invitations = [
+      makeInvitation({
+        id: "inv-expired",
+        code: "EXPIRED1",
+        expires_at: new Date(Date.now() - 86400000).toISOString(),
+      }),
+    ];
+    mockGetInvitations.mockImplementation(() =>
+      Promise.resolve({ invitations })
+    );
+
+    render(<InvitePage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Expired")).toBeDefined();
+    });
+
+    // No share or revoke button for expired
+    expect(screen.queryByText("Share")).toBeNull();
+    expect(screen.queryByText("Revoke")).toBeNull();
+  });
+
+  it("used invitations show used by info", async () => {
+    const invitations = [
+      makeInvitation({
+        id: "inv-used",
+        code: "USED1",
+        used_at: new Date().toISOString(),
+        used_by: { id: "u3", username: "bob", display_name: "Bob", image: null },
+      }),
+    ];
+    mockGetInvitations.mockImplementation(() =>
+      Promise.resolve({ invitations })
+    );
+
+    render(<InvitePage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("@bob")).toBeDefined();
+    });
+
+    // No share or revoke button for used invitations
+    expect(screen.queryByText("Revoke")).toBeNull();
+  });
+
+  it("auto-redeem from URL query parameter", async () => {
+    mockGetInvitations.mockImplementation(() =>
+      Promise.resolve({ invitations: [] })
+    );
+
+    render(<InvitePage />, { wrapper: WrapperWithCode });
+
+    await waitFor(() => {
+      expect(mockRedeemInvitation).toHaveBeenCalledWith("TESTCODE");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/You and @Alice are now following each other!/)).toBeDefined();
+    });
+  });
+
+  it("shows empty state when no invitations", async () => {
+    mockGetInvitations.mockImplementation(() =>
+      Promise.resolve({ invitations: [] })
+    );
+
+    render(<InvitePage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("No invitations yet. Create one to invite your friends!")).toBeDefined();
+    });
+  });
+
+  it("shows error when redeem fails", async () => {
+    mockRedeemInvitation.mockImplementation(() =>
+      Promise.reject(new Error("Invitation expired"))
+    );
+
+    render(<InvitePage />, { wrapper: WrapperWithCode });
+
+    await waitFor(() => {
+      expect(mockRedeemInvitation).toHaveBeenCalledWith("TESTCODE");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Invitation expired")).toBeDefined();
+    });
+  });
+});

--- a/frontend/src/pages/InvitePage.tsx
+++ b/frontend/src/pages/InvitePage.tsx
@@ -1,0 +1,287 @@
+import { useState, useEffect, useCallback } from "react";
+import { useSearchParams, Link } from "react-router";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { Plus, Trash2, Clock, CheckCircle2, XCircle, UserPlus } from "lucide-react";
+import * as api from "../api";
+import type { InvitationItem } from "../types";
+import ShareButton from "../components/ShareButton";
+
+type RedeemResult =
+  | { status: "success"; inviterName: string }
+  | { status: "error"; message: string }
+  | null;
+
+function getInviteUrl(code: string): string {
+  return `${window.location.origin}/invite?code=${code}`;
+}
+
+function getStatus(inv: InvitationItem): "pending" | "used" | "expired" {
+  if (inv.used_at) return "used";
+  if (new Date(inv.expires_at) < new Date()) return "expired";
+  return "pending";
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export default function InvitePage() {
+  const { t } = useTranslation();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [invitations, setInvitations] = useState<InvitationItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [revoking, setRevoking] = useState<string | null>(null);
+  const [redeemResult, setRedeemResult] = useState<RedeemResult>(null);
+  const [redeeming, setRedeeming] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await api.getInvitations();
+      setInvitations(data.invitations.sort((a, b) =>
+        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+      ));
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Auto-redeem from URL query parameter
+  useEffect(() => {
+    const code = searchParams.get("code");
+    if (!code || redeeming) return;
+
+    setRedeeming(true);
+    api.redeemInvitation(code)
+      .then((result) => {
+        const inviterName = result.inviter.display_name || result.inviter.username;
+        setRedeemResult({ status: "success", inviterName });
+        toast.success(t("invite.redeemSuccess", { name: inviterName }));
+      })
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        setRedeemResult({ status: "error", message });
+        toast.error(message);
+      })
+      .finally(() => {
+        setRedeeming(false);
+        // Remove code from URL
+        setSearchParams({}, { replace: true });
+      });
+  }, [searchParams, setSearchParams, redeeming, t]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  async function handleCreate() {
+    setCreating(true);
+    try {
+      await api.createInvitation();
+      await refresh();
+      toast.success(t("invite.created"));
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : String(err));
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleRevoke(id: string) {
+    setRevoking(id);
+    try {
+      await api.revokeInvitation(id);
+      setInvitations((prev) => prev.filter((inv) => inv.id !== id));
+      toast.success(t("invite.revoked"));
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : String(err));
+    } finally {
+      setRevoking(null);
+    }
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-6">
+      <div className="flex items-center gap-3">
+        <UserPlus className="size-6 text-amber-500" />
+        <h1 className="text-2xl font-bold text-white">{t("invite.title")}</h1>
+      </div>
+
+      {/* Redeem result banner */}
+      {redeemResult && (
+        <div
+          className={`p-4 rounded-lg border text-sm ${
+            redeemResult.status === "success"
+              ? "bg-green-900/20 border-green-700 text-green-200"
+              : "bg-red-900/20 border-red-700 text-red-200"
+          }`}
+        >
+          {redeemResult.status === "success"
+            ? t("invite.redeemSuccess", { name: redeemResult.inviterName })
+            : redeemResult.message}
+        </div>
+      )}
+
+      {redeeming && (
+        <div className="text-center py-8 text-zinc-400">{t("invite.redeeming")}</div>
+      )}
+
+      {/* Generate button */}
+      <button
+        onClick={handleCreate}
+        disabled={creating}
+        className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-amber-500 hover:bg-amber-400 text-zinc-950 font-semibold rounded-lg transition-colors disabled:opacity-50 cursor-pointer"
+      >
+        <Plus className="size-4" />
+        {creating ? t("invite.creating") : t("invite.createLink")}
+      </button>
+
+      {/* Invitations list */}
+      {loading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="bg-zinc-900 rounded-lg p-4 animate-pulse h-24" />
+          ))}
+        </div>
+      ) : invitations.length === 0 ? (
+        <p className="text-center py-8 text-zinc-500">{t("invite.empty")}</p>
+      ) : (
+        <div className="space-y-3">
+          {invitations.map((inv) => (
+            <InvitationCard
+              key={inv.id}
+              invitation={inv}
+              revoking={revoking === inv.id}
+              onRevoke={handleRevoke}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function InvitationCard({
+  invitation,
+  revoking,
+  onRevoke,
+}: {
+  invitation: InvitationItem;
+  revoking: boolean;
+  onRevoke: (id: string) => void;
+}) {
+  const { t } = useTranslation();
+  const status = getStatus(invitation);
+  const inviteUrl = getInviteUrl(invitation.code);
+
+  return (
+    <div
+      className={`rounded-lg p-4 border transition-colors ${
+        status === "used"
+          ? "bg-green-900/20 border-green-900/40"
+          : status === "expired"
+            ? "bg-zinc-900 border-white/[0.06] opacity-50"
+            : "bg-zinc-900 border-white/[0.06]"
+      }`}
+    >
+      {/* Status badge and code */}
+      <div className="flex items-center justify-between gap-2 mb-3">
+        <StatusBadge status={status} usedBy={invitation.used_by} />
+        <code
+          className={`text-xs font-mono px-2 py-1 rounded bg-zinc-800 text-zinc-300 ${
+            status === "expired" ? "line-through" : ""
+          }`}
+        >
+          {invitation.code}
+        </code>
+      </div>
+
+      {/* Dates */}
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-zinc-500 mb-3">
+        <span>{t("invite.created_at")}: {formatDate(invitation.created_at)}</span>
+        <span>{t("invite.expires_at")}: {formatDate(invitation.expires_at)}</span>
+      </div>
+
+      {/* Used by info */}
+      {status === "used" && invitation.used_by && (
+        <div className="text-sm text-green-300 mb-3">
+          {t("invite.usedBy", {
+            username: invitation.used_by.display_name || invitation.used_by.username,
+          })}
+          {" "}
+          <Link
+            to={`/user/${invitation.used_by.username}`}
+            className="text-amber-500 hover:text-amber-400 transition-colors"
+          >
+            @{invitation.used_by.username}
+          </Link>
+        </div>
+      )}
+
+      {/* Actions */}
+      {status === "pending" && (
+        <div className="flex items-center gap-2">
+          <ShareButton
+            title={t("invite.shareTitle")}
+            text={t("invite.shareText")}
+            url={inviteUrl}
+          />
+          <button
+            onClick={() => onRevoke(invitation.id)}
+            disabled={revoking}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors cursor-pointer bg-red-900/30 text-red-400 hover:bg-red-900/50 hover:text-red-300 disabled:opacity-50"
+          >
+            <Trash2 className="size-3.5" />
+            {revoking ? t("invite.revoking") : t("invite.revoke")}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatusBadge({
+  status,
+  usedBy,
+}: {
+  status: "pending" | "used" | "expired";
+  usedBy: InvitationItem["used_by"];
+}) {
+  const { t } = useTranslation();
+
+  if (status === "used") {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs font-medium text-green-400">
+        <CheckCircle2 className="size-3.5" />
+        {t("invite.statusUsed", {
+          username: usedBy?.display_name || usedBy?.username || "",
+        })}
+      </span>
+    );
+  }
+
+  if (status === "expired") {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs font-medium text-zinc-500">
+        <XCircle className="size-3.5" />
+        {t("invite.statusExpired")}
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-400">
+      <Clock className="size-3.5" />
+      {t("invite.statusPending")}
+    </span>
+  );
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -8,6 +8,7 @@ import type { JobsResponse, Notifier } from "../api";
 import type { AdminSettings, Title } from "../types";
 import { isPushSupported, subscribeToPush, unsubscribeFromPush, getExistingSubscription } from "../lib/push";
 import { authClient } from "../lib/auth-client";
+import { UserPlus } from "lucide-react";
 
 export default function SettingsPage() {
   const { user } = useAuth();
@@ -26,6 +27,7 @@ export default function SettingsPage() {
       <UserSection />
       <PasskeySection />
       <ProfileVisibilitySection />
+      <SocialSection />
       <WatchlistSection />
       {isPushSupported() && <PushNotificationsSection />}
       <NotificationsSection />
@@ -474,6 +476,25 @@ function ProfileVisibilitySection() {
         {titles.length === 0 && (
           <p className="text-zinc-500 text-sm">{t("settings.noTrackedTitles")}</p>
         )}
+      </div>
+    </section>
+  );
+}
+
+function SocialSection() {
+  const { t } = useTranslation();
+
+  return (
+    <section>
+      <h2 className="text-xl font-bold text-white mb-4">Social</h2>
+      <div className="bg-zinc-900 rounded-lg p-5">
+        <Link
+          to="/invite"
+          className="flex items-center gap-3 text-amber-500 hover:text-amber-400 transition-colors font-medium"
+        >
+          <UserPlus className="size-5" />
+          {t("invite.settingsLink")}
+        </Link>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- Add `/invite` page where users can generate invite links, view invitation history, and share/revoke invitations
- Each invitation card shows status (Pending/Used/Expired), dates, share button, and revoke option
- Auto-redeem flow when visiting `/invite?code=...` with success/error feedback
- Add "Social" section to Settings page with link to invite page
- Add i18n translations for all invite-related strings

## Test plan
- [ ] Verify invitation list renders with pending, used, and expired states
- [ ] Test "Create Invite Link" button generates new invitation
- [ ] Test share button appears only for pending invitations
- [ ] Test revoke button deletes invitation
- [ ] Test auto-redeem from URL query parameter shows success/error message
- [ ] Verify "Invite Friends" link appears in Settings page under Social section
- [ ] Run `bun test frontend/src/pages/InvitePage.test.tsx` (9 tests passing)

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)