### PR TITLE
feat: per-user Plex integration with watched status sync

### DIFF
--- a/drizzle/0014_add_integrations.sql
+++ b/drizzle/0014_add_integrations.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS `integrations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`provider` text NOT NULL,
+	`name` text NOT NULL,
+	`config` text NOT NULL,
+	`enabled` integer NOT NULL DEFAULT 1,
+	`last_sync_at` text,
+	`last_sync_error` text,
+	`created_at` text DEFAULT (datetime('now')),
+	`updated_at` text DEFAULT (datetime('now')),
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_integrations_user_id` ON `integrations` (`user_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_integrations_provider` ON `integrations` (`provider`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1775252400000,
       "tag": "0013_add_profile_visibility_states",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1775352400000,
+      "tag": "0014_add_integrations",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -493,3 +493,80 @@ export async function redeemInvitation(code: string): Promise<{ success: boolean
 export async function revokeInvitation(id: string): Promise<void> {
   await fetchJson(`/invitations/${encodeURIComponent(id)}`, { method: "DELETE" });
 }
+
+// ─── Integrations (Plex) ─────────────────────────────────────────────────────
+
+export interface PlexIntegrationConfig {
+  serverUrl: string;
+  serverId: string;
+  serverName: string;
+  plexUsername: string;
+  syncMovies: boolean;
+  syncEpisodes: boolean;
+}
+
+export interface Integration {
+  id: string;
+  user_id: string;
+  provider: string;
+  name: string;
+  config: PlexIntegrationConfig;
+  enabled: boolean;
+  last_sync_at: string | null;
+  last_sync_error: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PlexServer {
+  name: string;
+  clientIdentifier: string;
+  connections: Array<{ uri: string; local: boolean; relay: boolean }>;
+}
+
+export async function getIntegrations(): Promise<{ integrations: Integration[] }> {
+  return fetchJson("/integrations");
+}
+
+export async function createIntegration(data: {
+  provider: string;
+  name?: string;
+  config: Record<string, unknown>;
+}): Promise<{ integration: Integration }> {
+  return fetchJson("/integrations", {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateIntegration(
+  id: string,
+  data: Partial<{ name: string; enabled: boolean; config: Partial<PlexIntegrationConfig> }>
+): Promise<{ integration: Integration }> {
+  return fetchJson(`/integrations/${encodeURIComponent(id)}`, {
+    method: "PUT",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteIntegration(id: string): Promise<void> {
+  await fetchJson(`/integrations/${encodeURIComponent(id)}`, { method: "DELETE" });
+}
+
+export async function createPlexPin(): Promise<{ pinId: number; authUrl: string }> {
+  return fetchJson("/integrations/plex/pin", { method: "POST" });
+}
+
+export async function checkPlexPin(pinId: number): Promise<{
+  resolved: boolean;
+  authToken?: string;
+  servers?: PlexServer[];
+}> {
+  return fetchJson(`/integrations/plex/pin/${pinId}`, { method: "POST" });
+}
+
+export async function triggerPlexSync(
+  id: string
+): Promise<{ success: boolean; moviesMarked?: number; episodesMarked?: number; error?: string }> {
+  return fetchJson(`/integrations/${encodeURIComponent(id)}/sync`, { method: "POST" });
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { SUPPORTED_LANGUAGES, setLanguage } from "../i18n";
 import { useAuth } from "../context/AuthContext";
 import * as api from "../api";
-import type { JobsResponse, Notifier } from "../api";
+import type { JobsResponse, Notifier, Integration, PlexServer } from "../api";
 import type { AdminSettings, Title } from "../types";
 import { isPushSupported, subscribeToPush, unsubscribeFromPush, getExistingSubscription } from "../lib/push";
 import { authClient } from "../lib/auth-client";
@@ -30,6 +30,7 @@ export default function SettingsPage() {
       <SocialSection />
       <WatchlistSection />
       {isPushSupported() && <PushNotificationsSection />}
+      <PlexSection />
       <NotificationsSection />
       {user.is_admin && <BackgroundJobsSection />}
       {user.is_admin && <AdminSection />}
@@ -1469,5 +1470,360 @@ function SettingField({
         />
       )}
     </div>
+  );
+}
+
+// ─── Plex Integration ────────────────────────────────────────────────────────
+
+type ConnectStep =
+  | { type: "idle" }
+  | { type: "waiting"; pinId: number; authUrl: string }
+  | { type: "pick_server"; authToken: string; servers: PlexServer[] };
+
+function PlexSection() {
+  const [integrations, setIntegrations] = useState<Integration[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [step, setStep] = useState<ConnectStep>({ type: "idle" });
+  const [checking, setChecking] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [syncing, setSyncing] = useState<string | null>(null);
+  const [toggling, setToggling] = useState<string | null>(null);
+  const [msg, setMsg] = useState("");
+  const [err, setErr] = useState("");
+
+  // Server picker form state
+  const [selectedServer, setSelectedServer] = useState<PlexServer | null>(null);
+  const [selectedUri, setSelectedUri] = useState("");
+  const [syncMovies, setSyncMovies] = useState(true);
+  const [syncEpisodes, setSyncEpisodes] = useState(true);
+
+  const refresh = useCallback(() => {
+    api.getIntegrations()
+      .then((r) => {
+        setIntegrations(r.integrations.filter((i) => i.provider === "plex"));
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  async function handleConnect() {
+    setMsg("");
+    setErr("");
+    try {
+      const { pinId, authUrl } = await api.createPlexPin();
+      window.open(authUrl, "_blank", "noopener");
+      setStep({ type: "waiting", pinId, authUrl });
+    } catch {
+      setErr("Failed to start Plex authorization. Please try again.");
+    }
+  }
+
+  async function handleCheckAuth() {
+    if (step.type !== "waiting") return;
+    setChecking(true);
+    setErr("");
+    try {
+      const result = await api.checkPlexPin(step.pinId);
+      if (!result.resolved) {
+        setErr("Authorization not yet completed. Please authorize in the Plex window, then try again.");
+        return;
+      }
+      const servers = result.servers ?? [];
+      if (servers.length === 0) {
+        setErr("No Plex servers found on your account.");
+        return;
+      }
+      setStep({ type: "pick_server", authToken: result.authToken!, servers });
+      // Pre-select the first server + first connection
+      setSelectedServer(servers[0]);
+      const firstConn = servers[0].connections.find((c) => !c.relay) ?? servers[0].connections[0];
+      setSelectedUri(firstConn?.uri ?? "");
+    } catch {
+      setErr("Failed to check authorization. Please try again.");
+    } finally {
+      setChecking(false);
+    }
+  }
+
+  function handleCancelConnect() {
+    setStep({ type: "idle" });
+    setSelectedServer(null);
+    setSelectedUri("");
+    setErr("");
+  }
+
+  async function handleSaveServer() {
+    if (step.type !== "pick_server" || !selectedServer || !selectedUri) return;
+    setSaving(true);
+    setErr("");
+    try {
+      await api.createIntegration({
+        provider: "plex",
+        config: {
+          plexToken: step.authToken,
+          serverUrl: selectedUri,
+          serverId: selectedServer.clientIdentifier,
+          serverName: selectedServer.name,
+          syncMovies,
+          syncEpisodes,
+        },
+      });
+      setStep({ type: "idle" });
+      setMsg("Plex server connected successfully.");
+      refresh();
+    } catch (e: unknown) {
+      setErr(e instanceof Error ? e.message : "Failed to save integration.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleSync(id: string) {
+    setMsg("");
+    setErr("");
+    setSyncing(id);
+    try {
+      const result = await api.triggerPlexSync(id);
+      if (result.success) {
+        setMsg(`Sync complete — ${result.moviesMarked ?? 0} movies, ${result.episodesMarked ?? 0} episodes marked watched.`);
+      } else {
+        setErr(result.error ?? "Sync failed.");
+      }
+      refresh();
+    } catch {
+      setErr("Sync failed.");
+    } finally {
+      setSyncing(null);
+    }
+  }
+
+  async function handleToggle(integration: Integration) {
+    setMsg("");
+    setErr("");
+    setToggling(integration.id);
+    try {
+      await api.updateIntegration(integration.id, { enabled: !integration.enabled });
+      refresh();
+    } catch {
+      setErr("Failed to update integration.");
+    } finally {
+      setToggling(null);
+    }
+  }
+
+  async function handleDelete(id: string) {
+    setMsg("");
+    setErr("");
+    try {
+      await api.deleteIntegration(id);
+      setMsg("Plex integration disconnected.");
+      refresh();
+    } catch {
+      setErr("Failed to disconnect integration.");
+    }
+  }
+
+  function formatSyncTime(iso: string | null) {
+    if (!iso) return "Never";
+    try {
+      return new Date(iso).toLocaleString();
+    } catch {
+      return iso;
+    }
+  }
+
+  if (loading) return null;
+
+  return (
+    <section>
+      <h2 className="text-xl font-bold text-white mb-1">Plex</h2>
+      <p className="text-zinc-400 text-sm mb-4">Connect your Plex server to automatically sync your watched history.</p>
+
+      {msg && (
+        <div className="mb-4 p-3 rounded-lg bg-green-900/50 border border-green-700 text-green-200 text-sm">{msg}</div>
+      )}
+      {err && (
+        <div className="mb-4 p-3 rounded-lg bg-red-900/50 border border-red-700 text-red-200 text-sm">{err}</div>
+      )}
+
+      {/* Connected integrations */}
+      {integrations.length > 0 && (
+        <div className="space-y-3 mb-4">
+          {integrations.map((integration) => (
+            <div key={integration.id} className="bg-zinc-900 rounded-lg p-4">
+              <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center gap-2">
+                  <span className="text-white font-medium">{integration.name}</span>
+                  <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${
+                    integration.enabled ? "bg-green-900/50 text-green-300" : "bg-zinc-700 text-zinc-400"
+                  }`}>
+                    {integration.enabled ? "Enabled" : "Disabled"}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => handleToggle(integration)}
+                    disabled={toggling === integration.id}
+                    className="text-xs text-zinc-400 hover:text-white transition-colors disabled:opacity-50"
+                  >
+                    {toggling === integration.id ? "..." : integration.enabled ? "Disable" : "Enable"}
+                  </button>
+                  <button
+                    onClick={() => handleSync(integration.id)}
+                    disabled={syncing === integration.id || !integration.enabled}
+                    className="text-xs text-amber-500 hover:text-amber-400 transition-colors disabled:opacity-50"
+                  >
+                    {syncing === integration.id ? "Syncing..." : "Sync now"}
+                  </button>
+                  <button
+                    onClick={() => handleDelete(integration.id)}
+                    className="text-xs text-red-400 hover:text-red-300 transition-colors"
+                  >
+                    Disconnect
+                  </button>
+                </div>
+              </div>
+              <div className="text-xs text-zinc-500 space-y-0.5">
+                <div>Server: <span className="text-zinc-400">{integration.config.serverUrl}</span></div>
+                <div>Last sync: <span className="text-zinc-400">{formatSyncTime(integration.last_sync_at)}</span></div>
+                {integration.last_sync_error && (
+                  <div className="text-red-400">Error: {integration.last_sync_error}</div>
+                )}
+                <div className="flex gap-3 mt-1">
+                  <span className={integration.config.syncMovies ? "text-zinc-400" : "text-zinc-600"}>Movies</span>
+                  <span className={integration.config.syncEpisodes ? "text-zinc-400" : "text-zinc-600"}>Episodes</span>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Connect flow */}
+      {step.type === "idle" && (
+        <button
+          onClick={handleConnect}
+          className="px-4 py-2 bg-amber-500 hover:bg-amber-600 text-black font-medium rounded-lg text-sm transition-colors"
+        >
+          Connect Plex
+        </button>
+      )}
+
+      {step.type === "waiting" && (
+        <div className="bg-zinc-900 rounded-lg p-4 space-y-3">
+          <p className="text-sm text-zinc-300">
+            A Plex authorization window has been opened. Authorize Remindarr in that window, then click <strong>Check authorization</strong>.
+          </p>
+          <p className="text-xs text-zinc-500">
+            Didn't see a window?{" "}
+            <a href={step.authUrl} target="_blank" rel="noopener noreferrer" className="text-amber-500 hover:text-amber-400">
+              Open authorization page
+            </a>
+          </p>
+          <div className="flex gap-2">
+            <button
+              onClick={handleCheckAuth}
+              disabled={checking}
+              className="px-4 py-2 bg-amber-500 hover:bg-amber-600 text-black font-medium rounded-lg text-sm transition-colors disabled:opacity-50"
+            >
+              {checking ? "Checking..." : "Check authorization"}
+            </button>
+            <button
+              onClick={handleCancelConnect}
+              className="px-4 py-2 bg-zinc-700 hover:bg-zinc-600 text-white rounded-lg text-sm transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {step.type === "pick_server" && (
+        <div className="bg-zinc-900 rounded-lg p-4 space-y-4">
+          <h3 className="text-white font-medium">Select a Plex server</h3>
+
+          {/* Server selection */}
+          <div className="space-y-2">
+            {step.servers.map((server) => (
+              <label key={server.clientIdentifier} className="flex items-center gap-3 cursor-pointer">
+                <input
+                  type="radio"
+                  name="plex_server"
+                  checked={selectedServer?.clientIdentifier === server.clientIdentifier}
+                  onChange={() => {
+                    setSelectedServer(server);
+                    const firstConn = server.connections.find((c) => !c.relay) ?? server.connections[0];
+                    setSelectedUri(firstConn?.uri ?? "");
+                  }}
+                  className="accent-amber-500"
+                />
+                <span className="text-white text-sm">{server.name}</span>
+              </label>
+            ))}
+          </div>
+
+          {/* Connection URL */}
+          {selectedServer && (
+            <div>
+              <label className="block text-xs text-zinc-400 mb-1">Connection URL</label>
+              <select
+                value={selectedUri}
+                onChange={(e) => setSelectedUri(e.target.value)}
+                className="w-full px-3 py-2 bg-zinc-800 border border-white/[0.08] rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-amber-500/50"
+              >
+                {selectedServer.connections.map((conn) => (
+                  <option key={conn.uri} value={conn.uri}>
+                    {conn.uri}{conn.local ? " (local)" : conn.relay ? " (relay)" : ""}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {/* Sync options */}
+          <div>
+            <label className="block text-xs text-zinc-400 mb-2">Sync options</label>
+            <div className="space-y-2">
+              <label className="flex items-center gap-2 cursor-pointer text-sm text-zinc-300">
+                <input
+                  type="checkbox"
+                  checked={syncMovies}
+                  onChange={(e) => setSyncMovies(e.target.checked)}
+                  className="accent-amber-500"
+                />
+                Sync watched movies
+              </label>
+              <label className="flex items-center gap-2 cursor-pointer text-sm text-zinc-300">
+                <input
+                  type="checkbox"
+                  checked={syncEpisodes}
+                  onChange={(e) => setSyncEpisodes(e.target.checked)}
+                  className="accent-amber-500"
+                />
+                Sync watched episodes
+              </label>
+            </div>
+          </div>
+
+          <div className="flex gap-2">
+            <button
+              onClick={handleSaveServer}
+              disabled={saving || !selectedServer || !selectedUri}
+              className="px-4 py-2 bg-amber-500 hover:bg-amber-600 text-black font-medium rounded-lg text-sm transition-colors disabled:opacity-50"
+            >
+              {saving ? "Connecting..." : "Connect"}
+            </button>
+            <button
+              onClick={handleCancelConnect}
+              className="px-4 py-2 bg-zinc-700 hover:bg-zinc-600 text-white rounded-lg text-sm transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
   );
 }

--- a/server/config.ts
+++ b/server/config.ts
@@ -57,6 +57,10 @@ export const CONFIG = {
   STREAMING_AVAILABILITY_API_KEY: process.env.STREAMING_AVAILABILITY_API_KEY || "",
   SYNC_DEEP_LINKS_CRON: process.env.SYNC_DEEP_LINKS_CRON || "0 4 * * *",
 
+  // Plex
+  PLEX_CLIENT_ID: process.env.PLEX_CLIENT_ID || "remindarr-plex-client",
+  SYNC_PLEX_CRON: process.env.SYNC_PLEX_CRON || "0 5 * * *",
+
   // Sentry
   SENTRY_DSN: process.env.SENTRY_DSN || "",
 

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -129,10 +129,10 @@ describe("fixSkippedMigrations", () => {
     }>;
     expect(titleCols.some((c) => c.name === "genres")).toBe(false);
 
-    // All 14 migrations should be recorded
+    // All 15 migrations should be recorded
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(14);
+    expect(migrations.cnt).toBe(15);
   });
 });

--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -132,3 +132,15 @@ export {
   getUserInvitations,
   revokeInvitation,
 } from "./invitations";
+
+export {
+  createIntegration,
+  updateIntegration,
+  deleteIntegration,
+  getIntegrationsByUser,
+  getIntegrationById,
+  getEnabledIntegrationsByProvider,
+  updateIntegrationSyncStatus,
+  disableIntegration,
+} from "./integrations";
+export type { IntegrationConfig, PlexConfig } from "./integrations";

--- a/server/db/repository/integrations.ts
+++ b/server/db/repository/integrations.ts
@@ -1,0 +1,193 @@
+import { eq, and, sql } from "drizzle-orm";
+import { getDb } from "../schema";
+import { integrations } from "../schema";
+import { logger } from "../../logger";
+import { traceDbQuery } from "../../tracing";
+
+const log = logger.child({ module: "repository" });
+
+export type PlexConfig = {
+  plexToken: string;
+  serverUrl: string;
+  serverId: string;
+  serverName: string;
+  plexUsername: string;
+  syncMovies: boolean;
+  syncEpisodes: boolean;
+};
+
+export type IntegrationConfig = PlexConfig;
+
+export async function createIntegration(
+  userId: string,
+  provider: string,
+  name: string,
+  config: IntegrationConfig
+): Promise<string> {
+  return traceDbQuery("createIntegration", async () => {
+    const db = getDb();
+    const id = crypto.randomUUID();
+    await db.insert(integrations)
+      .values({
+        id,
+        userId,
+        provider,
+        name,
+        config: JSON.stringify(config),
+      })
+      .run();
+    return id;
+  });
+}
+
+export async function updateIntegration(
+  id: string,
+  userId: string,
+  updates: {
+    name?: string;
+    config?: IntegrationConfig;
+    enabled?: boolean;
+  }
+) {
+  return traceDbQuery("updateIntegration", async () => {
+    const db = getDb();
+    const set: Record<string, unknown> = { updatedAt: sql`datetime('now')` };
+    if (updates.name !== undefined) set.name = updates.name;
+    if (updates.config !== undefined) set.config = JSON.stringify(updates.config);
+    if (updates.enabled !== undefined) set.enabled = updates.enabled ? 1 : 0;
+
+    await db.update(integrations)
+      .set(set)
+      .where(and(eq(integrations.id, id), eq(integrations.userId, userId)))
+      .run();
+  });
+}
+
+export async function deleteIntegration(id: string, userId: string) {
+  return traceDbQuery("deleteIntegration", async () => {
+    const db = getDb();
+    await db.delete(integrations)
+      .where(and(eq(integrations.id, id), eq(integrations.userId, userId)))
+      .run();
+  });
+}
+
+function parseConfig(raw: string, id: string): IntegrationConfig {
+  try {
+    return JSON.parse(raw) as IntegrationConfig;
+  } catch {
+    log.warn("Failed to parse integration config", { id });
+    return {} as IntegrationConfig;
+  }
+}
+
+export async function getIntegrationsByUser(userId: string) {
+  return traceDbQuery("getIntegrationsByUser", async () => {
+    const db = getDb();
+    const rows = await db
+      .select({
+        id: integrations.id,
+        user_id: integrations.userId,
+        provider: integrations.provider,
+        name: integrations.name,
+        config: integrations.config,
+        enabled: integrations.enabled,
+        last_sync_at: integrations.lastSyncAt,
+        last_sync_error: integrations.lastSyncError,
+        created_at: integrations.createdAt,
+        updated_at: integrations.updatedAt,
+      })
+      .from(integrations)
+      .where(eq(integrations.userId, userId))
+      .all();
+
+    return rows.map((row) => ({
+      ...row,
+      config: parseConfig(row.config, row.id),
+      enabled: Boolean(row.enabled),
+    }));
+  });
+}
+
+export async function getIntegrationById(id: string, userId: string) {
+  return traceDbQuery("getIntegrationById", async () => {
+    const db = getDb();
+    const row = await db
+      .select({
+        id: integrations.id,
+        user_id: integrations.userId,
+        provider: integrations.provider,
+        name: integrations.name,
+        config: integrations.config,
+        enabled: integrations.enabled,
+        last_sync_at: integrations.lastSyncAt,
+        last_sync_error: integrations.lastSyncError,
+        created_at: integrations.createdAt,
+        updated_at: integrations.updatedAt,
+      })
+      .from(integrations)
+      .where(and(eq(integrations.id, id), eq(integrations.userId, userId)))
+      .get();
+
+    if (!row) return null;
+    return {
+      ...row,
+      config: parseConfig(row.config, row.id),
+      enabled: Boolean(row.enabled),
+    };
+  });
+}
+
+export async function getEnabledIntegrationsByProvider(provider: string) {
+  return traceDbQuery("getEnabledIntegrationsByProvider", async () => {
+    const db = getDb();
+    const rows = await db
+      .select({
+        id: integrations.id,
+        user_id: integrations.userId,
+        provider: integrations.provider,
+        name: integrations.name,
+        config: integrations.config,
+        enabled: integrations.enabled,
+        last_sync_at: integrations.lastSyncAt,
+        last_sync_error: integrations.lastSyncError,
+      })
+      .from(integrations)
+      .where(and(eq(integrations.provider, provider), eq(integrations.enabled, 1)))
+      .all();
+
+    return rows.map((row) => ({
+      ...row,
+      config: parseConfig(row.config, row.id),
+      enabled: Boolean(row.enabled),
+    }));
+  });
+}
+
+export async function updateIntegrationSyncStatus(
+  id: string,
+  lastSyncAt: string | null,
+  lastSyncError: string | null
+) {
+  return traceDbQuery("updateIntegrationSyncStatus", async () => {
+    const db = getDb();
+    await db.update(integrations)
+      .set({
+        lastSyncAt,
+        lastSyncError,
+        updatedAt: sql`datetime('now')`,
+      })
+      .where(eq(integrations.id, id))
+      .run();
+  });
+}
+
+export async function disableIntegration(id: string) {
+  return traceDbQuery("disableIntegration", async () => {
+    const db = getDb();
+    await db.update(integrations)
+      .set({ enabled: 0, updatedAt: sql`datetime('now')` })
+      .where(eq(integrations.id, id))
+      .run();
+  });
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -293,6 +293,28 @@ export const notifiers = sqliteTable(
   ]
 );
 
+export const integrations = sqliteTable(
+  "integrations",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    provider: text("provider").notNull(),
+    name: text("name").notNull(),
+    config: text("config").notNull(),
+    enabled: integer("enabled").notNull().default(1),
+    lastSyncAt: text("last_sync_at"),
+    lastSyncError: text("last_sync_error"),
+    createdAt: text("created_at").default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at").default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    index("idx_integrations_user_id").on(table.userId),
+    index("idx_integrations_provider").on(table.provider),
+  ]
+);
+
 export const passkey = sqliteTable("passkey", {
   id: text("id").primaryKey(),
   name: text("name"),
@@ -460,6 +482,11 @@ export const usersRelations = relations(users, ({ many }) => ({
   sentRecommendations: many(recommendations),
   recommendationReads: many(recommendationReads),
   createdInvitations: many(invitations, { relationName: "createdBy" }),
+  integrations: many(integrations),
+}));
+
+export const integrationsRelations = relations(integrations, ({ one }) => ({
+  user: one(users, { fields: [integrations.userId], references: [users.id] }),
 }));
 
 export const sessionsRelations = relations(sessions, ({ one }) => ({
@@ -523,11 +550,12 @@ export const passkeyRelations = relations(passkey, ({ one }) => ({
 
 export const schemaExports = {
   titles, providers, offers, scores, titleGenres, episodes, users, sessions, account, verification, passkey, settings, tracked, watchedEpisodes, watchedTitles, notifiers, oidcStates, jobs, cronJobs,
-  follows, ratings, recommendations, recommendationReads, invitations,
+  follows, ratings, recommendations, recommendationReads, invitations, integrations,
   titlesRelations, providersRelations, offersRelations, scoresRelations, titleGenresRelations, episodesRelations,
   passkeyRelations,
   usersRelations, sessionsRelations, accountRelations, trackedRelations, watchedEpisodesRelations, watchedTitlesRelations, notifiersRelations,
   followsRelations, ratingsRelations, recommendationsRelations, recommendationReadsRelations, invitationsRelations,
+  integrationsRelations,
 };
 
 // Re-export the union type from platform for convenience

--- a/server/index.ts
+++ b/server/index.ts
@@ -22,6 +22,7 @@ import jobsRoutes from "./routes/jobs";
 import browseRoutes from "./routes/browse";
 import detailsRoutes from "./routes/details";
 import notifierRoutes from "./routes/notifiers";
+import integrationRoutes from "./routes/integrations";
 import profileRoutes from "./routes/profile";
 import socialRoutes from "./routes/social";
 import ratingsRoutes from "./routes/ratings";
@@ -200,6 +201,10 @@ app.route("/api/imdb", imdbRoutes);
 app.use("/api/notifiers/*", requireAuth);
 app.use("/api/notifiers", requireAuth);
 app.route("/api/notifiers", notifierRoutes);
+
+app.use("/api/integrations/*", requireAuth);
+app.use("/api/integrations", requireAuth);
+app.route("/api/integrations", integrationRoutes);
 
 // Admin routes
 app.use("/api/admin/*", requireAuth, requireAdmin);

--- a/server/jobs/sync.ts
+++ b/server/jobs/sync.ts
@@ -1,5 +1,7 @@
 import { logger } from "../logger";
 import { registerHandler } from "./worker";
+import { getEnabledIntegrationsByProvider } from "../db/repository";
+import { syncPlexWatched } from "../plex/sync";
 
 const log = logger.child({ module: "sync" });
 import { registerCron, enqueueJob } from "./queue";
@@ -127,10 +129,36 @@ export function registerSyncJobs() {
     log.info("Deep link sync complete", { processed, enriched });
   });
 
+  registerHandler("sync-plex-watched", async () => {
+    const integrations = await getEnabledIntegrationsByProvider("plex");
+    if (integrations.length === 0) {
+      log.info("No enabled Plex integrations, skipping sync");
+      return;
+    }
+    log.info("Starting Plex watched sync", { count: integrations.length });
+    let synced = 0;
+    let failed = 0;
+    for (const integration of integrations) {
+      try {
+        const result = await syncPlexWatched(integration as any);
+        log.info("Plex sync done", {
+          integrationId: integration.id,
+          moviesMarked: result.moviesMarked,
+          episodesMarked: result.episodesMarked,
+        });
+        synced++;
+      } catch {
+        failed++;
+      }
+    }
+    log.info("Plex watched sync complete", { synced, failed });
+  });
+
   // ─── Cron Schedules ────────────────────────────────────────────────────
 
   registerCron("sync-titles", CONFIG.SYNC_TITLES_CRON);
   registerCron("sync-episodes", CONFIG.SYNC_EPISODES_CRON);
+  registerCron("sync-plex-watched", CONFIG.SYNC_PLEX_CRON);
 
   if (CONFIG.STREAMING_AVAILABILITY_API_KEY) {
     registerCron("sync-deep-links", CONFIG.SYNC_DEEP_LINKS_CRON);

--- a/server/plex/client.ts
+++ b/server/plex/client.ts
@@ -1,0 +1,183 @@
+import { CONFIG } from "../config";
+import { logger } from "../logger";
+
+const log = logger.child({ module: "plex" });
+
+const PLEX_TV_BASE = "https://plex.tv";
+
+function plexHeaders(token?: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    "X-Plex-Client-Identifier": CONFIG.PLEX_CLIENT_ID,
+    "X-Plex-Product": "Remindarr",
+    "X-Plex-Version": "1.0",
+    "X-Plex-Platform": "Web",
+    Accept: "application/json",
+  };
+  if (token) headers["X-Plex-Token"] = token;
+  return headers;
+}
+
+export class PlexAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PlexAuthError";
+  }
+}
+
+export class PlexApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number
+  ) {
+    super(message);
+    this.name = "PlexApiError";
+  }
+}
+
+async function plexFetch<T>(url: string, options: RequestInit = {}): Promise<T> {
+  const res = await fetch(url, options);
+  if (res.status === 401) throw new PlexAuthError("Plex token is invalid or revoked");
+  if (!res.ok) throw new PlexApiError(`Plex API error: ${res.status} ${res.statusText}`, res.status);
+  return res.json() as Promise<T>;
+}
+
+// ─── Auth / PIN flow ─────────────────────────────────────────────────────────
+
+export type PlexPin = {
+  id: number;
+  code: string;
+  authToken: string | null;
+  expiresAt: string;
+};
+
+export async function createPin(): Promise<PlexPin> {
+  const url = `${PLEX_TV_BASE}/api/v2/pins?strong=true`;
+  const data = await plexFetch<{ id: number; code: string; authToken: string | null; expiresAt: string }>(url, {
+    method: "POST",
+    headers: plexHeaders(),
+  });
+  log.debug("Plex PIN created", { pinId: data.id });
+  return data;
+}
+
+export async function checkPin(pinId: number): Promise<PlexPin> {
+  const url = `${PLEX_TV_BASE}/api/v2/pins/${pinId}`;
+  return plexFetch<PlexPin>(url, { headers: plexHeaders() });
+}
+
+export function buildPlexAuthUrl(pinCode: string): string {
+  const params = new URLSearchParams({
+    clientID: CONFIG.PLEX_CLIENT_ID,
+    code: pinCode,
+    "context[device][product]": "Remindarr",
+  });
+  return `https://app.plex.tv/auth#?${params.toString()}`;
+}
+
+// ─── Resources / Servers ─────────────────────────────────────────────────────
+
+export type PlexServer = {
+  name: string;
+  clientIdentifier: string;
+  connections: Array<{ uri: string; local: boolean; relay: boolean }>;
+};
+
+export async function getServers(token: string): Promise<PlexServer[]> {
+  const url = `${PLEX_TV_BASE}/api/v2/resources?includeHttps=1&includeRelay=1`;
+  const data = await plexFetch<PlexServer[]>(url, { headers: plexHeaders(token) });
+  // Only return MediaServer resources
+  return data.filter((r: any) => r.provides?.includes("server"));
+}
+
+// ─── Library ─────────────────────────────────────────────────────────────────
+
+export type PlexSection = {
+  key: string;
+  type: "movie" | "show";
+  title: string;
+};
+
+export async function getLibrarySections(serverUrl: string, token: string): Promise<PlexSection[]> {
+  const url = `${serverUrl}/library/sections`;
+  const data = await plexFetch<{ MediaContainer: { Directory: Array<{ key: string; type: string; title: string }> } }>(
+    url,
+    { headers: plexHeaders(token) }
+  );
+  return (data.MediaContainer?.Directory ?? [])
+    .filter((d) => d.type === "movie" || d.type === "show")
+    .map((d) => ({ key: d.key, type: d.type as "movie" | "show", title: d.title }));
+}
+
+// ─── Watched status ───────────────────────────────────────────────────────────
+
+export type PlexGuid = { id: string };
+
+export type PlexMovieItem = {
+  ratingKey: string;
+  title: string;
+  viewCount: number;
+  Guid?: PlexGuid[];
+  guid?: string;
+};
+
+export type PlexEpisodeItem = {
+  ratingKey: string;
+  title: string;
+  parentTitle: string;
+  grandparentTitle: string;
+  seasonNumber: number;
+  index: number;
+  viewCount: number;
+  Guid?: PlexGuid[];
+  guid?: string;
+  grandparentGuid?: string;
+  grandparentRatingKey?: string;
+};
+
+export type PlexShowItem = {
+  ratingKey: string;
+  title: string;
+  Guid?: PlexGuid[];
+  guid?: string;
+};
+
+export async function getWatchedMovies(
+  serverUrl: string,
+  token: string,
+  sectionKey: string
+): Promise<PlexMovieItem[]> {
+  const url = `${serverUrl}/library/sections/${sectionKey}/all?type=1&includeGuids=1`;
+  const data = await plexFetch<{ MediaContainer: { Metadata?: PlexMovieItem[] } }>(
+    url,
+    { headers: plexHeaders(token) }
+  );
+  const items = data.MediaContainer?.Metadata ?? [];
+  return items.filter((m) => (m.viewCount ?? 0) > 0);
+}
+
+export async function getWatchedEpisodes(
+  serverUrl: string,
+  token: string,
+  sectionKey: string
+): Promise<PlexEpisodeItem[]> {
+  const url = `${serverUrl}/library/sections/${sectionKey}/all?type=4&includeGuids=1`;
+  const data = await plexFetch<{ MediaContainer: { Metadata?: PlexEpisodeItem[] } }>(
+    url,
+    { headers: plexHeaders(token) }
+  );
+  const items = data.MediaContainer?.Metadata ?? [];
+  return items.filter((e) => (e.viewCount ?? 0) > 0);
+}
+
+export async function getShowsInSection(
+  serverUrl: string,
+  token: string,
+  sectionKey: string
+): Promise<PlexShowItem[]> {
+  const url = `${serverUrl}/library/sections/${sectionKey}/all?type=2&includeGuids=1`;
+  const data = await plexFetch<{ MediaContainer: { Metadata?: PlexShowItem[] } }>(
+    url,
+    { headers: plexHeaders(token) }
+  );
+  return data.MediaContainer?.Metadata ?? [];
+}

--- a/server/plex/guid.test.ts
+++ b/server/plex/guid.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "bun:test";
+import { parsePlexGuids, parseLegacyGuid, toRemindarrTitleId } from "./guid";
+
+describe("parsePlexGuids", () => {
+  it("parses new-format tmdb guid", () => {
+    const result = parsePlexGuids([{ id: "tmdb://12345" }]);
+    expect(result.tmdbId).toBe(12345);
+  });
+
+  it("parses new-format imdb guid", () => {
+    const result = parsePlexGuids([{ id: "imdb://tt1234567" }]);
+    expect(result.imdbId).toBe("tt1234567");
+  });
+
+  it("parses new-format tvdb guid", () => {
+    const result = parsePlexGuids([{ id: "tvdb://67890" }]);
+    expect(result.tvdbId).toBe(67890);
+  });
+
+  it("parses all three new-format guids together", () => {
+    const result = parsePlexGuids([
+      { id: "tmdb://12345" },
+      { id: "imdb://tt1234567" },
+      { id: "tvdb://67890" },
+    ]);
+    expect(result.tmdbId).toBe(12345);
+    expect(result.imdbId).toBe("tt1234567");
+    expect(result.tvdbId).toBe(67890);
+  });
+
+  it("parses legacy themoviedb agent format", () => {
+    const result = parsePlexGuids([{ id: "com.plexapp.agents.themoviedb://12345?lang=en" }]);
+    expect(result.tmdbId).toBe(12345);
+  });
+
+  it("parses legacy thetvdb agent format", () => {
+    const result = parsePlexGuids([{ id: "com.plexapp.agents.thetvdb://67890?lang=en" }]);
+    expect(result.tvdbId).toBe(67890);
+  });
+
+  it("parses legacy imdb agent format", () => {
+    const result = parsePlexGuids([{ id: "com.plexapp.agents.imdb://tt9876543?lang=en" }]);
+    expect(result.imdbId).toBe("tt9876543");
+  });
+
+  it("returns empty object for undefined input", () => {
+    expect(parsePlexGuids(undefined)).toEqual({});
+  });
+
+  it("returns empty object for empty array", () => {
+    expect(parsePlexGuids([])).toEqual({});
+  });
+
+  it("ignores unrecognized guid formats", () => {
+    const result = parsePlexGuids([{ id: "unknown://12345" }, { id: "tmdb://99" }]);
+    expect(result.tmdbId).toBe(99);
+  });
+});
+
+describe("parseLegacyGuid", () => {
+  it("parses legacy guid string", () => {
+    const result = parseLegacyGuid("com.plexapp.agents.themoviedb://777?lang=en");
+    expect(result.tmdbId).toBe(777);
+  });
+
+  it("returns empty for undefined", () => {
+    expect(parseLegacyGuid(undefined)).toEqual({});
+  });
+});
+
+describe("toRemindarrTitleId", () => {
+  it("creates movie title ID", () => {
+    expect(toRemindarrTitleId("movie", 12345)).toBe("movie-12345");
+  });
+
+  it("creates show title ID", () => {
+    expect(toRemindarrTitleId("show", 67890)).toBe("tv-67890");
+  });
+});

--- a/server/plex/guid.ts
+++ b/server/plex/guid.ts
@@ -1,0 +1,69 @@
+export type ParsedGuids = {
+  tmdbId?: number;
+  imdbId?: string;
+  tvdbId?: number;
+};
+
+/**
+ * Parses Plex's Guid array into external IDs.
+ * Handles both new format (`tmdb://12345`) and legacy format
+ * (`com.plexapp.agents.themoviedb://12345?lang=en`).
+ */
+export function parsePlexGuids(guids: Array<{ id: string }> | undefined): ParsedGuids {
+  if (!guids || guids.length === 0) return {};
+
+  const result: ParsedGuids = {};
+
+  for (const g of guids) {
+    const id = g.id;
+
+    // New format: tmdb://12345, imdb://tt1234567, tvdb://67890
+    const newMatch = id.match(/^(tmdb|imdb|tvdb):\/\/(.+)$/);
+    if (newMatch) {
+      const [, source, value] = newMatch;
+      if (source === "tmdb") result.tmdbId = parseInt(value, 10);
+      else if (source === "imdb") result.imdbId = value;
+      else if (source === "tvdb") result.tvdbId = parseInt(value, 10);
+      continue;
+    }
+
+    // Legacy format: com.plexapp.agents.themoviedb://12345?lang=en
+    const legacyMovieDb = id.match(/com\.plexapp\.agents\.themoviedb:\/\/(\d+)/);
+    if (legacyMovieDb) {
+      result.tmdbId = parseInt(legacyMovieDb[1], 10);
+      continue;
+    }
+
+    // Legacy format: com.plexapp.agents.thetvdb://12345?lang=en
+    const legacyTvDb = id.match(/com\.plexapp\.agents\.thetvdb:\/\/(\d+)/);
+    if (legacyTvDb) {
+      result.tvdbId = parseInt(legacyTvDb[1], 10);
+      continue;
+    }
+
+    // Legacy format: com.plexapp.agents.imdb://tt1234567?lang=en
+    const legacyImdb = id.match(/com\.plexapp\.agents\.imdb:\/\/(tt\d+)/);
+    if (legacyImdb) {
+      result.imdbId = legacyImdb[1];
+      continue;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Parses a single legacy guid string (the `guid` field on older Plex items).
+ * Falls back gracefully if the format is unrecognized.
+ */
+export function parseLegacyGuid(guid: string | undefined): ParsedGuids {
+  if (!guid) return {};
+  return parsePlexGuids([{ id: guid }]);
+}
+
+/**
+ * Converts a TMDB ID + media type to Remindarr's title ID format.
+ */
+export function toRemindarrTitleId(type: "movie" | "show", tmdbId: number): string {
+  return type === "movie" ? `movie-${tmdbId}` : `tv-${tmdbId}`;
+}

--- a/server/plex/sync.test.ts
+++ b/server/plex/sync.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach, afterAll, spyOn } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { getRawDb } from "../db/bun-db";
+
+// Mock Sentry to prevent noise in tests
+import Sentry from "../sentry";
+spyOn(Sentry, "startSpan").mockImplementation((_opts: any, fn: any) => fn({}));
+spyOn(Sentry, "captureException").mockImplementation(() => "");
+
+// Mock Plex client module so we never make real HTTP calls
+import * as plexClient from "./client";
+const mockGetLibrarySections = spyOn(plexClient, "getLibrarySections");
+const mockGetWatchedMovies = spyOn(plexClient, "getWatchedMovies");
+const mockGetWatchedEpisodes = spyOn(plexClient, "getWatchedEpisodes");
+const mockGetShowsInSection = spyOn(plexClient, "getShowsInSection");
+
+import { syncPlexWatched } from "./sync";
+import { createUser } from "../db/repository";
+
+function insertTitle(id: string, objectType: string, tmdbId: string) {
+  getRawDb()
+    .prepare(`INSERT INTO titles (id, object_type, tmdb_id, title, release_date) VALUES (?, ?, ?, ?, '2024-01-01')`)
+    .run(id, objectType, tmdbId, `Title ${id}`);
+}
+
+function insertEpisode(id: number, titleId: string, season: number, episode: number) {
+  getRawDb()
+    .prepare(`INSERT INTO episodes (id, title_id, season_number, episode_number, air_date) VALUES (?, ?, ?, ?, '2024-01-01')`)
+    .run(id, titleId, season, episode);
+}
+
+function isMovieWatched(titleId: string, userId: string): boolean {
+  const row = getRawDb()
+    .prepare(`SELECT 1 FROM watched_titles WHERE title_id = ? AND user_id = ?`)
+    .get(titleId, userId);
+  return !!row;
+}
+
+function isEpisodeWatched(episodeId: number, userId: string): boolean {
+  const row = getRawDb()
+    .prepare(`SELECT 1 FROM watched_episodes WHERE episode_id = ? AND user_id = ?`)
+    .get(episodeId, userId);
+  return !!row;
+}
+
+function getIntegration(id: string) {
+  return getRawDb()
+    .prepare(`SELECT last_sync_at, last_sync_error, enabled FROM integrations WHERE id = ?`)
+    .get(id) as { last_sync_at: string | null; last_sync_error: string | null; enabled: number } | null;
+}
+
+let userId: string;
+let integrationId: string;
+
+beforeEach(async () => {
+  setupTestDb();
+  userId = await createUser("plexuser", "hash");
+
+  getRawDb()
+    .prepare(`INSERT INTO integrations (id, user_id, provider, name, config, enabled) VALUES (?, ?, 'plex', 'My Plex', '{}', 1)`)
+    .run("int-1", userId);
+  integrationId = "int-1";
+
+  // Reset mocks between tests
+  mockGetLibrarySections.mockReset();
+  mockGetWatchedMovies.mockReset();
+  mockGetWatchedEpisodes.mockReset();
+  mockGetShowsInSection.mockReset();
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+const baseConfig = {
+  plexToken: "test-token",
+  serverUrl: "http://plex:32400",
+  serverId: "server-id",
+  serverName: "My Plex",
+  plexUsername: "user",
+  syncMovies: true,
+  syncEpisodes: true,
+};
+
+const integration = (overrides = {}) => ({
+  id: integrationId,
+  user_id: userId,
+  config: { ...baseConfig, ...overrides },
+});
+
+describe("syncPlexWatched — movies", () => {
+  it("marks a watched movie as watched in Remindarr", async () => {
+    insertTitle("movie-100", "MOVIE", "100");
+    mockGetLibrarySections.mockResolvedValue([{ key: "1", type: "movie", title: "Movies" }]);
+    mockGetWatchedMovies.mockResolvedValue([
+      { ratingKey: "1", title: "Movie A", viewCount: 2, Guid: [{ id: "tmdb://100" }] },
+    ]);
+    mockGetWatchedEpisodes.mockResolvedValue([]);
+
+    await syncPlexWatched(integration());
+
+    expect(isMovieWatched("movie-100", userId)).toBe(true);
+  });
+
+  it("skips movies without TMDB GUID", async () => {
+    insertTitle("movie-200", "MOVIE", "200");
+    mockGetLibrarySections.mockResolvedValue([{ key: "1", type: "movie", title: "Movies" }]);
+    mockGetWatchedMovies.mockResolvedValue([
+      { ratingKey: "2", title: "Unknown Movie", viewCount: 1, Guid: [{ id: "imdb://tt9999999" }] },
+    ]);
+    mockGetWatchedEpisodes.mockResolvedValue([]);
+
+    await syncPlexWatched(integration());
+
+    expect(isMovieWatched("movie-200", userId)).toBe(false);
+  });
+
+  it("skips movies not in Remindarr DB", async () => {
+    // title movie-999 doesn't exist in DB
+    mockGetLibrarySections.mockResolvedValue([{ key: "1", type: "movie", title: "Movies" }]);
+    mockGetWatchedMovies.mockResolvedValue([
+      { ratingKey: "3", title: "Unknown", viewCount: 1, Guid: [{ id: "tmdb://999" }] },
+    ]);
+    mockGetWatchedEpisodes.mockResolvedValue([]);
+
+    // Should not throw
+    await expect(syncPlexWatched(integration())).resolves.toBeDefined();
+  });
+
+  it("respects syncMovies: false", async () => {
+    insertTitle("movie-100", "MOVIE", "100");
+    mockGetLibrarySections.mockResolvedValue([{ key: "1", type: "movie", title: "Movies" }]);
+    mockGetWatchedMovies.mockResolvedValue([
+      { ratingKey: "1", title: "Movie A", viewCount: 1, Guid: [{ id: "tmdb://100" }] },
+    ]);
+    mockGetWatchedEpisodes.mockResolvedValue([]);
+
+    await syncPlexWatched(integration({ syncMovies: false }));
+
+    expect(isMovieWatched("movie-100", userId)).toBe(false);
+    expect(mockGetWatchedMovies).not.toHaveBeenCalled();
+  });
+
+  it("updates lastSyncAt on success", async () => {
+    mockGetLibrarySections.mockResolvedValue([]);
+    await syncPlexWatched(integration());
+
+    const row = getIntegration(integrationId);
+    expect(row?.last_sync_at).not.toBeNull();
+    expect(row?.last_sync_error).toBeNull();
+  });
+});
+
+describe("syncPlexWatched — episodes", () => {
+  it("marks watched episodes as watched in Remindarr", async () => {
+    insertTitle("tv-50", "SHOW", "50");
+    insertEpisode(10, "tv-50", 1, 1);
+    insertEpisode(11, "tv-50", 1, 2);
+
+    mockGetLibrarySections.mockResolvedValue([{ key: "2", type: "show", title: "TV" }]);
+    mockGetShowsInSection.mockResolvedValue([
+      { ratingKey: "show-1", title: "Show A", Guid: [{ id: "tmdb://50" }] },
+    ]);
+    mockGetWatchedEpisodes.mockResolvedValue([
+      {
+        ratingKey: "ep-10", title: "Ep 1", parentTitle: "S1", grandparentTitle: "Show A",
+        seasonNumber: 1, index: 1, viewCount: 1, grandparentRatingKey: "show-1",
+      },
+      {
+        ratingKey: "ep-11", title: "Ep 2", parentTitle: "S1", grandparentTitle: "Show A",
+        seasonNumber: 1, index: 2, viewCount: 2, grandparentRatingKey: "show-1",
+      },
+    ]);
+    mockGetWatchedMovies.mockResolvedValue([]);
+
+    await syncPlexWatched(integration());
+
+    expect(isEpisodeWatched(10, userId)).toBe(true);
+    expect(isEpisodeWatched(11, userId)).toBe(true);
+  });
+
+  it("skips shows whose TMDB ID is not in Remindarr DB", async () => {
+    mockGetLibrarySections.mockResolvedValue([{ key: "2", type: "show", title: "TV" }]);
+    mockGetShowsInSection.mockResolvedValue([
+      { ratingKey: "show-x", title: "Unknown Show", Guid: [{ id: "tmdb://9999" }] },
+    ]);
+    mockGetWatchedEpisodes.mockResolvedValue([
+      {
+        ratingKey: "ep-x", title: "Ep", parentTitle: "S1", grandparentTitle: "Unknown",
+        seasonNumber: 1, index: 1, viewCount: 1, grandparentRatingKey: "show-x",
+      },
+    ]);
+    mockGetWatchedMovies.mockResolvedValue([]);
+
+    await expect(syncPlexWatched(integration())).resolves.toBeDefined();
+  });
+});
+
+describe("syncPlexWatched — error handling", () => {
+  it("disables integration on PlexAuthError and records error", async () => {
+    mockGetLibrarySections.mockRejectedValue(new plexClient.PlexAuthError("Token revoked"));
+
+    await expect(syncPlexWatched(integration())).rejects.toThrow("Token revoked");
+
+    const row = getIntegration(integrationId);
+    expect(row?.enabled).toBe(0);
+    expect(row?.last_sync_error).toContain("Token revoked");
+  });
+
+  it("records error without disabling on non-auth errors", async () => {
+    mockGetLibrarySections.mockRejectedValue(new Error("Network error"));
+
+    await expect(syncPlexWatched(integration())).rejects.toThrow("Network error");
+
+    const row = getIntegration(integrationId);
+    expect(row?.enabled).toBe(1);
+    expect(row?.last_sync_error).toBe("Network error");
+  });
+});

--- a/server/plex/sync.ts
+++ b/server/plex/sync.ts
@@ -1,0 +1,109 @@
+import { logger } from "../logger";
+import {
+  getLibrarySections,
+  getWatchedMovies,
+  getWatchedEpisodes,
+  getShowsInSection,
+  PlexAuthError,
+} from "./client";
+import { parsePlexGuids, parseLegacyGuid, toRemindarrTitleId } from "./guid";
+import { watchTitle, watchEpisodesBulk, getEpisodeIdsBySE } from "../db/repository";
+import { updateIntegrationSyncStatus, disableIntegration } from "../db/repository";
+import type { PlexConfig } from "../db/repository/integrations";
+
+const log = logger.child({ module: "plex-sync" });
+
+export type SyncResult = {
+  moviesMarked: number;
+  episodesMarked: number;
+};
+
+type IntegrationRow = {
+  id: string;
+  user_id: string;
+  config: PlexConfig;
+};
+
+export async function syncPlexWatched(integration: IntegrationRow): Promise<SyncResult> {
+  const { id: integrationId, user_id: userId, config } = integration;
+  const { plexToken, serverUrl, syncMovies, syncEpisodes } = config;
+
+  let moviesMarked = 0;
+  let episodesMarked = 0;
+
+  try {
+    const sections = await getLibrarySections(serverUrl, plexToken);
+
+    // ─── Sync movies ───────────────────────────────────────────────────────
+    if (syncMovies) {
+      const movieSections = sections.filter((s) => s.type === "movie");
+      for (const section of movieSections) {
+        const watched = await getWatchedMovies(serverUrl, plexToken, section.key);
+        for (const item of watched) {
+          const guids = parsePlexGuids(item.Guid) || parseLegacyGuid(item.guid);
+          if (!guids.tmdbId) continue;
+          const titleId = toRemindarrTitleId("movie", guids.tmdbId);
+          try {
+            await watchTitle(titleId, userId);
+            moviesMarked++;
+          } catch {
+            // Title not in Remindarr DB — skip silently
+          }
+        }
+      }
+    }
+
+    // ─── Sync episodes ─────────────────────────────────────────────────────
+    if (syncEpisodes) {
+      const showSections = sections.filter((s) => s.type === "show");
+
+      for (const section of showSections) {
+        // Build a map of Plex ratingKey → TMDB ID from shows
+        const shows = await getShowsInSection(serverUrl, plexToken, section.key);
+        const showTmdbMap = new Map<string, number>();
+        for (const show of shows) {
+          const guids = parsePlexGuids(show.Guid) || parseLegacyGuid(show.guid);
+          if (guids.tmdbId) showTmdbMap.set(show.ratingKey, guids.tmdbId);
+        }
+
+        const watchedEps = await getWatchedEpisodes(serverUrl, plexToken, section.key);
+
+        // Group watched episodes by show (grandparentRatingKey)
+        const byShow = new Map<string, Array<{ season: number; episode: number }>>();
+        for (const ep of watchedEps) {
+          const showKey = ep.grandparentRatingKey ?? "";
+          if (!showKey) continue;
+          if (!byShow.has(showKey)) byShow.set(showKey, []);
+          byShow.get(showKey)!.push({ season: ep.seasonNumber, episode: ep.index });
+        }
+
+        for (const [showKey, sePairs] of byShow) {
+          const tmdbId = showTmdbMap.get(showKey);
+          if (!tmdbId) continue;
+          const titleId = toRemindarrTitleId("show", tmdbId);
+
+          const episodeIds = await getEpisodeIdsBySE(titleId, sePairs);
+          if (episodeIds.length === 0) continue;
+
+          await watchEpisodesBulk(episodeIds, userId);
+          episodesMarked += episodeIds.length;
+        }
+      }
+    }
+
+    await updateIntegrationSyncStatus(integrationId, new Date().toISOString(), null);
+    log.info("Plex sync complete", { integrationId, moviesMarked, episodesMarked });
+    return { moviesMarked, episodesMarked };
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : String(err);
+
+    if (err instanceof PlexAuthError) {
+      log.warn("Plex token revoked, disabling integration", { integrationId });
+      await disableIntegration(integrationId);
+    }
+
+    await updateIntegrationSyncStatus(integrationId, null, errorMsg);
+    log.error("Plex sync failed", { integrationId, error: errorMsg });
+    throw err;
+  }
+}

--- a/server/routes/integrations.test.ts
+++ b/server/routes/integrations.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, beforeEach, afterAll, afterEach, spyOn } from "bun:test";
+import { Hono } from "hono";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { createUser, createSession, getSessionWithUser } from "../db/repository";
+import { requireAuth } from "../middleware/auth";
+import integrationApp from "./integrations";
+import type { AppEnv } from "../types";
+
+// Mock Sentry
+import Sentry from "../sentry";
+spyOn(Sentry, "startSpan").mockImplementation((_opts: any, fn: any) => fn({}));
+spyOn(Sentry, "captureException").mockImplementation(() => "");
+
+// Mock Plex client so no real HTTP calls are made
+import * as plexClient from "../plex/client";
+const spies: ReturnType<typeof spyOn>[] = [];
+
+function createMockAuth() {
+  return {
+    api: {
+      getSession: async ({ headers }: { headers: Headers }) => {
+        const cookieHeader = headers.get("cookie") || "";
+        const match = cookieHeader.match(/better-auth\.session_token=([^;]+)/);
+        const token = match?.[1];
+        if (!token) return null;
+        const user = await getSessionWithUser(token);
+        if (!user) return null;
+        return {
+          session: { id: "session-id", userId: user.id },
+          user: {
+            id: user.id,
+            name: user.display_name,
+            username: user.username,
+            role: user.role || (user.is_admin ? "admin" : "user"),
+          },
+        };
+      },
+    },
+  };
+}
+
+let app: Hono<AppEnv>;
+let userToken: string;
+let userId: string;
+
+beforeEach(async () => {
+  setupTestDb();
+
+  userId = await createUser("integrationuser", "hash");
+  userToken = await createSession(userId);
+
+  app = new Hono<AppEnv>();
+  app.use("*", async (c, next) => {
+    c.set("auth", createMockAuth() as any);
+    await next();
+  });
+  app.use("/integrations/*", requireAuth);
+  app.use("/integrations", requireAuth);
+  app.route("/integrations", integrationApp);
+});
+
+afterEach(() => {
+  spies.forEach((s) => s.mockRestore());
+  spies.length = 0;
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+function headers() {
+  return { Cookie: `better-auth.session_token=${userToken}` };
+}
+
+function jsonHeaders() {
+  return { ...headers(), "Content-Type": "application/json" };
+}
+
+const validPlexIntegration = {
+  provider: "plex",
+  config: {
+    plexToken: "my-plex-token",
+    serverUrl: "http://plex:32400",
+    serverId: "server-abc",
+    serverName: "My Plex Server",
+    syncMovies: true,
+    syncEpisodes: true,
+  },
+};
+
+describe("GET /integrations", () => {
+  it("returns empty list for new user", async () => {
+    const res = await app.request("/integrations", { headers: headers() });
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.integrations).toEqual([]);
+  });
+
+  it("returns created integrations", async () => {
+    await app.request("/integrations", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify(validPlexIntegration),
+    });
+    const res = await app.request("/integrations", { headers: headers() });
+    const body = await res.json() as any;
+    expect(body.integrations).toHaveLength(1);
+    expect(body.integrations[0].provider).toBe("plex");
+  });
+
+  it("does not return plex token in config", async () => {
+    await app.request("/integrations", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify(validPlexIntegration),
+    });
+    const res = await app.request("/integrations", { headers: headers() });
+    const body = await res.json() as any;
+    expect(body.integrations[0].config.plexToken).toBeUndefined();
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await app.request("/integrations");
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /integrations", () => {
+  it("creates a Plex integration", async () => {
+    const res = await app.request("/integrations", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify(validPlexIntegration),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json() as any;
+    expect(body.integration.provider).toBe("plex");
+    expect(body.integration.name).toBe("My Plex Server");
+    expect(body.integration.enabled).toBe(true);
+  });
+
+  it("rejects unknown provider", async () => {
+    const res = await app.request("/integrations", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ provider: "jellyfin", config: {} }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects missing plex config fields", async () => {
+    const res = await app.request("/integrations", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ provider: "plex", config: { plexToken: "x" } }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("strips trailing slash from serverUrl", async () => {
+    const res = await app.request("/integrations", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        ...validPlexIntegration,
+        config: { ...validPlexIntegration.config, serverUrl: "http://plex:32400/" },
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json() as any;
+    expect(body.integration.config.serverUrl).toBe("http://plex:32400");
+  });
+});
+
+describe("PUT /integrations/:id", () => {
+  it("updates enabled state", async () => {
+    const createRes = await app.request("/integrations", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify(validPlexIntegration),
+    });
+    const { integration } = await createRes.json() as any;
+
+    const res = await app.request(`/integrations/${integration.id}`, {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ enabled: false }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.integration.enabled).toBe(false);
+  });
+
+  it("returns 404 for non-existent integration", async () => {
+    const res = await app.request("/integrations/nonexistent", {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ enabled: false }),
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("DELETE /integrations/:id", () => {
+  it("deletes an integration", async () => {
+    const createRes = await app.request("/integrations", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify(validPlexIntegration),
+    });
+    const { integration } = await createRes.json() as any;
+
+    const delRes = await app.request(`/integrations/${integration.id}`, {
+      method: "DELETE",
+      headers: headers(),
+    });
+    expect(delRes.status).toBe(200);
+
+    const listRes = await app.request("/integrations", { headers: headers() });
+    const body = await listRes.json() as any;
+    expect(body.integrations).toHaveLength(0);
+  });
+
+  it("returns 404 for non-existent integration", async () => {
+    const res = await app.request("/integrations/nonexistent", {
+      method: "DELETE",
+      headers: headers(),
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /integrations/plex/pin", () => {
+  it("creates a Plex PIN and returns authUrl", async () => {
+    const pinSpy = spyOn(plexClient, "createPin").mockResolvedValue({
+      id: 12345,
+      code: "ABCD",
+      authToken: null,
+      expiresAt: "2099-01-01T00:00:00Z",
+    });
+    spies.push(pinSpy);
+
+    const res = await app.request("/integrations/plex/pin", {
+      method: "POST",
+      headers: headers(),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.pinId).toBe(12345);
+    expect(body.authUrl).toContain("ABCD");
+  });
+});
+
+describe("POST /integrations/plex/pin/:pinId", () => {
+  it("returns resolved=false when pin not yet authorized", async () => {
+    const checkSpy = spyOn(plexClient, "checkPin").mockResolvedValue({
+      id: 1, code: "X", authToken: null, expiresAt: "2099-01-01",
+    });
+    spies.push(checkSpy);
+
+    const res = await app.request("/integrations/plex/pin/1", {
+      method: "POST",
+      headers: headers(),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.resolved).toBe(false);
+  });
+
+  it("returns resolved=true with servers when pin is authorized", async () => {
+    const checkSpy = spyOn(plexClient, "checkPin").mockResolvedValue({
+      id: 1, code: "X", authToken: "my-token", expiresAt: "2099-01-01",
+    });
+    const serversSpy = spyOn(plexClient, "getServers").mockResolvedValue([
+      { name: "Home Server", clientIdentifier: "server-id", connections: [{ uri: "http://192.168.1.1:32400", local: true, relay: false }] },
+    ]);
+    spies.push(checkSpy, serversSpy);
+
+    const res = await app.request("/integrations/plex/pin/1", {
+      method: "POST",
+      headers: headers(),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.resolved).toBe(true);
+    expect(body.authToken).toBe("my-token");
+    expect(body.servers).toHaveLength(1);
+  });
+});

--- a/server/routes/integrations.ts
+++ b/server/routes/integrations.ts
@@ -1,0 +1,185 @@
+import { Hono } from "hono";
+import type { AppEnv } from "../types";
+import {
+  createIntegration,
+  updateIntegration,
+  deleteIntegration,
+  getIntegrationsByUser,
+  getIntegrationById,
+} from "../db/repository";
+import { createPin, checkPin, buildPlexAuthUrl, getServers } from "../plex/client";
+import { syncPlexWatched } from "../plex/sync";
+import { ok, err } from "./response";
+import Sentry from "../sentry";
+
+const app = new Hono<AppEnv>();
+
+// GET / — list user's integrations (strip token from response)
+app.get("/", async (c) => {
+  const user = c.get("user")!;
+  const rows = await getIntegrationsByUser(user.id);
+  const integrations = rows.map(sanitize);
+  return ok(c, { integrations });
+});
+
+// POST /plex/pin — start Plex OAuth PIN flow
+app.post("/plex/pin", async (c) => {
+  try {
+    const pin = await createPin();
+    const authUrl = buildPlexAuthUrl(pin.code);
+    return ok(c, { pinId: pin.id, authUrl });
+  } catch (e) {
+    Sentry.captureException(e);
+    return err(c, "Failed to create Plex PIN", 500);
+  }
+});
+
+// POST /plex/pin/:pinId — poll PIN; if resolved returns server list
+app.post("/plex/pin/:pinId", async (c) => {
+  const pinId = parseInt(c.req.param("pinId"), 10);
+  if (isNaN(pinId)) return err(c, "Invalid pin ID");
+
+  let pin;
+  try {
+    pin = await checkPin(pinId);
+  } catch (e) {
+    Sentry.captureException(e);
+    return err(c, "Failed to check Plex PIN", 500);
+  }
+
+  if (!pin.authToken) {
+    return ok(c, { resolved: false });
+  }
+
+  let servers;
+  try {
+    servers = await getServers(pin.authToken);
+  } catch (e) {
+    Sentry.captureException(e);
+    return err(c, "Failed to fetch Plex servers", 500);
+  }
+
+  return ok(c, {
+    resolved: true,
+    authToken: pin.authToken,
+    servers: servers.map((s) => ({
+      name: s.name,
+      clientIdentifier: s.clientIdentifier,
+      connections: s.connections,
+    })),
+  });
+});
+
+// POST / — save a new integration
+app.post("/", async (c) => {
+  const user = c.get("user")!;
+  const body = await c.req.json();
+
+  const { provider, name, config } = body;
+  if (!provider || !config) return err(c, "provider and config are required");
+  if (provider !== "plex") return err(c, `Unknown provider: ${provider}`);
+
+  const { plexToken, serverUrl, serverId, serverName, plexUsername } = config;
+  if (!plexToken || !serverUrl || !serverId || !serverName) {
+    return err(c, "Plex config requires: plexToken, serverUrl, serverId, serverName");
+  }
+
+  const integrationName = name || serverName;
+  const integrationConfig = {
+    plexToken,
+    serverUrl: serverUrl.replace(/\/$/, ""),
+    serverId,
+    serverName,
+    plexUsername: plexUsername ?? "",
+    syncMovies: config.syncMovies !== false,
+    syncEpisodes: config.syncEpisodes !== false,
+  };
+
+  const id = await createIntegration(user.id, provider, integrationName, integrationConfig);
+  const integration = await getIntegrationById(id, user.id);
+  return c.json({ integration: sanitize(integration!) }, 201);
+});
+
+// PUT /:id — update integration
+app.put("/:id", async (c) => {
+  const user = c.get("user")!;
+  const id = c.req.param("id");
+  const body = await c.req.json();
+
+  const existing = await getIntegrationById(id, user.id);
+  if (!existing) return err(c, "Integration not found", 404);
+
+  const updates: Parameters<typeof updateIntegration>[2] = {};
+  if (body.name !== undefined) updates.name = body.name;
+  if (body.enabled !== undefined) updates.enabled = Boolean(body.enabled);
+  if (body.config !== undefined) {
+    updates.config = {
+      ...existing.config,
+      ...body.config,
+      serverUrl: (body.config.serverUrl ?? existing.config.serverUrl).replace(/\/$/, ""),
+    } as any;
+  }
+
+  await updateIntegration(id, user.id, updates);
+  const integration = await getIntegrationById(id, user.id);
+  return ok(c, { integration: sanitize(integration!) });
+});
+
+// DELETE /:id — delete integration
+app.delete("/:id", async (c) => {
+  const user = c.get("user")!;
+  const id = c.req.param("id");
+
+  const existing = await getIntegrationById(id, user.id);
+  if (!existing) return err(c, "Integration not found", 404);
+
+  await deleteIntegration(id, user.id);
+  return ok(c, {});
+});
+
+// POST /:id/sync — trigger manual Plex sync
+app.post("/:id/sync", async (c) => {
+  const user = c.get("user")!;
+  const id = c.req.param("id");
+
+  const integration = await getIntegrationById(id, user.id);
+  if (!integration) return err(c, "Integration not found", 404);
+  if (integration.provider !== "plex") return err(c, "Only Plex integrations support manual sync");
+
+  try {
+    const result = await syncPlexWatched({ id, user_id: user.id, config: integration.config as any });
+    return ok(c, { success: true, ...result });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "Sync failed";
+    return ok(c, { success: false, error: message });
+  }
+});
+
+// GET /:id/status — get last sync status
+app.get("/:id/status", async (c) => {
+  const user = c.get("user")!;
+  const id = c.req.param("id");
+
+  const integration = await getIntegrationById(id, user.id);
+  if (!integration) return err(c, "Integration not found", 404);
+
+  return ok(c, {
+    last_sync_at: integration.last_sync_at,
+    last_sync_error: integration.last_sync_error,
+    enabled: integration.enabled,
+  });
+});
+
+function sanitize(row: Awaited<ReturnType<typeof getIntegrationById>>) {
+  if (!row) return row;
+  // Strip the Plex token from API responses
+  const { config, ...rest } = row;
+  const safeConfig = { ...config };
+  if ("plexToken" in safeConfig) {
+    (safeConfig as any).plexToken = undefined;
+    delete (safeConfig as any).plexToken;
+  }
+  return { ...rest, config: safeConfig };
+}
+
+export default app;

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -57,6 +57,7 @@ import adminRoutes, { setOnOidcSettingsChanged } from "./routes/admin";
 import browseRoutes from "./routes/browse";
 import detailsRoutes from "./routes/details";
 import notifierRoutes from "./routes/notifiers";
+import integrationRoutes from "./routes/integrations";
 import jobsCfRoutes from "./routes/jobs-cf";
 import profileRoutes from "./routes/profile";
 import socialRoutes from "./routes/social";
@@ -313,6 +314,10 @@ function createApp(env: Env) {
   app.use("/api/notifiers/*", requireAuth);
   app.use("/api/notifiers", requireAuth);
   app.route("/api/notifiers", notifierRoutes);
+
+  app.use("/api/integrations/*", requireAuth);
+  app.use("/api/integrations", requireAuth);
+  app.route("/api/integrations", integrationRoutes);
 
   // Admin routes
   app.use("/api/admin/*", requireAuth, requireAdmin);


### PR DESCRIPTION
## Summary

- Users can connect their Plex server via OAuth PIN flow (Settings → Plex) and have watched movies/episodes automatically synced into Remindarr's existing watched status system
- Adds a generic `integrations` table and repository layer for future third-party connections, following the same per-user pattern as notifiers
- Daily background sync job (`sync-plex-watched`, default 05:00) runs after TMDB episode sync; configurable via `SYNC_PLEX_CRON` env var

## Architecture

**Data model:** New `integrations` table (migration `0014`) with `userId` FK, `provider` discriminator, JSON `config`, `enabled`, `last_sync_at`, `last_sync_error`.

**Plex client (`server/plex/`):**
- `client.ts` — PIN OAuth flow, server listing, library sections, watched items (with `includeGuids=1`)
- `guid.ts` — parses both new (`tmdb://ID`) and legacy (`com.plexapp.agents.themoviedb://ID?lang=en`) GUID formats
- `sync.ts` — walks movie/show sections, resolves TMDB IDs → Remindarr title IDs, calls existing `watchTitle()` / `watchEpisodesBulk()` repos; auto-disables on `PlexAuthError`

**API (`/api/integrations`):** CRUD + PIN flow endpoints + manual sync trigger. Plex token is stored server-side and never returned in API responses.

**Frontend:** `PlexSection` in Settings with full PIN auth flow (open popup → poll → server picker → sync options → save), connected integration cards with enable/disable, sync now, and disconnect.

## Test plan

- [ ] Unit tests for GUID parser (new + legacy formats): `server/plex/guid.test.ts`
- [ ] Sync logic tests with mocked Plex client (movie/episode sync, error handling): `server/plex/sync.test.ts`
- [ ] Integration route tests (CRUD, PIN flow): `server/routes/integrations.test.ts`
- [ ] Manual: connect a real Plex account via Settings → Plex, trigger "Sync now", verify watched movies/episodes appear
- [ ] `bun run check` passes: 1449 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)