### PR TITLE
feat: keyboard shortcuts and accessibility improvements (#388)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useState } from "react";
 import { Routes, Route, NavLink, Link, Navigate, useLocation } from "react-router";
 import { Toaster } from "sonner";
 import { useTranslation } from "react-i18next";
@@ -9,9 +9,11 @@ import BottomTabBar from "./components/BottomTabBar";
 import OfflineIndicator from "./components/OfflineIndicator";
 import InstallPrompt from "./components/InstallPrompt";
 import NotificationPrompt from "./components/NotificationPrompt";
+import KeyboardShortcutsModal from "./components/KeyboardShortcutsModal";
 import { Github, Settings } from "lucide-react";
 import { navLinkClass } from "./nav-utils";
 import { usePushSubscriptionSync } from "./hooks/usePushSubscriptionSync";
+import { useKeyboardShortcut } from "./hooks/useKeyboardShortcut";
 
 const LAZY_RETRY_KEY = "__lazy_retry";
 
@@ -68,6 +70,16 @@ export default function App() {
   const { t } = useTranslation();
   const isReelsPage = location.pathname === "/reels";
   usePushSubscriptionSync();
+
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  useKeyboardShortcut("?", () => setShortcutsOpen((v) => !v));
+  useKeyboardShortcut("/", () => {
+    const input = document.getElementById("search-input") as HTMLInputElement | null;
+    if (input) {
+      input.focus();
+      input.select();
+    }
+  });
 
   return (
     <div className={`bg-zinc-950 text-zinc-100 ${isReelsPage ? "h-[100dvh] overflow-hidden" : "min-h-screen"}`}>
@@ -201,6 +213,7 @@ export default function App() {
       <BottomTabBar />
       <OfflineIndicator />
       <Toaster theme="dark" position="bottom-center" richColors />
+      <KeyboardShortcutsModal open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />
     </div>
   );
 }

--- a/frontend/src/components/BottomTabBar.tsx
+++ b/frontend/src/components/BottomTabBar.tsx
@@ -42,6 +42,7 @@ export default function BottomTabBar() {
                 {unreadCount > 0 && (
                   <span
                     data-testid="unread-badge"
+                    aria-label={t("bottomNav.unreadRecommendations", { count: unreadCount })}
                     className="absolute -top-1 -right-2 min-w-4 h-4 px-1 flex items-center justify-center rounded-full bg-amber-500 text-zinc-950 text-[9px] font-bold leading-none"
                   >
                     {unreadCount > 99 ? "99+" : unreadCount}

--- a/frontend/src/components/KeyboardShortcutsModal.test.tsx
+++ b/frontend/src/components/KeyboardShortcutsModal.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import KeyboardShortcutsModal from "./KeyboardShortcutsModal";
+import "../i18n";
+
+afterEach(cleanup);
+
+describe("KeyboardShortcutsModal", () => {
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <KeyboardShortcutsModal open={false} onClose={() => {}} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders dialog when open", () => {
+    render(<KeyboardShortcutsModal open={true} onClose={() => {}} />);
+    expect(screen.getByRole("dialog")).toBeDefined();
+  });
+
+  it("calls onClose when backdrop is clicked", () => {
+    let closed = false;
+    render(<KeyboardShortcutsModal open={true} onClose={() => { closed = true; }} />);
+    const backdrop = document.querySelector(".absolute.inset-0.bg-black\\/60") as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(closed).toBe(true);
+  });
+
+  it("calls onClose when Escape is pressed", () => {
+    let closed = false;
+    render(<KeyboardShortcutsModal open={true} onClose={() => { closed = true; }} />);
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(closed).toBe(true);
+  });
+
+  it("shows shortcut keys", () => {
+    render(<KeyboardShortcutsModal open={true} onClose={() => {}} />);
+    expect(screen.getByText("/")).toBeDefined();
+    expect(screen.getByText("j")).toBeDefined();
+    expect(screen.getByText("k")).toBeDefined();
+  });
+});

--- a/frontend/src/components/KeyboardShortcutsModal.tsx
+++ b/frontend/src/components/KeyboardShortcutsModal.tsx
@@ -1,0 +1,78 @@
+import { useEffect } from "react";
+import { X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+interface Shortcut {
+  key: string;
+  descKey: string;
+}
+
+const SHORTCUTS: Shortcut[] = [
+  { key: "?", descKey: "shortcuts.showHelp" },
+  { key: "/", descKey: "shortcuts.focusSearch" },
+  { key: "j", descKey: "shortcuts.nextTitle" },
+  { key: "k", descKey: "shortcuts.prevTitle" },
+  { key: "Enter", descKey: "shortcuts.openTitle" },
+];
+
+export default function KeyboardShortcutsModal({ open, onClose }: Props) {
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    if (!open) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape" || e.key === "?") {
+        e.preventDefault();
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[200] flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="shortcuts-title"
+        className="relative bg-zinc-900 border border-white/[0.08] rounded-2xl p-6 max-w-sm w-full shadow-2xl"
+      >
+        <div className="flex items-center justify-between mb-5">
+          <h2 id="shortcuts-title" className="text-base font-semibold">
+            {t("shortcuts.title")}
+          </h2>
+          <button
+            onClick={onClose}
+            aria-label={t("shortcuts.close")}
+            className="text-zinc-400 hover:text-white transition-colors cursor-pointer"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+        <div className="space-y-3">
+          {SHORTCUTS.map((s) => (
+            <div key={s.key} className="flex items-center justify-between gap-4">
+              <span className="text-sm text-zinc-300">{t(s.descKey)}</span>
+              <kbd className="shrink-0 text-xs font-mono bg-zinc-800 border border-white/[0.1] px-2 py-0.5 rounded text-zinc-300">
+                {s.key}
+              </kbd>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -28,10 +28,12 @@ export default function SearchBar({ onSearch, onImdb, loading }: Props) {
   return (
     <form onSubmit={handleSubmit} className="flex gap-2">
       <input
+        id="search-input"
         type="text"
         value={value}
         onChange={(e) => setValue(e.target.value)}
         placeholder={t("search.placeholder")}
+        aria-label={t("search.label")}
         className="flex-1 bg-zinc-900 border border-white/[0.06] rounded-lg px-4 py-2.5 text-sm text-white placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-transparent"
       />
       <button

--- a/frontend/src/components/TitleCard.tsx
+++ b/frontend/src/components/TitleCard.tsx
@@ -20,10 +20,10 @@ const TitleCard = memo(function TitleCard({ title, onTrackToggle, showVisibility
   const [userStatus, setUserStatus] = useState(title.user_status ?? null);
 
   return (
-    <div className={`bg-zinc-900 rounded-xl overflow-hidden hover:scale-[1.02] transition-transform duration-200 flex flex-col${title.show_status === "completed" ? " opacity-75" : ""}`}>
+    <article aria-label={title.title} className={`bg-zinc-900 rounded-xl overflow-hidden hover:scale-[1.02] transition-transform duration-200 flex flex-col${title.show_status === "completed" ? " opacity-75" : ""}`}>
       {/* Poster — clickable link to detail page */}
       <div className="aspect-[2/3] bg-zinc-800 relative">
-        <Link to={`/title/${title.id}`} className="block w-full h-full">
+        <Link to={`/title/${title.id}`} data-title-link className="block w-full h-full focus:outline-none focus:ring-2 focus:ring-amber-500/70 focus:ring-inset">
           {title.poster_url ? (
             <img
               src={title.poster_url}
@@ -160,7 +160,7 @@ const TitleCard = memo(function TitleCard({ title, onTrackToggle, showVisibility
           )}
         </div>
       </div>
-    </div>
+    </article>
   );
 });
 

--- a/frontend/src/hooks/useGridNavigation.ts
+++ b/frontend/src/hooks/useGridNavigation.ts
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from "react";
+import { isInputFocused } from "./useKeyboardShortcut";
+
+/**
+ * Enables j/k keyboard navigation through title cards on the current page.
+ * TitleCard marks its primary link with data-title-link for discovery.
+ */
+export function useGridNavigation(enabled = true) {
+  const indexRef = useRef(-1);
+
+  useEffect(() => {
+    if (!enabled) return;
+    indexRef.current = -1;
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (isInputFocused()) return;
+      if (e.key !== "j" && e.key !== "k") return;
+
+      const cards = Array.from(document.querySelectorAll<HTMLElement>("[data-title-link]"));
+      if (cards.length === 0) return;
+
+      e.preventDefault();
+
+      // Sync index with actual DOM focus in case user clicked or tabbed
+      const focusedIndex = cards.indexOf(document.activeElement as HTMLElement);
+      const current = focusedIndex >= 0 ? focusedIndex : indexRef.current;
+
+      if (e.key === "j") {
+        indexRef.current = Math.min(current + 1, cards.length - 1);
+      } else {
+        indexRef.current = Math.max(current - 1, 0);
+      }
+
+      cards[indexRef.current].focus();
+      cards[indexRef.current].scrollIntoView({ behavior: "smooth", block: "nearest" });
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [enabled]);
+}

--- a/frontend/src/hooks/useKeyboardShortcut.test.ts
+++ b/frontend/src/hooks/useKeyboardShortcut.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { renderHook } from "@testing-library/react";
+import { useKeyboardShortcut, isInputFocused } from "./useKeyboardShortcut";
+
+function fireKey(key: string) {
+  window.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+}
+
+describe("isInputFocused", () => {
+  it("returns false when body is focused", () => {
+    document.body.focus();
+    expect(isInputFocused()).toBe(false);
+  });
+
+  it("returns true when an input is focused", () => {
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    expect(isInputFocused()).toBe(true);
+    document.body.removeChild(input);
+  });
+
+  it("returns true when a textarea is focused", () => {
+    const ta = document.createElement("textarea");
+    document.body.appendChild(ta);
+    ta.focus();
+    expect(isInputFocused()).toBe(true);
+    document.body.removeChild(ta);
+  });
+});
+
+describe("useKeyboardShortcut", () => {
+  let calls: number;
+
+  beforeEach(() => {
+    calls = 0;
+    document.body.focus();
+  });
+
+  it("fires callback when key is pressed", () => {
+    const { unmount } = renderHook(() => useKeyboardShortcut("j", () => calls++));
+    fireKey("j");
+    expect(calls).toBe(1);
+    unmount();
+  });
+
+  it("does not fire for a different key", () => {
+    const { unmount } = renderHook(() => useKeyboardShortcut("j", () => calls++));
+    fireKey("k");
+    expect(calls).toBe(0);
+    unmount();
+  });
+
+  it("does not fire when an input is focused", () => {
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    const { unmount } = renderHook(() => useKeyboardShortcut("j", () => calls++));
+    fireKey("j");
+    expect(calls).toBe(0);
+
+    unmount();
+    document.body.removeChild(input);
+  });
+
+  it("does not fire with modifier keys", () => {
+    const { unmount } = renderHook(() => useKeyboardShortcut("j", () => calls++));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "j", ctrlKey: true }));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "j", metaKey: true }));
+    expect(calls).toBe(0);
+    unmount();
+  });
+
+  it("removes listener on unmount", () => {
+    const { unmount } = renderHook(() => useKeyboardShortcut("j", () => calls++));
+    unmount();
+    fireKey("j");
+    expect(calls).toBe(0);
+  });
+
+  it("always uses the latest callback without re-registering", () => {
+    const { rerender, unmount } = renderHook(
+      ({ val }: { val: number }) => useKeyboardShortcut("j", () => { calls += val; }),
+      { initialProps: { val: 1 } }
+    );
+    rerender({ val: 10 });
+    fireKey("j");
+    // Should use updated callback value of 10
+    expect(calls).toBe(10);
+    unmount();
+  });
+});

--- a/frontend/src/hooks/useKeyboardShortcut.ts
+++ b/frontend/src/hooks/useKeyboardShortcut.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from "react";
+
+export function isInputFocused(): boolean {
+  const el = document.activeElement;
+  if (!el) return false;
+  const tag = el.tagName.toLowerCase();
+  return tag === "input" || tag === "textarea" || tag === "select" || (el as HTMLElement).isContentEditable;
+}
+
+/**
+ * Registers a global keyboard shortcut. The callback is skipped when focus is
+ * inside an input, textarea, select, or contenteditable element.
+ */
+export function useKeyboardShortcut(key: string, callback: () => void) {
+  const callbackRef = useRef(callback);
+  useEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (isInputFocused()) return;
+      if (e.key === key && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        callbackRef.current();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [key]);
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -17,7 +17,18 @@
     "calendar": "Calendar",
     "discovery": "Discovery",
     "profile": "Profile",
-    "signIn": "Sign In"
+    "signIn": "Sign In",
+    "unreadRecommendations_one": "{{count}} unread recommendation",
+    "unreadRecommendations_other": "{{count}} unread recommendations"
+  },
+  "shortcuts": {
+    "title": "Keyboard Shortcuts",
+    "close": "Close keyboard shortcuts",
+    "showHelp": "Show keyboard shortcuts",
+    "focusSearch": "Focus search",
+    "nextTitle": "Next title",
+    "prevTitle": "Previous title",
+    "openTitle": "Open focused title"
   },
   "home": {
     "welcomeTitle": "Welcome to Remindarr",
@@ -167,6 +178,7 @@
   },
   "search": {
     "placeholder": "Search titles or paste IMDB link...",
+    "label": "Search titles or paste IMDB link",
     "button": "Search"
   },
   "releases": {

--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { useSearchParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import SearchBar from "../components/SearchBar";
@@ -9,7 +9,7 @@ import TitleList from "../components/TitleList";
 import * as api from "../api";
 import type { Title } from "../types";
 import { normalizeSearchTitle } from "../types";
-import { useState } from "react";
+import { useGridNavigation } from "../hooks/useGridNavigation";
 
 const VALID_CATEGORIES: BrowseCategory[] = ["new_releases", "popular", "upcoming", "top_rated"];
 
@@ -92,6 +92,7 @@ export default function BrowsePage() {
   const [searchLoading, setSearchLoading] = useState(false);
   const [searchError, setSearchError] = useState("");
   const { t } = useTranslation();
+  useGridNavigation();
 
   const rawCategory = searchParams.get("category") || "popular";
   const category: BrowseCategory = VALID_CATEGORIES.includes(rawCategory as BrowseCategory)

--- a/frontend/src/pages/TrackedPage.tsx
+++ b/frontend/src/pages/TrackedPage.tsx
@@ -6,11 +6,13 @@ import TitleList from "../components/TitleList";
 import { TitleGridSkeleton } from "../components/SkeletonComponents";
 import { useApiCall } from "../hooks/useApiCall";
 import { groupShowsByStatus } from "../lib/groupShows";
+import { useGridNavigation } from "../hooks/useGridNavigation";
 
 export default function TrackedPage() {
   const { data, loading, refetch } = useApiCall(() => api.getTrackedTitles(), []);
   const titles: Title[] = useMemo(() => data?.titles ?? [], [data]);
   const { t } = useTranslation();
+  useGridNavigation();
 
   const { showGroups, movies } = useMemo(() => {
     const shows = titles.filter((t) => t.object_type === "SHOW");


### PR DESCRIPTION
## Summary
- Global keyboard shortcut system with `?` help overlay
- `useKeyboardShortcut` hook — fires callback on key press, skips when focus is in input/textarea/select/contenteditable, uses stable callback ref pattern
- `useGridNavigation` hook — `j`/`k` to move focus through title cards on BrowsePage and TrackedPage
- `/` shortcut globally focuses the search input (`#search-input`) if present in DOM
- `KeyboardShortcutsModal` component — lists all shortcuts in a dark overlay dialog (Escape or `?` to close)

## Accessibility improvements
- `SearchBar` input: added `id="search-input"` and `aria-label` (enables `/` shortcut and screen reader labelling)
- `TitleCard`: outer `<div>` → `<article aria-label={title.title}>`, poster link gets `data-title-link` attribute and a visible amber focus ring for keyboard focus
- `BottomTabBar` unread badge: added `aria-label` announcing the count to screen readers

## Shortcuts implemented
| Key | Action |
|-----|--------|
| `?` | Open/close keyboard shortcuts help |
| `/` | Focus search input |
| `j` | Move focus to next title card |
| `k` | Move focus to previous title card |
| `Enter` | Open focused title (native browser behaviour on focused link) |

## Test plan
- [ ] Press `?` on any page — shortcuts modal opens; press `?` or `Escape` to close
- [ ] Press `/` on BrowsePage — search input is focused
- [ ] On TrackedPage or BrowsePage press `j`/`k` — focus cycles through title cards with amber ring and smooth scroll
- [ ] Pressing `j`/`k` while typing in search does nothing
- [ ] Screen reader announces title cards by name via `aria-label`

Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)