### PR TITLE
feat: iCal calendar feed export (#366)

### DIFF
--- a/drizzle/0019_users_feed_token.sql
+++ b/drizzle/0019_users_feed_token.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN feed_token text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1743984000000,
       "tag": "0018_users_homepage_layout",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1744070400000,
+      "tag": "0019_users_feed_token",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -653,3 +653,13 @@ export async function unbanAdminUser(userId: string): Promise<{ message: string 
 export async function deleteAdminUser(userId: string): Promise<{ message: string }> {
   return fetchJson(`/admin/users/${encodeURIComponent(userId)}`, { method: "DELETE" });
 }
+
+// ─── Calendar feed ────────────────────────────────────────────────────────────
+
+export async function getFeedToken(): Promise<{ token: string | null }> {
+  return fetchJson("/feed/token");
+}
+
+export async function regenerateFeedToken(): Promise<{ token: string }> {
+  return fetchJson("/feed/token/regenerate", { method: "POST" });
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -359,5 +359,17 @@
     "error": "An error occurred",
     "save": "Save",
     "cancel": "Cancel"
+  },
+  "feed": {
+    "title": "Calendar Feed",
+    "description": "Subscribe to your upcoming episodes and movie releases in any calendar app (Google Calendar, Apple Calendar, Outlook).",
+    "noToken": "Generate a feed URL to subscribe from your calendar app.",
+    "generate": "Generate Feed URL",
+    "generating": "Generating...",
+    "regenerate": "Regenerate URL",
+    "regenerating": "Regenerating...",
+    "copyUrl": "Copy",
+    "copied": "Copied!",
+    "warning": "Keep this URL private — anyone with it can see your upcoming releases."
   }
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -32,6 +32,7 @@ export default function SettingsPage() {
       <WatchlistSection />
       {isPushSupported() && <PushNotificationsSection />}
       <HomepageLayoutSection />
+      <CalendarFeedSection />
       <PlexSection />
       <NotificationsSection />
       {user.is_admin && <BackgroundJobsSection />}
@@ -2046,6 +2047,83 @@ function PlexSection() {
             </button>
           </div>
         </div>
+      )}
+    </section>
+  );
+}
+
+function CalendarFeedSection() {
+  const { t } = useTranslation();
+  const [token, setToken] = useState<string | null>(null);
+  const [loadingToken, setLoadingToken] = useState(true);
+  const [regenerating, setRegenerating] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    api.getFeedToken()
+      .then(({ token: tok }) => { setToken(tok); setLoadingToken(false); })
+      .catch(() => setLoadingToken(false));
+  }, []);
+
+  const feedUrl = token ? `${window.location.origin}/api/feed/calendar.ics?token=${token}` : null;
+
+  async function handleRegenerate() {
+    setRegenerating(true);
+    try {
+      const { token: newToken } = await api.regenerateFeedToken();
+      setToken(newToken);
+    } finally {
+      setRegenerating(false);
+    }
+  }
+
+  async function handleCopy() {
+    if (!feedUrl) return;
+    await navigator.clipboard.writeText(feedUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <section className="bg-zinc-900 rounded-xl p-6 space-y-4">
+      <h2 className="text-lg font-semibold">{t("feed.title")}</h2>
+      <p className="text-sm text-zinc-400">{t("feed.description")}</p>
+      {loadingToken ? (
+        <p className="text-sm text-zinc-500">{t("common.loading")}</p>
+      ) : token ? (
+        <div className="space-y-3">
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={feedUrl!}
+              readOnly
+              aria-label={t("feed.title")}
+              className="flex-1 min-w-0 bg-zinc-800 border border-white/[0.06] rounded-lg px-3 py-2 text-xs text-zinc-300 font-mono focus:outline-none"
+            />
+            <button
+              onClick={handleCopy}
+              className="px-3 py-2 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 text-sm rounded-lg transition-colors cursor-pointer whitespace-nowrap"
+            >
+              {copied ? t("feed.copied") : t("feed.copyUrl")}
+            </button>
+          </div>
+          <p className="text-xs text-zinc-500">{t("feed.warning")}</p>
+          <button
+            onClick={handleRegenerate}
+            disabled={regenerating}
+            className="text-sm text-zinc-400 hover:text-white transition-colors cursor-pointer disabled:opacity-50"
+          >
+            {regenerating ? t("feed.regenerating") : t("feed.regenerate")}
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={handleRegenerate}
+          disabled={regenerating}
+          className="px-4 py-2 bg-amber-500 hover:bg-amber-400 text-black font-medium text-sm rounded-lg transition-colors cursor-pointer disabled:opacity-50"
+        >
+          {regenerating ? t("feed.generating") : t("feed.generate")}
+        </button>
       )}
     </section>
   );

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -129,10 +129,10 @@ describe("fixSkippedMigrations", () => {
     }>;
     expect(titleCols.some((c) => c.name === "genres")).toBe(false);
 
-    // All 19 migrations should be recorded
+    // All 20 migrations should be recorded
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(19);
+    expect(migrations.cnt).toBe(20);
   });
 });

--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -50,6 +50,7 @@ export {
   updateTrackedVisibility,
   updateAllTrackedVisibility,
   getTrackedMoviesByReleaseDate,
+  getUpcomingTrackedMovies,
   updateTrackedStatus,
 } from "./tracked";
 export type { UserStatus } from "./tracked";
@@ -78,6 +79,9 @@ export {
   banUser,
   unbanUser,
   deleteUser,
+  getFeedToken,
+  setFeedToken,
+  getUserByFeedToken,
 } from "./users";
 
 export {

--- a/server/db/repository/tracked.ts
+++ b/server/db/repository/tracked.ts
@@ -1,4 +1,4 @@
-import { eq, and, sql, desc } from "drizzle-orm";
+import { eq, and, sql, desc, gte, lt, asc } from "drizzle-orm";
 import { getDb } from "../schema";
 import { titles, scores, tracked, watchedTitles } from "../schema";
 import { traceDbQuery } from "../../tracing";
@@ -229,6 +229,30 @@ export async function getTrackedMoviesByReleaseDate(date: string, userId: string
 }
 
 export type UserStatus = "plan_to_watch" | "watching" | "on_hold" | "dropped" | "completed";
+
+export async function getUpcomingTrackedMovies(userId: string, startDate: string, endDate: string) {
+  return traceDbQuery("getUpcomingTrackedMovies", async () => {
+    const db = getDb();
+    return db
+      .select({
+        id: titles.id,
+        title: titles.title,
+        release_date: titles.releaseDate,
+      })
+      .from(tracked)
+      .innerJoin(titles, eq(titles.id, tracked.titleId))
+      .where(
+        and(
+          eq(tracked.userId, userId),
+          sql`${titles.objectType} = 'MOVIE'`,
+          gte(titles.releaseDate, startDate),
+          lt(titles.releaseDate, endDate),
+        )
+      )
+      .orderBy(asc(titles.releaseDate))
+      .all();
+  });
+}
 
 export async function updateTrackedStatus(titleId: string, userId: string, status: UserStatus | null) {
   return traceDbQuery("updateTrackedStatus", async () => {

--- a/server/db/repository/users.ts
+++ b/server/db/repository/users.ts
@@ -366,3 +366,28 @@ export async function deleteUser(userId: string) {
     await db.delete(users).where(eq(users.id, userId)).run();
   });
 }
+
+// ─── Calendar feed token ──────────────────────────────────────────────────────
+
+export async function getFeedToken(userId: string): Promise<string | null> {
+  return traceDbQuery("getFeedToken", async () => {
+    const db = getDb();
+    const row = await db.select({ feedToken: users.feedToken }).from(users).where(eq(users.id, userId)).get();
+    return row?.feedToken ?? null;
+  });
+}
+
+export async function setFeedToken(userId: string, token: string): Promise<void> {
+  return traceDbQuery("setFeedToken", async () => {
+    const db = getDb();
+    await db.update(users).set({ feedToken: token }).where(eq(users.id, userId)).run();
+  });
+}
+
+export async function getUserByFeedToken(token: string): Promise<{ id: string } | null> {
+  return traceDbQuery("getUserByFeedToken", async () => {
+    const db = getDb();
+    const row = await db.select({ id: users.id }).from(users).where(eq(users.feedToken, token)).get();
+    return row ?? null;
+  });
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -158,6 +158,7 @@ export const users = sqliteTable(
     profilePublic: integer("profile_public").notNull().default(0),
     profileVisibility: text("profile_visibility").notNull().default("private"),
     homepageLayout: text("homepage_layout"),
+    feedToken: text("feed_token"),
   },
   (table) => [
     uniqueIndex("users_auth_provider_subject").on(

--- a/server/index.ts
+++ b/server/index.ts
@@ -32,6 +32,7 @@ import healthRoutes from "./routes/health";
 import metricsRoutes from "./routes/metrics";
 import statsRoutes from "./routes/stats";
 import userSettingsRoutes from "./routes/user-settings";
+import feedRoutes from "./routes/feed";
 import type { AppEnv } from "./types";
 import Sentry from "./sentry";
 import { logger, requestLogger } from "./logger";
@@ -217,6 +218,10 @@ app.route("/api/stats", statsRoutes);
 
 app.use("/api/user/settings/*", requireAuth);
 app.route("/api/user/settings", userSettingsRoutes);
+
+// Calendar feed — /calendar.ics is public (token-authenticated); /token endpoints require session
+app.use("/api/feed/token*", requireAuth);
+app.route("/api/feed", feedRoutes);
 
 // Admin routes
 app.use("/api/admin/*", requireAuth, requireAdmin);

--- a/server/routes/feed.test.ts
+++ b/server/routes/feed.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { makeParsedTitle } from "../test-utils/fixtures";
+import { createUser, createSession, getSessionWithUser, upsertTitles, trackTitle } from "../db/repository";
+import { requireAuth } from "../middleware/auth";
+import feedApp from "./feed";
+import type { AppEnv } from "../types";
+
+function createMockAuth() {
+  return {
+    api: {
+      getSession: async ({ headers }: { headers: Headers }) => {
+        const cookieHeader = headers.get("cookie") || "";
+        const match = cookieHeader.match(/better-auth\.session_token=([^;]+)/);
+        const token = match?.[1];
+        if (!token) return null;
+        const user = await getSessionWithUser(token);
+        if (!user) return null;
+        return {
+          session: { id: "session-id", userId: user.id },
+          user: {
+            id: user.id,
+            name: user.display_name,
+            username: user.username,
+            role: user.role || (user.is_admin ? "admin" : "user"),
+          },
+        };
+      },
+    },
+  };
+}
+
+let app: Hono<AppEnv>;
+let userToken: string;
+let userId: string;
+
+beforeEach(async () => {
+  setupTestDb();
+
+  userId = await createUser("feeduser", "hash");
+  userToken = await createSession(userId);
+
+  app = new Hono<AppEnv>();
+  app.use("*", async (c, next) => {
+    c.set("auth", createMockAuth() as any);
+    await next();
+  });
+  app.use("/feed/token*", requireAuth);
+  app.route("/feed", feedApp);
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+function authHeaders() {
+  return { Cookie: `better-auth.session_token=${userToken}` };
+}
+
+describe("GET /feed/calendar.ics", () => {
+  it("returns 401 when token is missing", async () => {
+    const res = await app.request("/feed/calendar.ics");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 for invalid token", async () => {
+    const res = await app.request("/feed/calendar.ics?token=not-a-real-token");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns valid iCal after regenerating token", async () => {
+    // Generate a token first
+    const tokenRes = await app.request("/feed/token/regenerate", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    expect(tokenRes.status).toBe(200);
+    const { token } = await tokenRes.json() as { token: string };
+    expect(typeof token).toBe("string");
+    expect(token.length).toBeGreaterThan(0);
+
+    // Fetch the feed with the token
+    const feedRes = await app.request(`/feed/calendar.ics?token=${token}`);
+    expect(feedRes.status).toBe(200);
+    expect(feedRes.headers.get("Content-Type")).toContain("text/calendar");
+
+    const body = await feedRes.text();
+    expect(body).toContain("BEGIN:VCALENDAR");
+    expect(body).toContain("END:VCALENDAR");
+    expect(body).toContain("VERSION:2.0");
+  });
+
+  it("includes tracked upcoming movies in the feed", async () => {
+    // Generate token
+    const tokenRes = await app.request("/feed/token/regenerate", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    const { token } = await tokenRes.json() as { token: string };
+
+    // Create and track a future movie
+    const futureDate = new Date();
+    futureDate.setDate(futureDate.getDate() + 10);
+    const releaseDate = futureDate.toISOString().slice(0, 10);
+
+    await upsertTitles([makeParsedTitle({
+      id: "movie-future",
+      objectType: "MOVIE",
+      title: "Future Movie",
+      releaseDate,
+    })]);
+    await trackTitle("movie-future", userId);
+
+    const feedRes = await app.request(`/feed/calendar.ics?token=${token}`);
+    const body = await feedRes.text();
+    expect(body).toContain("Future Movie");
+    expect(body).toContain(`remindarr-movie-movie-future@remindarr`);
+  });
+});
+
+describe("GET /feed/token", () => {
+  it("returns 401 without auth", async () => {
+    const res = await app.request("/feed/token");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns null token before any regeneration", async () => {
+    const res = await app.request("/feed/token", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { token: string | null };
+    expect(body.token).toBeNull();
+  });
+
+  it("returns token after regeneration", async () => {
+    await app.request("/feed/token/regenerate", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    const res = await app.request("/feed/token", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { token: string };
+    expect(typeof body.token).toBe("string");
+  });
+});
+
+describe("POST /feed/token/regenerate", () => {
+  it("returns 401 without auth", async () => {
+    const res = await app.request("/feed/token/regenerate", { method: "POST" });
+    expect(res.status).toBe(401);
+  });
+
+  it("generates a new token", async () => {
+    const res = await app.request("/feed/token/regenerate", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { token: string };
+    expect(typeof body.token).toBe("string");
+    expect(body.token.length).toBeGreaterThan(0);
+  });
+
+  it("new token replaces the old one", async () => {
+    const res1 = await app.request("/feed/token/regenerate", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    const { token: token1 } = await res1.json() as { token: string };
+
+    const res2 = await app.request("/feed/token/regenerate", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    const { token: token2 } = await res2.json() as { token: string };
+
+    expect(token1).not.toBe(token2);
+
+    // Old token no longer works
+    const feedRes = await app.request(`/feed/calendar.ics?token=${token1}`);
+    expect(feedRes.status).toBe(401);
+
+    // New token works
+    const feedRes2 = await app.request(`/feed/calendar.ics?token=${token2}`);
+    expect(feedRes2.status).toBe(200);
+  });
+});

--- a/server/routes/feed.ts
+++ b/server/routes/feed.ts
@@ -1,0 +1,117 @@
+import { Hono } from "hono";
+import {
+  getUserByFeedToken,
+  getFeedToken,
+  setFeedToken,
+  getEpisodesByDateRange,
+  getUpcomingTrackedMovies,
+} from "../db/repository";
+import { requireAuth } from "../middleware/auth";
+import type { AppEnv } from "../types";
+
+const app = new Hono<AppEnv>();
+
+function addDays(dateStr: string, days: number): string {
+  const d = new Date(dateStr + "T00:00:00Z");
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+function escapeIcal(str: string): string {
+  return str.replace(/\\/g, "\\\\").replace(/;/g, "\\;").replace(/,/g, "\\,").replace(/\n/g, "\\n");
+}
+
+function foldLine(line: string): string {
+  const result: string[] = [];
+  while (line.length > 75) {
+    result.push(line.slice(0, 75));
+    line = " " + line.slice(75);
+  }
+  result.push(line);
+  return result.join("\r\n");
+}
+
+function dateToIcal(dateStr: string): string {
+  return dateStr.replace(/-/g, "");
+}
+
+// GET /api/feed/calendar.ics?token=<token>  (public, token-authenticated)
+app.get("/calendar.ics", async (c) => {
+  const token = c.req.query("token");
+  if (!token) return c.json({ error: "Missing token" }, 401);
+
+  const user = await getUserByFeedToken(token);
+  if (!user) return c.json({ error: "Invalid token" }, 401);
+
+  const today = new Date().toISOString().slice(0, 10);
+  const endDate = addDays(today, 90);
+
+  const [episodes, movies] = await Promise.all([
+    getEpisodesByDateRange(today, endDate, user.id),
+    getUpcomingTrackedMovies(user.id, today, endDate),
+  ]);
+
+  const lines: string[] = [];
+  lines.push("BEGIN:VCALENDAR");
+  lines.push("VERSION:2.0");
+  lines.push("PRODID:-//Remindarr//EN");
+  lines.push("X-WR-CALNAME:Remindarr");
+  lines.push("X-WR-TIMEZONE:UTC");
+  lines.push("CALSCALE:GREGORIAN");
+  lines.push("METHOD:PUBLISH");
+
+  for (const ep of episodes) {
+    if (!ep.air_date) continue;
+    const dtStart = dateToIcal(ep.air_date);
+    const dtEnd = dateToIcal(addDays(ep.air_date, 1));
+    const epLabel = `S${String(ep.season_number).padStart(2, "0")}E${String(ep.episode_number).padStart(2, "0")}`;
+    const summary = ep.name
+      ? `${escapeIcal(ep.show_title)} ${epLabel} – ${escapeIcal(ep.name)}`
+      : `${escapeIcal(ep.show_title)} ${epLabel}`;
+    lines.push("BEGIN:VEVENT");
+    lines.push(foldLine(`UID:remindarr-episode-${ep.id}@remindarr`));
+    lines.push(`DTSTART;VALUE=DATE:${dtStart}`);
+    lines.push(`DTEND;VALUE=DATE:${dtEnd}`);
+    lines.push(foldLine(`SUMMARY:${summary}`));
+    lines.push("END:VEVENT");
+  }
+
+  for (const movie of movies) {
+    if (!movie.release_date) continue;
+    const dtStart = dateToIcal(movie.release_date);
+    const dtEnd = dateToIcal(addDays(movie.release_date, 1));
+    lines.push("BEGIN:VEVENT");
+    lines.push(foldLine(`UID:remindarr-movie-${movie.id}@remindarr`));
+    lines.push(`DTSTART;VALUE=DATE:${dtStart}`);
+    lines.push(`DTEND;VALUE=DATE:${dtEnd}`);
+    lines.push(foldLine(`SUMMARY:${escapeIcal(movie.title)}`));
+    lines.push("END:VEVENT");
+  }
+
+  lines.push("END:VCALENDAR");
+
+  const body = lines.join("\r\n") + "\r\n";
+
+  return c.body(body, 200, {
+    "Content-Type": "text/calendar; charset=utf-8",
+    "Content-Disposition": 'attachment; filename="remindarr.ics"',
+    "Cache-Control": "no-cache, no-store",
+  });
+});
+
+// GET /api/feed/token  (requireAuth)
+app.get("/token", requireAuth, async (c) => {
+  const user = c.get("user")!;
+  const token = await getFeedToken(user.id);
+  return c.json({ token });
+});
+
+// POST /api/feed/token/regenerate  (requireAuth)
+app.post("/token/regenerate", requireAuth, async (c) => {
+  const user = c.get("user")!;
+  const token = crypto.randomUUID().replace(/-/g, "");
+  await setFeedToken(user.id, token);
+  return c.json({ token });
+});
+
+export default app;

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -67,6 +67,7 @@ import invitationsRoutes from "./routes/invitations";
 import healthRoutes from "./routes/health";
 import statsRoutes from "./routes/stats";
 import userSettingsRoutes from "./routes/user-settings";
+import feedRoutes from "./routes/feed";
 import type { AppEnv } from "./types";
 import { logger, requestLogger, resetLogLevel } from "./logger";
 import { patchConfig } from "./config";
@@ -331,6 +332,10 @@ function createApp(env: Env) {
 
   app.use("/api/user/settings/*", requireAuth);
   app.route("/api/user/settings", userSettingsRoutes);
+
+  // Calendar feed
+  app.use("/api/feed/token*", requireAuth);
+  app.route("/api/feed", feedRoutes);
 
   // Admin routes
   app.use("/api/admin/*", requireAuth, requireAdmin);


### PR DESCRIPTION
## Summary

- Adds a personal iCal feed URL users can subscribe to from Google Calendar, Apple Calendar, Outlook, etc.
- Feed covers upcoming episodes (next 90 days) and tracked movie release dates
- Token-authenticated: calendar apps subscribe without needing a session cookie

## Changes

**Backend**
- Migration 0019: `feed_token text` column on `users`
- `GET /api/feed/calendar.ics?token=<tok>` — returns `text/calendar` iCal (no session required, token-authenticated)
- `GET /api/feed/token` — returns current token (requires auth)
- `POST /api/feed/token/regenerate` — creates a new token, invalidating the old one (requires auth)
- New repository functions: `getFeedToken`, `setFeedToken`, `getUserByFeedToken`
- New query: `getUpcomingTrackedMovies` in `tracked.ts`

**Frontend**
- `CalendarFeedSection` in Settings: generate URL, copy to clipboard, regenerate (invalidates old URL)
- Two new API client functions: `getFeedToken`, `regenerateFeedToken`
- i18n keys under `feed.*`

## Test plan

- [ ] Generate a feed URL in Settings — button appears, URL is shown
- [ ] Copy URL and paste into Google Calendar "Add by URL" — upcoming episodes/movies appear
- [ ] Regenerate URL — old URL returns 401, new URL works
- [ ] No token → 401; invalid token → 401
- 10 automated tests covering token lifecycle and iCal output format

🤖 Generated with [Claude Code](https://claude.com/claude-code)