### PR TITLE
feat: custom homepage layout — reorder and show/hide sections (#387)

### DIFF
--- a/drizzle/0018_users_homepage_layout.sql
+++ b/drizzle/0018_users_homepage_layout.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN homepage_layout text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1743897600000,
       "tag": "0017_tracked_user_status",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1743984000000,
+      "tag": "0018_users_homepage_layout",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -18,6 +18,7 @@ import type {
   SentRecommendation,
   RecommendationsResponse,
   InvitationItem,
+  HomepageSection,
 } from "./types";
 
 const BASE = "/api";
@@ -591,4 +592,19 @@ export async function triggerPlexSync(
 
 export async function getStats(): Promise<StatsResponse> {
   return fetchJson("/stats");
+}
+
+
+// ─── User settings ────────────────────────────────────────────────────────────
+
+export async function getHomepageLayout(): Promise<{ homepage_layout: HomepageSection[] }> {
+  return fetchJson("/user/settings/homepage-layout");
+}
+
+export async function updateHomepageLayout(layout: HomepageSection[]): Promise<{ homepage_layout: HomepageSection[] }> {
+  return fetchJson("/user/settings/homepage-layout", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ homepage_layout: layout }),
+  });
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -243,6 +243,20 @@
   "settings": {
     "title": "Settings",
     "viewProfile": "View Profile",
+    "homepage": {
+      "title": "Homepage Layout",
+      "description": "Drag to reorder sections. Toggle the eye icon to show or hide a section.",
+      "saved": "Layout saved",
+      "saving": "Saving...",
+      "showSection": "Show section",
+      "hideSection": "Hide section",
+      "sections": {
+        "unwatched": "Unwatched Episodes",
+        "recommendations": "Recommended for You",
+        "today": "Today's Episodes",
+        "upcoming": "Coming Up"
+      }
+    },
     "profileVisibility": "Profile Visibility",
     "profileVisibilityDescription": "Control which titles are visible on your public profile.",
     "showWatchlist": "Show watchlist on public profile",

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -5,8 +5,8 @@ import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../context/AuthContext";
 import * as api from "../api";
-import type { Episode, Title, Recommendation } from "../types";
-import { normalizeSearchTitle } from "../types";
+import type { Episode, Title, Recommendation, HomepageSection } from "../types";
+import { normalizeSearchTitle, DEFAULT_HOMEPAGE_LAYOUT } from "../types";
 import TitleList from "../components/TitleList";
 import { TitleGridSkeleton, EpisodeListSkeleton } from "../components/SkeletonComponents";
 import { groupByShow, formatUpcomingDate } from "../components/EpisodeComponents";
@@ -78,6 +78,7 @@ export default function HomePage() {
   const [unwatched, setUnwatched] = useState<Episode[]>([]);
   const [popularTitles, setPopularTitles] = useState<Title[]>([]);
   const [recommendations, setRecommendations] = useState<Recommendation[]>([]);
+  const [layout, setLayout] = useState<HomepageSection[]>(DEFAULT_HOMEPAGE_LAYOUT);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [confirmingTitleId, setConfirmingTitleId] = useState<string | null>(null);
@@ -95,14 +96,16 @@ export default function HomePage() {
 
     async function load() {
       try {
-        const [episodeData, recData] = await Promise.all([
+        const [episodeData, recData, layoutData] = await Promise.all([
           api.getUpcomingEpisodes(),
           api.getRecommendations(6).catch(() => ({ recommendations: [], count: 0 })),
+          api.getHomepageLayout().catch(() => ({ homepage_layout: DEFAULT_HOMEPAGE_LAYOUT })),
         ]);
         setToday(episodeData.today);
         setUpcoming(episodeData.upcoming);
         setUnwatched(episodeData.unwatched);
         setRecommendations(recData.recommendations);
+        setLayout(layoutData.homepage_layout);
       } catch (err: unknown) {
         setError(err instanceof Error ? err.message : String(err));
       } finally {
@@ -248,153 +251,164 @@ export default function HomePage() {
 
   const noEpisodes = today.length === 0 && upcoming.length === 0 && unwatched.length === 0;
 
+  function renderSection(sectionId: string) {
+    switch (sectionId) {
+      case "unwatched":
+        return unwatched.length > 0 ? (
+          <>
+            <div className="-mt-6">
+              <HeroBanner episodes={unwatched} />
+            </div>
+            <section key="unwatched">
+              <div className="flex items-center gap-3 mb-4">
+                <h2 className="text-xl font-bold text-white">{t("home.unwatched")}</h2>
+                <Link
+                  to="/reels"
+                  className="flex items-center gap-1 text-xs text-zinc-400 hover:text-amber-400 transition-colors sm:hidden"
+                  title="Full-screen reels view"
+                >
+                  <Maximize2 size={14} />
+                  {t("home.reels")}
+                </Link>
+              </div>
+              <UnwatchedCarousel>
+                {unwatchedCards.map((card) => (
+                  <div key={card.titleId} className="w-80 flex-shrink-0" style={{ scrollSnapAlign: "start" }}>
+                    <DeckCardWrapper episodeCount={card.totalEpisodeCount}>
+                      <EpisodeShowCard
+                        episode={card.episode}
+                        episodeCount={card.totalEpisodeCount}
+                        showActions
+                        allEpisodeIds={card.allEpisodeIds}
+                        onToggleWatched={toggleWatched}
+                        onMarkAllWatched={(ids) => handleMarkAllWatched(card.titleId, ids)}
+                        isConfirming={confirmingTitleId === card.titleId}
+                      />
+                    </DeckCardWrapper>
+                  </div>
+                ))}
+              </UnwatchedCarousel>
+            </section>
+          </>
+        ) : null;
+
+      case "recommendations":
+        return recommendations.length > 0 ? (
+          <section key="recommendations">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-xl font-bold text-white">{t("home.recommendedForYou")}</h2>
+              <Link to="/discovery" className="text-sm text-amber-400 hover:text-amber-300 transition-colors">
+                {t("home.seeAll")} →
+              </Link>
+            </div>
+            <UnwatchedCarousel>
+              {recommendations.map((rec) => {
+                const posterSrc = rec.title.poster_url
+                  ? `https://image.tmdb.org/t/p/w185${rec.title.poster_url}`
+                  : null;
+                const isUnread = !rec.read_at;
+                return (
+                  <Link
+                    key={rec.id}
+                    to={`/title/${rec.title.id}`}
+                    className="w-32 flex-shrink-0 group"
+                    style={{ scrollSnapAlign: "start" }}
+                  >
+                    <div className={`relative aspect-[2/3] rounded-lg overflow-hidden bg-zinc-800 ${isUnread ? "ring-2 ring-amber-500/60" : ""}`}>
+                      {posterSrc ? (
+                        <img
+                          src={posterSrc}
+                          alt={rec.title.title}
+                          className="w-full h-full object-cover group-hover:scale-105 transition-transform"
+                          loading="lazy"
+                        />
+                      ) : (
+                        <div className="w-full h-full flex items-center justify-center text-zinc-600 text-xs">
+                          N/A
+                        </div>
+                      )}
+                      {isUnread && (
+                        <div className="absolute top-1.5 right-1.5 w-2 h-2 rounded-full bg-amber-500" />
+                      )}
+                    </div>
+                    <p className="text-sm text-white mt-1.5 line-clamp-2 group-hover:text-amber-400 transition-colors">
+                      {rec.title.title}
+                    </p>
+                    <p className="text-xs text-zinc-400 truncate">
+                      from @{rec.from_user.username}
+                    </p>
+                  </Link>
+                );
+              })}
+            </UnwatchedCarousel>
+          </section>
+        ) : null;
+
+      case "today":
+        return (
+          <section key="today">
+            <h2 className="text-xl font-bold text-white mb-4">{t("home.today")}</h2>
+            {today.length === 0 ? (
+              <p className="text-zinc-500 text-sm">
+                {noEpisodes ? t("home.noEpisodes") : t("home.noEpisodesToday")}
+              </p>
+            ) : (
+              <UnwatchedCarousel>
+                {Array.from(groupByShow(today).entries()).map(([titleId, eps]) => (
+                  <div key={titleId} className="w-80 flex-shrink-0" style={{ scrollSnapAlign: "start" }}>
+                    <DeckCardWrapper episodeCount={eps.length}>
+                      <EpisodeShowCard
+                        episode={eps[0]}
+                        episodeCount={eps.length}
+                      />
+                    </DeckCardWrapper>
+                  </div>
+                ))}
+              </UnwatchedCarousel>
+            )}
+          </section>
+        );
+
+      case "upcoming":
+        return upcoming.length > 0 ? (
+          <section key="upcoming">
+            <h2 className="text-lg font-semibold text-zinc-300 mb-4">{t("home.comingUp")}</h2>
+            <div className="space-y-4">
+              {Array.from(upcomingByDate.entries()).map(([date, eps]) => {
+                const byShow = groupByShow(eps);
+                const dateLabel = formatUpcomingDate(date);
+                return (
+                  <div key={date}>
+                    <h3 className="text-sm font-medium text-zinc-500 mb-2">{dateLabel === "__TOMORROW__" ? t("episodes.tomorrow") : dateLabel}</h3>
+                    <UnwatchedCarousel>
+                      {Array.from(byShow.entries()).map(([titleId, showEps]) => (
+                        <div key={titleId} className="w-80 flex-shrink-0" style={{ scrollSnapAlign: "start" }}>
+                          <DeckCardWrapper episodeCount={showEps.length}>
+                            <EpisodeShowCard
+                              episode={showEps[0]}
+                              episodeCount={showEps.length}
+                            />
+                          </DeckCardWrapper>
+                        </div>
+                      ))}
+                    </UnwatchedCarousel>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        ) : null;
+
+      default:
+        return null;
+    }
+  }
+
   return (
     <div className="space-y-8">
-      {/* Hero Banner (desktop only, full-width) */}
-      {unwatched.length > 0 && (
-        <div className="-mt-6">
-          <HeroBanner episodes={unwatched} />
-        </div>
-      )}
-
-      {/* Unwatched Episodes */}
-      {unwatched.length > 0 && (
-        <section>
-          <div className="flex items-center gap-3 mb-4">
-            <h2 className="text-xl font-bold text-white">{t("home.unwatched")}</h2>
-            <Link
-              to="/reels"
-              className="flex items-center gap-1 text-xs text-zinc-400 hover:text-amber-400 transition-colors sm:hidden"
-              title="Full-screen reels view"
-            >
-              <Maximize2 size={14} />
-              {t("home.reels")}
-            </Link>
-          </div>
-          <UnwatchedCarousel>
-            {unwatchedCards.map((card) => (
-              <div key={card.titleId} className="w-80 flex-shrink-0" style={{ scrollSnapAlign: "start" }}>
-                <DeckCardWrapper episodeCount={card.totalEpisodeCount}>
-                  <EpisodeShowCard
-                    episode={card.episode}
-                    episodeCount={card.totalEpisodeCount}
-                    showActions
-                    allEpisodeIds={card.allEpisodeIds}
-                    onToggleWatched={toggleWatched}
-                    onMarkAllWatched={(ids) => handleMarkAllWatched(card.titleId, ids)}
-                    isConfirming={confirmingTitleId === card.titleId}
-                  />
-                </DeckCardWrapper>
-              </div>
-            ))}
-          </UnwatchedCarousel>
-        </section>
-      )}
-
-      {/* Recommended for You */}
-      {recommendations.length > 0 && (
-        <section>
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-xl font-bold text-white">{t("home.recommendedForYou")}</h2>
-            <Link to="/discovery" className="text-sm text-amber-400 hover:text-amber-300 transition-colors">
-              {t("home.seeAll")} →
-            </Link>
-          </div>
-          <UnwatchedCarousel>
-            {recommendations.map((rec) => {
-              const posterSrc = rec.title.poster_url
-                ? `https://image.tmdb.org/t/p/w185${rec.title.poster_url}`
-                : null;
-              const isUnread = !rec.read_at;
-              return (
-                <Link
-                  key={rec.id}
-                  to={`/title/${rec.title.id}`}
-                  className="w-32 flex-shrink-0 group"
-                  style={{ scrollSnapAlign: "start" }}
-                >
-                  <div className={`relative aspect-[2/3] rounded-lg overflow-hidden bg-zinc-800 ${isUnread ? "ring-2 ring-amber-500/60" : ""}`}>
-                    {posterSrc ? (
-                      <img
-                        src={posterSrc}
-                        alt={rec.title.title}
-                        className="w-full h-full object-cover group-hover:scale-105 transition-transform"
-                        loading="lazy"
-                      />
-                    ) : (
-                      <div className="w-full h-full flex items-center justify-center text-zinc-600 text-xs">
-                        N/A
-                      </div>
-                    )}
-                    {isUnread && (
-                      <div className="absolute top-1.5 right-1.5 w-2 h-2 rounded-full bg-amber-500" />
-                    )}
-                  </div>
-                  <p className="text-sm text-white mt-1.5 line-clamp-2 group-hover:text-amber-400 transition-colors">
-                    {rec.title.title}
-                  </p>
-                  <p className="text-xs text-zinc-400 truncate">
-                    from @{rec.from_user.username}
-                  </p>
-                </Link>
-              );
-            })}
-          </UnwatchedCarousel>
-        </section>
-      )}
-
-      {/* Today's Episodes */}
-      <section>
-        <h2 className="text-xl font-bold text-white mb-4">{t("home.today")}</h2>
-        {today.length === 0 ? (
-          <p className="text-zinc-500 text-sm">
-            {noEpisodes ? t("home.noEpisodes") : t("home.noEpisodesToday")}
-          </p>
-        ) : (
-          <UnwatchedCarousel>
-            {Array.from(groupByShow(today).entries()).map(([titleId, eps]) => (
-              <div key={titleId} className="w-80 flex-shrink-0" style={{ scrollSnapAlign: "start" }}>
-                <DeckCardWrapper episodeCount={eps.length}>
-                  <EpisodeShowCard
-                    episode={eps[0]}
-                    episodeCount={eps.length}
-                  />
-                </DeckCardWrapper>
-              </div>
-            ))}
-          </UnwatchedCarousel>
-        )}
-      </section>
-
-      {/* Upcoming Episodes */}
-      {upcoming.length > 0 && (
-        <section>
-          <h2 className="text-lg font-semibold text-zinc-300 mb-4">{t("home.comingUp")}</h2>
-          <div className="space-y-4">
-            {Array.from(upcomingByDate.entries()).map(([date, eps]) => {
-              const byShow = groupByShow(eps);
-              const dateLabel = formatUpcomingDate(date);
-              return (
-                <div key={date}>
-                  <h3 className="text-sm font-medium text-zinc-500 mb-2">{dateLabel === "__TOMORROW__" ? t("episodes.tomorrow") : dateLabel}</h3>
-                  <UnwatchedCarousel>
-                    {Array.from(byShow.entries()).map(([titleId, showEps]) => (
-                      <div key={titleId} className="w-80 flex-shrink-0" style={{ scrollSnapAlign: "start" }}>
-                        <DeckCardWrapper episodeCount={showEps.length}>
-                          <EpisodeShowCard
-                            episode={showEps[0]}
-                            episodeCount={showEps.length}
-                          />
-                        </DeckCardWrapper>
-                      </div>
-                    ))}
-                  </UnwatchedCarousel>
-                </div>
-              );
-            })}
-          </div>
-        </section>
-      )}
+      {layout
+        .filter((s) => s.enabled)
+        .map((s) => renderSection(s.id))}
     </div>
   );
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,14 +1,15 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import { SUPPORTED_LANGUAGES, setLanguage } from "../i18n";
 import { useAuth } from "../context/AuthContext";
 import * as api from "../api";
 import type { JobsResponse, Notifier, Integration, PlexServer } from "../api";
-import type { AdminSettings, Title } from "../types";
+import type { AdminSettings, Title, HomepageSection } from "../types";
+import { DEFAULT_HOMEPAGE_LAYOUT } from "../types";
 import { isPushSupported, subscribeToPush, unsubscribeFromPush, getExistingSubscription } from "../lib/push";
 import { authClient } from "../lib/auth-client";
-import { UserPlus } from "lucide-react";
+import { UserPlus, GripVertical, Eye, EyeOff } from "lucide-react";
 
 export default function SettingsPage() {
   const { user } = useAuth();
@@ -30,6 +31,7 @@ export default function SettingsPage() {
       <SocialSection />
       <WatchlistSection />
       {isPushSupported() && <PushNotificationsSection />}
+      <HomepageLayoutSection />
       <PlexSection />
       <NotificationsSection />
       {user.is_admin && <BackgroundJobsSection />}
@@ -1581,6 +1583,99 @@ type ConnectStep =
 
 const PLEX_POPUP_FEATURES = "width=800,height=700,menubar=no,toolbar=no,location=no,status=no";
 const PIN_POLL_INTERVAL_MS = 2000;
+
+const SECTION_LABELS: Record<string, string> = {
+  unwatched: "settings.homepage.sections.unwatched",
+  recommendations: "settings.homepage.sections.recommendations",
+  today: "settings.homepage.sections.today",
+  upcoming: "settings.homepage.sections.upcoming",
+};
+
+function HomepageLayoutSection() {
+  const { t } = useTranslation();
+  const [layout, setLayout] = useState<HomepageSection[]>(DEFAULT_HOMEPAGE_LAYOUT);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const dragIndexRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    api.getHomepageLayout()
+      .then((res) => setLayout(res.homepage_layout))
+      .catch(() => {});
+  }, []);
+
+  async function save(newLayout: HomepageSection[]) {
+    setSaving(true);
+    setSaved(false);
+    try {
+      const res = await api.updateHomepageLayout(newLayout);
+      setLayout(res.homepage_layout);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch {
+      // silently ignore
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function toggleEnabled(id: string) {
+    const updated = layout.map((s) => s.id === id ? { ...s, enabled: !s.enabled } : s);
+    setLayout(updated);
+    save(updated);
+  }
+
+  function handleDragStart(index: number) {
+    dragIndexRef.current = index;
+  }
+
+  function handleDragOver(e: React.DragEvent, index: number) {
+    e.preventDefault();
+    const from = dragIndexRef.current;
+    if (from === null || from === index) return;
+    const updated = [...layout];
+    const [moved] = updated.splice(from, 1);
+    updated.splice(index, 0, moved);
+    dragIndexRef.current = index;
+    setLayout(updated);
+  }
+
+  function handleDrop() {
+    dragIndexRef.current = null;
+    save(layout);
+  }
+
+  return (
+    <section>
+      <h2 className="text-lg font-semibold mb-1">{t("settings.homepage.title")}</h2>
+      <p className="text-sm text-zinc-400 mb-4">{t("settings.homepage.description")}</p>
+      <div className="space-y-2">
+        {layout.map((section, index) => (
+          <div
+            key={section.id}
+            draggable
+            onDragStart={() => handleDragStart(index)}
+            onDragOver={(e) => handleDragOver(e, index)}
+            onDrop={handleDrop}
+            className="flex items-center gap-3 bg-zinc-900 border border-white/[0.06] rounded-lg px-4 py-3 cursor-grab active:cursor-grabbing select-none"
+          >
+            <GripVertical size={16} className="text-zinc-500 flex-shrink-0" aria-hidden="true" />
+            <span className="flex-1 text-sm text-zinc-100">{t(SECTION_LABELS[section.id] ?? section.id)}</span>
+            <button
+              onClick={() => toggleEnabled(section.id)}
+              className="text-zinc-400 hover:text-white transition-colors cursor-pointer"
+              aria-label={section.enabled ? t("settings.homepage.hideSection") : t("settings.homepage.showSection")}
+            >
+              {section.enabled ? <Eye size={16} /> : <EyeOff size={16} />}
+            </button>
+          </div>
+        ))}
+      </div>
+      {saved && <p className="text-xs text-emerald-400 mt-2">{t("settings.homepage.saved")}</p>}
+      {saving && <p className="text-xs text-zinc-400 mt-2">{t("settings.homepage.saving")}</p>}
+    </section>
+  );
+}
 
 function PlexSection() {
   const [integrations, setIntegrations] = useState<Integration[]>([]);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -532,6 +532,20 @@ export interface InvitationItem {
   used_by: UserSummary | null;
 }
 
+export type HomepageSectionId = "unwatched" | "recommendations" | "today" | "upcoming";
+
+export interface HomepageSection {
+  id: HomepageSectionId;
+  enabled: boolean;
+}
+
+export const DEFAULT_HOMEPAGE_LAYOUT: HomepageSection[] = [
+  { id: "unwatched", enabled: true },
+  { id: "recommendations", enabled: true },
+  { id: "today", enabled: true },
+  { id: "upcoming", enabled: true },
+];
+
 // Normalize search results to same shape as DB titles
 export function normalizeSearchTitle(t: SearchTitle): Title {
   return {

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -129,10 +129,10 @@ describe("fixSkippedMigrations", () => {
     }>;
     expect(titleCols.some((c) => c.name === "genres")).toBe(false);
 
-    // All 18 migrations should be recorded
+    // All 19 migrations should be recorded
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(18);
+    expect(migrations.cnt).toBe(19);
   });
 });

--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -70,6 +70,8 @@ export {
   getSessionWithUser,
   deleteSession,
   deleteExpiredSessions,
+  getHomepageLayout,
+  setHomepageLayout,
 } from "./users";
 
 export {

--- a/server/db/repository/users.ts
+++ b/server/db/repository/users.ts
@@ -234,3 +234,24 @@ export async function deleteExpiredSessions() {
     }
   });
 }
+
+export async function getHomepageLayout(userId: string): Promise<string | null> {
+  return traceDbQuery("getHomepageLayout", async () => {
+    const db = getDb();
+    const row = await db.select({ homepageLayout: users.homepageLayout })
+      .from(users)
+      .where(eq(users.id, userId))
+      .get();
+    return row?.homepageLayout ?? null;
+  });
+}
+
+export async function setHomepageLayout(userId: string, layout: string): Promise<void> {
+  return traceDbQuery("setHomepageLayout", async () => {
+    const db = getDb();
+    await db.update(users)
+      .set({ homepageLayout: layout })
+      .where(eq(users.id, userId))
+      .run();
+  });
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -157,6 +157,7 @@ export const users = sqliteTable(
     isAdmin: integer("is_admin").notNull().default(0),
     profilePublic: integer("profile_public").notNull().default(0),
     profileVisibility: text("profile_visibility").notNull().default("private"),
+    homepageLayout: text("homepage_layout"),
   },
   (table) => [
     uniqueIndex("users_auth_provider_subject").on(

--- a/server/index.ts
+++ b/server/index.ts
@@ -31,6 +31,7 @@ import invitationsRoutes from "./routes/invitations";
 import healthRoutes from "./routes/health";
 import metricsRoutes from "./routes/metrics";
 import statsRoutes from "./routes/stats";
+import userSettingsRoutes from "./routes/user-settings";
 import type { AppEnv } from "./types";
 import Sentry from "./sentry";
 import { logger, requestLogger } from "./logger";
@@ -213,6 +214,9 @@ app.route("/api/integrations", integrationRoutes);
 app.use("/api/stats/*", requireAuth);
 app.use("/api/stats", requireAuth);
 app.route("/api/stats", statsRoutes);
+
+app.use("/api/user/settings/*", requireAuth);
+app.route("/api/user/settings", userSettingsRoutes);
 
 // Admin routes
 app.use("/api/admin/*", requireAuth, requireAdmin);

--- a/server/routes/user-settings.test.ts
+++ b/server/routes/user-settings.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { createUser } from "../db/repository";
+import userSettingsApp, { DEFAULT_HOMEPAGE_LAYOUT } from "./user-settings";
+import type { AppEnv } from "../types";
+
+let userId: string;
+
+function makeAuthedApp() {
+  const a = new Hono<AppEnv>();
+  a.use("*", async (c, next) => {
+    c.set("user", { id: userId, username: "testuser", name: null, role: null, is_admin: false });
+    await next();
+  });
+  a.route("/user/settings", userSettingsApp);
+  return a;
+}
+
+function jsonHeaders() {
+  return { "Content-Type": "application/json" };
+}
+
+beforeEach(async () => {
+  setupTestDb();
+  userId = await createUser("testuser", "hash");
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+describe("GET /user/settings/homepage-layout", () => {
+  it("returns default layout for new user", async () => {
+    const app = makeAuthedApp();
+    const res = await app.request("/user/settings/homepage-layout");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.homepage_layout).toEqual(DEFAULT_HOMEPAGE_LAYOUT);
+  });
+
+  it("returns saved layout after update", async () => {
+    const app = makeAuthedApp();
+    const newLayout = [
+      { id: "today", enabled: true },
+      { id: "upcoming", enabled: false },
+      { id: "unwatched", enabled: true },
+      { id: "recommendations", enabled: true },
+    ];
+    await app.request("/user/settings/homepage-layout", {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ homepage_layout: newLayout }),
+    });
+
+    const res = await app.request("/user/settings/homepage-layout");
+    const body = await res.json();
+    expect(body.homepage_layout[0].id).toBe("today");
+    expect(body.homepage_layout[1].enabled).toBe(false);
+  });
+});
+
+describe("PUT /user/settings/homepage-layout", () => {
+  it("saves a valid layout", async () => {
+    const app = makeAuthedApp();
+    const layout = [
+      { id: "recommendations", enabled: false },
+      { id: "today", enabled: true },
+      { id: "unwatched", enabled: true },
+      { id: "upcoming", enabled: true },
+    ];
+    const res = await app.request("/user/settings/homepage-layout", {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ homepage_layout: layout }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.homepage_layout[0].id).toBe("recommendations");
+    expect(body.homepage_layout[0].enabled).toBe(false);
+  });
+
+  it("returns 400 for non-array payload", async () => {
+    const app = makeAuthedApp();
+    const res = await app.request("/user/settings/homepage-layout", {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ homepage_layout: "invalid" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for unknown section id", async () => {
+    const app = makeAuthedApp();
+    const res = await app.request("/user/settings/homepage-layout", {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ homepage_layout: [{ id: "unknown_section", enabled: true }] }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for duplicate section ids", async () => {
+    const app = makeAuthedApp();
+    const res = await app.request("/user/settings/homepage-layout", {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        homepage_layout: [
+          { id: "today", enabled: true },
+          { id: "today", enabled: false },
+        ],
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("partial layout: missing sections are appended with defaults", async () => {
+    const app = makeAuthedApp();
+    // Save only 2 sections
+    await app.request("/user/settings/homepage-layout", {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        homepage_layout: [
+          { id: "today", enabled: true },
+          { id: "unwatched", enabled: false },
+        ],
+      }),
+    });
+
+    const res = await app.request("/user/settings/homepage-layout");
+    const body = await res.json();
+    // All 4 sections returned; the 2 missing ones are appended
+    expect(body.homepage_layout).toHaveLength(4);
+    expect(body.homepage_layout[0].id).toBe("today");
+    expect(body.homepage_layout[1].id).toBe("unwatched");
+  });
+});

--- a/server/routes/user-settings.ts
+++ b/server/routes/user-settings.ts
@@ -1,0 +1,97 @@
+import { Hono } from "hono";
+import { getHomepageLayout, setHomepageLayout } from "../db/repository";
+import type { AppEnv } from "../types";
+import { ok } from "./response";
+
+export const HOMEPAGE_SECTION_IDS = ["unwatched", "recommendations", "today", "upcoming"] as const;
+export type HomepageSectionId = (typeof HOMEPAGE_SECTION_IDS)[number];
+
+export interface HomepageSection {
+  id: HomepageSectionId;
+  enabled: boolean;
+}
+
+export const DEFAULT_HOMEPAGE_LAYOUT: HomepageSection[] = [
+  { id: "unwatched", enabled: true },
+  { id: "recommendations", enabled: true },
+  { id: "today", enabled: true },
+  { id: "upcoming", enabled: true },
+];
+
+function parseLayout(raw: string | null): HomepageSection[] {
+  if (!raw) return DEFAULT_HOMEPAGE_LAYOUT;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return DEFAULT_HOMEPAGE_LAYOUT;
+
+    // Validate and normalise: keep only known section IDs, fill in any missing ones
+    const seen = new Set<string>();
+    const valid: HomepageSection[] = [];
+    for (const item of parsed) {
+      if (
+        typeof item === "object" &&
+        item !== null &&
+        typeof (item as Record<string, unknown>).id === "string" &&
+        HOMEPAGE_SECTION_IDS.includes((item as Record<string, unknown>).id as HomepageSectionId) &&
+        !seen.has((item as Record<string, unknown>).id as string)
+      ) {
+        seen.add((item as Record<string, unknown>).id as string);
+        valid.push({
+          id: (item as Record<string, unknown>).id as HomepageSectionId,
+          enabled: (item as Record<string, unknown>).enabled !== false,
+        });
+      }
+    }
+
+    // Append any sections that weren't in the saved layout (new sections added later)
+    for (const def of DEFAULT_HOMEPAGE_LAYOUT) {
+      if (!seen.has(def.id)) {
+        valid.push({ id: def.id, enabled: true });
+      }
+    }
+    return valid.length > 0 ? valid : DEFAULT_HOMEPAGE_LAYOUT;
+  } catch {
+    return DEFAULT_HOMEPAGE_LAYOUT;
+  }
+}
+
+const app = new Hono<AppEnv>();
+
+app.get("/homepage-layout", async (c) => {
+  const user = c.get("user")!;
+  const raw = await getHomepageLayout(user.id);
+  return ok(c, { homepage_layout: parseLayout(raw) });
+});
+
+app.put("/homepage-layout", async (c) => {
+  const user = c.get("user")!;
+  const body = await c.req.json<{ homepage_layout: unknown }>();
+
+  if (!Array.isArray(body.homepage_layout)) {
+    return c.json({ error: "homepage_layout must be an array" }, 400);
+  }
+
+  // Validate each entry
+  const layout: HomepageSection[] = [];
+  const seen = new Set<string>();
+  for (const item of body.homepage_layout) {
+    if (
+      typeof item !== "object" ||
+      item === null ||
+      !HOMEPAGE_SECTION_IDS.includes((item as Record<string, unknown>).id as HomepageSectionId) ||
+      seen.has((item as Record<string, unknown>).id as string)
+    ) {
+      return c.json({ error: `Invalid section entry: ${JSON.stringify(item)}` }, 400);
+    }
+    seen.add((item as Record<string, unknown>).id as string);
+    layout.push({
+      id: (item as Record<string, unknown>).id as HomepageSectionId,
+      enabled: (item as Record<string, unknown>).enabled !== false,
+    });
+  }
+
+  await setHomepageLayout(user.id, JSON.stringify(layout));
+  return ok(c, { homepage_layout: parseLayout(JSON.stringify(layout)) });
+});
+
+export default app;

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -66,6 +66,7 @@ import recommendationsRoutes from "./routes/recommendations";
 import invitationsRoutes from "./routes/invitations";
 import healthRoutes from "./routes/health";
 import statsRoutes from "./routes/stats";
+import userSettingsRoutes from "./routes/user-settings";
 import type { AppEnv } from "./types";
 import { logger, requestLogger, resetLogLevel } from "./logger";
 import { patchConfig } from "./config";
@@ -327,6 +328,9 @@ function createApp(env: Env) {
   app.use("/api/stats/*", requireAuth);
   app.use("/api/stats", requireAuth);
   app.route("/api/stats", statsRoutes);
+
+  app.use("/api/user/settings/*", requireAuth);
+  app.route("/api/user/settings", userSettingsRoutes);
 
   // Admin routes
   app.use("/api/admin/*", requireAuth, requireAdmin);


### PR DESCRIPTION
## Summary
- Users can reorder homepage sections and show/hide individual sections
- Layout is persisted per-user in the database and loaded on page render
- Settings panel in Settings → Homepage Layout with drag-and-drop reorder and eye-icon toggles

## What was built

**Backend:**
- DB migration 0018: `ALTER TABLE users ADD COLUMN homepage_layout text`
- `getHomepageLayout` / `setHomepageLayout` repository functions
- `GET /api/user/settings/homepage-layout` — returns saved layout or default for new users
- `PUT /api/user/settings/homepage-layout` — validates section IDs, rejects duplicates/unknowns; `parseLayout` fills in any new sections that weren't in the saved layout
- Route registered in both `index.ts` and `worker.ts` with `requireAuth`

**Frontend:**
- `HomepageSectionId`, `HomepageSection`, `DEFAULT_HOMEPAGE_LAYOUT` types in `types.ts`
- `getHomepageLayout()` / `updateHomepageLayout()` in `api.ts`
- `HomePage.tsx`: layout fetched alongside episode data; sections rendered via `renderSection(id)` switch and filtered/ordered by user's saved layout
- `SettingsPage.tsx` `HomepageLayoutSection`: HTML5 drag-and-drop (`draggable` + `onDragOver`/`onDrop`) + eye-icon visibility toggle; auto-saves after each interaction

## Configurable sections
| Section ID | Label |
|---|---|
| `unwatched` | Unwatched Episodes |
| `recommendations` | Recommended for You |
| `today` | Today's Episodes |
| `upcoming` | Coming Up |

## Test plan
- [ ] New user: homepage shows default section order
- [ ] Open Settings → drag a section to a different position → homepage reflects new order after reload
- [ ] Toggle eye icon to hide a section → it disappears from homepage
- [ ] Re-enable a section → it reappears in its saved position
- [ ] All 7 server-side tests pass (`bun test server/routes/user-settings.test.ts`)

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)