### PR TITLE
Make agenda calendar header sticky with scroll offset

### DIFF
--- a/frontend/src/components/AgendaCalendar.tsx
+++ b/frontend/src/components/AgendaCalendar.tsx
@@ -608,7 +608,7 @@ export default function AgendaCalendar({
       {/* Main content */}
       <div className="flex-1 min-w-0 space-y-4">
         {/* Header */}
-        <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-3 sticky top-14 z-30 bg-zinc-950 pb-2">
           <div className="flex items-center gap-3">
             <Popover.Root open={pickerOpen} onOpenChange={setPickerOpen}>
               <Popover.Trigger
@@ -764,7 +764,7 @@ export default function AgendaCalendar({
                           (todayRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
                         }
                       }}
-                      className="space-y-3"
+                      className="space-y-3 scroll-mt-36"
                     >
                       {/* Compact day header */}
                       <DayHeader


### PR DESCRIPTION
## Summary
Improved the agenda calendar UI by making the header sticky and adding proper scroll behavior to ensure content doesn't get hidden behind the fixed header.

## Key Changes
- Made the calendar header sticky by adding `sticky top-14 z-30 bg-zinc-950 pb-2` classes to the header container, positioning it below the main navigation bar
- Added `scroll-mt-36` class to the day content container to provide proper scroll margin offset, preventing content from being obscured when scrolling to specific dates

## Implementation Details
- The header now stays visible at the top of the calendar view as users scroll through agenda items
- The `top-14` offset positions the sticky header below the main app navigation (which is 56px/14 units tall)
- The `z-30` ensures the header appears above scrollable content
- The `bg-zinc-950` maintains visual consistency with the dark theme background
- The `scroll-mt-36` offset on the day container ensures smooth scrolling with adequate spacing from the sticky header

https://claude.ai/code/session_01KxccDvVKp5PZ2eXK7EDVvd