### PR TITLE
Fix date picker UI: align weekdays, fix month/arrow overlap, dim outside dates

### DIFF
--- a/frontend/src/components/AgendaCalendar.tsx
+++ b/frontend/src/components/AgendaCalendar.tsx
@@ -637,6 +637,7 @@ export default function AgendaCalendar({
                         weekday: "!text-zinc-500",
                         today: "!bg-amber-500/20 !text-amber-400",
                         day: "text-zinc-300",
+                        outside: "!text-zinc-600",
                       }}
                       onSelect={(date) => {
                         if (date) {

--- a/frontend/src/components/ui/calendar.tsx
+++ b/frontend/src/components/ui/calendar.tsx
@@ -65,7 +65,7 @@ function Calendar({
           defaultClassNames.button_next
         ),
         month_caption: cn(
-          "flex h-(--cell-size) w-full items-center justify-center px-(--cell-size)",
+          "flex h-(--cell-size) w-full items-center justify-center px-10",
           defaultClassNames.month_caption
         ),
         dropdowns: cn(
@@ -90,7 +90,7 @@ function Calendar({
         table: "w-full border-collapse",
         weekdays: cn("flex w-full", defaultClassNames.weekdays),
         weekday: cn(
-          "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",
+          "flex-1 rounded-(--cell-radius) text-center text-[0.8rem] font-normal text-muted-foreground select-none",
           defaultClassNames.weekday
         ),
         week: cn("mt-2 flex w-full", defaultClassNames.week),


### PR DESCRIPTION
- Add text-center to weekday headers for proper grid alignment
- Increase month caption padding (px-10) to prevent overlap with nav arrows
- Add explicit outside date styling (!text-zinc-600) in AgendaCalendar

https://claude.ai/code/session_01Fva1SVW5NWYwiZXDjZCFD6