### PR TITLE
fix: light theme opacity-variant backgrounds and border overrides

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -156,6 +156,39 @@
 .theme-light .hover\:bg-zinc-800:hover {
   background-color: #e2e8f0;
 }
+/* bg-zinc-700 (used for active states, e.g. date sidebar active button) */
+.theme-light .bg-zinc-700 {
+  background-color: #94a3b8;
+}
+/* Opacity-modifier bg variants */
+.theme-light .bg-zinc-800\/50 {
+  background-color: rgba(226, 232, 240, 0.7);
+}
+.theme-light .bg-zinc-900\/30 {
+  background-color: rgba(241, 245, 249, 0.5);
+}
+.theme-light .bg-zinc-900\/60 {
+  background-color: rgba(241, 245, 249, 0.8);
+}
+.theme-light .bg-zinc-900\/80 {
+  background-color: rgba(241, 245, 249, 0.9);
+}
+.theme-light .bg-zinc-950\/50 {
+  background-color: rgba(250, 250, 250, 0.5);
+}
+.theme-light .bg-zinc-950\/95 {
+  background-color: rgba(250, 250, 250, 0.95);
+}
+/* Border variants not yet covered */
+.theme-light .border-white\/\[0\.08\] {
+  border-color: rgb(0 0 0 / 0.1);
+}
+.theme-light .border-zinc-700 {
+  border-color: #cbd5e1;
+}
+.theme-light .border-zinc-800\/60 {
+  border-color: rgba(203, 213, 225, 0.6);
+}
 
 /* OLED theme overrides */
 .theme-oled .bg-zinc-950 {


### PR DESCRIPTION
## Summary

- Adds light theme CSS overrides for Tailwind opacity-modifier classes (`bg-zinc-900/60`, `bg-zinc-950/95`, etc.) that were generating separate selectors not covered by existing overrides
- Fixes dark backgrounds on: CategoryBar, Calendar empty cells, AgendaCalendar date headers and episode cards, SlideOver panel (header + episode items), HeroBanner sidebar, active date sidebar button
- Adds missing `border-zinc-700`, `border-zinc-800/60`, and `border-white/[0.08]` light overrides

## Test plan

- [ ] Switch to light theme in Settings
- [ ] Browse page: category bar (New Releases / Popular / Upcoming / Top Rated) should have light background
- [ ] Calendar grid view: empty padding cells should be near-white, not dark
- [ ] Calendar list (agenda) view: date header bars (`Thu, Apr 2` etc.) should be light
- [ ] Calendar list: date number sidebar should have light active state
- [ ] Calendar grid: click a day to open the slide-over panel — header and episode items should be light
- [ ] Home page: HeroBanner "Continue Watching" sidebar card should be light

🤖 Generated with [Claude Code](https://claude.com/claude-code)