### PR TITLE
Add route parity test and integrate social/ratings/recommendations/invitations routes

### DIFF
--- a/server/routes/worker-routes.test.ts
+++ b/server/routes/worker-routes.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Ensures that route imports in server/worker.ts stay in sync with server/index.ts.
+ *
+ * When new routes are added to index.ts, they must also be added to worker.ts
+ * (the Cloudflare Workers entry point) or explicitly listed as excluded.
+ */
+
+// Routes intentionally excluded from CF Workers (with reason)
+const EXCLUDED_ROUTES = [
+  "jobsRoutes",    // Uses Bun-only in-memory job queue
+  "metricsRoutes", // Prometheus metrics not applicable to CF Workers
+];
+
+function extractRouteImports(source: string): string[] {
+  const imports: string[] = [];
+  const regex = /import\s+(\w+Routes)\s+from\s+["']\.\/routes\//g;
+  let match;
+  while ((match = regex.exec(source)) !== null) {
+    imports.push(match[1]);
+  }
+  return imports.sort();
+}
+
+describe("worker.ts route parity", () => {
+  const root = join(import.meta.dir, "..");
+  const indexSource = readFileSync(join(root, "index.ts"), "utf-8");
+  const workerSource = readFileSync(join(root, "worker.ts"), "utf-8");
+
+  const indexRoutes = extractRouteImports(indexSource);
+  const workerRoutes = extractRouteImports(workerSource);
+
+  test("all routes from index.ts are present in worker.ts or explicitly excluded", () => {
+    const missingRoutes = indexRoutes.filter(
+      (route) => !workerRoutes.includes(route) && !EXCLUDED_ROUTES.includes(route),
+    );
+
+    expect(missingRoutes).toEqual([]);
+  });
+
+  test("excluded routes list is up to date (no stale entries)", () => {
+    const staleExclusions = EXCLUDED_ROUTES.filter(
+      (route) => !indexRoutes.includes(route),
+    );
+
+    expect(staleExclusions).toEqual([]);
+  });
+});

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -58,6 +58,10 @@ import browseRoutes from "./routes/browse";
 import detailsRoutes from "./routes/details";
 import notifierRoutes from "./routes/notifiers";
 import profileRoutes from "./routes/profile";
+import socialRoutes from "./routes/social";
+import ratingsRoutes from "./routes/ratings";
+import recommendationsRoutes from "./routes/recommendations";
+import invitationsRoutes from "./routes/invitations";
 import healthRoutes from "./routes/health";
 import type { AppEnv } from "./types";
 import { logger, requestLogger, resetLogLevel } from "./logger";
@@ -267,6 +271,30 @@ function createApp(env: Env) {
   app.use("/api/user/*", optionalAuth);
   app.use("/api/user", optionalAuth);
   app.route("/api/user", profileRoutes);
+
+  // Social routes — follow/unfollow (auth), follower/following lists (public)
+  app.use("/api/social/follow/*", requireAuth);
+  app.use("/api/social/follow", requireAuth);
+  app.use("/api/social/followers/*", optionalAuth);
+  app.use("/api/social/followers", optionalAuth);
+  app.use("/api/social/following/*", optionalAuth);
+  app.use("/api/social/following", optionalAuth);
+  app.route("/api/social", socialRoutes);
+
+  // Ratings routes — optionalAuth base, POST/DELETE check auth internally
+  app.use("/api/ratings/*", optionalAuth);
+  app.use("/api/ratings", optionalAuth);
+  app.route("/api/ratings", ratingsRoutes);
+
+  // Recommendations routes
+  app.use("/api/recommendations/*", requireAuth);
+  app.use("/api/recommendations", requireAuth);
+  app.route("/api/recommendations", recommendationsRoutes);
+
+  // Invitations routes
+  app.use("/api/invitations/*", requireAuth);
+  app.use("/api/invitations", requireAuth);
+  app.route("/api/invitations", invitationsRoutes);
 
   // Protected routes
   app.use("/api/track/*", requireAuth);


### PR DESCRIPTION
## Summary
This PR adds four new route modules to the Cloudflare Workers entry point and introduces a test to ensure route consistency between the main server and worker configurations.

## Key Changes
- **New test file** (`server/routes/worker-routes.test.ts`): Validates that all routes imported in `index.ts` are either present in `worker.ts` or explicitly listed in an `EXCLUDED_ROUTES` array with documented reasons. This prevents accidental route drift between the two entry points.

- **Route integrations in `worker.ts`**:
  - Added `socialRoutes` with granular auth middleware (auth required for follow actions, optional for follower/following lists)
  - Added `ratingsRoutes` with optional auth (internal auth checks for POST/DELETE)
  - Added `recommendationsRoutes` with required auth
  - Added `invitationsRoutes` with required auth

- **Excluded routes** (documented in test):
  - `jobsRoutes` — uses Bun-only in-memory job queue
  - `metricsRoutes` — Prometheus metrics not applicable to Cloudflare Workers

## Implementation Details
- The test uses regex pattern matching to extract route imports from source files, ensuring maintainability as new routes are added
- Auth middleware is applied at the path level before route registration, allowing fine-grained control (e.g., social routes have different auth requirements for different endpoints)
- The exclusion list is validated to prevent stale entries, ensuring documentation stays accurate

https://claude.ai/code/session_01QcAVNmbheUj8N2v7MsmcRA