### PR TITLE
Fix popover z-index stacking and calendar width issues

### DIFF
--- a/frontend/src/components/AgendaCalendar.tsx
+++ b/frontend/src/components/AgendaCalendar.tsx
@@ -624,8 +624,8 @@ export default function AgendaCalendar({
                 </span>
               </Popover.Trigger>
               <Popover.Portal>
-                <Popover.Positioner side="bottom" align="start" sideOffset={4}>
-                  <Popover.Popup className="z-50 rounded-lg border border-white/[0.08] bg-zinc-900 shadow-xl p-2">
+                <Popover.Positioner side="bottom" align="start" sideOffset={4} className="z-50">
+                  <Popover.Popup className="rounded-lg border border-white/[0.08] bg-zinc-900 shadow-xl p-2">
                     <Calendar
                       mode="single"
                       selected={activeDate}

--- a/frontend/src/components/ui/calendar.tsx
+++ b/frontend/src/components/ui/calendar.tsx
@@ -88,7 +88,7 @@ function Calendar({
           defaultClassNames.caption_label
         ),
         table: "w-full border-collapse",
-        weekdays: cn("flex", defaultClassNames.weekdays),
+        weekdays: cn("flex w-full", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",
           defaultClassNames.weekday


### PR DESCRIPTION
## Summary
This PR fixes z-index stacking context and layout issues in the AgendaCalendar popover and Calendar components to ensure proper layering and full-width calendar rendering.

## Key Changes
- **AgendaCalendar popover**: Moved `z-50` class from `Popover.Popup` to `Popover.Positioner` to properly establish the stacking context at the correct DOM level
- **Calendar weekdays**: Added `w-full` class to the weekdays container to ensure the calendar stretches to full width of its container

## Implementation Details
The z-index fix addresses a common issue where z-index values on child elements don't create proper stacking contexts when the parent lacks the z-index property. By moving `z-50` to the `Popover.Positioner`, the entire popover subtree now respects the intended stacking order.

The calendar width fix ensures consistent layout by making the weekdays flex container span the full width, preventing potential layout shifts or misalignment with the calendar grid.

https://claude.ai/code/session_01Cs3SFBy6Vj8mk2HGhEzbEx