### PR TITLE
Add season selector dropdown to SeasonDetailPage

### DIFF
--- a/frontend/src/pages/SeasonDetailPage.test.tsx
+++ b/frontend/src/pages/SeasonDetailPage.test.tsx
@@ -12,6 +12,11 @@ mock.module("../context/AuthContext", () => ({
   AuthContext: { Provider: ({ children }: any) => children },
 }));
 
+const defaultSeasons = [
+  { id: 1, name: "Season 1", overview: "", air_date: "2024-01-01", episode_count: 3, poster_path: null, season_number: 1, vote_average: 8.0 },
+  { id: 2, name: "Season 2", overview: "", air_date: "2024-06-01", episode_count: 5, poster_path: null, season_number: 2, vote_average: 7.5 },
+];
+
 const mockGetSeasonDetails = mock(() => Promise.resolve({
   title: { id: "tv-100", title: "Test Show", is_tracked: true },
   tmdb: {
@@ -31,6 +36,7 @@ const mockGetSeasonDetails = mock(() => Promise.resolve({
   },
   seasonNumber: 1,
   country: "US",
+  seasons: defaultSeasons,
 }));
 
 const mockGetSeasonEpisodeStatus = mock(() => Promise.resolve({
@@ -90,6 +96,7 @@ afterEach(() => {
       credits: { cast: [], crew: [] },
     },
     seasonNumber: 1, country: "US",
+    seasons: defaultSeasons,
   }));
 
   mockGetSeasonEpisodeStatus.mockImplementation(() => Promise.resolve({
@@ -228,5 +235,41 @@ describe("SeasonDetailPage", () => {
     await waitFor(() => {
       expect(mockWatchEpisodesBulk).toHaveBeenCalledWith([10, 11], true);
     });
+  });
+
+  it("renders season selector when multiple seasons exist", async () => {
+    render(<SeasonDetailPage />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByText("Pilot")).toBeDefined());
+
+    const selector = screen.getByRole("combobox");
+    expect(selector).toBeDefined();
+
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(2);
+    expect(options[0].textContent).toBe("Season 1");
+    expect(options[1].textContent).toBe("Season 2");
+  });
+
+  it("does not render season selector when only one season", async () => {
+    mockGetSeasonDetails.mockImplementation(() => Promise.resolve({
+      title: { id: "tv-100", title: "Test Show", is_tracked: true },
+      tmdb: {
+        id: 1, name: "Season 1", overview: "Overview", air_date: "2024-01-01", poster_path: null, season_number: 1, vote_average: 8.0,
+        episodes: [
+          { id: 101, name: "Pilot", overview: "First", air_date: "2024-01-01", episode_number: 1, season_number: 1, still_path: null, runtime: 45, vote_average: 8.5, guest_stars: [], crew: [] },
+        ],
+        credits: { cast: [], crew: [] },
+      },
+      seasonNumber: 1, country: "US",
+      seasons: [{ id: 1, name: "Season 1", overview: "", air_date: "2024-01-01", episode_count: 1, poster_path: null, season_number: 1, vote_average: 8.0 }],
+    }));
+
+    render(<SeasonDetailPage />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByText("Pilot")).toBeDefined());
+
+    const selector = screen.queryByRole("combobox");
+    expect(selector).toBeNull();
   });
 });

--- a/frontend/src/pages/SeasonDetailPage.tsx
+++ b/frontend/src/pages/SeasonDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useParams, Link } from "react-router";
+import { useParams, Link, useNavigate } from "react-router";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import * as api from "../api";
@@ -32,6 +32,7 @@ export default function SeasonDetailPage() {
   const { id, season } = useParams<{ id: string; season: string }>();
   const { user } = useAuth();
   const { t } = useTranslation();
+  const navigate = useNavigate();
 
   const { data, loading, error } = useApiCall<SeasonDetailsResponse>(
     () => api.getSeasonDetails(id!, Number(season)),
@@ -126,7 +127,7 @@ export default function SeasonDetailPage() {
     );
   }
 
-  const { title, tmdb, seasonNumber } = data;
+  const { title, tmdb, seasonNumber, seasons } = data;
   const posterUrl = tmdb?.poster_path ? `${TMDB_IMG}/w500${tmdb.poster_path}` : title.poster_url;
   const episodes = tmdb?.episodes || [];
 
@@ -140,7 +141,21 @@ export default function SeasonDetailPage() {
       <div className="flex items-center gap-2 text-sm text-zinc-400">
         <Link to={`/title/${title.id}`} className="hover:text-white transition-colors">{title.title}</Link>
         <span className="text-zinc-600">/</span>
-        <span className="text-white">{tmdb?.name || `Season ${seasonNumber}`}</span>
+        {seasons && seasons.length > 1 ? (
+          <select
+            value={seasonNumber}
+            onChange={(e) => navigate(`/title/${title.id}/season/${e.target.value}`)}
+            className="bg-zinc-800 text-white text-sm rounded-lg border border-white/[0.06] px-2 py-1 focus:border-amber-500/50 focus:outline-none cursor-pointer"
+          >
+            {seasons.map((s) => (
+              <option key={s.season_number} value={s.season_number} className="bg-zinc-900">
+                {s.name}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <span className="text-white">{tmdb?.name || `Season ${seasonNumber}`}</span>
+        )}
       </div>
 
       {/* Header */}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -291,6 +291,7 @@ export interface SeasonDetailsResponse {
   } | null;
   seasonNumber: number;
   country: string;
+  seasons: SeasonSummary[];
 }
 
 export interface EpisodeDetailsResponse {

--- a/server/routes/details.test.ts
+++ b/server/routes/details.test.ts
@@ -143,6 +143,40 @@ describe("GET /details/show/:id/season/:season", () => {
     const body = await res.json();
     expect(body.error).toBe("Invalid season number");
   });
+
+  it("includes seasons array from show details", async () => {
+    upsertTitles([makeParsedTitle({ id: "tv-555", objectType: "SHOW", title: "Season Show", tmdbId: "555" })]);
+
+    (tmdbClient.fetchShowFullDetails as any).mockResolvedValueOnce({
+      seasons: [
+        { season_number: 0, name: "Specials", episode_count: 2, air_date: null, poster_path: null },
+        { season_number: 1, name: "Season 1", episode_count: 10, air_date: "2024-01-01", poster_path: "/s1.jpg" },
+        { season_number: 2, name: "Season 2", episode_count: 8, air_date: "2024-06-01", poster_path: "/s2.jpg" },
+      ],
+    });
+
+    const res = await app.request("/details/show/tv-555/season/1");
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.seasons).toHaveLength(2);
+    expect(body.seasons[0].season_number).toBe(1);
+    expect(body.seasons[1].season_number).toBe(2);
+    // Season 0 (Specials) should be filtered out
+    expect(body.seasons.find((s: any) => s.season_number === 0)).toBeUndefined();
+  });
+
+  it("returns empty seasons array when show details fetch fails", async () => {
+    upsertTitles([makeParsedTitle({ id: "tv-555", objectType: "SHOW", title: "Season Show", tmdbId: "555" })]);
+
+    (tmdbClient.fetchShowFullDetails as any).mockRejectedValueOnce(new Error("TMDB error"));
+
+    const res = await app.request("/details/show/tv-555/season/1");
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.seasons).toEqual([]);
+  });
 });
 
 describe("GET /details/show/:id/season/:season/episode/:episode", () => {

--- a/server/routes/details.ts
+++ b/server/routes/details.ts
@@ -97,15 +97,35 @@ app.get("/show/:id/season/:season", async (c) => {
   if (isNaN(seasonNumber)) return c.json({ error: "Invalid season number" }, 400);
 
   let tmdb = null;
+  let seasons: { season_number: number; name: string; episode_count: number; air_date: string | null; poster_path: string | null }[] = [];
+
   if (title.tmdb_id && CONFIG.TMDB_API_KEY) {
-    try {
-      tmdb = await fetchSeasonDetails(title.tmdb_id, seasonNumber);
-    } catch (e) {
-      log.error("TMDB season fetch failed", { tmdbId: title.tmdb_id, season: seasonNumber, err: e });
+    const [seasonResult, showResult] = await Promise.allSettled([
+      fetchSeasonDetails(title.tmdb_id, seasonNumber),
+      fetchShowFullDetails(title.tmdb_id),
+    ]);
+
+    if (seasonResult.status === "fulfilled") {
+      tmdb = seasonResult.value;
+    } else {
+      log.error("TMDB season fetch failed", { tmdbId: title.tmdb_id, season: seasonNumber, err: seasonResult.reason });
+    }
+
+    if (showResult.status === "fulfilled" && showResult.value?.seasons) {
+      seasons = showResult.value.seasons
+        .filter((s: { season_number: number }) => s.season_number > 0)
+        .sort((a: { season_number: number }, b: { season_number: number }) => a.season_number - b.season_number)
+        .map((s: { season_number: number; name: string; episode_count: number; air_date: string | null; poster_path: string | null }) => ({
+          season_number: s.season_number,
+          name: s.name,
+          episode_count: s.episode_count,
+          air_date: s.air_date,
+          poster_path: s.poster_path,
+        }));
     }
   }
 
-  return ok(c, { title, tmdb, seasonNumber, country });
+  return ok(c, { title, tmdb, seasonNumber, country, seasons });
 });
 
 app.get("/show/:id/season/:season/episode/:episode", async (c) => {


### PR DESCRIPTION
## Summary
This PR adds a season selector dropdown to the SeasonDetailPage that allows users to quickly navigate between seasons of a TV show. The dropdown is only displayed when a show has multiple seasons.

## Key Changes
- **Backend (details.ts)**: Modified the `/show/:id/season/:season` endpoint to fetch and return a list of all seasons for a show alongside the current season details. Seasons are filtered to exclude season 0 (specials) and sorted by season number.
- **Frontend (SeasonDetailPage.tsx)**: Added a season selector dropdown in the breadcrumb navigation that conditionally renders only when multiple seasons exist. Users can select a different season to navigate to it.
- **Type definitions (types.ts)**: Extended `SeasonDetailsResponse` to include a `seasons` array of `SeasonSummary` objects.
- **Tests**: Added comprehensive test coverage for both backend and frontend:
  - Backend tests verify that seasons are correctly fetched, filtered (excluding season 0), and returned in the response
  - Backend test confirms graceful handling when show details fetch fails (returns empty array)
  - Frontend tests verify the dropdown renders with correct options when multiple seasons exist
  - Frontend test confirms the dropdown is hidden when only one season exists

## Implementation Details
- The season selector uses a native HTML `<select>` element styled to match the application's design system
- Navigation is handled via `useNavigate` hook when a season is selected
- The backend uses `Promise.allSettled()` to fetch both season and show details independently, ensuring one failure doesn't block the other
- Season 0 (specials) is filtered out from the returned seasons list as it's typically not a selectable season

https://claude.ai/code/session_012ReALTT79sTgGLTajAUbt5