### PR TITLE
fix: light theme color issues — navbar, headings, nav hover

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -133,11 +133,28 @@
 .theme-light .bg-zinc-950\/80 {
   background-color: rgba(250, 250, 250, 0.8);
 }
+.theme-light .bg-zinc-950\/90 {
+  background-color: rgba(250, 250, 250, 0.9);
+}
+/* Fallback: override nav bg directly in case Tailwind @layer wins */
+:root.theme-light nav {
+  background-color: rgba(250, 250, 250, 0.85) !important;
+  border-color: rgb(0 0 0 / 0.1) !important;
+}
+.theme-light .text-white {
+  color: #18181b;
+}
+.theme-light .hover\:text-white:hover {
+  color: #18181b;
+}
 .theme-light .hover\:bg-zinc-700:hover {
   background-color: #cbd5e1;
 }
 .theme-light .hover\:text-zinc-100:hover {
   color: #18181b;
+}
+.theme-light .hover\:bg-zinc-800:hover {
+  background-color: #e2e8f0;
 }
 
 /* OLED theme overrides */


### PR DESCRIPTION
Fixes multiple light theme rendering issues visible in the Settings page.

## Problems fixed

**Navbar stays dark on light theme**
The `bg-zinc-950/80` CSS class override was being overridden by Tailwind's `@layer utilities`. Added `:root.theme-light nav { background-color: ... !important }` as a reliable fallback that targets the nav element directly. Also added `bg-zinc-950/90` override for the mobile BottomTabBar.

**Section headings invisible on light theme**
All section headings in Settings (Profile, Change Password, Theme, Passkeys, Visibility, etc.) use hardcoded `text-white` class. On a light background they become invisible. Added `.theme-light .text-white { color: #18181b }` to fix all of them globally, including the "Remindarr" logo in the navbar.

**Nav link hover states broken on light theme**
- `hover:text-white` — link hover text was invisible on light background
- `hover:bg-zinc-800` — link hover background was dark on light background

🤖 Generated with [Claude Code](https://claude.com/claude-code)