### PR TITLE
fix: re-enrich titles whose SA fetch ran before the offer-creation fix

### DIFF
--- a/server/db/repository/offers.ts
+++ b/server/db/repository/offers.ts
@@ -61,7 +61,7 @@ export async function getTitlesNeedingSaEnrichment(limit = 500) {
       .from(titles)
       .leftJoin(tracked, eq(titles.id, tracked.titleId))
       .where(
-        sql`${titles.tmdbId} IS NOT NULL AND (${titles.saFetchedAt} IS NULL OR ${titles.saFetchedAt} < '2026-03-30')`,
+        sql`${titles.tmdbId} IS NOT NULL AND (${titles.saFetchedAt} IS NULL OR ${titles.saFetchedAt} < '2026-03-31')`,
       )
       .orderBy(
         sql`CASE


### PR DESCRIPTION
## Summary
- Bumps the SA re-enrichment cutoff from `'2026-03-30'` to `'2026-03-31'` so titles enriched on 2026-03-30 before the `createOfferFromSA` fix was deployed are picked up again
- Root cause: Harley Quinn was SA-enriched at 04:00 on 2026-03-30, ~16 hours before the fix landed at 20:15. TMDB had no providers for it in HR, so the old code (update-only) silently discarded the SA data. The `< '2026-03-30'` cutoff excluded it from re-processing.

## Test plan
- [ ] All existing tests pass (`bun run check`)
- [ ] After deploy, next `sync-deep-links` cron picks up Harley Quinn and creates an offer: `SELECT * FROM offers WHERE title_id = 'tv-74440'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)