### PR TITLE
feat: show multiple streaming providers with dropdown split button

### DIFF
--- a/frontend/src/components/AgendaCalendar.tsx
+++ b/frontend/src/components/AgendaCalendar.tsx
@@ -18,12 +18,11 @@ import type { Title, Episode } from "../types";
 import { CalendarSkeleton } from "../components/SkeletonComponents";
 import {
   formatEpisodeCode,
-  getUniqueProviders,
   getEpisodeCardImageUrl,
   groupByShow,
 } from "../components/EpisodeComponents";
 import WatchedToggleButton from "../components/WatchedToggleButton";
-import WatchButton from "../components/WatchButton";
+import WatchButtonGroup from "../components/WatchButtonGroup";
 
 
 // ─── Types & Helpers ───────────────────────────────────────────────────────
@@ -781,7 +780,6 @@ export default function AgendaCalendar({
                           {dayEpisodes.map((ep) => {
                             const showEps = episodesByShow.get(ep.title_id) ?? [ep];
                             const imgUrl = getEpisodeCardImageUrl(ep);
-                            const providers = getUniqueProviders(ep.offers);
                             return (
                               <div
                                 key={ep.id}
@@ -836,16 +834,9 @@ export default function AgendaCalendar({
                                           )}
                                         </p>
                                       </Link>
-                                      {isEpisodeReleased(ep) && providers.length > 0 && (
+                                      {isEpisodeReleased(ep) && (
                                         <div className="mt-2">
-                                          <WatchButton
-                                            url={providers[0].url}
-                                            providerId={providers[0].provider_id}
-                                            providerName={providers[0].provider_name}
-                                            providerIconUrl={providers[0].provider_icon_url}
-                                            monetizationType={providers[0].monetization_type}
-                                            variant="full"
-                                          />
+                                          <WatchButtonGroup offers={ep.offers ?? []} variant="dropdown" />
                                         </div>
                                       )}
                                     </div>

--- a/frontend/src/components/EpisodeComponents.tsx
+++ b/frontend/src/components/EpisodeComponents.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router";
 import type { Episode, Offer } from "../types";
-import WatchButton from "./WatchButton";
+import WatchButtonGroup from "./WatchButtonGroup";
 import WatchedToggleButton from "./WatchedToggleButton";
 
 export function formatEpisodeCode(ep: Episode): string {
@@ -60,7 +60,6 @@ export function WatchedIcon({ watched, onClick, disabled, size = "sm", compactOn
 }
 
 export function EpisodeCard({ episode, compact, onToggleWatched }: { episode: Episode; compact?: boolean; onToggleWatched: (id: number, current: boolean) => void }) {
-  const providers = getUniqueProviders(episode.offers);
   const unreleased = !isEpisodeReleased(episode);
 
   if (compact) {
@@ -87,9 +86,9 @@ export function EpisodeCard({ episode, compact, onToggleWatched }: { episode: Ep
             </p>
           </Link>
         </div>
-        {!unreleased && providers.length > 0 && (
+        {!unreleased && (
           <div className="flex-shrink-0">
-            <WatchButton url={providers[0].url} providerId={providers[0].provider_id} providerName={providers[0].provider_name} providerIconUrl={providers[0].provider_icon_url} monetizationType={providers[0].monetization_type} variant="full" />
+            <WatchButtonGroup offers={episode.offers ?? []} variant="dropdown" />
           </div>
         )}
         <div className="flex-shrink-0">
@@ -125,9 +124,9 @@ export function EpisodeCard({ episode, compact, onToggleWatched }: { episode: Ep
           {episode.overview && (
             <p className="text-sm text-zinc-400 mt-2 line-clamp-2">{episode.overview}</p>
           )}
-          {!unreleased && providers.length > 0 && (
+          {!unreleased && (
             <div className="mt-3">
-              <WatchButton url={providers[0].url} providerId={providers[0].provider_id} providerName={providers[0].provider_name} providerIconUrl={providers[0].provider_icon_url} monetizationType={providers[0].monetization_type} variant="full" />
+              <WatchButtonGroup offers={episode.offers ?? []} variant="dropdown" />
             </div>
           )}
         </div>
@@ -150,7 +149,6 @@ export function ShowEpisodeGroup({ showTitle, episodes, posterUrl, compact, onTo
     return <EpisodeCard episode={episodes[0]} compact={compact} onToggleWatched={onToggleWatched} />;
   }
 
-  const providers = getUniqueProviders(episodes[0].offers);
   const allUnreleased = episodes.every((ep) => !isEpisodeReleased(ep));
 
   if (compact) {
@@ -176,9 +174,9 @@ export function ShowEpisodeGroup({ showTitle, episodes, posterUrl, compact, onTo
             ))}
           </div>
         </div>
-        {!allUnreleased && providers.length > 0 && (
+        {!allUnreleased && (
           <div className="flex-shrink-0">
-            <WatchButton url={providers[0].url} providerId={providers[0].provider_id} providerName={providers[0].provider_name} providerIconUrl={providers[0].provider_icon_url} monetizationType={providers[0].monetization_type} variant="full" />
+            <WatchButtonGroup offers={episodes[0].offers ?? []} variant="dropdown" />
           </div>
         )}
       </div>
@@ -210,9 +208,9 @@ export function ShowEpisodeGroup({ showTitle, episodes, posterUrl, compact, onTo
               </div>
             ))}
           </div>
-          {!allUnreleased && providers.length > 0 && (
+          {!allUnreleased && (
             <div className="mt-3">
-              <WatchButton url={providers[0].url} providerId={providers[0].provider_id} providerName={providers[0].provider_name} providerIconUrl={providers[0].provider_icon_url} monetizationType={providers[0].monetization_type} variant="full" />
+              <WatchButtonGroup offers={episodes[0].offers ?? []} variant="dropdown" />
             </div>
           )}
         </div>

--- a/frontend/src/components/EpisodeShowCard.tsx
+++ b/frontend/src/components/EpisodeShowCard.tsx
@@ -6,11 +6,10 @@ import ScrollableRow from "./ScrollableRow";
 import type { Episode } from "../types";
 import {
   formatEpisodeCode,
-  getUniqueProviders,
   getEpisodeCardImageUrl,
   isEpisodeReleased,
 } from "./EpisodeComponents";
-import WatchButton from "./WatchButton";
+import WatchButtonGroup from "./WatchButtonGroup";
 
 /** Shared card component used across Unwatched, Today, Coming Up, and Calendar sections */
 export const EpisodeShowCard = memo(function EpisodeShowCard({
@@ -32,7 +31,6 @@ export const EpisodeShowCard = memo(function EpisodeShowCard({
 }) {
   const { t } = useTranslation();
   const imageUrl = getEpisodeCardImageUrl(episode);
-  const providers = getUniqueProviders(episode.offers);
 
   return (
     <div className="bg-zinc-900 rounded-xl overflow-hidden flex flex-col h-full">
@@ -73,9 +71,9 @@ export const EpisodeShowCard = memo(function EpisodeShowCard({
         </p>
 
         {/* Stream button — only for released episodes */}
-        {isEpisodeReleased(episode) && providers.length > 0 && (
+        {isEpisodeReleased(episode) && (
           <div className="mt-2">
-            <WatchButton url={providers[0].url} providerId={providers[0].provider_id} providerName={providers[0].provider_name} providerIconUrl={providers[0].provider_icon_url} monetizationType={providers[0].monetization_type} variant="full" />
+            <WatchButtonGroup offers={episode.offers ?? []} variant="dropdown" />
           </div>
         )}
 

--- a/frontend/src/components/HeroBanner.tsx
+++ b/frontend/src/components/HeroBanner.tsx
@@ -2,9 +2,9 @@ import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { Link } from "react-router";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import type { Episode } from "../types";
-import { formatEpisodeCode, getUniqueProviders } from "./EpisodeComponents";
+import { formatEpisodeCode } from "./EpisodeComponents";
 import { useDominantColors } from "./useDominantColor";
-import WatchButton from "./WatchButton";
+import WatchButtonGroup from "./WatchButtonGroup";
 
 export interface HeroBannerSlide {
   featured: Episode;
@@ -245,25 +245,9 @@ export default function HeroBanner({ episodes }: { episodes: Episode[] }) {
               {current.remainingCount} episode
               {current.remainingCount !== 1 ? "s" : ""} remaining
             </p>
-            {(() => {
-              const providers = getUniqueProviders(current.featured.offers);
-              if (providers.length === 0) return null;
-              return (
-                <div className="flex gap-2 mt-3">
-                  {providers.slice(0, 4).map((o) => (
-                    <WatchButton
-                      key={o.provider_id}
-                      url={o.url}
-                      providerId={o.provider_id}
-                      providerName={o.provider_name}
-                      providerIconUrl={o.provider_icon_url}
-                      monetizationType={o.monetization_type}
-                      variant="full"
-                    />
-                  ))}
-                </div>
-              );
-            })()}
+            <div className="mt-3">
+              <WatchButtonGroup offers={current.featured.offers ?? []} variant="inline" maxVisible={4} />
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/ReelsCard.tsx
+++ b/frontend/src/components/ReelsCard.tsx
@@ -1,7 +1,7 @@
 import { CheckCircle, Check } from "lucide-react";
 import { Link } from "react-router";
-import type { Episode, Offer } from "../types";
-import WatchButton from "./WatchButton";
+import type { Episode } from "../types";
+import WatchButtonGroup from "./WatchButtonGroup";
 
 function formatEpisodeCode(ep: Episode): string {
   const s = String(ep.season_number).padStart(2, "0");
@@ -19,17 +19,6 @@ function isToday(dateStr: string | null): boolean {
   if (!dateStr) return false;
   const today = new Date().toISOString().slice(0, 10);
   return dateStr === today;
-}
-
-function getUniqueProviders(offers?: Offer[]) {
-  if (!offers?.length) return [];
-  const map = new Map<number, Offer>();
-  for (const o of offers) {
-    if (o.monetization_type === "FLATRATE" || o.monetization_type === "FREE" || o.monetization_type === "ADS") {
-      if (!map.has(o.provider_id)) map.set(o.provider_id, o);
-    }
-  }
-  return Array.from(map.values());
 }
 
 export function getBackgroundImageUrl(episode: Episode): string | null {
@@ -52,7 +41,6 @@ interface ReelsCardProps {
 
 export default function ReelsCard({ episode, caughtUp, onMarkWatched, index, total }: ReelsCardProps) {
   const bgUrl = getBackgroundImageUrl(episode);
-  const providers = getUniqueProviders(episode.offers);
   const airDateFormatted = formatAirDate(episode.air_date);
   const isNew = isToday(episode.air_date);
 
@@ -134,19 +122,9 @@ export default function ReelsCard({ episode, caughtUp, onMarkWatched, index, tot
             )}
 
             {/* Watch on provider button */}
-            {providers.length > 0 && (
-              <div className="mb-2">
-                <WatchButton
-                  url={providers[0].url}
-                  providerId={providers[0].provider_id}
-                  providerName={providers[0].provider_name}
-                  providerIconUrl={providers[0].provider_icon_url}
-                  monetizationType={providers[0].monetization_type}
-                  variant="full"
-                  className="w-full justify-center px-6 py-3 rounded-xl text-base font-semibold"
-                />
-              </div>
-            )}
+            <div className="mb-2">
+              <WatchButtonGroup offers={episode.offers ?? []} variant="dropdown" size="lg" fullWidth />
+            </div>
 
             {/* Mark as watched button */}
             <button

--- a/frontend/src/components/TitleCard.tsx
+++ b/frontend/src/components/TitleCard.tsx
@@ -2,7 +2,7 @@ import { memo } from "react";
 import { Link } from "react-router";
 import type { Title } from "../types";
 import TrackButton from "./TrackButton";
-import WatchButton from "./WatchButton";
+import WatchButtonGroup from "./WatchButtonGroup";
 import VisibilityButton from "./VisibilityButton";
 
 interface Props {
@@ -15,16 +15,6 @@ interface Props {
 }
 
 const TitleCard = memo(function TitleCard({ title, onTrackToggle, showVisibilityToggle, onVisibilityToggle, hideTypeBadge, showProgressBar }: Props) {
-  // Deduplicate offers by provider (keep best quality)
-  const uniqueProviders = new Map<number, Title["offers"][0]>();
-  for (const offer of title.offers) {
-    if (offer.monetization_type === "FLATRATE" || offer.monetization_type === "FREE" || offer.monetization_type === "ADS") {
-      if (!uniqueProviders.has(offer.provider_id)) {
-        uniqueProviders.set(offer.provider_id, offer);
-      }
-    }
-  }
-  const streamingOffers = Array.from(uniqueProviders.values());
 
   return (
     <div className={`bg-zinc-900 rounded-xl overflow-hidden hover:scale-[1.02] transition-transform duration-200 flex flex-col${title.show_status === "completed" ? " opacity-75" : ""}`}>
@@ -135,16 +125,7 @@ const TitleCard = memo(function TitleCard({ title, onTrackToggle, showVisibility
 
         {/* Buttons — always anchored at bottom */}
         <div className="mt-auto flex flex-col gap-2">
-          {streamingOffers.length > 0 && (
-            <WatchButton
-              url={streamingOffers[0].url}
-              providerId={streamingOffers[0].provider_id}
-              providerName={streamingOffers[0].provider_name}
-              providerIconUrl={streamingOffers[0].provider_icon_url}
-              monetizationType={streamingOffers[0].monetization_type}
-              variant="full"
-            />
-          )}
+          <WatchButtonGroup offers={title.offers} variant="dropdown" />
           <TrackButton
             titleId={title.id}
             isTracked={title.is_tracked}

--- a/frontend/src/components/WatchButton.tsx
+++ b/frontend/src/components/WatchButton.tsx
@@ -12,7 +12,7 @@ interface WatchButtonProps {
   className?: string;
 }
 
-function monetizationLabel(type?: string): string | null {
+export function monetizationLabel(type?: string): string | null {
   switch (type) {
     case "FLATRATE": return "Stream";
     case "FREE": return "Free";

--- a/frontend/src/components/WatchButtonGroup.test.tsx
+++ b/frontend/src/components/WatchButtonGroup.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { render, screen, cleanup } from "@testing-library/react";
+import WatchButtonGroup from "./WatchButtonGroup";
+import type { Offer } from "../types";
+
+afterEach(cleanup);
+
+function makeOffer(overrides: Partial<Offer> = {}): Offer {
+  return {
+    id: 1,
+    title_id: "title-1",
+    provider_id: 8,
+    monetization_type: "FLATRATE",
+    presentation_type: "HD",
+    price_value: null,
+    price_currency: null,
+    url: "https://netflix.com/watch",
+    available_to: null,
+    provider_name: "Netflix",
+    provider_technical_name: "netflix",
+    provider_icon_url: "https://example.com/netflix.png",
+    ...overrides,
+  };
+}
+
+describe("WatchButtonGroup", () => {
+  it("returns null for empty offers", () => {
+    const { container } = render(<WatchButtonGroup offers={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null for RENT/BUY-only offers", () => {
+    const { container } = render(
+      <WatchButtonGroup offers={[makeOffer({ monetization_type: "RENT" }), makeOffer({ monetization_type: "BUY", id: 2 })]} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a single provider link without caret", () => {
+    render(<WatchButtonGroup offers={[makeOffer()]} />);
+    const link = screen.getByRole("link");
+    expect(link.getAttribute("href")).toBe("https://netflix.com/watch");
+    expect(screen.queryByLabelText(/More streaming options/)).toBeNull();
+  });
+
+  it("renders a split button with caret for 2 providers", () => {
+    const offers = [
+      makeOffer(),
+      makeOffer({ id: 2, provider_id: 15, provider_name: "Hulu", url: "https://hulu.com/watch", provider_icon_url: "https://example.com/hulu.png" }),
+    ];
+    render(<WatchButtonGroup offers={offers} />);
+    const primaryLink = screen.getByRole("link");
+    expect(primaryLink.getAttribute("href")).toBe("https://netflix.com/watch");
+    const caretBtn = screen.getByLabelText(/More streaming options/);
+    expect(caretBtn).toBeDefined();
+  });
+
+  it("deduplicates providers by provider_id", () => {
+    const offers = [
+      makeOffer({ id: 1, presentation_type: "HD" }),
+      makeOffer({ id: 2, presentation_type: "4K", url: "https://netflix.com/4k" }),
+    ];
+    render(<WatchButtonGroup offers={offers} />);
+    // Same provider_id=8, deduped → single provider, no caret
+    const links = screen.getAllByRole("link");
+    expect(links.length).toBe(1);
+    expect(links[0].getAttribute("href")).toBe("https://netflix.com/watch");
+  });
+
+  it("renders inline variant with multiple buttons", () => {
+    const offers = [
+      makeOffer(),
+      makeOffer({ id: 2, provider_id: 15, provider_name: "Hulu", url: "https://hulu.com/watch", provider_icon_url: "https://example.com/hulu.png" }),
+    ];
+    render(<WatchButtonGroup offers={offers} variant="inline" />);
+    const links = screen.getAllByRole("link");
+    expect(links.length).toBe(2);
+  });
+
+  it("respects maxVisible in inline variant", () => {
+    const offers = [
+      makeOffer({ id: 1, provider_id: 1, url: "https://a.com" }),
+      makeOffer({ id: 2, provider_id: 2, url: "https://b.com" }),
+      makeOffer({ id: 3, provider_id: 3, url: "https://c.com" }),
+    ];
+    render(<WatchButtonGroup offers={offers} variant="inline" maxVisible={2} />);
+    const links = screen.getAllByRole("link");
+    expect(links.length).toBe(2);
+  });
+
+  it("shows Stream label for FLATRATE offer", () => {
+    render(<WatchButtonGroup offers={[makeOffer()]} />);
+    expect(screen.getByText("Stream")).toBeDefined();
+  });
+
+  it("shows Free label for FREE offer", () => {
+    render(<WatchButtonGroup offers={[makeOffer({ monetization_type: "FREE" })]} />);
+    expect(screen.getByText("Free")).toBeDefined();
+  });
+});

--- a/frontend/src/components/WatchButtonGroup.tsx
+++ b/frontend/src/components/WatchButtonGroup.tsx
@@ -1,0 +1,137 @@
+import { useState } from "react";
+import { ChevronDown, ExternalLink } from "lucide-react";
+import { Popover } from "@base-ui/react/popover";
+import type { Offer } from "../types";
+import WatchButton, { monetizationLabel } from "./WatchButton";
+import { getUniqueProviders } from "./EpisodeComponents";
+import { getProviderColor } from "../data/providerColors";
+
+interface Props {
+  offers: Offer[];
+  variant?: "dropdown" | "inline";
+  maxVisible?: number;
+  size?: "sm" | "lg";
+  fullWidth?: boolean;
+}
+
+export default function WatchButtonGroup({ offers, variant = "dropdown", maxVisible = 4, size = "sm", fullWidth }: Props) {
+  const providers = getUniqueProviders(offers);
+  if (providers.length === 0) return null;
+
+  if (variant === "inline") {
+    return (
+      <div className="flex flex-wrap gap-2">
+        {providers.slice(0, maxVisible).map((o) => (
+          <WatchButton
+            key={o.provider_id}
+            url={o.url}
+            providerId={o.provider_id}
+            providerName={o.provider_name}
+            providerIconUrl={o.provider_icon_url}
+            monetizationType={o.monetization_type}
+            variant="full"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  // dropdown variant — single provider: plain button, no caret
+  if (providers.length === 1) {
+    const isLg = size === "lg";
+    return (
+      <WatchButton
+        url={providers[0].url}
+        providerId={providers[0].provider_id}
+        providerName={providers[0].provider_name}
+        providerIconUrl={providers[0].provider_icon_url}
+        monetizationType={providers[0].monetization_type}
+        variant="full"
+        className={isLg ? "w-full justify-center px-6 py-3 rounded-xl text-base font-semibold" : fullWidth ? "w-full justify-center" : undefined}
+      />
+    );
+  }
+
+  return <SplitWatchButton providers={providers} size={size} fullWidth={fullWidth} />;
+}
+
+function SplitWatchButton({ providers, size, fullWidth }: { providers: Offer[]; size: "sm" | "lg"; fullWidth?: boolean }) {
+  const [primaryHovered, setPrimaryHovered] = useState(false);
+  const [caretHovered, setCaretHovered] = useState(false);
+  const primary = providers[0];
+  const rest = providers.slice(1);
+  const color = getProviderColor(primary.provider_id);
+  const label = monetizationLabel(primary.monetization_type);
+  const isLg = size === "lg";
+
+  return (
+    <div className={`flex${fullWidth || isLg ? " w-full" : ""}`} style={{ minHeight: isLg ? "52px" : "32px" }}>
+      {/* Primary provider link */}
+      <a
+        href={primary.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`flex-1 flex items-center justify-center gap-1.5 transition-colors duration-200 font-semibold ${
+          isLg
+            ? "rounded-l-xl px-6 py-3 text-base"
+            : "rounded-l-lg px-3 py-1.5 text-xs"
+        }`}
+        style={{ backgroundColor: primaryHovered ? color.hover : color.bg, color: color.text }}
+        onMouseEnter={() => setPrimaryHovered(true)}
+        onMouseLeave={() => setPrimaryHovered(false)}
+      >
+        {label && <span className="opacity-75">{label}</span>}
+        <img src={primary.provider_icon_url} alt={primary.provider_name} className="w-5 h-5 rounded" loading="lazy" />
+        <ExternalLink size={14} className="opacity-60" />
+      </a>
+
+      {/* Caret / dropdown trigger */}
+      <Popover.Root>
+        <Popover.Trigger
+          className={`flex items-center border-l border-white/20 transition-colors duration-200 cursor-pointer ${
+            isLg ? "rounded-r-xl px-2.5" : "rounded-r-lg px-1.5"
+          }`}
+          style={{ backgroundColor: caretHovered ? color.hover : color.bg, color: color.text }}
+          onMouseEnter={() => setCaretHovered(true)}
+          onMouseLeave={() => setCaretHovered(false)}
+          aria-label={`More streaming options (${rest.length} more)`}
+        >
+          <ChevronDown size={isLg ? 14 : 12} className="opacity-70" />
+        </Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Positioner side="bottom" align="end" sideOffset={4} className="z-50">
+            <Popover.Popup className="bg-zinc-900 border border-white/[0.08] rounded-lg shadow-xl p-1 min-w-[160px]">
+              {rest.map((o) => {
+                const c = getProviderColor(o.provider_id);
+                const lbl = monetizationLabel(o.monetization_type);
+                return (
+                  <a
+                    key={o.provider_id}
+                    href={o.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-2 px-3 py-2 rounded-md hover:bg-zinc-800 transition-colors"
+                  >
+                    <div
+                      className="w-6 h-6 rounded flex-shrink-0 flex items-center justify-center"
+                      style={{ backgroundColor: c.bg }}
+                    >
+                      <img src={o.provider_icon_url} alt={o.provider_name} className="w-5 h-5 rounded" loading="lazy" />
+                    </div>
+                    {lbl && (
+                      <span className="text-xs font-semibold" style={{ color: c.text }}>
+                        {lbl}
+                      </span>
+                    )}
+                    <span className="text-xs text-zinc-300 flex-1 truncate">{o.provider_name}</span>
+                    <ExternalLink size={11} className="text-zinc-600 flex-shrink-0" />
+                  </a>
+                );
+              })}
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover.Portal>
+      </Popover.Root>
+    </div>
+  );
+}

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -15,11 +15,10 @@ import type { Title, Episode } from "../types";
 import { GridCalendarSkeleton } from "../components/SkeletonComponents";
 import {
   formatEpisodeCode,
-  getUniqueProviders,
   groupByShow,
 } from "../components/EpisodeComponents";
 import WatchedToggleButton from "../components/WatchedToggleButton";
-import WatchButton from "../components/WatchButton";
+import WatchButtonGroup from "../components/WatchButtonGroup";
 import AgendaCalendar, {
   type CalendarItem,
   type ViewMode,
@@ -182,7 +181,6 @@ function SlideOverPanel({
                   <div className="space-y-2">
                     {showEps.map((ep) => {
                       const released = isEpisodeReleased(ep);
-                      const providers = getUniqueProviders(ep.offers);
                       return (
                         <div
                           key={ep.id}
@@ -236,16 +234,9 @@ function SlideOverPanel({
                                 {ep.overview}
                               </p>
                             )}
-                            {released && providers.length > 0 && (
+                            {released && (
                               <div className="mt-2">
-                                <WatchButton
-                                  url={providers[0].url}
-                                  providerId={providers[0].provider_id}
-                                  providerName={providers[0].provider_name}
-                                  providerIconUrl={providers[0].provider_icon_url}
-                                  monetizationType={providers[0].monetization_type}
-                                  variant="full"
-                                />
+                                <WatchButtonGroup offers={ep.offers ?? []} variant="dropdown" />
                               </div>
                             )}
                           </div>

--- a/frontend/src/pages/TitleDetailPage.tsx
+++ b/frontend/src/pages/TitleDetailPage.tsx
@@ -19,6 +19,7 @@ import PersonCard from "../components/PersonCard";
 import { DetailPageSkeleton } from "../components/SkeletonComponents";
 import ExternalLinks from "../components/ExternalLinks";
 import WatchButton from "../components/WatchButton";
+import WatchButtonGroup from "../components/WatchButtonGroup";
 import VisibilityButton from "../components/VisibilityButton";
 import ShareButton from "../components/ShareButton";
 import RecommendButton from "../components/RecommendButton";
@@ -343,22 +344,7 @@ function MovieDetail({ data }: { data: MovieDetailsResponse }) {
               >
                 {watched ? t("episodes.markAsUnwatched") : t("episodes.markAsWatched")}
               </button>
-              {(() => {
-                const streamingOffer = dedupeOffers(title.offers).find(o =>
-                  o.monetization_type === "FLATRATE" || o.monetization_type === "FREE" || o.monetization_type === "ADS"
-                );
-                if (!streamingOffer) return null;
-                return (
-                  <WatchButton
-                    url={streamingOffer.url}
-                    providerId={streamingOffer.provider_id}
-                    providerName={streamingOffer.provider_name}
-                    providerIconUrl={streamingOffer.provider_icon_url}
-                    monetizationType={streamingOffer.monetization_type}
-                    variant="full"
-                  />
-                );
-              })()}
+              <WatchButtonGroup offers={title.offers} variant="inline" maxVisible={3} />
             </div>
           </div>
         </div>
@@ -647,22 +633,7 @@ function ShowDetail({ data }: { data: ShowDetailsResponse }) {
             <div className="pt-2 flex flex-wrap items-center gap-2">
               <TrackButton titleId={title.id} isTracked={title.is_tracked} titleData={title} />
               <VisibilityButton titleId={title.id} isPublic={title.is_public ?? true} isTracked={title.is_tracked} />
-              {(() => {
-                const streamingOffer = dedupeOffers(title.offers).find(o =>
-                  o.monetization_type === "FLATRATE" || o.monetization_type === "FREE" || o.monetization_type === "ADS"
-                );
-                if (!streamingOffer) return null;
-                return (
-                  <WatchButton
-                    url={streamingOffer.url}
-                    providerId={streamingOffer.provider_id}
-                    providerName={streamingOffer.provider_name}
-                    providerIconUrl={streamingOffer.provider_icon_url}
-                    monetizationType={streamingOffer.monetization_type}
-                    variant="full"
-                  />
-                );
-              })()}
+              <WatchButtonGroup offers={title.offers} variant="inline" maxVisible={3} />
             </div>
           </div>
         </div>
@@ -840,16 +811,6 @@ function getCertification(results: { iso_3166_1: string; rating: string }[] | un
   if (!results) return null;
   const match = results.find(r => r.iso_3166_1 === country) || results.find(r => r.iso_3166_1 === "US");
   return match?.rating || null;
-}
-
-function dedupeOffers(offers: Title["offers"]) {
-  const map = new Map<number, Title["offers"][0]>();
-  for (const o of offers) {
-    if (!map.has(o.provider_id)) {
-      map.set(o.provider_id, o);
-    }
-  }
-  return Array.from(map.values());
 }
 
 const MONETIZATION_ORDER = [


### PR DESCRIPTION
## Summary

- Add `WatchButtonGroup` component: when a title has multiple streaming providers, cards show a split button (primary provider link + chevron that opens a popover listing all other providers); detail page heroes and HeroBanner show providers side-by-side
- Export `monetizationLabel` from `WatchButton.tsx` for reuse
- Consolidate 3 duplicate `getUniqueProviders` implementations (TitleCard inline, ReelsCard local copy) — all now use the canonical export from `EpisodeComponents.tsx`
- Remove now-unused `dedupeOffers` function from `TitleDetailPage.tsx`

**Affected locations:**
| Location | Before | After |
|---|---|---|
| TitleCard, TrackedPage cards | 1 provider button | Split button with dropdown if 2+ |
| EpisodeCard, EpisodeShowCard | 1 provider | Split button with dropdown |
| ShowEpisodeGroup | 1 provider | Split button with dropdown |
| ReelsCard | 1 full-width provider | Full-width split button |
| AgendaCalendar, CalendarPage | 1 provider | Split button with dropdown |
| TitleDetailPage heroes | 1 provider | Up to 3 inline side-by-side |
| HeroBanner | Up to 4 inline (unchanged behavior) | Uses WatchButtonGroup inline |

## Test plan

- [ ] `bun run check` passes (1402 tests, 0 errors)
- [ ] Cards with 1 provider render identically to before (no caret)
- [ ] Cards with 2+ providers show split button; chevron opens popover listing other providers
- [ ] Popover closes on click-outside and navigates on item click
- [ ] Title detail page hero shows multiple stream buttons side-by-side
- [ ] ReelsCard split button is full-width
- [ ] Calendar page slide-over dropdown works

🤖 Generated with [Claude Code](https://claude.com/claude-code)