### PR TITLE
fix: replace placeholder Plex icon with actual logo mark

### DIFF
--- a/frontend/public/plex-icon.svg
+++ b/frontend/public/plex-icon.svg
@@ -1,3 +1,12 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#E5A00D">
-  <path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4.5 13.5L10 19V5l6.5 3.5v7z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <radialGradient id="A" cx="1244.322" cy="919.871" r=".925"
+      gradientTransform="matrix(30.05255,0,0,-49.291108,-37348.37,45373.334)"
+      gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#f9be03"/>
+      <stop offset="1" stop-color="#cc7c19"/>
+    </radialGradient>
+  </defs>
+  <path d="M64 52.8C64 59 59 64 52.8 64H11.2C5 64 0 59 0 52.8V11.2C0 5 5 0 11.2 0h41.6C59 0 64 5 64 11.2z" fill="#494949"/>
+  <path d="M19.885 7.354h14.287L49.937 32 34.172 56.646H19.885L35.65 32 19.885 7.354" fill="url(#A)"/>
 </svg>


### PR DESCRIPTION
## Summary
- Replaces the generic play-button-in-circle SVG with the actual Plex chevron logo mark
- Fixes invisible icon issue: the old SVG used `fill="#E5A00D"` (gold), identical to the Plex button background color, making it invisible

## Test plan
- [ ] Navigate to a title with Plex availability
- [ ] Confirm the Plex icon is visible on the Stream button (golden chevron on dark rounded rectangle)
- [ ] Verify the icon appears correctly in both compact card view and full Stream button

🤖 Generated with [Claude Code](https://claude.com/claude-code)