### PR TITLE
fix: light theme — calendar hover states and dark hero text

### DIFF
--- a/frontend/src/components/HeroBanner.tsx
+++ b/frontend/src/components/HeroBanner.tsx
@@ -98,7 +98,7 @@ export default function HeroBanner({ episodes }: { episodes: Episode[] }) {
 
   return (
     <div
-      className="group hidden lg:block w-[100vw] relative left-[50%] ml-[-50vw] overflow-hidden h-[450px]"
+      className="group hidden lg:block w-[100vw] relative left-[50%] ml-[-50vw] overflow-hidden h-[450px] dark-section"
       onMouseEnter={() => setIsPaused(true)}
       onMouseLeave={() => setIsPaused(false)}
     >

--- a/frontend/src/components/ProfileBanner.tsx
+++ b/frontend/src/components/ProfileBanner.tsx
@@ -34,7 +34,7 @@ export default function ProfileBanner({ backdrops, user, stats, isOwnProfile, au
 
   return (
     <div
-      className="w-[100vw] relative left-[50%] ml-[-50vw] overflow-hidden h-[28rem] sm:h-[22rem] -mt-6"
+      className="w-[100vw] relative left-[50%] ml-[-50vw] overflow-hidden h-[28rem] sm:h-[22rem] -mt-6 dark-section"
       onMouseEnter={() => setIsPaused(true)}
       onMouseLeave={() => setIsPaused(false)}
     >

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -189,6 +189,31 @@
 .theme-light .border-zinc-800\/60 {
   border-color: rgba(203, 213, 225, 0.6);
 }
+/* Calendar cell hover states */
+.theme-light .hover\:bg-zinc-900\/60:hover {
+  background-color: rgba(241, 245, 249, 0.8);
+}
+.theme-light .hover\:bg-zinc-950\/80:hover {
+  background-color: rgba(250, 250, 250, 0.8);
+}
+
+/* Dark-section: preserve original dark-mode colors inside cinematic hero areas.
+   Applied to TitleDetailPage hero, HeroBanner, and ProfileBanner — all use
+   dark backgrounds via inline styles so text must stay light. */
+.theme-light .dark-section .text-white { color: white; }
+.theme-light .dark-section .text-zinc-100 { color: #f4f4f5; }
+.theme-light .dark-section .text-zinc-200 { color: #e4e4e7; }
+.theme-light .dark-section .text-zinc-300 { color: #d4d4d8; }
+.theme-light .dark-section .text-zinc-400 { color: #a1a1aa; }
+.theme-light .dark-section .text-zinc-500 { color: #71717a; }
+.theme-light .dark-section .bg-zinc-700 { background-color: #3f3f46; }
+.theme-light .dark-section .bg-zinc-800 { background-color: #27272a; }
+.theme-light .dark-section .bg-zinc-900 { background-color: #18181b; }
+.theme-light .dark-section .bg-zinc-900\/60 { background-color: rgba(24, 24, 27, 0.6); }
+.theme-light .dark-section .bg-zinc-900\/70 { background-color: rgba(24, 24, 27, 0.7); }
+.theme-light .dark-section .bg-zinc-900\/80 { background-color: rgba(24, 24, 27, 0.8); }
+.theme-light .dark-section .border-white\/\[0\.06\] { border-color: rgb(255 255 255 / 0.06); }
+.theme-light .dark-section .border-white\/\[0\.08\] { border-color: rgb(255 255 255 / 0.08); }
 
 /* OLED theme overrides */
 .theme-oled .bg-zinc-950 {

--- a/frontend/src/pages/TitleDetailPage.tsx
+++ b/frontend/src/pages/TitleDetailPage.tsx
@@ -255,7 +255,7 @@ function MovieDetail({ data }: { data: MovieDetailsResponse }) {
   return (
     <div className="space-y-8 pb-12">
       {/* Hero */}
-      <div className="relative -mx-4 -mt-6 px-4 pt-6 pb-8" style={backdropUrl ? {
+      <div className="relative -mx-4 -mt-6 px-4 pt-6 pb-8 dark-section" style={backdropUrl ? {
         backgroundImage: `linear-gradient(to bottom, rgba(3,7,18,0.6), rgba(3,7,18,1)), url(${backdropUrl})`,
         backgroundSize: "cover",
         backgroundPosition: "center top",
@@ -541,7 +541,7 @@ function ShowDetail({ data }: { data: ShowDetailsResponse }) {
   return (
     <div className="space-y-8 pb-12">
       {/* Hero */}
-      <div className="relative -mx-4 -mt-6 px-4 pt-6 pb-8" style={backdropUrl ? {
+      <div className="relative -mx-4 -mt-6 px-4 pt-6 pb-8 dark-section" style={backdropUrl ? {
         backgroundImage: `linear-gradient(to bottom, rgba(3,7,18,0.6), rgba(3,7,18,1)), url(${backdropUrl})`,
         backgroundSize: "cover",
         backgroundPosition: "center top",


### PR DESCRIPTION
## Summary

- Add hover state CSS overrides for calendar cells (`hover:bg-zinc-900/60`, `hover:bg-zinc-950/80`) so hovering a cell doesn't flash dark in light mode
- Introduce `dark-section` CSS utility class that restores original dark-mode colors (text, bg) inside components with dark backgrounds driven by inline styles
- Apply `dark-section` to `HeroBanner`, `ProfileBanner`, and `TitleDetailPage` hero — all use dark gradient/backdrop inline styles so their text must stay white even in light theme

## Test plan

- [ ] Calendar grid: hover over a cell — background should be a soft light color, not dark gray
- [ ] Home page (logged in, with tracked shows): hero banner text (show title, episode info, overview) should be white/light on the dark cinematic background
- [ ] Title detail page (e.g. a movie with a backdrop): title, tagline, metadata should be readable (white on dark background)
- [ ] User profile page: username, stats cards, progress bars in the banner should render correctly (white text on dark banner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)