### PR TITLE
feat: Android deep link for Plex via watch.plex.tv

### DIFF
--- a/drizzle/0016_plex_slug.sql
+++ b/drizzle/0016_plex_slug.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `plex_library_items` ADD `plex_slug` text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1775452400000,
       "tag": "0015_add_plex_library",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1775552400000,
+      "tag": "0016_plex_slug",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/src/components/WatchButton.tsx
+++ b/frontend/src/components/WatchButton.tsx
@@ -4,18 +4,34 @@ import { getProviderColor } from "../data/providerColors";
 
 export const PLEX_PROVIDER_ID = 9999;
 
-function isMobileDevice(): boolean {
-  return /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+type PlexPlatform = "ios" | "android" | "desktop";
+
+export function getPlexPlatform(): PlexPlatform {
+  const ua = navigator.userAgent;
+  if (/iPhone|iPad|iPod/i.test(ua)) return "ios";
+  if (/Android/i.test(ua)) return "android";
+  return "desktop";
 }
 
-export function plexDeepLink(webUrl: string): string {
-  // Input:  https://app.plex.tv/#!/server/{serverId}/details?key=%2Flibrary%2Fmetadata%2F{ratingKey}
-  // Output: plex://preplay/?metadataKey=/library/metadata/{ratingKey}&server={serverId}
+export function plexDeepLink(webUrl: string, platform: PlexPlatform): string {
   try {
     const hashPart = webUrl.split("#!/")[1];
     const [pathPart, queryPart] = hashPart.split("?");
+    const params = new URLSearchParams(queryPart);
+
+    if (platform === "android") {
+      // Use watch.plex.tv deep link if a slug was embedded by the server
+      const slug = params.get("watchSlug");
+      const mediaType = params.get("mediaType");
+      if (slug && mediaType) {
+        return `https://watch.plex.tv/${mediaType}/${slug}`;
+      }
+      return webUrl; // No slug — fall back to browser
+    }
+
+    // iOS: plex://preplay/?metadataKey=...&server=...
     const serverId = pathPart.split("/")[1];
-    const metadataKey = new URLSearchParams(queryPart).get("key");
+    const metadataKey = params.get("key");
     if (!serverId || !metadataKey) return webUrl;
     return `plex://preplay/?metadataKey=${encodeURIComponent(metadataKey)}&server=${serverId}`;
   } catch {
@@ -56,8 +72,9 @@ export default function WatchButton({
   const color = getProviderColor(providerId);
   const [hovered, setHovered] = useState(false);
   const isPlex = providerId === PLEX_PROVIDER_ID;
-  const useMobileDeepLink = isPlex && isMobileDevice();
-  const effectiveUrl = useMobileDeepLink ? plexDeepLink(url) : url;
+  const platform = isPlex ? getPlexPlatform() : "desktop";
+  const useMobileDeepLink = platform === "ios" || platform === "android";
+  const effectiveUrl = useMobileDeepLink ? plexDeepLink(url, platform) : url;
   const target = useMobileDeepLink ? undefined : "_blank";
 
   if (variant === "compact") {

--- a/frontend/src/components/WatchButtonGroup.tsx
+++ b/frontend/src/components/WatchButtonGroup.tsx
@@ -2,7 +2,7 @@ import { useState, useRef } from "react";
 import { ChevronDown, ExternalLink } from "lucide-react";
 import { Popover } from "@base-ui/react/popover";
 import type { Offer } from "../types";
-import WatchButton, { monetizationLabel, PLEX_PROVIDER_ID, plexDeepLink } from "./WatchButton";
+import WatchButton, { monetizationLabel, PLEX_PROVIDER_ID, plexDeepLink, getPlexPlatform } from "./WatchButton";
 import { getUniqueProviders } from "./EpisodeComponents";
 import { getProviderColor } from "../data/providerColors";
 
@@ -59,8 +59,9 @@ function DropdownProviderItem({ offer, isLg }: { offer: Offer; isLg: boolean }) 
   const [hovered, setHovered] = useState(false);
   const c = getProviderColor(offer.provider_id);
   const lbl = monetizationLabel(offer.monetization_type);
-  const useMobileDeepLink = offer.provider_id === PLEX_PROVIDER_ID && /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
-  const effectiveUrl = useMobileDeepLink ? plexDeepLink(offer.url) : offer.url;
+  const platform = offer.provider_id === PLEX_PROVIDER_ID ? getPlexPlatform() : "desktop";
+  const useMobileDeepLink = platform === "ios" || platform === "android";
+  const effectiveUrl = useMobileDeepLink ? plexDeepLink(offer.url, platform) : offer.url;
 
   return (
     <a
@@ -91,8 +92,9 @@ function SplitWatchButton({ providers, size, fullWidth }: { providers: Offer[]; 
   const label = monetizationLabel(primary.monetization_type);
   const isLg = size === "lg";
 
-  const useMobileDeepLink = primary.provider_id === PLEX_PROVIDER_ID && /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
-  const primaryUrl = useMobileDeepLink ? plexDeepLink(primary.url) : primary.url;
+  const platform = primary.provider_id === PLEX_PROVIDER_ID ? getPlexPlatform() : "desktop";
+  const useMobileDeepLink = platform === "ios" || platform === "android";
+  const primaryUrl = useMobileDeepLink ? plexDeepLink(primary.url, platform) : primary.url;
 
   return (
     <div ref={containerRef} className={`flex${fullWidth || isLg ? " w-full" : ""}`} style={{ minHeight: isLg ? "52px" : "32px" }}>

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -129,10 +129,10 @@ describe("fixSkippedMigrations", () => {
     }>;
     expect(titleCols.some((c) => c.name === "genres")).toBe(false);
 
-    // All 16 migrations should be recorded
+    // All 17 migrations should be recorded
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(16);
+    expect(migrations.cnt).toBe(17);
   });
 });

--- a/server/db/repository/plex-library.test.ts
+++ b/server/db/repository/plex-library.test.ts
@@ -159,6 +159,19 @@ describe("getPlexOffersForUser", () => {
     );
   });
 
+  it("embeds watchSlug and mediaType in URL when plex_slug is set", async () => {
+    insertTitle("movie-1");
+    insertIntegration("int-1", userId, "my-server-id");
+
+    getRawDb().prepare(`INSERT INTO plex_library_items (integration_id, user_id, title_id, rating_key, media_type, plex_slug) VALUES (?, ?, ?, ?, ?, ?)`)
+      .run("int-1", userId, "movie-1", "rk-42", "movie", "zoolander");
+
+    const result = await getPlexOffersForUser(["movie-1"], userId);
+    const offer = result.get("movie-1")![0];
+    expect(offer.url).toContain("watchSlug=zoolander");
+    expect(offer.url).toContain("mediaType=movie");
+  });
+
   it("returns empty map when user has no Plex library items", async () => {
     const result = await getPlexOffersForUser(["movie-1"], userId);
     expect(result.size).toBe(0);

--- a/server/db/repository/plex-library.ts
+++ b/server/db/repository/plex-library.ts
@@ -14,6 +14,7 @@ export type PlexLibraryItem = {
   titleId: string;
   ratingKey: string;
   mediaType: "movie" | "show";
+  plexSlug?: string | null;
 };
 
 export async function upsertPlexLibraryItems(items: PlexLibraryItem[]) {
@@ -28,6 +29,7 @@ export async function upsertPlexLibraryItems(items: PlexLibraryItem[]) {
           titleId: item.titleId,
           ratingKey: item.ratingKey,
           mediaType: item.mediaType,
+          plexSlug: item.plexSlug ?? null,
           syncedAt: sql`datetime('now')`,
         })
         .onConflictDoUpdate({
@@ -36,6 +38,8 @@ export async function upsertPlexLibraryItems(items: PlexLibraryItem[]) {
             integrationId: sql`excluded.integration_id`,
             ratingKey: sql`excluded.rating_key`,
             mediaType: sql`excluded.media_type`,
+            // Preserve existing slug if the new value is null (lookup may have failed)
+            plexSlug: sql`COALESCE(excluded.plex_slug, plex_library_items.plex_slug)`,
             syncedAt: sql`datetime('now')`,
           },
         })
@@ -104,6 +108,8 @@ export async function getPlexOffersForUser(
       .select({
         titleId: plexLibraryItems.titleId,
         ratingKey: plexLibraryItems.ratingKey,
+        mediaType: plexLibraryItems.mediaType,
+        plexSlug: plexLibraryItems.plexSlug,
         config: integrations.config,
       })
       .from(plexLibraryItems)
@@ -135,7 +141,7 @@ export async function getPlexOffersForUser(
         presentation_type: null,
         price_value: null,
         price_currency: null,
-        url: buildPlexDeepLink(serverId, row.ratingKey),
+        url: buildPlexDeepLink(serverId, row.ratingKey, row.plexSlug, row.mediaType),
         available_to: null,
         provider_name: "Plex",
         provider_technical_name: "plex",

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -420,6 +420,7 @@ export const plexLibraryItems = sqliteTable(
     titleId: text("title_id").notNull(),
     ratingKey: text("rating_key").notNull(),
     mediaType: text("media_type").notNull(), // "movie" or "show"
+    plexSlug: text("plex_slug"), // watch.plex.tv slug for Android deep linking
     syncedAt: text("synced_at").default(sql`(datetime('now'))`),
   },
   (table) => [

--- a/server/plex/client.ts
+++ b/server/plex/client.ts
@@ -194,3 +194,27 @@ export async function getShowsInSection(
   );
   return data.MediaContainer?.Metadata ?? [];
 }
+
+// ─── Metadata / slugs ────────────────────────────────────────────────────────
+
+/**
+ * Looks up the watch.plex.tv slug for a title via the Plex metadata provider API.
+ * Returns null if the lookup fails or the title has no slug.
+ */
+export async function getPlexMetadataSlug(
+  tmdbId: string,
+  mediaType: "movie" | "show",
+  token: string
+): Promise<string | null> {
+  const type = mediaType === "movie" ? 1 : 2;
+  const url = `https://metadata.provider.plex.tv/library/metadata/matches?guid=tmdb://${tmdbId}&type=${type}`;
+  try {
+    const data = await plexFetch<{ MediaContainer?: { Metadata?: Array<{ slug?: string }> } }>(
+      url,
+      { headers: plexHeaders(token) }
+    );
+    return data.MediaContainer?.Metadata?.[0]?.slug ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/server/plex/deep-link.ts
+++ b/server/plex/deep-link.ts
@@ -1,9 +1,20 @@
 /**
  * Builds a Plex deep link for a specific media item.
- * Uses app.plex.tv/#!/... (without /desktop) so the URL works cross-platform:
- * web browsers load the Plex web app, and on mobile it can trigger universal
- * links to open the native Plex app if installed.
+ *
+ * The base URL uses app.plex.tv/#!/... so desktop browsers open the Plex web
+ * app. When a watch.plex.tv slug is available, it is embedded as extra query
+ * params so the frontend can construct a watch.plex.tv Android deep link
+ * without an additional API call. app.plex.tv ignores these extra params.
  */
-export function buildPlexDeepLink(serverId: string, ratingKey: string): string {
-  return `https://app.plex.tv/#!/server/${serverId}/details?key=${encodeURIComponent(`/library/metadata/${ratingKey}`)}`;
+export function buildPlexDeepLink(
+  serverId: string,
+  ratingKey: string,
+  slug?: string | null,
+  mediaType?: string | null
+): string {
+  let url = `https://app.plex.tv/#!/server/${serverId}/details?key=${encodeURIComponent(`/library/metadata/${ratingKey}`)}`;
+  if (slug && mediaType) {
+    url += `&watchSlug=${encodeURIComponent(slug)}&mediaType=${encodeURIComponent(mediaType)}`;
+  }
+  return url;
 }

--- a/server/plex/library-sync.ts
+++ b/server/plex/library-sync.ts
@@ -1,5 +1,5 @@
 import { logger } from "../logger";
-import { getLibrarySections, getAllMoviesInSection, getShowsInSection, PlexAuthError } from "./client";
+import { getLibrarySections, getAllMoviesInSection, getShowsInSection, getPlexMetadataSlug, PlexAuthError } from "./client";
 import { parsePlexGuids, parseLegacyGuid, toRemindarrTitleId } from "./guid";
 import { upsertPlexLibraryItems, deleteStaleLibraryItems } from "../db/repository/plex-library";
 import { updateIntegrationSyncStatus, disableIntegration } from "../db/repository";
@@ -34,17 +34,29 @@ export async function syncPlexLibrary(integration: IntegrationRow): Promise<Libr
     const movieSections = sections.filter((s) => s.type === "movie");
     for (const section of movieSections) {
       const movies = await getAllMoviesInSection(serverUrl, plexToken, section.key);
-      for (const item of movies) {
+      const slugResults = await Promise.allSettled(
+        movies.map((item) => {
+          const guids = parsePlexGuids(item.Guid) || parseLegacyGuid(item.guid);
+          return guids.tmdbId
+            ? getPlexMetadataSlug(guids.tmdbId.toString(), "movie", plexToken)
+            : Promise.resolve(null);
+        })
+      );
+      for (let i = 0; i < movies.length; i++) {
+        const item = movies[i];
         const guids = parsePlexGuids(item.Guid) || parseLegacyGuid(item.guid);
         if (!guids.tmdbId) continue;
         const titleId = toRemindarrTitleId("movie", guids.tmdbId);
         currentTitleIds.push(titleId);
+        const slugResult = slugResults[i];
+        const slug = slugResult.status === "fulfilled" ? slugResult.value : null;
         itemsToUpsert.push({
           integrationId,
           userId,
           titleId,
           ratingKey: item.ratingKey,
           mediaType: "movie",
+          plexSlug: slug,
         });
         moviesAdded++;
       }
@@ -54,17 +66,29 @@ export async function syncPlexLibrary(integration: IntegrationRow): Promise<Libr
     const showSections = sections.filter((s) => s.type === "show");
     for (const section of showSections) {
       const shows = await getShowsInSection(serverUrl, plexToken, section.key);
-      for (const item of shows) {
+      const slugResults = await Promise.allSettled(
+        shows.map((item) => {
+          const guids = parsePlexGuids(item.Guid) || parseLegacyGuid(item.guid);
+          return guids.tmdbId
+            ? getPlexMetadataSlug(guids.tmdbId.toString(), "show", plexToken)
+            : Promise.resolve(null);
+        })
+      );
+      for (let i = 0; i < shows.length; i++) {
+        const item = shows[i];
         const guids = parsePlexGuids(item.Guid) || parseLegacyGuid(item.guid);
         if (!guids.tmdbId) continue;
         const titleId = toRemindarrTitleId("show", guids.tmdbId);
         currentTitleIds.push(titleId);
+        const slugResult = slugResults[i];
+        const slug = slugResult.status === "fulfilled" ? slugResult.value : null;
         itemsToUpsert.push({
           integrationId,
           userId,
           titleId,
           ratingKey: item.ratingKey,
           mediaType: "show",
+          plexSlug: slug,
         });
         showsAdded++;
       }


### PR DESCRIPTION
## Summary
- Fetches a `watch.plex.tv` slug for each title during Plex library sync via `metadata.provider.plex.tv/library/metadata/matches`
- Stores slug in new `plex_library_items.plex_slug` column (migration `0016`)
- Embeds slug + mediaType as extra query params in the offer URL (ignored by the Plex web app on desktop)
- Frontend reads the params and routes per platform:
  - **iOS**: `plex://preplay/?metadataKey=...&server=...` → opens directly to content ✓
  - **Android**: `https://watch.plex.tv/{movie|show}/{slug}` → opens Plex app via Android App Links to Discover detail page, personal library listed as source (one extra tap)
  - **Desktop**: `app.plex.tv/#!/...` unchanged ✓
- Slug lookup is concurrent per section (`Promise.allSettled`); failures are silent (fallback to browser on Android)
- `COALESCE` on upsert preserves existing slug if a re-sync lookup fails

## Test plan
- [ ] Android: tap Plex Stream button → Plex app opens to content detail page (not browser)
- [ ] iOS: unchanged — tap opens directly to preplay screen
- [ ] Desktop: unchanged — opens app.plex.tv in new tab
- [ ] Title without a slug (obscure content): Android falls back to browser gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)