### PR TITLE
feat: multi-channel notifications — Telegram, Ntfy, Gotify, Webhook (#367)

### DIFF
--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -816,6 +816,11 @@ function NotificationsSection() {
   // Form fields
   const [formProvider, setFormProvider] = useState("discord");
   const [formWebhookUrl, setFormWebhookUrl] = useState("");
+  const [formUrl, setFormUrl] = useState("");
+  const [formToken, setFormToken] = useState("");
+  const [formSecret, setFormSecret] = useState("");
+  const [formBotToken, setFormBotToken] = useState("");
+  const [formChatId, setFormChatId] = useState("");
   const [formTime, setFormTime] = useState("09:00");
   const [formTimezone, setFormTimezone] = useState(USER_TIMEZONE);
   const [saving, setSaving] = useState(false);
@@ -838,6 +843,11 @@ function NotificationsSection() {
   function resetForm() {
     setFormProvider("discord");
     setFormWebhookUrl("");
+    setFormUrl("");
+    setFormToken("");
+    setFormSecret("");
+    setFormBotToken("");
+    setFormChatId("");
     setFormTime("09:00");
     setFormTimezone(USER_TIMEZONE);
     setShowForm(false);
@@ -848,6 +858,11 @@ function NotificationsSection() {
     setEditingId(n.id);
     setFormProvider(n.provider);
     setFormWebhookUrl(n.config.webhookUrl || "");
+    setFormUrl(n.config.url || "");
+    setFormToken(n.config.token || "");
+    setFormSecret(n.config.secret || "");
+    setFormBotToken(n.config.botToken || "");
+    setFormChatId(n.config.chatId || "");
     setFormTime(n.notify_time);
     setFormTimezone(n.timezone);
     setShowForm(true);
@@ -864,6 +879,18 @@ function NotificationsSection() {
     const config: Record<string, string> = {};
     if (formProvider === "discord") {
       config.webhookUrl = formWebhookUrl;
+    } else if (formProvider === "ntfy") {
+      config.url = formUrl;
+      if (formToken) config.token = formToken;
+    } else if (formProvider === "webhook") {
+      config.url = formUrl;
+      if (formSecret) config.secret = formSecret;
+    } else if (formProvider === "telegram") {
+      config.botToken = formBotToken;
+      config.chatId = formChatId;
+    } else if (formProvider === "gotify") {
+      config.url = formUrl;
+      config.token = formToken;
     }
 
     try {
@@ -1052,6 +1079,78 @@ function NotificationsSection() {
                 required
               />
             </div>
+          )}
+
+          {(formProvider === "ntfy" || formProvider === "webhook" || formProvider === "gotify") && (
+            <div>
+              <label className="block text-sm font-medium text-zinc-300 mb-1">
+                {formProvider === "ntfy" ? "Topic URL (e.g. https://ntfy.sh/my-topic)" : formProvider === "gotify" ? "Server URL (e.g. https://gotify.example.com)" : "Webhook URL"}
+              </label>
+              <input
+                type="url"
+                value={formUrl}
+                onChange={(e) => setFormUrl(e.target.value)}
+                placeholder={formProvider === "ntfy" ? "https://ntfy.sh/my-topic" : formProvider === "gotify" ? "https://gotify.example.com" : "https://your-server.com/hook"}
+                className="w-full px-3 py-2 bg-zinc-800 border border-white/[0.08] rounded-lg text-white placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-transparent"
+                required
+              />
+            </div>
+          )}
+
+          {(formProvider === "ntfy" || formProvider === "gotify") && (
+            <div>
+              <label className="block text-sm font-medium text-zinc-300 mb-1">
+                {formProvider === "gotify" ? "Application Token" : "Access Token"}{formProvider === "ntfy" ? " (optional)" : ""}
+              </label>
+              <input
+                type="password"
+                value={formToken}
+                onChange={(e) => setFormToken(e.target.value)}
+                placeholder={formProvider === "gotify" ? "App token from Gotify" : "Bearer token (leave empty for public topics)"}
+                className="w-full px-3 py-2 bg-zinc-800 border border-white/[0.08] rounded-lg text-white placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-transparent"
+                required={formProvider === "gotify"}
+              />
+            </div>
+          )}
+
+          {formProvider === "webhook" && (
+            <div>
+              <label className="block text-sm font-medium text-zinc-300 mb-1">Signing Secret <span className="text-zinc-500">(optional — enables HMAC-SHA256 signature header)</span></label>
+              <input
+                type="password"
+                value={formSecret}
+                onChange={(e) => setFormSecret(e.target.value)}
+                placeholder="Leave empty to skip request signing"
+                className="w-full px-3 py-2 bg-zinc-800 border border-white/[0.08] rounded-lg text-white placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-transparent"
+              />
+            </div>
+          )}
+
+          {formProvider === "telegram" && (
+            <>
+              <div>
+                <label className="block text-sm font-medium text-zinc-300 mb-1">Bot Token</label>
+                <input
+                  type="password"
+                  value={formBotToken}
+                  onChange={(e) => setFormBotToken(e.target.value)}
+                  placeholder="123456789:ABCdef..."
+                  className="w-full px-3 py-2 bg-zinc-800 border border-white/[0.08] rounded-lg text-white placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-transparent"
+                  required
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-zinc-300 mb-1">Chat ID</label>
+                <input
+                  type="text"
+                  value={formChatId}
+                  onChange={(e) => setFormChatId(e.target.value)}
+                  placeholder="-1001234567890"
+                  className="w-full px-3 py-2 bg-zinc-800 border border-white/[0.08] rounded-lg text-white placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-transparent"
+                  required
+                />
+              </div>
+            </>
           )}
 
           <div className="grid grid-cols-2 gap-4">

--- a/server/notifications/gotify.test.ts
+++ b/server/notifications/gotify.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { GotifyProvider } from "./gotify";
+import type { NotificationContent } from "./types";
+
+const gotify = new GotifyProvider();
+
+describe("GotifyProvider.validateConfig", () => {
+  it("accepts valid server URL and token", () => {
+    const result = gotify.validateConfig({
+      url: "https://gotify.example.com",
+      token: "AbCdEfGhIj",
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it("accepts http URL", () => {
+    const result = gotify.validateConfig({
+      url: "http://gotify.local",
+      token: "mytoken",
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects missing url", () => {
+    const result = gotify.validateConfig({ token: "mytoken" });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("URL");
+  });
+
+  it("rejects non-http(s) URL", () => {
+    const result = gotify.validateConfig({ url: "ftp://gotify.example.com", token: "mytoken" });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("http");
+  });
+
+  it("rejects invalid URL", () => {
+    const result = gotify.validateConfig({ url: "not-a-url", token: "mytoken" });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Invalid");
+  });
+
+  it("rejects missing token", () => {
+    const result = gotify.validateConfig({ url: "https://gotify.example.com" });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("token");
+  });
+});
+
+describe("GotifyProvider.send", () => {
+  let fetchCalls: Array<{ url: string; options: RequestInit }> = [];
+  let fetchSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    fetchCalls = [];
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async (url: string | URL | Request, options?: RequestInit) => {
+      fetchCalls.push({ url: url as string, options: options ?? {} });
+      return new Response(JSON.stringify({ id: 1 }), { status: 200 });
+    }) as typeof fetch);
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  const config = { url: "https://gotify.example.com", token: "myapptoken" };
+
+  const sampleContent: NotificationContent = {
+    date: "2026-03-12",
+    episodes: [
+      {
+        showTitle: "Breaking Bad",
+        seasonNumber: 1,
+        episodeNumber: 3,
+        episodeName: "...And the Bag's in the River",
+        posterUrl: null,
+        offers: [{ providerName: "Netflix", providerIconUrl: null }],
+      },
+    ],
+    movies: [
+      {
+        title: "The Matrix",
+        releaseYear: 1999,
+        posterUrl: null,
+        offers: [{ providerName: "HBO Max", providerIconUrl: null }],
+      },
+    ],
+  };
+
+  it("posts to /message endpoint with token in query string", async () => {
+    await gotify.send(config, sampleContent);
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0].url).toContain("/message");
+    expect(fetchCalls[0].url).toContain("token=myapptoken");
+  });
+
+  it("strips trailing slash from base URL", async () => {
+    await gotify.send({ url: "https://gotify.example.com/", token: "mytoken" }, sampleContent);
+    expect(fetchCalls[0].url).toBe("https://gotify.example.com/message?token=mytoken");
+  });
+
+  it("payload includes title and message", async () => {
+    await gotify.send(config, sampleContent);
+    const body = JSON.parse(fetchCalls[0].options.body as string);
+    expect(body.title).toContain("Remindarr");
+    expect(body.message).toContain("Breaking Bad");
+    expect(body.message).toContain("S01E03");
+    expect(body.message).toContain("The Matrix");
+    expect(body.priority).toBe(5);
+  });
+
+  it("skips sending when content is empty", async () => {
+    await gotify.send(config, { date: "2026-03-12", episodes: [], movies: [] });
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("throws on non-2xx response", async () => {
+    fetchSpy.mockImplementation(async () => new Response("Unauthorized", { status: 401 }));
+    await expect(gotify.send(config, sampleContent)).rejects.toThrow("401");
+  });
+});

--- a/server/notifications/gotify.ts
+++ b/server/notifications/gotify.ts
@@ -1,0 +1,82 @@
+import { traceHttp } from "../tracing";
+import type { NotificationContent, NotificationProvider } from "./types";
+
+export class GotifyProvider implements NotificationProvider {
+  readonly name = "gotify";
+
+  validateConfig(config: Record<string, string>): { valid: boolean; error?: string } {
+    if (!config.url) {
+      return { valid: false, error: "Gotify server URL is required (e.g. https://gotify.example.com)" };
+    }
+    try {
+      const u = new URL(config.url);
+      if (!["http:", "https:"].includes(u.protocol)) {
+        return { valid: false, error: "URL must use http or https" };
+      }
+    } catch {
+      return { valid: false, error: "Invalid URL" };
+    }
+    if (!config.token) {
+      return { valid: false, error: "Application token is required" };
+    }
+    return { valid: true };
+  }
+
+  async send(config: Record<string, string>, content: NotificationContent): Promise<void> {
+    const { episodes, movies } = content;
+    if (episodes.length === 0 && movies.length === 0) return;
+
+    const title = this.buildTitle(content);
+    const message = this.buildMessage(content);
+    const base = config.url.replace(/\/$/, "");
+    const url = `${base}/message?token=${encodeURIComponent(config.token)}`;
+
+    await traceHttp("POST", url, async () => {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title, message, priority: 5 }),
+      });
+
+      if (!response.ok) {
+        const text = await response.text().catch(() => "");
+        throw new Error(`Gotify request failed (${response.status}): ${text}`);
+      }
+    });
+  }
+
+  private buildTitle(content: NotificationContent): string {
+    const { episodes, movies } = content;
+    const parts: string[] = [];
+    if (episodes.length > 0) parts.push(`${episodes.length} episode${episodes.length !== 1 ? "s" : ""}`);
+    if (movies.length > 0) parts.push(`${movies.length} movie${movies.length !== 1 ? "s" : ""}`);
+    return `Remindarr — ${parts.join(" and ")} today`;
+  }
+
+  private buildMessage(content: NotificationContent): string {
+    const lines: string[] = [];
+
+    const showMap = new Map<string, typeof content.episodes>();
+    for (const ep of content.episodes) {
+      const existing = showMap.get(ep.showTitle) ?? [];
+      existing.push(ep);
+      showMap.set(ep.showTitle, existing);
+    }
+
+    for (const [showTitle, eps] of showMap) {
+      const codes = eps.map(
+        (ep) => `S${String(ep.seasonNumber).padStart(2, "0")}E${String(ep.episodeNumber).padStart(2, "0")}`
+      );
+      const providers = [...new Set(eps[0].offers.map((o) => o.providerName))].join(", ");
+      lines.push(`${showTitle} ${codes.join(", ")}${providers ? ` (${providers})` : ""}`);
+    }
+
+    for (const movie of content.movies) {
+      const providers = [...new Set(movie.offers.map((o) => o.providerName))].join(", ");
+      const label = movie.releaseYear ? `${movie.title} (${movie.releaseYear})` : movie.title;
+      lines.push(`${label}${providers ? ` (${providers})` : ""}`);
+    }
+
+    return lines.join("\n");
+  }
+}

--- a/server/notifications/ntfy.test.ts
+++ b/server/notifications/ntfy.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { NtfyProvider } from "./ntfy";
+import type { NotificationContent } from "./types";
+
+const ntfy = new NtfyProvider();
+
+describe("NtfyProvider.validateConfig", () => {
+  it("accepts valid topic URL", () => {
+    const result = ntfy.validateConfig({ url: "https://ntfy.sh/my-topic" });
+    expect(result.valid).toBe(true);
+  });
+
+  it("accepts self-hosted URL with topic", () => {
+    const result = ntfy.validateConfig({ url: "https://ntfy.example.com/alerts" });
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects missing url", () => {
+    const result = ntfy.validateConfig({});
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("required");
+  });
+
+  it("rejects URL without topic path", () => {
+    const result = ntfy.validateConfig({ url: "https://ntfy.sh/" });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("topic");
+  });
+
+  it("rejects URL without topic path (bare host)", () => {
+    const result = ntfy.validateConfig({ url: "https://ntfy.sh" });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("topic");
+  });
+
+  it("rejects non-http(s) URL", () => {
+    const result = ntfy.validateConfig({ url: "ftp://ntfy.sh/my-topic" });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("http");
+  });
+
+  it("rejects invalid URL string", () => {
+    const result = ntfy.validateConfig({ url: "not-a-url" });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Invalid");
+  });
+
+  it("accepts token when provided", () => {
+    const result = ntfy.validateConfig({ url: "https://ntfy.sh/secure", token: "tk_abc123" });
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("NtfyProvider.send", () => {
+  let fetchCalls: Array<{ url: string; options: RequestInit }> = [];
+  let fetchSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    fetchCalls = [];
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async (url: string | URL | Request, options?: RequestInit) => {
+      fetchCalls.push({ url: url as string, options: options ?? {} });
+      return new Response("", { status: 200 });
+    }) as typeof fetch);
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  const sampleContent: NotificationContent = {
+    date: "2026-03-12",
+    episodes: [
+      {
+        showTitle: "Breaking Bad",
+        seasonNumber: 1,
+        episodeNumber: 3,
+        episodeName: "...And the Bag's in the River",
+        posterUrl: null,
+        offers: [{ providerName: "Netflix", providerIconUrl: null }],
+      },
+    ],
+    movies: [
+      {
+        title: "The Matrix",
+        releaseYear: 1999,
+        posterUrl: null,
+        offers: [{ providerName: "HBO Max", providerIconUrl: null }],
+      },
+    ],
+  };
+
+  it("posts to the topic URL", async () => {
+    await ntfy.send({ url: "https://ntfy.sh/my-topic" }, sampleContent);
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0].url).toBe("https://ntfy.sh/my-topic");
+  });
+
+  it("sets Title and Tags headers", async () => {
+    await ntfy.send({ url: "https://ntfy.sh/my-topic" }, sampleContent);
+    const headers = fetchCalls[0].options.headers as Record<string, string>;
+    expect(headers["Title"]).toContain("Remindarr");
+    expect(headers["Tags"]).toContain("tv");
+  });
+
+  it("includes Authorization header when token is provided", async () => {
+    await ntfy.send({ url: "https://ntfy.sh/my-topic", token: "tk_secret" }, sampleContent);
+    const headers = fetchCalls[0].options.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer tk_secret");
+  });
+
+  it("omits Authorization header when no token", async () => {
+    await ntfy.send({ url: "https://ntfy.sh/my-topic" }, sampleContent);
+    const headers = fetchCalls[0].options.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBeUndefined();
+  });
+
+  it("message body includes show and movie info", async () => {
+    await ntfy.send({ url: "https://ntfy.sh/my-topic" }, sampleContent);
+    const body = fetchCalls[0].options.body as string;
+    expect(body).toContain("Breaking Bad");
+    expect(body).toContain("S01E03");
+    expect(body).toContain("The Matrix");
+  });
+
+  it("skips sending when content is empty", async () => {
+    await ntfy.send({ url: "https://ntfy.sh/my-topic" }, { date: "2026-03-12", episodes: [], movies: [] });
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("throws on non-2xx response", async () => {
+    fetchSpy.mockImplementation(async () => new Response("Forbidden", { status: 403 }));
+    await expect(ntfy.send({ url: "https://ntfy.sh/my-topic" }, sampleContent)).rejects.toThrow("403");
+  });
+});

--- a/server/notifications/ntfy.ts
+++ b/server/notifications/ntfy.ts
@@ -1,0 +1,92 @@
+import { traceHttp } from "../tracing";
+import type { NotificationContent, NotificationProvider } from "./types";
+
+export class NtfyProvider implements NotificationProvider {
+  readonly name = "ntfy";
+
+  validateConfig(config: Record<string, string>): { valid: boolean; error?: string } {
+    if (!config.url) {
+      return { valid: false, error: "Ntfy topic URL is required (e.g. https://ntfy.sh/my-topic)" };
+    }
+    try {
+      const u = new URL(config.url);
+      if (!["http:", "https:"].includes(u.protocol)) {
+        return { valid: false, error: "URL must use http or https" };
+      }
+      // Topic must be part of the path
+      if (u.pathname === "/" || u.pathname === "") {
+        return { valid: false, error: "URL must include a topic (e.g. https://ntfy.sh/my-topic)" };
+      }
+    } catch {
+      return { valid: false, error: "Invalid URL" };
+    }
+    return { valid: true };
+  }
+
+  async send(config: Record<string, string>, content: NotificationContent): Promise<void> {
+    const { episodes, movies } = content;
+    if (episodes.length === 0 && movies.length === 0) return;
+
+    const title = this.buildTitle(content);
+    const message = this.buildMessage(content);
+
+    const headers: Record<string, string> = {
+      "Content-Type": "text/plain",
+      "Title": title,
+      "Priority": "default",
+      "Tags": "tv,movie",
+    };
+
+    if (config.token) {
+      headers["Authorization"] = `Bearer ${config.token}`;
+    }
+
+    await traceHttp("POST", config.url, async () => {
+      const response = await fetch(config.url, {
+        method: "POST",
+        headers,
+        body: message,
+      });
+
+      if (!response.ok) {
+        const text = await response.text().catch(() => "");
+        throw new Error(`Ntfy request failed (${response.status}): ${text}`);
+      }
+    });
+  }
+
+  private buildTitle(content: NotificationContent): string {
+    const { episodes, movies } = content;
+    const parts: string[] = [];
+    if (episodes.length > 0) parts.push(`${episodes.length} episode${episodes.length !== 1 ? "s" : ""}`);
+    if (movies.length > 0) parts.push(`${movies.length} movie${movies.length !== 1 ? "s" : ""}`);
+    return `Remindarr — ${parts.join(" and ")} today`;
+  }
+
+  private buildMessage(content: NotificationContent): string {
+    const lines: string[] = [];
+
+    const showMap = new Map<string, typeof content.episodes>();
+    for (const ep of content.episodes) {
+      const existing = showMap.get(ep.showTitle) ?? [];
+      existing.push(ep);
+      showMap.set(ep.showTitle, existing);
+    }
+
+    for (const [showTitle, eps] of showMap) {
+      const codes = eps.map(
+        (ep) => `S${String(ep.seasonNumber).padStart(2, "0")}E${String(ep.episodeNumber).padStart(2, "0")}`
+      );
+      const providers = [...new Set(eps[0].offers.map((o) => o.providerName))].join(", ");
+      lines.push(`${showTitle} ${codes.join(", ")}${providers ? ` · ${providers}` : ""}`);
+    }
+
+    for (const movie of content.movies) {
+      const providers = [...new Set(movie.offers.map((o) => o.providerName))].join(", ");
+      const label = movie.releaseYear ? `${movie.title} (${movie.releaseYear})` : movie.title;
+      lines.push(`${label}${providers ? ` · ${providers}` : ""}`);
+    }
+
+    return lines.join("\n");
+  }
+}

--- a/server/notifications/registry.ts
+++ b/server/notifications/registry.ts
@@ -1,10 +1,18 @@
 import { DiscordProvider } from "./discord";
 import { WebPushProvider } from "./webpush";
+import { NtfyProvider } from "./ntfy";
+import { WebhookProvider } from "./webhook";
+import { TelegramProvider } from "./telegram";
+import { GotifyProvider } from "./gotify";
 import type { NotificationProvider } from "./types";
 
 const providers = new Map<string, NotificationProvider>();
 providers.set("discord", new DiscordProvider());
 providers.set("webpush", new WebPushProvider());
+providers.set("ntfy", new NtfyProvider());
+providers.set("webhook", new WebhookProvider());
+providers.set("telegram", new TelegramProvider());
+providers.set("gotify", new GotifyProvider());
 
 export function getProvider(name: string): NotificationProvider | undefined {
   return providers.get(name);

--- a/server/notifications/telegram.test.ts
+++ b/server/notifications/telegram.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { TelegramProvider } from "./telegram";
+import type { NotificationContent } from "./types";
+
+const telegram = new TelegramProvider();
+
+describe("TelegramProvider.validateConfig", () => {
+  it("accepts valid bot token and numeric chat ID", () => {
+    const result = telegram.validateConfig({
+      botToken: "123456789:ABCdefGHIjklMNOpqrSTUvwxYZ_abcde12345",
+      chatId: "-1001234567890",
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it("accepts positive chat ID", () => {
+    const result = telegram.validateConfig({
+      botToken: "123456789:ABCdefGHIjklMNOpqrSTUvwxYZ_abcde12345",
+      chatId: "987654321",
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects missing botToken", () => {
+    const result = telegram.validateConfig({ chatId: "-1001234567890" });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("token");
+  });
+
+  it("rejects invalid botToken format", () => {
+    const result = telegram.validateConfig({ botToken: "bad-token", chatId: "-1001234567890" });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Invalid bot token");
+  });
+
+  it("rejects missing chatId", () => {
+    const result = telegram.validateConfig({
+      botToken: "123456789:ABCdefGHIjklMNOpqrSTUvwxYZ_abcde12345",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Chat ID");
+  });
+
+  it("rejects non-numeric chatId", () => {
+    const result = telegram.validateConfig({
+      botToken: "123456789:ABCdefGHIjklMNOpqrSTUvwxYZ_abcde12345",
+      chatId: "my_channel",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("number");
+  });
+});
+
+describe("TelegramProvider.send", () => {
+  let fetchCalls: Array<{ url: string; options: RequestInit }> = [];
+  let fetchSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    fetchCalls = [];
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async (url: string | URL | Request, options?: RequestInit) => {
+      fetchCalls.push({ url: url as string, options: options ?? {} });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as typeof fetch);
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  const config = {
+    botToken: "123456789:ABCdefGHIjklMNOpqrSTUvwxYZ_abcde12345",
+    chatId: "-1001234567890",
+  };
+
+  const sampleContent: NotificationContent = {
+    date: "2026-03-12",
+    episodes: [
+      {
+        showTitle: "Breaking Bad",
+        seasonNumber: 1,
+        episodeNumber: 3,
+        episodeName: "...And the Bag's in the River",
+        posterUrl: null,
+        offers: [{ providerName: "Netflix", providerIconUrl: null }],
+      },
+    ],
+    movies: [
+      {
+        title: "The Matrix",
+        releaseYear: 1999,
+        posterUrl: null,
+        offers: [{ providerName: "HBO Max", providerIconUrl: null }],
+      },
+    ],
+  };
+
+  it("posts to Telegram sendMessage endpoint", async () => {
+    await telegram.send(config, sampleContent);
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0].url).toContain("api.telegram.org");
+    expect(fetchCalls[0].url).toContain("sendMessage");
+  });
+
+  it("sends HTML parse_mode", async () => {
+    await telegram.send(config, sampleContent);
+    const body = JSON.parse(fetchCalls[0].options.body as string);
+    expect(body.parse_mode).toBe("HTML");
+    expect(body.chat_id).toBe(config.chatId);
+  });
+
+  it("message contains episode codes and movie title", async () => {
+    await telegram.send(config, sampleContent);
+    const body = JSON.parse(fetchCalls[0].options.body as string);
+    expect(body.text).toContain("S01E03");
+    expect(body.text).toContain("The Matrix");
+    expect(body.text).toContain("Remindarr");
+  });
+
+  it("escapes HTML special characters in show titles", async () => {
+    const content: NotificationContent = {
+      date: "2026-03-12",
+      episodes: [],
+      movies: [
+        {
+          title: "AT&T <Story>",
+          releaseYear: 2025,
+          posterUrl: null,
+          offers: [],
+        },
+      ],
+    };
+    await telegram.send(config, content);
+    const body = JSON.parse(fetchCalls[0].options.body as string);
+    expect(body.text).toContain("AT&amp;T");
+    expect(body.text).toContain("&lt;Story&gt;");
+  });
+
+  it("skips sending when content is empty", async () => {
+    await telegram.send(config, { date: "2026-03-12", episodes: [], movies: [] });
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("throws on non-2xx response", async () => {
+    fetchSpy.mockImplementation(async () =>
+      new Response(JSON.stringify({ ok: false, description: "Bad Request" }), { status: 400 })
+    );
+    await expect(telegram.send(config, sampleContent)).rejects.toThrow("400");
+  });
+});

--- a/server/notifications/telegram.ts
+++ b/server/notifications/telegram.ts
@@ -1,0 +1,88 @@
+import { traceHttp } from "../tracing";
+import type { NotificationContent, NotificationProvider } from "./types";
+
+const TELEGRAM_API = "https://api.telegram.org";
+
+export class TelegramProvider implements NotificationProvider {
+  readonly name = "telegram";
+
+  validateConfig(config: Record<string, string>): { valid: boolean; error?: string } {
+    if (!config.botToken) {
+      return { valid: false, error: "Bot token is required" };
+    }
+    if (!/^\d+:[A-Za-z0-9_-]{35,}$/.test(config.botToken)) {
+      return { valid: false, error: "Invalid bot token format (expected 123456:ABC...)" };
+    }
+    if (!config.chatId) {
+      return { valid: false, error: "Chat ID is required" };
+    }
+    if (!/^-?\d+$/.test(config.chatId)) {
+      return { valid: false, error: "Chat ID must be a number (e.g. -1001234567890)" };
+    }
+    return { valid: true };
+  }
+
+  async send(config: Record<string, string>, content: NotificationContent): Promise<void> {
+    const { episodes, movies } = content;
+    if (episodes.length === 0 && movies.length === 0) return;
+
+    const text = this.buildMessage(content);
+    const url = `${TELEGRAM_API}/bot${config.botToken}/sendMessage`;
+
+    await traceHttp("POST", url, async () => {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          chat_id: config.chatId,
+          text,
+          parse_mode: "HTML",
+          disable_web_page_preview: true,
+        }),
+      });
+
+      if (!response.ok) {
+        const json = await response.json().catch(() => ({}));
+        throw new Error(`Telegram API error (${response.status}): ${json.description ?? "Unknown error"}`);
+      }
+    });
+  }
+
+  private buildMessage(content: NotificationContent): string {
+    const { episodes, movies, date } = content;
+    const parts: string[] = [];
+    if (episodes.length > 0) parts.push(`${episodes.length} episode${episodes.length !== 1 ? "s" : ""}`);
+    if (movies.length > 0) parts.push(`${movies.length} movie${movies.length !== 1 ? "s" : ""}`);
+
+    const lines: string[] = [`<b>📺 Remindarr — ${parts.join(" and ")} today (${date})</b>`, ""];
+
+    const showMap = new Map<string, typeof episodes>();
+    for (const ep of episodes) {
+      const existing = showMap.get(ep.showTitle) ?? [];
+      existing.push(ep);
+      showMap.set(ep.showTitle, existing);
+    }
+
+    for (const [showTitle, eps] of showMap) {
+      const codes = eps.map(
+        (ep) => `S${String(ep.seasonNumber).padStart(2, "0")}E${String(ep.episodeNumber).padStart(2, "0")}`
+      );
+      const providers = [...new Set(eps[0].offers.map((o) => o.providerName))].join(", ");
+      const providerStr = providers ? ` <i>(${providers})</i>` : "";
+      lines.push(`🎬 <b>${escapeHtml(showTitle)}</b> — ${codes.join(", ")}${providerStr}`);
+    }
+
+    for (const movie of movies) {
+      const providers = [...new Set(movie.offers.map((o) => o.providerName))].join(", ");
+      const providerStr = providers ? ` <i>(${providers})</i>` : "";
+      const label = movie.releaseYear ? `${movie.title} (${movie.releaseYear})` : movie.title;
+      lines.push(`🎥 <b>${escapeHtml(label)}</b>${providerStr}`);
+    }
+
+    return lines.join("\n");
+  }
+}
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}

--- a/server/notifications/webhook.test.ts
+++ b/server/notifications/webhook.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { WebhookProvider } from "./webhook";
+import type { NotificationContent } from "./types";
+
+const webhook = new WebhookProvider();
+
+describe("WebhookProvider.validateConfig", () => {
+  it("accepts valid https URL", () => {
+    const result = webhook.validateConfig({ url: "https://example.com/hook" });
+    expect(result.valid).toBe(true);
+  });
+
+  it("accepts http URL", () => {
+    const result = webhook.validateConfig({ url: "http://internal.local/hook" });
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects missing url", () => {
+    const result = webhook.validateConfig({});
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("required");
+  });
+
+  it("rejects non-http(s) URL", () => {
+    const result = webhook.validateConfig({ url: "ftp://example.com/hook" });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("http");
+  });
+
+  it("rejects invalid URL", () => {
+    const result = webhook.validateConfig({ url: "not-a-url" });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Invalid");
+  });
+});
+
+describe("WebhookProvider.send", () => {
+  let fetchCalls: Array<{ url: string; options: RequestInit }> = [];
+  let fetchSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    fetchCalls = [];
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async (url: string | URL | Request, options?: RequestInit) => {
+      fetchCalls.push({ url: url as string, options: options ?? {} });
+      return new Response("ok", { status: 200 });
+    }) as typeof fetch);
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  const sampleContent: NotificationContent = {
+    date: "2026-03-12",
+    episodes: [
+      {
+        showTitle: "Breaking Bad",
+        seasonNumber: 1,
+        episodeNumber: 3,
+        episodeName: "...And the Bag's in the River",
+        posterUrl: null,
+        offers: [{ providerName: "Netflix", providerIconUrl: null }],
+      },
+    ],
+    movies: [
+      {
+        title: "The Matrix",
+        releaseYear: 1999,
+        posterUrl: null,
+        offers: [{ providerName: "HBO Max", providerIconUrl: null }],
+      },
+    ],
+  };
+
+  it("posts JSON payload to the webhook URL", async () => {
+    await webhook.send({ url: "https://example.com/hook" }, sampleContent);
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0].url).toBe("https://example.com/hook");
+    const body = JSON.parse(fetchCalls[0].options.body as string);
+    expect(body.source).toBe("remindarr");
+    expect(body.date).toBe("2026-03-12");
+    expect(body.episodes).toBeArray();
+    expect(body.movies).toBeArray();
+  });
+
+  it("payload includes episode and movie details", async () => {
+    await webhook.send({ url: "https://example.com/hook" }, sampleContent);
+    const body = JSON.parse(fetchCalls[0].options.body as string);
+    expect(body.episodes[0].show).toBe("Breaking Bad");
+    expect(body.episodes[0].season).toBe(1);
+    expect(body.episodes[0].episode).toBe(3);
+    expect(body.movies[0].title).toBe("The Matrix");
+    expect(body.movies[0].year).toBe(1999);
+  });
+
+  it("includes X-Remindarr-Signature header when secret provided", async () => {
+    await webhook.send({ url: "https://example.com/hook", secret: "my-secret" }, sampleContent);
+    const headers = fetchCalls[0].options.headers as Record<string, string>;
+    expect(headers["X-Remindarr-Signature"]).toMatch(/^sha256=[0-9a-f]{64}$/);
+  });
+
+  it("omits signature header when no secret", async () => {
+    await webhook.send({ url: "https://example.com/hook" }, sampleContent);
+    const headers = fetchCalls[0].options.headers as Record<string, string>;
+    expect(headers["X-Remindarr-Signature"]).toBeUndefined();
+  });
+
+  it("includes User-Agent header", async () => {
+    await webhook.send({ url: "https://example.com/hook" }, sampleContent);
+    const headers = fetchCalls[0].options.headers as Record<string, string>;
+    expect(headers["User-Agent"]).toContain("Remindarr");
+  });
+
+  it("skips sending when content is empty", async () => {
+    await webhook.send({ url: "https://example.com/hook" }, { date: "2026-03-12", episodes: [], movies: [] });
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("throws on non-2xx response", async () => {
+    fetchSpy.mockImplementation(async () => new Response("Server Error", { status: 500 }));
+    await expect(webhook.send({ url: "https://example.com/hook" }, sampleContent)).rejects.toThrow("500");
+  });
+
+  it("signature is deterministic for same body and secret", async () => {
+    await webhook.send({ url: "https://example.com/hook", secret: "abc" }, sampleContent);
+    const sig1 = (fetchCalls[0].options.headers as Record<string, string>)["X-Remindarr-Signature"];
+    await webhook.send({ url: "https://example.com/hook", secret: "abc" }, sampleContent);
+    const sig2 = (fetchCalls[1].options.headers as Record<string, string>)["X-Remindarr-Signature"];
+    expect(sig1).toBe(sig2);
+  });
+});

--- a/server/notifications/webhook.ts
+++ b/server/notifications/webhook.ts
@@ -1,0 +1,105 @@
+import { traceHttp } from "../tracing";
+import type { NotificationContent, NotificationProvider } from "./types";
+
+export class WebhookProvider implements NotificationProvider {
+  readonly name = "webhook";
+
+  validateConfig(config: Record<string, string>): { valid: boolean; error?: string } {
+    if (!config.url) {
+      return { valid: false, error: "Webhook URL is required" };
+    }
+    try {
+      const u = new URL(config.url);
+      if (!["http:", "https:"].includes(u.protocol)) {
+        return { valid: false, error: "URL must use http or https" };
+      }
+    } catch {
+      return { valid: false, error: "Invalid URL" };
+    }
+    return { valid: true };
+  }
+
+  async send(config: Record<string, string>, content: NotificationContent): Promise<void> {
+    const { episodes, movies } = content;
+    if (episodes.length === 0 && movies.length === 0) return;
+
+    const payload = this.buildPayload(content);
+    const body = JSON.stringify(payload);
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "User-Agent": "Remindarr/1.0",
+    };
+
+    if (config.secret) {
+      headers["X-Remindarr-Signature"] = await this.sign(body, config.secret);
+    }
+
+    await traceHttp("POST", config.url, async () => {
+      const response = await fetch(config.url, {
+        method: "POST",
+        headers,
+        body,
+      });
+
+      if (!response.ok) {
+        const text = await response.text().catch(() => "");
+        throw new Error(`Webhook request failed (${response.status}): ${text}`);
+      }
+    });
+  }
+
+  private buildPayload(content: NotificationContent) {
+    const { episodes, movies, date } = content;
+
+    const summaryLines: string[] = [];
+    const showMap = new Map<string, typeof episodes>();
+    for (const ep of episodes) {
+      const existing = showMap.get(ep.showTitle) ?? [];
+      existing.push(ep);
+      showMap.set(ep.showTitle, existing);
+    }
+    for (const [showTitle, eps] of showMap) {
+      const codes = eps.map(
+        (ep) => `S${String(ep.seasonNumber).padStart(2, "0")}E${String(ep.episodeNumber).padStart(2, "0")}`
+      );
+      summaryLines.push(`${showTitle} ${codes.join(", ")}`);
+    }
+    for (const movie of movies) {
+      summaryLines.push(movie.releaseYear ? `${movie.title} (${movie.releaseYear})` : movie.title);
+    }
+
+    const total = episodes.length + movies.length;
+    return {
+      source: "remindarr",
+      date,
+      title: `Remindarr — ${total} new release${total !== 1 ? "s" : ""}`,
+      summary: summaryLines.join(", "),
+      episodes: episodes.map((ep) => ({
+        show: ep.showTitle,
+        season: ep.seasonNumber,
+        episode: ep.episodeNumber,
+        name: ep.episodeName,
+        providers: ep.offers.map((o) => o.providerName),
+      })),
+      movies: movies.map((m) => ({
+        title: m.title,
+        year: m.releaseYear,
+        providers: m.offers.map((o) => o.providerName),
+      })),
+    };
+  }
+
+  private async sign(body: string, secret: string): Promise<string> {
+    const encoder = new TextEncoder();
+    const key = await crypto.subtle.importKey(
+      "raw",
+      encoder.encode(secret),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"]
+    );
+    const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(body));
+    return "sha256=" + Array.from(new Uint8Array(signature)).map((b) => b.toString(16).padStart(2, "0")).join("");
+  }
+}

--- a/server/routes/notifiers.test.ts
+++ b/server/routes/notifiers.test.ts
@@ -125,7 +125,7 @@ describe("POST /notifiers", () => {
     const res = await app.request("/notifiers", {
       method: "POST",
       headers: jsonHeaders(),
-      body: JSON.stringify({ ...validNotifier, provider: "telegram" }),
+      body: JSON.stringify({ ...validNotifier, provider: "nonexistent_provider" }),
     });
     expect(res.status).toBe(400);
     const body = await res.json();


### PR DESCRIPTION
## Summary

- Adds **4 new notification providers**: Telegram (HTML Bot API), Ntfy (self-hosted push), Gotify (self-hosted push), and generic Webhook (JSON payload)
- Webhook provider supports optional HMAC-SHA256 request signing via `X-Remindarr-Signature` header
- Settings UI now renders provider-specific config fields (bot token + chat ID for Telegram, topic URL + optional auth token for Ntfy, etc.)
- Registers all new providers in the registry alongside existing Discord and Web Push
- Fixes the "rejects unknown provider" test to use a truly unknown provider name

## Test plan

- [x] `bun run check` passes — 1577 tests, 0 failures, 0 lint errors
- [x] 51 new unit tests across 4 provider files covering `validateConfig` and `send` for each provider
- [x] HMAC-SHA256 signature determinism tested
- [x] HTML escaping for Telegram tested (`&`, `<`, `>`)
- [x] Empty content short-circuits all providers (no HTTP call made)
- [x] Non-2xx responses throw with status code in message

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)