### PR TITLE
fix: post-merge review fixes (#383 #381)

### DIFF
--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -35,7 +35,6 @@ export function useTheme(): { theme: Theme; setTheme: (theme: Theme) => void } {
   function setTheme(newTheme: Theme) {
     localStorage.setItem(STORAGE_KEY, newTheme);
     setThemeState(newTheme);
-    applyTheme(newTheme);
   }
 
   return { theme, setTheme };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -133,6 +133,12 @@
 .theme-light .bg-zinc-950\/80 {
   background-color: rgba(250, 250, 250, 0.8);
 }
+.theme-light .hover\:bg-zinc-700:hover {
+  background-color: #cbd5e1;
+}
+.theme-light .hover\:text-zinc-100:hover {
+  color: #18181b;
+}
 
 /* OLED theme overrides */
 .theme-oled .bg-zinc-950 {

--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -162,16 +162,24 @@ export default function BrowsePage() {
     [setHideTrackedStr]
   );
 
-  async function runSearch(query: string) {
+  async function runSearch(
+    query: string,
+    overrides?: { type?: "" | "MOVIE" | "SHOW"; yearMin?: string; yearMax?: string; minRating?: string; language?: string }
+  ) {
     setSearchLoading(true);
     setSearchError("");
     try {
+      const effectiveType = overrides?.type !== undefined ? overrides.type : searchType;
+      const effectiveYearMin = overrides?.yearMin !== undefined ? overrides.yearMin : yearMin;
+      const effectiveYearMax = overrides?.yearMax !== undefined ? overrides.yearMax : yearMax;
+      const effectiveMinRating = overrides?.minRating !== undefined ? overrides.minRating : minRating;
+      const effectiveLanguage = overrides?.language !== undefined ? overrides.language : searchLanguage;
       const filters = {
-        type: (searchType || undefined) as "MOVIE" | "SHOW" | undefined,
-        yearMin: yearMin ? parseInt(yearMin, 10) : undefined,
-        yearMax: yearMax ? parseInt(yearMax, 10) : undefined,
-        minRating: minRating ? parseFloat(minRating) : undefined,
-        language: searchLanguage || undefined,
+        type: (effectiveType || undefined) as "MOVIE" | "SHOW" | undefined,
+        yearMin: effectiveYearMin ? parseInt(effectiveYearMin, 10) : undefined,
+        yearMax: effectiveYearMax ? parseInt(effectiveYearMax, 10) : undefined,
+        minRating: effectiveMinRating ? parseFloat(effectiveMinRating) : undefined,
+        language: effectiveLanguage || undefined,
       };
       const res = await api.searchTitles(query, filters);
       setSearchResults(res.titles.map(normalizeSearchTitle));
@@ -239,19 +247,19 @@ export default function BrowsePage() {
             <div className="flex items-center gap-1">
               <button
                 className={`${pillBase} ${searchType === "" ? pillActive : pillInactive}`}
-                onClick={() => { setSearchType(""); void runSearch(lastQuery); }}
+                onClick={() => { setSearchType(""); void runSearch(lastQuery, { type: "" }); }}
               >
                 {t("filter.all")}
               </button>
               <button
                 className={`${pillBase} ${searchType === "MOVIE" ? pillActive : pillInactive}`}
-                onClick={() => { setSearchType("MOVIE"); void runSearch(lastQuery); }}
+                onClick={() => { setSearchType("MOVIE"); void runSearch(lastQuery, { type: "MOVIE" }); }}
               >
                 {t("filter.movies")}
               </button>
               <button
                 className={`${pillBase} ${searchType === "SHOW" ? pillActive : pillInactive}`}
-                onClick={() => { setSearchType("SHOW"); void runSearch(lastQuery); }}
+                onClick={() => { setSearchType("SHOW"); void runSearch(lastQuery, { type: "SHOW" }); }}
               >
                 {t("filter.shows")}
               </button>
@@ -285,7 +293,7 @@ export default function BrowsePage() {
               <select
                 className={selectCls}
                 value={minRating}
-                onChange={(e) => { setMinRating(e.target.value); void runSearch(lastQuery); }}
+                onChange={(e) => { setMinRating(e.target.value); void runSearch(lastQuery, { minRating: e.target.value }); }}
               >
                 <option value="">{t("filter.anyRating")}</option>
                 {RATING_OPTIONS.map((v) => (
@@ -301,7 +309,7 @@ export default function BrowsePage() {
                 <select
                   className={selectCls}
                   value={searchLanguage}
-                  onChange={(e) => { setSearchLanguage(e.target.value); void runSearch(lastQuery); }}
+                  onChange={(e) => { setSearchLanguage(e.target.value); void runSearch(lastQuery, { language: e.target.value }); }}
                 >
                   <option value="">{t("filter.allLanguages")}</option>
                   {availableLanguages.map(({ code, label }) => (


### PR DESCRIPTION
Fixes three issues found during code review of the recently merged PRs.

## Changes

**Bug fix — BrowsePage stale filter state (#383)**
Filter pill clicks and select `onChange` handlers called `setState(newVal)` then immediately `runSearch()` in the same event. Since React state updates are async, `runSearch` would read the previous state value, causing results to lag one interaction behind. Fixed by adding an `overrides` parameter to `runSearch` so the fresh value is passed directly.

**Minor — useTheme double `applyTheme` call (#381)**
`setTheme()` called `applyTheme(newTheme)` directly AND the `useEffect` also called it on state change — running it twice per theme switch. Removed the redundant direct call.

**Minor — ThemePicker hover styles on light theme (#381)**
`hover:bg-zinc-700` and `hover:text-zinc-100` Tailwind classes on inactive ThemePicker buttons weren't overridden in `.theme-light`, so hovering showed dark background/text on a light background. Added the missing overrides to `index.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)