### PR TITLE
feat: admin user management panel (#380)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -53,6 +53,7 @@ const UpcomingPage = lazyWithRetry(() => import("./pages/UpcomingPage"));
 const DiscoveryPage = lazyWithRetry(() => import("./pages/DiscoveryPage"));
 const InvitePage = lazyWithRetry(() => import("./pages/InvitePage"));
 const StatsPage = lazyWithRetry(() => import("./pages/StatsPage"));
+const AdminUsersPage = lazyWithRetry(() => import("./pages/AdminUsersPage"));
 const NotFoundPage = lazyWithRetry(() => import("./pages/NotFoundPage"));
 
 function MobileHomeRedirect() {
@@ -185,6 +186,7 @@ export default function App() {
             <Route path="/discovery" element={<RequireAuth><DiscoveryPage /></RequireAuth>} />
             <Route path="/invite" element={<RequireAuth><InvitePage /></RequireAuth>} />
             <Route path="/stats" element={<RequireAuth><StatsPage /></RequireAuth>} />
+            <Route path="/admin/users" element={<RequireAuth><AdminUsersPage /></RequireAuth>} />
             <Route path="/user/:username" element={<UserProfilePage />} />
             <Route path="/settings" element={<RequireAuth><SettingsPage /></RequireAuth>} />
             <Route path="/profile" element={<ProfilePage />} />

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -12,6 +12,8 @@ import type {
   AdminSettings,
   AdminSettingsUpdateRequest,
   AdminSettingsUpdateResponse,
+  AdminUser,
+  AdminUsersResponse,
   UserProfileResponse,
   UserSummary,
   TitleRatingResponse,
@@ -607,4 +609,47 @@ export async function updateHomepageLayout(layout: HomepageSection[]): Promise<{
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ homepage_layout: layout }),
   });
+}
+
+// ─── Admin user management ────────────────────────────────────────────────────
+
+export async function getAdminUsers(opts: { search?: string; filter?: string; page?: number } = {}): Promise<AdminUsersResponse> {
+  const params = new URLSearchParams();
+  if (opts.search) params.set("search", opts.search);
+  if (opts.filter) params.set("filter", opts.filter);
+  if (opts.page) params.set("page", String(opts.page));
+  const qs = params.toString();
+  return fetchJson(`/admin/users${qs ? `?${qs}` : ""}`);
+}
+
+export async function getAdminUser(userId: string): Promise<{ user: AdminUser }> {
+  return fetchJson(`/admin/users/${encodeURIComponent(userId)}`);
+}
+
+export async function setAdminUserRole(userId: string, role: "admin" | "user"): Promise<{ message: string }> {
+  return fetchJson(`/admin/users/${encodeURIComponent(userId)}/role`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ role }),
+  });
+}
+
+export async function banAdminUser(userId: string, reason?: string): Promise<{ message: string }> {
+  return fetchJson(`/admin/users/${encodeURIComponent(userId)}/ban`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ reason }),
+  });
+}
+
+export async function unbanAdminUser(userId: string): Promise<{ message: string }> {
+  return fetchJson(`/admin/users/${encodeURIComponent(userId)}/unban`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+  });
+}
+
+export async function deleteAdminUser(userId: string): Promise<{ message: string }> {
+  return fetchJson(`/admin/users/${encodeURIComponent(userId)}`, { method: "DELETE" });
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,4 +1,43 @@
 {
+  "admin": {
+    "accessDenied": "Access denied",
+    "backToSettings": "Back to Settings",
+    "cancel": "Cancel",
+    "users": {
+      "title": "User Management",
+      "total": "{{count}} users",
+      "searchPlaceholder": "Search by username or name...",
+      "loading": "Loading users...",
+      "empty": "No users found",
+      "you": "you",
+      "promote": "Promote to admin",
+      "demote": "Demote to user",
+      "ban": "Ban user",
+      "unban": "Unban user",
+      "delete": "Delete user",
+      "banTitle": "Ban User",
+      "banReasonPlaceholder": "Reason (optional)",
+      "banConfirm": "Ban User",
+      "deleteTitle": "Delete User",
+      "deleteConfirm": "This action is permanent and cannot be undone.",
+      "deleteConfirmButton": "Delete permanently",
+      "prevPage": "Previous page",
+      "nextPage": "Next page",
+      "page": "Page {{page}} of {{total}}",
+      "filter": {
+        "all": "All",
+        "active": "Active",
+        "banned": "Banned"
+      },
+      "col": {
+        "user": "User",
+        "role": "Role",
+        "provider": "Auth",
+        "joined": "Joined",
+        "actions": "Actions"
+      }
+    }
+  },
   "nav": {
     "skipToMain": "Skip to main content",
     "home": "Home",

--- a/frontend/src/pages/AdminUsersPage.tsx
+++ b/frontend/src/pages/AdminUsersPage.tsx
@@ -1,0 +1,347 @@
+import { useState, useEffect, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router";
+import { Search, Shield, ShieldOff, Trash2, ChevronLeft, ChevronRight } from "lucide-react";
+import * as api from "../api";
+import type { AdminUser, AdminUsersResponse } from "../types";
+import { useAuth } from "../context/AuthContext";
+
+type Filter = "all" | "active" | "banned";
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString();
+}
+
+function RoleBadge({ user }: { user: AdminUser }) {
+  const isAdmin = user.role === "admin" || user.is_admin === 1;
+  return (
+    <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${isAdmin ? "bg-amber-500/20 text-amber-400" : "bg-zinc-700 text-zinc-400"}`}>
+      {isAdmin ? "Admin" : "User"}
+    </span>
+  );
+}
+
+function BannedBadge() {
+  return (
+    <span className="text-[10px] font-bold px-1.5 py-0.5 rounded bg-red-900/40 text-red-400">
+      Banned
+    </span>
+  );
+}
+
+export default function AdminUsersPage() {
+  const { user: me } = useAuth();
+  const { t } = useTranslation();
+
+  const [data, setData] = useState<AdminUsersResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState<Filter>("all");
+  const [page, setPage] = useState(1);
+  const [actionError, setActionError] = useState("");
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [banReason, setBanReason] = useState("");
+  const [banTarget, setBanTarget] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const res = await api.getAdminUsers({ search, filter, page });
+      setData(res);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [search, filter, page]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Reset to page 1 when search/filter changes
+  useEffect(() => {
+    setPage(1);
+  }, [search, filter]);
+
+  async function handleRoleToggle(user: AdminUser) {
+    setActionError("");
+    const newRole = user.role === "admin" || user.is_admin === 1 ? "user" : "admin";
+    try {
+      await api.setAdminUserRole(user.id, newRole);
+      await load();
+    } catch (e: unknown) {
+      setActionError(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  async function handleBan(userId: string) {
+    setActionError("");
+    try {
+      await api.banAdminUser(userId, banReason || undefined);
+      setBanTarget(null);
+      setBanReason("");
+      await load();
+    } catch (e: unknown) {
+      setActionError(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  async function handleUnban(userId: string) {
+    setActionError("");
+    try {
+      await api.unbanAdminUser(userId);
+      await load();
+    } catch (e: unknown) {
+      setActionError(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  async function handleDelete(userId: string) {
+    setActionError("");
+    try {
+      await api.deleteAdminUser(userId);
+      setConfirmDelete(null);
+      await load();
+    } catch (e: unknown) {
+      setActionError(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  if (!me?.is_admin) {
+    return <div className="text-zinc-500">{t("admin.accessDenied")}</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Link to="/settings" className="text-zinc-400 hover:text-white transition-colors text-sm">
+          ← {t("admin.backToSettings")}
+        </Link>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-white">{t("admin.users.title")}</h1>
+        {data && (
+          <span className="text-sm text-zinc-400">{t("admin.users.total", { count: data.total })}</span>
+        )}
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <div className="relative flex-1">
+          <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500" aria-hidden="true" />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={t("admin.users.searchPlaceholder")}
+            aria-label={t("admin.users.searchPlaceholder")}
+            className="w-full bg-zinc-900 border border-white/[0.06] rounded-lg pl-8 pr-4 py-2 text-sm text-white placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-amber-500/50"
+          />
+        </div>
+        <div className="flex gap-1">
+          {(["all", "active", "banned"] as Filter[]).map((f) => (
+            <button
+              key={f}
+              onClick={() => setFilter(f)}
+              className={`px-3 py-2 text-sm rounded-lg transition-colors cursor-pointer ${filter === f ? "bg-amber-500 text-black font-medium" : "bg-zinc-900 text-zinc-400 hover:text-white border border-white/[0.06]"}`}
+            >
+              {t(`admin.users.filter.${f}`)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {actionError && (
+        <div className="bg-red-900/30 border border-red-800 text-red-300 px-4 py-2 rounded-lg text-sm">
+          {actionError}
+        </div>
+      )}
+
+      {/* Ban reason modal */}
+      {banTarget && (
+        <div className="fixed inset-0 z-[200] flex items-center justify-center p-4">
+          <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={() => setBanTarget(null)} aria-hidden="true" />
+          <div role="dialog" aria-modal="true" className="relative bg-zinc-900 border border-white/[0.08] rounded-2xl p-6 max-w-sm w-full shadow-2xl space-y-4">
+            <h2 className="text-base font-semibold">{t("admin.users.banTitle")}</h2>
+            <input
+              type="text"
+              value={banReason}
+              onChange={(e) => setBanReason(e.target.value)}
+              placeholder={t("admin.users.banReasonPlaceholder")}
+              className="w-full bg-zinc-800 border border-white/[0.06] rounded-lg px-3 py-2 text-sm text-white placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-amber-500/50"
+            />
+            <div className="flex gap-2">
+              <button
+                onClick={() => handleBan(banTarget)}
+                className="flex-1 py-2 bg-red-700 hover:bg-red-600 text-white text-sm font-medium rounded-lg transition-colors cursor-pointer"
+              >
+                {t("admin.users.banConfirm")}
+              </button>
+              <button
+                onClick={() => { setBanTarget(null); setBanReason(""); }}
+                className="px-4 py-2 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 text-sm rounded-lg transition-colors cursor-pointer"
+              >
+                {t("admin.cancel")}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete confirmation modal */}
+      {confirmDelete && (
+        <div className="fixed inset-0 z-[200] flex items-center justify-center p-4">
+          <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={() => setConfirmDelete(null)} aria-hidden="true" />
+          <div role="dialog" aria-modal="true" className="relative bg-zinc-900 border border-white/[0.08] rounded-2xl p-6 max-w-sm w-full shadow-2xl space-y-4">
+            <h2 className="text-base font-semibold text-red-400">{t("admin.users.deleteTitle")}</h2>
+            <p className="text-sm text-zinc-400">{t("admin.users.deleteConfirm")}</p>
+            <div className="flex gap-2">
+              <button
+                onClick={() => handleDelete(confirmDelete)}
+                className="flex-1 py-2 bg-red-800 hover:bg-red-700 text-white text-sm font-medium rounded-lg transition-colors cursor-pointer"
+              >
+                {t("admin.users.deleteConfirmButton")}
+              </button>
+              <button
+                onClick={() => setConfirmDelete(null)}
+                className="px-4 py-2 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 text-sm rounded-lg transition-colors cursor-pointer"
+              >
+                {t("admin.cancel")}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* User table */}
+      {loading ? (
+        <div className="text-zinc-500 text-sm py-8 text-center">{t("admin.users.loading")}</div>
+      ) : error ? (
+        <div className="text-red-400 text-sm">{error}</div>
+      ) : !data || data.users.length === 0 ? (
+        <div className="text-zinc-500 text-sm py-8 text-center">{t("admin.users.empty")}</div>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-white/[0.06]">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-white/[0.06] text-zinc-400 text-xs uppercase tracking-wide">
+                <th className="text-left px-4 py-3 font-medium">{t("admin.users.col.user")}</th>
+                <th className="text-left px-4 py-3 font-medium hidden sm:table-cell">{t("admin.users.col.role")}</th>
+                <th className="text-left px-4 py-3 font-medium hidden md:table-cell">{t("admin.users.col.provider")}</th>
+                <th className="text-left px-4 py-3 font-medium hidden lg:table-cell">{t("admin.users.col.joined")}</th>
+                <th className="text-right px-4 py-3 font-medium">{t("admin.users.col.actions")}</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/[0.04]">
+              {data.users.map((user) => (
+                <tr key={user.id} className="hover:bg-white/[0.02] transition-colors">
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      <div>
+                        <div className="flex items-center gap-1.5">
+                          <span className="font-medium text-white">{user.username}</span>
+                          {user.banned && <BannedBadge />}
+                          <span className="sm:hidden"><RoleBadge user={user} /></span>
+                        </div>
+                        {user.name && <div className="text-xs text-zinc-500">{user.name}</div>}
+                        {user.email && <div className="text-xs text-zinc-600">{user.email}</div>}
+                      </div>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 hidden sm:table-cell">
+                    <RoleBadge user={user} />
+                  </td>
+                  <td className="px-4 py-3 hidden md:table-cell text-zinc-400 capitalize">
+                    {user.auth_provider}
+                  </td>
+                  <td className="px-4 py-3 hidden lg:table-cell text-zinc-500">
+                    {formatDate(user.created_at)}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center justify-end gap-1">
+                      {user.id !== me.id && (
+                        <>
+                          {/* Role toggle */}
+                          <button
+                            onClick={() => handleRoleToggle(user)}
+                            title={user.role === "admin" ? t("admin.users.demote") : t("admin.users.promote")}
+                            aria-label={user.role === "admin" ? t("admin.users.demote") : t("admin.users.promote")}
+                            className="p-1.5 rounded-lg text-zinc-400 hover:text-amber-400 hover:bg-amber-500/10 transition-colors cursor-pointer"
+                          >
+                            <Shield size={14} />
+                          </button>
+                          {/* Ban/unban */}
+                          {user.banned ? (
+                            <button
+                              onClick={() => handleUnban(user.id)}
+                              title={t("admin.users.unban")}
+                              aria-label={t("admin.users.unban")}
+                              className="p-1.5 rounded-lg text-zinc-400 hover:text-emerald-400 hover:bg-emerald-500/10 transition-colors cursor-pointer"
+                            >
+                              <ShieldOff size={14} />
+                            </button>
+                          ) : (
+                            <button
+                              onClick={() => { setBanTarget(user.id); setBanReason(""); }}
+                              title={t("admin.users.ban")}
+                              aria-label={t("admin.users.ban")}
+                              className="p-1.5 rounded-lg text-zinc-400 hover:text-red-400 hover:bg-red-500/10 transition-colors cursor-pointer"
+                            >
+                              <ShieldOff size={14} />
+                            </button>
+                          )}
+                          {/* Delete */}
+                          <button
+                            onClick={() => setConfirmDelete(user.id)}
+                            title={t("admin.users.delete")}
+                            aria-label={t("admin.users.delete")}
+                            className="p-1.5 rounded-lg text-zinc-400 hover:text-red-400 hover:bg-red-500/10 transition-colors cursor-pointer"
+                          >
+                            <Trash2 size={14} />
+                          </button>
+                        </>
+                      )}
+                      {user.id === me.id && (
+                        <span className="text-xs text-zinc-600 px-2">{t("admin.users.you")}</span>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Pagination */}
+      {data && data.total_pages > 1 && (
+        <div className="flex items-center justify-center gap-2">
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page <= 1}
+            aria-label={t("admin.users.prevPage")}
+            className="p-2 rounded-lg bg-zinc-900 border border-white/[0.06] text-zinc-400 hover:text-white disabled:opacity-40 disabled:cursor-not-allowed transition-colors cursor-pointer"
+          >
+            <ChevronLeft size={16} />
+          </button>
+          <span className="text-sm text-zinc-400">
+            {t("admin.users.page", { page, total: data.total_pages })}
+          </span>
+          <button
+            onClick={() => setPage((p) => Math.min(data.total_pages, p + 1))}
+            disabled={page >= data.total_pages}
+            aria-label={t("admin.users.nextPage")}
+            className="p-2 rounded-lg bg-zinc-900 border border-white/[0.06] text-zinc-400 hover:text-white disabled:opacity-40 disabled:cursor-not-allowed transition-colors cursor-pointer"
+          >
+            <ChevronRight size={16} />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1452,8 +1452,13 @@ function AdminSection() {
   if (loading) return <div className="text-zinc-500">Loading settings...</div>;
 
   return (
-    <section>
-      <h2 className="text-xl font-bold text-white mb-4">Admin Settings</h2>
+    <section className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-bold text-white">Admin Settings</h2>
+        <Link to="/admin/users" className="text-sm px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white rounded-lg transition-colors border border-white/[0.06]">
+          Manage Users →
+        </Link>
+      </div>
 
       <div className="bg-zinc-900 rounded-lg p-5">
         <div className="flex items-center justify-between mb-4">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -430,6 +430,32 @@ export interface AdminSettingsUpdateResponse {
   oidc_configured: boolean;
 }
 
+// ─── Admin Types ────────────────────────────────────────────────────────────
+
+export interface AdminUser {
+  id: string;
+  username: string;
+  name: string | null;
+  email: string | null;
+  role: string | null;
+  is_admin: number;
+  auth_provider: string;
+  banned: boolean | null;
+  ban_reason: string | null;
+  ban_expires: number | null;
+  created_at: string | null;
+  updated_at: string | null;
+  tracked_count?: number;
+}
+
+export interface AdminUsersResponse {
+  users: AdminUser[];
+  total: number;
+  page: number;
+  page_size: number;
+  total_pages: number;
+}
+
 // ─── User Summary Type ──────────────────────────────────────────────────────
 
 export interface UserSummary {

--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -72,6 +72,12 @@ export {
   deleteExpiredSessions,
   getHomepageLayout,
   setHomepageLayout,
+  getAllUsers,
+  getAdminUserCount,
+  getUserTrackedCount,
+  banUser,
+  unbanUser,
+  deleteUser,
 } from "./users";
 
 export {

--- a/server/db/repository/users.ts
+++ b/server/db/repository/users.ts
@@ -1,6 +1,6 @@
-import { eq, and, sql, count } from "drizzle-orm";
+import { eq, and, sql, count, desc } from "drizzle-orm";
 import { getDb } from "../schema";
-import { users, sessions, account } from "../schema";
+import { users, sessions, account, tracked } from "../schema";
 import { logger } from "../../logger";
 import { traceDbQuery } from "../../tracing";
 
@@ -253,5 +253,116 @@ export async function setHomepageLayout(userId: string, layout: string): Promise
       .set({ homepageLayout: layout })
       .where(eq(users.id, userId))
       .run();
+  });
+}
+
+// ─── Admin user management ────────────────────────────────────────────────────
+
+export async function getAllUsers(opts: { search?: string; filter?: "all" | "banned" | "active"; limit?: number; offset?: number } = {}) {
+  return traceDbQuery("getAllUsers", async () => {
+    const db = getDb();
+    const { search, filter = "all", limit = 50, offset = 0 } = opts;
+
+    const conditions: ReturnType<typeof sql>[] = [];
+
+    if (search) {
+      const pattern = `%${search}%`;
+      conditions.push(sql`(${users.username} LIKE ${pattern} OR ${users.name} LIKE ${pattern})`);
+    }
+
+    if (filter === "banned") {
+      conditions.push(sql`COALESCE(${users.banned}, 0) = 1`);
+    } else if (filter === "active") {
+      conditions.push(sql`COALESCE(${users.banned}, 0) = 0`);
+    }
+
+    const rows = await db
+      .select({
+        id: users.id,
+        username: users.username,
+        name: users.name,
+        email: users.email,
+        role: users.role,
+        is_admin: users.isAdmin,
+        auth_provider: users.authProvider,
+        banned: users.banned,
+        ban_reason: users.banReason,
+        ban_expires: users.banExpires,
+        created_at: users.createdAt,
+        updated_at: users.updatedAt,
+      })
+      .from(users)
+      .where(conditions.length > 0 ? and(...conditions) : undefined)
+      .orderBy(desc(users.createdAt))
+      .limit(limit)
+      .offset(offset)
+      .all();
+
+    return rows;
+  });
+}
+
+export async function getAdminUserCount(opts: { search?: string; filter?: "all" | "banned" | "active" } = {}) {
+  return traceDbQuery("getAdminUserCount", async () => {
+    const db = getDb();
+    const { search, filter = "all" } = opts;
+
+    const conditions: ReturnType<typeof sql>[] = [];
+
+    if (search) {
+      const pattern = `%${search}%`;
+      conditions.push(sql`(${users.username} LIKE ${pattern} OR ${users.name} LIKE ${pattern})`);
+    }
+
+    if (filter === "banned") {
+      conditions.push(sql`COALESCE(${users.banned}, 0) = 1`);
+    } else if (filter === "active") {
+      conditions.push(sql`COALESCE(${users.banned}, 0) = 0`);
+    }
+
+    const row = await db
+      .select({ cnt: count() })
+      .from(users)
+      .where(conditions.length > 0 ? and(...conditions) : undefined)
+      .get();
+
+    return row?.cnt ?? 0;
+  });
+}
+
+export async function getUserTrackedCount(userId: string): Promise<number> {
+  return traceDbQuery("getUserTrackedCount", async () => {
+    const db = getDb();
+    const row = await db.select({ cnt: count() }).from(tracked).where(eq(tracked.userId, userId)).get();
+    return row?.cnt ?? 0;
+  });
+}
+
+export async function banUser(userId: string, reason: string | null, expiresAt: number | null) {
+  return traceDbQuery("banUser", async () => {
+    const db = getDb();
+    await db
+      .update(users)
+      .set({ banned: true, banReason: reason, banExpires: expiresAt })
+      .where(eq(users.id, userId))
+      .run();
+  });
+}
+
+export async function unbanUser(userId: string) {
+  return traceDbQuery("unbanUser", async () => {
+    const db = getDb();
+    await db
+      .update(users)
+      .set({ banned: false, banReason: null, banExpires: null })
+      .where(eq(users.id, userId))
+      .run();
+  });
+}
+
+export async function deleteUser(userId: string) {
+  return traceDbQuery("deleteUser", async () => {
+    const db = getDb();
+    await db.delete(users).where(eq(users.id, userId)).run();
   });
 }

--- a/server/routes/admin.test.ts
+++ b/server/routes/admin.test.ts
@@ -7,6 +7,7 @@ import {
   getSessionWithUser,
   getSetting,
   setSetting,
+  getUserById,
 } from "../db/repository";
 import { requireAuth, requireAdmin } from "../middleware/auth";
 import adminApp from "./admin";
@@ -191,5 +192,191 @@ describe("PUT /admin/settings", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.oidc_configured).toBeDefined();
+  });
+});
+
+// ─── User management tests ────────────────────────────────────────────────────
+
+describe("GET /admin/users", () => {
+  it("returns user list for admin", async () => {
+    await createUser("alice", "hash");
+    await createUser("bob", "hash");
+    const res = await app.request("/admin/users", {
+      headers: { Cookie: adminCookie },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.users)).toBe(true);
+    expect(body.total).toBeGreaterThanOrEqual(3); // admin + alice + bob
+    expect(body.page).toBe(1);
+    expect(body.page_size).toBe(50);
+  });
+
+  it("filters by search query", async () => {
+    await createUser("searchable_user", "hash");
+    const res = await app.request("/admin/users?search=searchable", {
+      headers: { Cookie: adminCookie },
+    });
+    const body = await res.json();
+    expect(body.users.some((u: { username: string }) => u.username === "searchable_user")).toBe(true);
+  });
+
+  it("filters banned users", async () => {
+    const userId = await createUser("tobebanned", "hash");
+    await app.request(`/admin/users/${userId}/ban`, {
+      method: "PUT",
+      headers: { Cookie: adminCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ reason: "test ban" }),
+    });
+    const res = await app.request("/admin/users?filter=banned", {
+      headers: { Cookie: adminCookie },
+    });
+    const body = await res.json();
+    expect(body.users.some((u: { username: string }) => u.username === "tobebanned")).toBe(true);
+  });
+
+  it("returns 403 for non-admin", async () => {
+    const userId = await createUser("regular", "hash");
+    const token = await createSession(userId);
+    const res = await app.request("/admin/users", {
+      headers: { Cookie: `better-auth.session_token=${token}` },
+    });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("GET /admin/users/:id", () => {
+  it("returns user details with tracked count", async () => {
+    const userId = await createUser("detailuser", "hash");
+    const res = await app.request(`/admin/users/${userId}`, {
+      headers: { Cookie: adminCookie },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.user.username).toBe("detailuser");
+    expect(typeof body.user.tracked_count).toBe("number");
+  });
+
+  it("returns 404 for non-existent user", async () => {
+    const res = await app.request("/admin/users/nonexistent-id", {
+      headers: { Cookie: adminCookie },
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("PUT /admin/users/:id/role", () => {
+  it("promotes a user to admin", async () => {
+    const userId = await createUser("toPromote", "hash");
+    const res = await app.request(`/admin/users/${userId}/role`, {
+      method: "PUT",
+      headers: { Cookie: adminCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ role: "admin" }),
+    });
+    expect(res.status).toBe(200);
+    const user = await getUserById(userId);
+    expect(user?.role).toBe("admin");
+  });
+
+  it("demotes admin to user", async () => {
+    const userId = await createUser("toDemote", "hash", undefined, "local", undefined, true);
+    const res = await app.request(`/admin/users/${userId}/role`, {
+      method: "PUT",
+      headers: { Cookie: adminCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ role: "user" }),
+    });
+    expect(res.status).toBe(200);
+    const user = await getUserById(userId);
+    expect(user?.role).toBe("user");
+  });
+
+  it("returns 400 for invalid role", async () => {
+    const userId = await createUser("roletest", "hash");
+    const res = await app.request(`/admin/users/${userId}/role`, {
+      method: "PUT",
+      headers: { Cookie: adminCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ role: "superuser" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when trying to change own role", async () => {
+    // Get admin's userId from the session
+    const sessionUser = await getSessionWithUser(adminCookie.split("=")[1]);
+    const res = await app.request(`/admin/users/${sessionUser!.id}/role`, {
+      method: "PUT",
+      headers: { Cookie: adminCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ role: "user" }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("PUT /admin/users/:id/ban and /unban", () => {
+  it("bans a user with a reason", async () => {
+    const userId = await createUser("tobanned", "hash");
+    const res = await app.request(`/admin/users/${userId}/ban`, {
+      method: "PUT",
+      headers: { Cookie: adminCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ reason: "spam" }),
+    });
+    expect(res.status).toBe(200);
+    const user = await getUserById(userId);
+    expect(user).not.toBeNull();
+  });
+
+  it("unbans a user", async () => {
+    const userId = await createUser("bannedUser", "hash");
+    await app.request(`/admin/users/${userId}/ban`, {
+      method: "PUT",
+      headers: { Cookie: adminCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    const res = await app.request(`/admin/users/${userId}/unban`, {
+      method: "PUT",
+      headers: { Cookie: adminCookie, "Content-Type": "application/json" },
+      body: "{}",
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 400 when trying to ban yourself", async () => {
+    const sessionUser = await getSessionWithUser(adminCookie.split("=")[1]);
+    const res = await app.request(`/admin/users/${sessionUser!.id}/ban`, {
+      method: "PUT",
+      headers: { Cookie: adminCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("DELETE /admin/users/:id", () => {
+  it("deletes a user", async () => {
+    const userId = await createUser("todelete", "hash");
+    const res = await app.request(`/admin/users/${userId}`, {
+      method: "DELETE",
+      headers: { Cookie: adminCookie },
+    });
+    expect(res.status).toBe(200);
+    const user = await getUserById(userId);
+    expect(user).toBeNull();
+  });
+
+  it("returns 404 for non-existent user", async () => {
+    const res = await app.request("/admin/users/nonexistent", {
+      method: "DELETE",
+      headers: { Cookie: adminCookie },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when trying to delete yourself", async () => {
+    const sessionUser = await getSessionWithUser(adminCookie.split("=")[1]);
+    const res = await app.request(`/admin/users/${sessionUser!.id}`, {
+      method: "DELETE",
+      headers: { Cookie: adminCookie },
+    });
+    expect(res.status).toBe(400);
   });
 });

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -6,10 +6,21 @@ import {
   getSettingsByPrefix,
   isOidcConfigured,
   getOidcConfig,
+  getAllUsers,
+  getAdminUserCount,
+  getUserTrackedCount,
+  getUserById,
+  banUser,
+  unbanUser,
+  deleteUser,
+  updateUserAdmin,
 } from "../db/repository";
 import { CONFIG } from "../config";
 import type { AppEnv } from "../types";
 import { ok } from "./response";
+import { logger } from "../logger";
+
+const log = logger.child({ module: "admin" });
 
 /**
  * Callback to recreate the auth instance after OIDC settings change.
@@ -85,6 +96,110 @@ app.put("/settings", async (c) => {
   }
 
   return ok(c, { oidc_configured: await isOidcConfigured() });
+});
+
+// ─── User management ─────────────────────────────────────────────────────────
+
+const PAGE_SIZE = 50;
+
+// GET /api/admin/users?search=&filter=all|active|banned&page=1
+app.get("/users", async (c) => {
+  const search = c.req.query("search") || undefined;
+  const filter = (c.req.query("filter") as "all" | "active" | "banned") || "all";
+  const page = Math.max(1, parseInt(c.req.query("page") || "1", 10));
+  const offset = (page - 1) * PAGE_SIZE;
+
+  const [rows, total] = await Promise.all([
+    getAllUsers({ search, filter, limit: PAGE_SIZE, offset }),
+    getAdminUserCount({ search, filter }),
+  ]);
+
+  return ok(c, {
+    users: rows,
+    total,
+    page,
+    page_size: PAGE_SIZE,
+    total_pages: Math.ceil(total / PAGE_SIZE),
+  });
+});
+
+// GET /api/admin/users/:id
+app.get("/users/:id", async (c) => {
+  const id = c.req.param("id");
+  const user = await getUserById(id);
+  if (!user) return c.json({ error: "User not found" }, 404);
+
+  const trackedCount = await getUserTrackedCount(id);
+  return ok(c, { user: { ...user, tracked_count: trackedCount } });
+});
+
+// PUT /api/admin/users/:id/role  { role: "admin" | "user" }
+app.put("/users/:id/role", async (c) => {
+  const id = c.req.param("id");
+  const actingUser = c.get("user")!;
+
+  if (id === actingUser.id) {
+    return c.json({ error: "Cannot change your own role" }, 400);
+  }
+
+  const body = await c.req.json<{ role: string }>();
+  if (body.role !== "admin" && body.role !== "user") {
+    return c.json({ error: "role must be 'admin' or 'user'" }, 400);
+  }
+
+  const target = await getUserById(id);
+  if (!target) return c.json({ error: "User not found" }, 404);
+
+  await updateUserAdmin(id, body.role === "admin");
+  log.info("Admin role changed", { targetUserId: id, newRole: body.role, by: actingUser.id });
+  return ok(c, { message: `User role updated to ${body.role}` });
+});
+
+// PUT /api/admin/users/:id/ban  { reason?: string }
+app.put("/users/:id/ban", async (c) => {
+  const id = c.req.param("id");
+  const actingUser = c.get("user")!;
+
+  if (id === actingUser.id) {
+    return c.json({ error: "Cannot ban yourself" }, 400);
+  }
+
+  const target = await getUserById(id);
+  if (!target) return c.json({ error: "User not found" }, 404);
+
+  const body = await c.req.json<{ reason?: string }>().catch(() => ({ reason: undefined }));
+  const reason = "reason" in body ? (body.reason ?? null) : null;
+  await banUser(id, reason, null);
+  log.info("User banned", { targetUserId: id, reason, by: actingUser.id });
+  return ok(c, { message: "User banned" });
+});
+
+// PUT /api/admin/users/:id/unban
+app.put("/users/:id/unban", async (c) => {
+  const id = c.req.param("id");
+  const target = await getUserById(id);
+  if (!target) return c.json({ error: "User not found" }, 404);
+
+  await unbanUser(id);
+  log.info("User unbanned", { targetUserId: id, by: c.get("user")!.id });
+  return ok(c, { message: "User unbanned" });
+});
+
+// DELETE /api/admin/users/:id
+app.delete("/users/:id", async (c) => {
+  const id = c.req.param("id");
+  const actingUser = c.get("user")!;
+
+  if (id === actingUser.id) {
+    return c.json({ error: "Cannot delete your own account from admin panel" }, 400);
+  }
+
+  const target = await getUserById(id);
+  if (!target) return c.json({ error: "User not found" }, 404);
+
+  await deleteUser(id);
+  log.info("User deleted by admin", { targetUserId: id, by: actingUser.id });
+  return ok(c, { message: "User deleted" });
 });
 
 export default app;


### PR DESCRIPTION
## Summary
Full admin panel for managing users: list, search/filter, promote/demote, ban/unban, and delete. Accessible from Settings → Admin Settings → Manage Users.

## Backend

**New repository functions** (`server/db/repository/users.ts`):
- `getAllUsers({ search, filter, limit, offset })` — paginated, filterable user list
- `getAdminUserCount({ search, filter })` — total count for pagination
- `getUserTrackedCount(userId)` — per-user tracked title count
- `banUser(userId, reason, expiresAt)` — set ban flag
- `unbanUser(userId)` — clear ban
- `deleteUser(userId)` — permanent delete

**New endpoints** added to `server/routes/admin.ts`:
| Method | Path | Description |
|---|---|---|
| `GET` | `/api/admin/users` | Paginated user list (`?search=&filter=all\|active\|banned&page=`) |
| `GET` | `/api/admin/users/:id` | User detail + tracked count |
| `PUT` | `/api/admin/users/:id/role` | Set role `admin` or `user` |
| `PUT` | `/api/admin/users/:id/ban` | Ban with optional reason |
| `PUT` | `/api/admin/users/:id/unban` | Remove ban |
| `DELETE` | `/api/admin/users/:id` | Permanent delete |

All endpoints guard against self-modification (can't ban/delete/demote yourself).

## Frontend

**`/admin/users`** — new `AdminUsersPage`:
- Responsive table: username, display name, email, role badge, banned badge, auth provider, join date
- Search input + filter pills (All / Active / Banned)
- Per-row actions: role toggle (Shield icon), ban/unban (ShieldOff), delete (Trash2)
- Ban modal with optional reason input
- Delete confirmation modal
- Pagination with prev/next controls
- "you" label on the acting admin's own row (actions disabled)

**Settings page** — "Manage Users →" button added to existing Admin Settings section.

## Test plan
- [ ] As admin: Settings → Admin Settings → Manage Users → user table loads
- [ ] Search by username filters results
- [ ] Filter = "Banned" shows only banned users
- [ ] Promote a user → role badge updates to Admin
- [ ] Ban a user with reason → "Banned" badge appears, user disappears from "Active" filter
- [ ] Unban → badge removed
- [ ] Delete → user gone from list; 404 if queried again
- [ ] Cannot ban/delete/demote yourself (400 response, no action)

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)