### PR TITLE
feat: weekly digest, streaming alerts, rewatch tracking, CSV import (#369 #368 #364 #365)

### DIFF
--- a/drizzle/0022_notifier_digest_mode.sql
+++ b/drizzle/0022_notifier_digest_mode.sql
@@ -1,0 +1,3 @@
+ALTER TABLE notifiers ADD COLUMN digest_mode text;
+--> statement-breakpoint
+ALTER TABLE notifiers ADD COLUMN digest_day integer;

--- a/drizzle/0023_watch_history.sql
+++ b/drizzle/0023_watch_history.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS watch_history (
+  id text PRIMARY KEY,
+  user_id text NOT NULL,
+  title_id text NOT NULL,
+  episode_id integer,
+  watched_at text NOT NULL DEFAULT (datetime('now')),
+  note text
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS watch_history_user_title ON watch_history(user_id, title_id);

--- a/drizzle/0024_streaming_alerts.sql
+++ b/drizzle/0024_streaming_alerts.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS streaming_alerts (
+  id text PRIMARY KEY,
+  user_id text NOT NULL,
+  title_id text NOT NULL,
+  provider_id integer NOT NULL,
+  provider_name text NOT NULL,
+  alerted_at text NOT NULL DEFAULT (datetime('now'))
+);
+--> statement-breakpoint
+ALTER TABLE notifiers ADD COLUMN streaming_alerts_enabled integer NOT NULL DEFAULT 1;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -155,6 +155,27 @@
       "when": 1744243200000,
       "tag": "0021_title_tags",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "6",
+      "when": 1744329600000,
+      "tag": "0022_notifier_digest_mode",
+      "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "6",
+      "when": 1744416000000,
+      "tag": "0023_watch_history",
+      "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "6",
+      "when": 1744502400000,
+      "tag": "0024_streaming_alerts",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -21,6 +21,7 @@ import type {
   RecommendationsResponse,
   InvitationItem,
   HomepageSection,
+  WatchHistoryEntry,
 } from "./types";
 
 const BASE = "/api";
@@ -157,6 +158,21 @@ export async function importWatchlist(file: File): Promise<{ success: boolean; i
   });
 }
 
+export async function importCsv(file: File): Promise<{ imported: number; failed: number; skipped: number; errors: string[] }> {
+  const form = new FormData();
+  form.append("file", file);
+  const res = await fetch(`${BASE}/import/csv`, { method: "POST", body: form });
+  if (res.status === 401) {
+    window.dispatchEvent(new CustomEvent("auth:unauthorized"));
+    throw new Error("Authentication required");
+  }
+  if (!res.ok) {
+    const e = await res.json().catch(() => ({ error: res.statusText }));
+    throw new Error(e.error || `Request failed: ${res.status}`);
+  }
+  return res.json();
+}
+
 // ─── User Profile ──────────────────────────────────────────────────────────
 
 export async function getUserProfile(username: string): Promise<UserProfileResponse> {
@@ -268,6 +284,12 @@ export async function unwatchMovie(titleId: string): Promise<void> {
   await fetchJson(`/watched/movies/${encodeURIComponent(titleId)}`, { method: "DELETE" });
 }
 
+// ─── Watch History ───────────────────────────────────────────────────────────
+
+export async function getWatchHistory(titleId: string): Promise<{ history: WatchHistoryEntry[]; playCount: number }> {
+  return fetchJson(`/watched/history/${encodeURIComponent(titleId)}`);
+}
+
 // ─── Details ────────────────────────────────────────────────────────────────
 
 export async function getMovieDetails(titleId: string): Promise<MovieDetailsResponse> {
@@ -358,6 +380,9 @@ export interface Notifier {
   timezone: string;
   enabled: boolean;
   last_sent_date: string | null;
+  digest_mode: "weekly" | "off" | null;
+  digest_day: number | null;
+  streaming_alerts_enabled: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -379,6 +404,9 @@ export async function createNotifier(data: {
   config: Record<string, string>;
   notify_time: string;
   timezone: string;
+  digest_mode?: "weekly" | "off" | null;
+  digest_day?: number | null;
+  streaming_alerts_enabled?: boolean;
 }): Promise<{ notifier: Notifier }> {
   return fetchJson("/notifiers", {
     method: "POST",
@@ -393,6 +421,9 @@ export async function updateNotifier(
     notify_time: string;
     timezone: string;
     enabled: boolean;
+    digest_mode: "weekly" | "off" | null;
+    digest_day: number | null;
+    streaming_alerts_enabled: boolean;
   }>
 ): Promise<{ notifier: Notifier }> {
   return fetchJson(`/notifiers/${encodeURIComponent(id)}`, {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -69,6 +69,16 @@
     "prevTitle": "Previous title",
     "openTitle": "Open focused title"
   },
+  "import": {
+    "title": "Import from CSV",
+    "description": "Import your watchlist from Letterboxd, IMDB, or Trakt by uploading a CSV export file. Up to 500 titles will be processed per import.",
+    "letterboxdHint": "Export from letterboxd.com — go to your profile, then Export.",
+    "imdbHint": "Export your ratings or watchlist from imdb.com — go to your list, then Export.",
+    "traktHint": "Export your watchlist from trakt.tv — go to Settings, then Data Export.",
+    "dropHint": "Drag and drop a CSV file here, or click to choose a file",
+    "importing": "Importing...",
+    "chooseFile": "Choose CSV file"
+  },
   "home": {
     "welcomeTitle": "Welcome to Remindarr",
     "welcomeMessage": "Sign in to see your upcoming episodes.",

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -86,6 +86,7 @@ export default function SettingsPage() {
           <PlexSection />
           <CalendarFeedSection />
           <WatchlistSection />
+          <CsvImportSection />
         </TabsContent>
 
         {user.is_admin && (
@@ -662,6 +663,111 @@ function WatchlistSection() {
   );
 }
 
+function CsvImportSection() {
+  const [importing, setImporting] = useState(false);
+  const [dragOver, setDragOver] = useState(false);
+  const [msg, setMsg] = useState("");
+  const [err, setErr] = useState("");
+  const { t } = useTranslation();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  async function handleFile(file: File) {
+    setMsg("");
+    setErr("");
+    setImporting(true);
+    try {
+      const result = await api.importCsv(file);
+      const parts: string[] = [`${result.imported} title${result.imported !== 1 ? "s" : ""} imported`];
+      if (result.failed > 0) parts.push(`${result.failed} failed`);
+      if (result.skipped > 0) parts.push(`${result.skipped} skipped`);
+      setMsg(parts.join(", ") + ".");
+    } catch (e: unknown) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setImporting(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  }
+
+  function handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) void handleFile(file);
+  }
+
+  function handleDrop(e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+    setDragOver(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file) void handleFile(file);
+  }
+
+  return (
+    <section>
+      <h2 className="text-xl font-bold text-white mb-4">{t("import.title")}</h2>
+
+      {msg && (
+        <div className="mb-4 p-3 rounded-lg bg-green-900/50 border border-green-700 text-green-200 text-sm">
+          {msg}
+        </div>
+      )}
+      {err && (
+        <div className="mb-4 p-3 rounded-lg bg-red-900/50 border border-red-700 text-red-200 text-sm">
+          {err}
+        </div>
+      )}
+
+      <div className="bg-zinc-900 rounded-lg p-5 space-y-4">
+        <p className="text-sm text-zinc-400">{t("import.description")}</p>
+
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 text-sm">
+          <div className="bg-zinc-800 rounded-lg p-3">
+            <p className="text-white font-medium mb-1">Letterboxd</p>
+            <p className="text-zinc-400 text-xs">{t("import.letterboxdHint")}</p>
+          </div>
+          <div className="bg-zinc-800 rounded-lg p-3">
+            <p className="text-white font-medium mb-1">IMDB</p>
+            <p className="text-zinc-400 text-xs">{t("import.imdbHint")}</p>
+          </div>
+          <div className="bg-zinc-800 rounded-lg p-3">
+            <p className="text-white font-medium mb-1">Trakt</p>
+            <p className="text-zinc-400 text-xs">{t("import.traktHint")}</p>
+          </div>
+        </div>
+
+        <div
+          className={`border-2 border-dashed rounded-lg p-8 text-center transition-colors ${dragOver ? "border-amber-500 bg-amber-500/10" : "border-zinc-700 hover:border-zinc-500"} ${importing ? "opacity-50 pointer-events-none" : "cursor-pointer"}`}
+          onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
+          onDragLeave={() => setDragOver(false)}
+          onDrop={handleDrop}
+          onClick={() => fileInputRef.current?.click()}
+        >
+          <p className="text-zinc-400 text-sm mb-2">{t("import.dropHint")}</p>
+          <p className="text-zinc-500 text-xs">.csv</p>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".csv,text/csv"
+            onChange={handleInputChange}
+            className="hidden"
+            disabled={importing}
+          />
+        </div>
+
+        <label className={`inline-block px-4 py-2 bg-amber-500 hover:bg-amber-400 text-zinc-950 font-medium rounded-lg transition-colors cursor-pointer ${importing ? "opacity-50 pointer-events-none" : ""}`}>
+          {importing ? t("import.importing") : t("import.chooseFile")}
+          <input
+            type="file"
+            accept=".csv,text/csv"
+            onChange={handleInputChange}
+            className="hidden"
+            disabled={importing}
+          />
+        </label>
+      </div>
+    </section>
+  );
+}
+
 function PushNotificationsSection() {
   const [loading, setLoading] = useState(true);
   const [enabling, setEnabling] = useState(false);
@@ -897,6 +1003,9 @@ function NotificationsSection() {
   const [formChatId, setFormChatId] = useState("");
   const [formTime, setFormTime] = useState("09:00");
   const [formTimezone, setFormTimezone] = useState(USER_TIMEZONE);
+  const [formDigestMode, setFormDigestMode] = useState<"daily" | "weekly" | "off">("daily");
+  const [formDigestDay, setFormDigestDay] = useState<number>(1);
+  const [formStreamingAlerts, setFormStreamingAlerts] = useState(true);
   const [saving, setSaving] = useState(false);
 
   const refresh = useCallback(() => {
@@ -924,6 +1033,9 @@ function NotificationsSection() {
     setFormChatId("");
     setFormTime("09:00");
     setFormTimezone(USER_TIMEZONE);
+    setFormDigestMode("daily");
+    setFormDigestDay(1);
+    setFormStreamingAlerts(true);
     setShowForm(false);
     setEditingId(null);
   }
@@ -939,6 +1051,9 @@ function NotificationsSection() {
     setFormChatId(n.config.chatId || "");
     setFormTime(n.notify_time);
     setFormTimezone(n.timezone);
+    setFormDigestMode(n.digest_mode === "weekly" ? "weekly" : n.digest_mode === "off" ? "off" : "daily");
+    setFormDigestDay(n.digest_day ?? 1);
+    setFormStreamingAlerts(n.streaming_alerts_enabled !== false);
     setShowForm(true);
     setMsg("");
     setErr("");
@@ -967,12 +1082,18 @@ function NotificationsSection() {
       config.token = formToken;
     }
 
+    const digestModeValue = formDigestMode === "daily" ? null : formDigestMode;
+    const digestDayValue = formDigestMode === "weekly" ? formDigestDay : null;
+
     try {
       if (editingId) {
         await api.updateNotifier(editingId, {
           config,
           notify_time: formTime,
           timezone: formTimezone,
+          digest_mode: digestModeValue,
+          digest_day: digestDayValue,
+          streaming_alerts_enabled: formStreamingAlerts,
         });
         setMsg("Notifier updated");
       } else {
@@ -981,6 +1102,9 @@ function NotificationsSection() {
           config,
           notify_time: formTime,
           timezone: formTimezone,
+          digest_mode: digestModeValue,
+          digest_day: digestDayValue,
+          streaming_alerts_enabled: formStreamingAlerts,
         });
         setMsg("Notifier created");
       }
@@ -1108,6 +1232,16 @@ function NotificationsSection() {
                 <div>
                   Time: <span className="text-zinc-300">{n.notify_time}</span>{" "}
                   <span className="text-zinc-500">({n.timezone})</span>
+                </div>
+                <div>
+                  Frequency:{" "}
+                  <span className="text-zinc-300">
+                    {n.digest_mode === "weekly"
+                      ? `Weekly (${["Sun","Mon","Tue","Wed","Thu","Fri","Sat"][n.digest_day ?? 1]})`
+                      : n.digest_mode === "off"
+                        ? "Off"
+                        : "Daily"}
+                  </span>
                 </div>
                 {n.last_sent_date && (
                   <div>Last sent: {n.last_sent_date}</div>
@@ -1254,6 +1388,54 @@ function NotificationsSection() {
                 ))}
               </datalist>
             </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-zinc-300 mb-1">Notification Frequency</label>
+            <select
+              value={formDigestMode}
+              onChange={(e) => setFormDigestMode(e.target.value as "daily" | "weekly" | "off")}
+              className="w-full px-3 py-2 bg-zinc-800 border border-white/[0.08] rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-transparent"
+            >
+              <option value="daily">Daily</option>
+              <option value="weekly">Weekly</option>
+              <option value="off">Off</option>
+            </select>
+            {formDigestMode === "weekly" && (
+              <div className="mt-2">
+                <label className="block text-sm font-medium text-zinc-300 mb-1">Send digest on</label>
+                <select
+                  value={formDigestDay}
+                  onChange={(e) => setFormDigestDay(Number(e.target.value))}
+                  className="w-full px-3 py-2 bg-zinc-800 border border-white/[0.08] rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-transparent"
+                >
+                  <option value={0}>Sunday</option>
+                  <option value={1}>Monday</option>
+                  <option value={2}>Tuesday</option>
+                  <option value={3}>Wednesday</option>
+                  <option value={4}>Thursday</option>
+                  <option value={5}>Friday</option>
+                  <option value={6}>Saturday</option>
+                </select>
+                <p className="text-xs text-zinc-500 mt-1">Covers the next 7 days of releases</p>
+              </div>
+            )}
+            {formDigestMode === "off" && (
+              <p className="text-xs text-zinc-500 mt-1">Notifications from this notifier will be suppressed</p>
+            )}
+          </div>
+
+          <div>
+            <label className="flex items-center gap-2 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={formStreamingAlerts}
+                onChange={(e) => setFormStreamingAlerts(e.target.checked)}
+                className="w-4 h-4 rounded accent-amber-500 cursor-pointer"
+              />
+              <span className="text-sm text-zinc-300">Streaming alerts</span>
+            </label>
+            <p className="text-xs text-zinc-500 mt-1 ml-6">Notify when a tracked title becomes available to stream</p>
           </div>
 
           <div className="flex gap-3">

--- a/frontend/src/pages/TitleDetailPage.tsx
+++ b/frontend/src/pages/TitleDetailPage.tsx
@@ -13,6 +13,7 @@ import type {
   ReleaseDatesResult,
   SeasonSummary,
 } from "../types";
+import type { WatchHistoryEntry } from "../types";
 import TrackButton from "../components/TrackButton";
 import RatingButtons from "../components/RatingButtons";
 import PersonCard from "../components/PersonCard";
@@ -214,6 +215,16 @@ function MovieDetail({ data }: { data: MovieDetailsResponse }) {
   const { t } = useTranslation();
   const { title, tmdb, country } = data;
   const [watched, setWatched] = useState(title.is_watched ?? false);
+  const [playCount, setPlayCount] = useState(0);
+  const [watchHistory, setWatchHistory] = useState<WatchHistoryEntry[]>([]);
+  const [historyOpen, setHistoryOpen] = useState(false);
+
+  useEffect(() => {
+    api.getWatchHistory(title.id).then(({ history, playCount: cnt }) => {
+      setWatchHistory(history);
+      setPlayCount(cnt);
+    }).catch(() => {});
+  }, [title.id]);
 
   async function toggleWatched() {
     const prev = watched;
@@ -223,6 +234,10 @@ function MovieDetail({ data }: { data: MovieDetailsResponse }) {
         await api.unwatchMovie(title.id);
       } else {
         await api.watchMovie(title.id);
+        // Refresh history after marking watched
+        const { history, playCount: cnt } = await api.getWatchHistory(title.id);
+        setWatchHistory(history);
+        setPlayCount(cnt);
       }
     } catch {
       setWatched(prev);
@@ -336,8 +351,31 @@ function MovieDetail({ data }: { data: MovieDetailsResponse }) {
               >
                 {watched ? t("episodes.markAsUnwatched") : t("episodes.markAsWatched")}
               </button>
+              {playCount > 0 && (
+                <button
+                  onClick={() => setHistoryOpen((o) => !o)}
+                  className="min-h-8 inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium bg-zinc-800 text-zinc-400 hover:bg-zinc-700 transition-colors cursor-pointer"
+                  title="Watch history"
+                >
+                  <span>Watched {playCount}x</span>
+                  <span className="text-zinc-600">{historyOpen ? "▲" : "▼"}</span>
+                </button>
+              )}
               <WatchButtonGroup offers={title.offers} variant="inline" maxVisible={3} />
             </div>
+            {historyOpen && watchHistory.length > 0 && (
+              <div className="mt-3 rounded-lg bg-zinc-900/60 border border-white/[0.06] overflow-hidden">
+                <div className="px-3 py-2 text-xs font-medium text-zinc-400 border-b border-white/[0.06]">Watch History</div>
+                <ul>
+                  {watchHistory.map((entry, i) => (
+                    <li key={entry.id} className={`px-3 py-2 text-xs text-zinc-300 flex items-center gap-2 ${i < watchHistory.length - 1 ? "border-b border-zinc-800/50" : ""}`}>
+                      <span className="text-zinc-500 shrink-0">{new Date(entry.watchedAt).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" })}</span>
+                      {entry.note && <span className="text-zinc-400 italic">{entry.note}</span>}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -119,6 +119,13 @@ export interface Provider {
   icon_url: string;
 }
 
+export interface WatchHistoryEntry {
+  id: string;
+  watchedAt: string;
+  episodeId: number | null;
+  note: string | null;
+}
+
 // ─── Detail Types ────────────────────────────────────────────────────────────
 
 export interface CastMember {

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -129,10 +129,10 @@ describe("fixSkippedMigrations", () => {
     }>;
     expect(titleCols.some((c) => c.name === "genres")).toBe(false);
 
-    // All 22 migrations should be recorded
+    // All 25 migrations should be recorded
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(22);
+    expect(migrations.cnt).toBe(25);
   });
 });

--- a/server/db/repository/episodes.ts
+++ b/server/db/repository/episodes.ts
@@ -217,6 +217,31 @@ export async function getEpisodeAirDate(episodeId: number): Promise<string | nul
   });
 }
 
+export async function getEpisodeTitleId(episodeId: number): Promise<string | null> {
+  return traceDbQuery("getEpisodeTitleId", async () => {
+    const db = getDb();
+    const row = await db
+      .select({ titleId: episodes.titleId })
+      .from(episodes)
+      .where(eq(episodes.id, episodeId))
+      .get();
+    return row?.titleId ?? null;
+  });
+}
+
+export async function getEpisodeTitleIds(episodeIds: number[]): Promise<Map<number, string>> {
+  return traceDbQuery("getEpisodeTitleIds", async () => {
+    if (episodeIds.length === 0) return new Map();
+    const db = getDb();
+    const rows = await db
+      .select({ id: episodes.id, titleId: episodes.titleId })
+      .from(episodes)
+      .where(inArray(episodes.id, episodeIds))
+      .all();
+    return new Map(rows.map((r) => [r.id, r.titleId]));
+  });
+}
+
 export async function getReleasedEpisodeIds(episodeIds: number[], timezone = "UTC"): Promise<number[]> {
   return traceDbQuery("getReleasedEpisodeIds", async () => {
     const today = localDateForTimezone(timezone);

--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -30,6 +30,8 @@ export {
   deleteEpisodesForTitle,
   getUnwatchedEpisodes,
   getEpisodeAirDate,
+  getEpisodeTitleId,
+  getEpisodeTitleIds,
   getReleasedEpisodeIds,
   watchEpisode,
   unwatchEpisode,
@@ -41,6 +43,12 @@ export {
 } from "./episodes";
 
 export {
+  logWatch,
+  getTitlePlayCount,
+  getTitleWatchHistory,
+} from "./watch-history";
+
+export {
   trackTitle,
   untrackTitle,
   getTrackedTitleIds,
@@ -50,11 +58,13 @@ export {
   updateTrackedVisibility,
   updateAllTrackedVisibility,
   getTrackedMoviesByReleaseDate,
+  getTrackedMoviesByReleaseDateRange,
   getUpcomingTrackedMovies,
   updateTrackedStatus,
   updateNotificationMode,
   getTrackedTitlesForNotifications,
   updateTrackedNotes,
+  getUsersTrackingTitles,
 } from "./tracked";
 export type { UserStatus, NotificationMode } from "./tracked";
 
@@ -118,6 +128,7 @@ export {
   markNotifierSent,
   getDistinctNotifierTimezones,
   getEnabledNotifierSchedules,
+  getStreamingAlertNotifiersForUser,
 } from "./notifiers";
 
 export {
@@ -171,3 +182,8 @@ export {
   disableIntegration,
 } from "./integrations";
 export type { IntegrationConfig, PlexConfig } from "./integrations";
+
+export {
+  getUnalertedProviders,
+  markAlerted,
+} from "./streaming-alerts";

--- a/server/db/repository/notifiers.ts
+++ b/server/db/repository/notifiers.ts
@@ -12,7 +12,10 @@ export async function createNotifier(
   name: string,
   config: Record<string, string>,
   notifyTime: string,
-  timezone: string
+  timezone: string,
+  digestMode?: string | null,
+  digestDay?: number | null,
+  streamingAlertsEnabled = true
 ): Promise<string> {
   return traceDbQuery("createNotifier", async () => {
     const db = getDb();
@@ -26,6 +29,9 @@ export async function createNotifier(
         config: JSON.stringify(config),
         notifyTime,
         timezone,
+        digestMode: digestMode ?? null,
+        digestDay: digestDay ?? null,
+        streamingAlertsEnabled: streamingAlertsEnabled ? 1 : 0,
       })
       .run();
     return id;
@@ -41,6 +47,9 @@ export async function updateNotifier(
     notifyTime?: string;
     timezone?: string;
     enabled?: boolean;
+    digestMode?: string | null;
+    digestDay?: number | null;
+    streamingAlertsEnabled?: boolean;
   }
 ) {
   return traceDbQuery("updateNotifier", async () => {
@@ -51,6 +60,9 @@ export async function updateNotifier(
     if (updates.notifyTime !== undefined) set.notifyTime = updates.notifyTime;
     if (updates.timezone !== undefined) set.timezone = updates.timezone;
     if (updates.enabled !== undefined) set.enabled = updates.enabled ? 1 : 0;
+    if ("digestMode" in updates) set.digestMode = updates.digestMode ?? null;
+    if ("digestDay" in updates) set.digestDay = updates.digestDay ?? null;
+    if (updates.streamingAlertsEnabled !== undefined) set.streamingAlertsEnabled = updates.streamingAlertsEnabled ? 1 : 0;
 
     await db.update(notifiers)
       .set(set)
@@ -82,6 +94,9 @@ export async function getNotifiersByUser(userId: string) {
         timezone: notifiers.timezone,
         enabled: notifiers.enabled,
         last_sent_date: notifiers.lastSentDate,
+        digest_mode: notifiers.digestMode,
+        digest_day: notifiers.digestDay,
+        streaming_alerts_enabled: notifiers.streamingAlertsEnabled,
         created_at: notifiers.createdAt,
         updated_at: notifiers.updatedAt,
       })
@@ -102,6 +117,7 @@ export async function getNotifiersByUser(userId: string) {
         ...row,
         config,
         enabled: Boolean(row.enabled),
+        streaming_alerts_enabled: Boolean(row.streaming_alerts_enabled),
       };
     });
   });
@@ -121,6 +137,9 @@ export async function getNotifierById(id: string, userId: string) {
         timezone: notifiers.timezone,
         enabled: notifiers.enabled,
         last_sent_date: notifiers.lastSentDate,
+        digest_mode: notifiers.digestMode,
+        digest_day: notifiers.digestDay,
+        streaming_alerts_enabled: notifiers.streamingAlertsEnabled,
         created_at: notifiers.createdAt,
         updated_at: notifiers.updatedAt,
       })
@@ -140,6 +159,7 @@ export async function getNotifierById(id: string, userId: string) {
       ...row,
       config,
       enabled: Boolean(row.enabled),
+      streaming_alerts_enabled: Boolean(row.streaming_alerts_enabled),
     };
   });
 }
@@ -161,6 +181,9 @@ export async function getDueNotifiers(
         notify_time: notifiers.notifyTime,
         timezone: notifiers.timezone,
         last_sent_date: notifiers.lastSentDate,
+        digest_mode: notifiers.digestMode,
+        digest_day: notifiers.digestDay,
+        streaming_alerts_enabled: notifiers.streamingAlertsEnabled,
       })
       .from(notifiers)
       .where(eq(notifiers.enabled, 1))
@@ -235,5 +258,35 @@ export async function getEnabledNotifierSchedules(): Promise<{ notify_time: stri
       .where(eq(notifiers.enabled, 1))
       .all();
     return rows;
+  });
+}
+
+/**
+ * Returns all enabled notifiers for a user that have streaming alerts enabled.
+ * Used during sync to dispatch streaming availability notifications.
+ */
+export async function getStreamingAlertNotifiersForUser(userId: string) {
+  return traceDbQuery("getStreamingAlertNotifiersForUser", async () => {
+    const db = getDb();
+    const rows = await db
+      .select({
+        id: notifiers.id,
+        user_id: notifiers.userId,
+        provider: notifiers.provider,
+        config: notifiers.config,
+      })
+      .from(notifiers)
+      .where(and(eq(notifiers.userId, userId), eq(notifiers.enabled, 1), eq(notifiers.streamingAlertsEnabled, 1)))
+      .all();
+    return rows.map((row) => {
+      let config: Record<string, string>;
+      try {
+        config = JSON.parse(row.config);
+      } catch {
+        log.warn("Failed to parse notifier config", { id: row.id });
+        config = {};
+      }
+      return { ...row, config };
+    });
   });
 }

--- a/server/db/repository/streaming-alerts.test.ts
+++ b/server/db/repository/streaming-alerts.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
+import { createUser, upsertTitles } from "../repository";
+import { makeParsedTitle } from "../../test-utils/fixtures";
+import { getUnalertedProviders, markAlerted } from "./streaming-alerts";
+
+let userId: string;
+const TITLE_ID = "movie-streaming-1";
+
+beforeEach(async () => {
+  setupTestDb();
+  userId = await createUser("alertuser", "hash");
+  await upsertTitles([makeParsedTitle({ id: TITLE_ID, title: "Streaming Movie" })]);
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+describe("getUnalertedProviders", () => {
+  it("returns all providerIds when none have been alerted", async () => {
+    const result = await getUnalertedProviders(userId, TITLE_ID, [8, 119, 337]);
+    expect(result).toEqual([8, 119, 337]);
+  });
+
+  it("returns empty array when providerIds is empty", async () => {
+    const result = await getUnalertedProviders(userId, TITLE_ID, []);
+    expect(result).toEqual([]);
+  });
+
+  it("excludes already-alerted providerIds", async () => {
+    await markAlerted(userId, TITLE_ID, 8, "Netflix");
+    const result = await getUnalertedProviders(userId, TITLE_ID, [8, 119, 337]);
+    expect(result).not.toContain(8);
+    expect(result).toContain(119);
+    expect(result).toContain(337);
+  });
+
+  it("returns empty array when all providers have been alerted", async () => {
+    await markAlerted(userId, TITLE_ID, 8, "Netflix");
+    await markAlerted(userId, TITLE_ID, 119, "Amazon Prime");
+    const result = await getUnalertedProviders(userId, TITLE_ID, [8, 119]);
+    expect(result).toEqual([]);
+  });
+
+  it("is scoped per user — other user's alerts don't affect this user", async () => {
+    const otherUserId = await createUser("otheruser", "hash");
+    await markAlerted(otherUserId, TITLE_ID, 8, "Netflix");
+    // userId has NOT been alerted, so 8 should still show as unalerted
+    const result = await getUnalertedProviders(userId, TITLE_ID, [8]);
+    expect(result).toContain(8);
+  });
+
+  it("is scoped per title — alerts for other titles don't affect this title", async () => {
+    const OTHER_TITLE_ID = "movie-streaming-2";
+    await upsertTitles([makeParsedTitle({ id: OTHER_TITLE_ID, title: "Other Movie" })]);
+    await markAlerted(userId, OTHER_TITLE_ID, 8, "Netflix");
+    // TITLE_ID has NOT been alerted for provider 8
+    const result = await getUnalertedProviders(userId, TITLE_ID, [8]);
+    expect(result).toContain(8);
+  });
+});
+
+describe("markAlerted", () => {
+  it("marks a provider as alerted", async () => {
+    await markAlerted(userId, TITLE_ID, 8, "Netflix");
+    const result = await getUnalertedProviders(userId, TITLE_ID, [8]);
+    expect(result).toEqual([]);
+  });
+
+  it("is idempotent — calling twice does not throw", async () => {
+    await markAlerted(userId, TITLE_ID, 8, "Netflix");
+    await markAlerted(userId, TITLE_ID, 8, "Netflix");
+    const result = await getUnalertedProviders(userId, TITLE_ID, [8]);
+    expect(result).toEqual([]);
+  });
+});

--- a/server/db/repository/streaming-alerts.ts
+++ b/server/db/repository/streaming-alerts.ts
@@ -1,0 +1,58 @@
+import { eq, and, inArray } from "drizzle-orm";
+import { getDb } from "../schema";
+import { streamingAlerts } from "../schema";
+import { traceDbQuery } from "../../tracing";
+
+/**
+ * Returns the subset of providerIds that have NOT yet been alerted for
+ * the given (userId, titleId) combination.
+ */
+export async function getUnalertedProviders(
+  userId: string,
+  titleId: string,
+  providerIds: number[]
+): Promise<number[]> {
+  return traceDbQuery("getUnalertedProviders", async () => {
+    if (providerIds.length === 0) return [];
+    const db = getDb();
+    const alreadyAlerted = await db
+      .select({ providerId: streamingAlerts.providerId })
+      .from(streamingAlerts)
+      .where(
+        and(
+          eq(streamingAlerts.userId, userId),
+          eq(streamingAlerts.titleId, titleId),
+          inArray(streamingAlerts.providerId, providerIds)
+        )
+      )
+      .all();
+    const alerted = new Set(alreadyAlerted.map((r) => r.providerId));
+    return providerIds.filter((id) => !alerted.has(id));
+  });
+}
+
+/**
+ * Marks a (userId, titleId, providerId) triple as alerted so we don't
+ * send duplicate notifications.
+ */
+export async function markAlerted(
+  userId: string,
+  titleId: string,
+  providerId: number,
+  providerName: string
+): Promise<void> {
+  return traceDbQuery("markAlerted", async () => {
+    const db = getDb();
+    await db
+      .insert(streamingAlerts)
+      .values({
+        id: crypto.randomUUID(),
+        userId,
+        titleId,
+        providerId,
+        providerName,
+      })
+      .onConflictDoNothing()
+      .run();
+  });
+}

--- a/server/db/repository/tracked.ts
+++ b/server/db/repository/tracked.ts
@@ -1,4 +1,4 @@
-import { eq, and, sql, desc, gte, lt, asc } from "drizzle-orm";
+import { eq, and, sql, desc, gte, lt, asc, inArray } from "drizzle-orm";
 import { getDb } from "../schema";
 import { titles, scores, tracked, watchedTitles } from "../schema";
 import { traceDbQuery } from "../../tracing";
@@ -306,5 +306,62 @@ export async function updateTrackedNotes(titleId: string, userId: string, notes:
       .set({ notes })
       .where(and(eq(tracked.titleId, titleId), eq(tracked.userId, userId)))
       .run();
+  });
+}
+
+/**
+ * Get tracked movies releasing within [startDate, endDate) for a user.
+ * Used for weekly digest notifications.
+ */
+export async function getTrackedMoviesByReleaseDateRange(startDate: string, endDate: string, userId: string) {
+  return traceDbQuery("getTrackedMoviesByReleaseDateRange", async () => {
+    const db = getDb();
+    const rows = await db
+      .select({
+        id: titles.id,
+        title: titles.title,
+        release_year: titles.releaseYear,
+        release_date: titles.releaseDate,
+        poster_url: titles.posterUrl,
+      })
+      .from(titles)
+      .innerJoin(tracked, and(eq(tracked.titleId, titles.id), eq(tracked.userId, userId)))
+      .where(
+        and(
+          gte(titles.releaseDate, startDate),
+          lt(titles.releaseDate, endDate),
+          eq(titles.objectType, "MOVIE")
+        )
+      )
+      .all();
+
+    const offersByTitle = await getOffersWithPlex(rows.map((r) => r.id), userId);
+    return rows.map((row) => ({
+      ...row,
+      offers: offersByTitle.get(row.id) ?? [],
+    }));
+  });
+}
+
+/**
+ * Returns a map of titleId -> userIds for all users tracking any of the given titleIds.
+ * Used during sync to find who should receive streaming availability alerts.
+ */
+export async function getUsersTrackingTitles(titleIds: string[]): Promise<Map<string, string[]>> {
+  return traceDbQuery("getUsersTrackingTitles", async () => {
+    if (titleIds.length === 0) return new Map();
+    const db = getDb();
+    const rows = await db
+      .select({ titleId: tracked.titleId, userId: tracked.userId })
+      .from(tracked)
+      .where(inArray(tracked.titleId, titleIds))
+      .all();
+    const map = new Map<string, string[]>();
+    for (const row of rows) {
+      const list = map.get(row.titleId) ?? [];
+      list.push(row.userId);
+      map.set(row.titleId, list);
+    }
+    return map;
   });
 }

--- a/server/db/repository/watch-history.ts
+++ b/server/db/repository/watch-history.ts
@@ -1,0 +1,52 @@
+import { eq, and, count, desc } from "drizzle-orm";
+import { getDb } from "../schema";
+import { watchHistory } from "../schema";
+import { traceDbQuery } from "../../tracing";
+import { randomUUID } from "node:crypto";
+
+export async function logWatch(userId: string, titleId: string, episodeId?: number): Promise<void> {
+  return traceDbQuery("logWatch", async () => {
+    const db = getDb();
+    await db.insert(watchHistory)
+      .values({
+        id: randomUUID(),
+        userId,
+        titleId,
+        episodeId: episodeId ?? null,
+      })
+      .run();
+  });
+}
+
+export async function getTitlePlayCount(userId: string, titleId: string): Promise<number> {
+  return traceDbQuery("getTitlePlayCount", async () => {
+    const db = getDb();
+    const row = await db
+      .select({ cnt: count() })
+      .from(watchHistory)
+      .where(and(eq(watchHistory.userId, userId), eq(watchHistory.titleId, titleId)))
+      .get();
+    return row?.cnt ?? 0;
+  });
+}
+
+export async function getTitleWatchHistory(
+  userId: string,
+  titleId: string
+): Promise<{ id: string; watchedAt: string; episodeId: number | null; note: string | null }[]> {
+  return traceDbQuery("getTitleWatchHistory", async () => {
+    const db = getDb();
+    const rows = await db
+      .select({
+        id: watchHistory.id,
+        watchedAt: watchHistory.watchedAt,
+        episodeId: watchHistory.episodeId,
+        note: watchHistory.note,
+      })
+      .from(watchHistory)
+      .where(and(eq(watchHistory.userId, userId), eq(watchHistory.titleId, titleId)))
+      .orderBy(desc(watchHistory.watchedAt))
+      .all();
+    return rows;
+  });
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -288,6 +288,9 @@ export const notifiers = sqliteTable(
     timezone: text("timezone").notNull().default("UTC"),
     enabled: integer("enabled").notNull().default(1),
     lastSentDate: text("last_sent_date"),
+    digestMode: text("digest_mode"),
+    digestDay: integer("digest_day"),
+    streamingAlertsEnabled: integer("streaming_alerts_enabled").notNull().default(1),
     createdAt: text("created_at").default(sql`(datetime('now'))`),
     updatedAt: text("updated_at").default(sql`(datetime('now'))`),
   },
@@ -478,6 +481,36 @@ export const titleTags = sqliteTable(
   ]
 );
 
+export const watchHistory = sqliteTable(
+  "watch_history",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id").notNull(),
+    titleId: text("title_id").notNull(),
+    episodeId: integer("episode_id"),
+    watchedAt: text("watched_at").notNull().default(sql`(datetime('now'))`),
+    note: text("note"),
+  },
+  (table) => [
+    index("watch_history_user_title").on(table.userId, table.titleId),
+  ]
+);
+
+export const streamingAlerts = sqliteTable(
+  "streaming_alerts",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id").notNull(),
+    titleId: text("title_id").notNull(),
+    providerId: integer("provider_id").notNull(),
+    providerName: text("provider_name").notNull(),
+    alertedAt: text("alerted_at").notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    index("idx_streaming_alerts_user_title").on(table.userId, table.titleId),
+  ]
+);
+
 // ─── Relations ──────────────────────────────────────────────────────────────
 
 export const titlesRelations = relations(titles, ({ many, one }) => ({
@@ -599,6 +632,7 @@ export const passkeyRelations = relations(passkey, ({ one }) => ({
 export const schemaExports = {
   titles, providers, offers, scores, titleGenres, episodes, users, sessions, account, verification, passkey, settings, tracked, watchedEpisodes, watchedTitles, notifiers, oidcStates, jobs, cronJobs,
   follows, ratings, recommendations, recommendationReads, invitations, integrations, plexLibraryItems, titleTags,
+  watchHistory, streamingAlerts,
   titlesRelations, providersRelations, offersRelations, scoresRelations, titleGenresRelations, episodesRelations,
   passkeyRelations,
   usersRelations, sessionsRelations, accountRelations, trackedRelations, watchedEpisodesRelations, watchedTitlesRelations, notifiersRelations,

--- a/server/index.ts
+++ b/server/index.ts
@@ -23,6 +23,7 @@ import browseRoutes from "./routes/browse";
 import detailsRoutes from "./routes/details";
 import notifierRoutes from "./routes/notifiers";
 import integrationRoutes from "./routes/integrations";
+import importRoutes from "./routes/import";
 import profileRoutes from "./routes/profile";
 import socialRoutes from "./routes/social";
 import ratingsRoutes from "./routes/ratings";
@@ -211,6 +212,10 @@ app.route("/api/notifiers", notifierRoutes);
 app.use("/api/integrations/*", requireAuth);
 app.use("/api/integrations", requireAuth);
 app.route("/api/integrations", integrationRoutes);
+
+app.use("/api/import/*", requireAuth);
+app.use("/api/import", requireAuth);
+app.route("/api/import", importRoutes);
 
 app.use("/api/stats/*", requireAuth);
 app.use("/api/stats", requireAuth);

--- a/server/jobs/check-streaming-alerts.ts
+++ b/server/jobs/check-streaming-alerts.ts
@@ -1,0 +1,111 @@
+import { logger } from "../logger";
+import {
+  getOffersForTitles,
+  getUsersTrackingTitles,
+  getUnalertedProviders,
+  markAlerted,
+  getStreamingAlertNotifiersForUser,
+  getTitleById,
+} from "../db/repository";
+import { getProvider } from "../notifications/registry";
+
+const log = logger.child({ module: "streaming-alerts" });
+
+/**
+ * After a batch of titles has been upserted, check whether any tracked title
+ * has new flatrate/free streaming offers for any user. If so, send an
+ * immediate notification via each user's enabled streaming-alert notifiers.
+ */
+export async function checkStreamingAlerts(titleIds: string[]): Promise<void> {
+  if (titleIds.length === 0) return;
+
+  // 1. Get all current offers for these titles
+  const offersByTitle = await getOffersForTitles(titleIds);
+
+  // 2. Find titles that have flatrate/free offers
+  const titlesWithStreamingOffers = titleIds.filter((id) => {
+    const titleOffers = offersByTitle.get(id) ?? [];
+    return titleOffers.some(
+      (o) => o.monetization_type === "FLATRATE" || o.monetization_type === "FREE"
+    );
+  });
+  if (titlesWithStreamingOffers.length === 0) return;
+
+  // 3. Find users tracking these titles
+  const trackersByTitle = await getUsersTrackingTitles(titlesWithStreamingOffers);
+  if (trackersByTitle.size === 0) return;
+
+  for (const [titleId, userIds] of trackersByTitle) {
+    const titleOffers = offersByTitle.get(titleId) ?? [];
+    const streamingProviders = titleOffers
+      .filter((o) => o.monetization_type === "FLATRATE" || o.monetization_type === "FREE")
+      .map((o) => ({ id: o.provider_id!, name: o.provider_name }))
+      .filter((p) => p.id != null);
+
+    if (streamingProviders.length === 0) continue;
+
+    const providerIds = streamingProviders.map((p) => p.id);
+
+    for (const userId of userIds) {
+      // 4. Find providers not yet alerted for this (user, title)
+      const newProviderIds = await getUnalertedProviders(userId, titleId, providerIds);
+      if (newProviderIds.length === 0) continue;
+
+      // 5. Get enabled streaming-alert notifiers for this user
+      const userNotifiers = await getStreamingAlertNotifiersForUser(userId);
+
+      // 6. Fetch title info for the notification message
+      const titleRow = await getTitleById(titleId);
+      if (!titleRow) continue;
+
+      const today = new Date().toISOString().slice(0, 10);
+
+      for (const pid of newProviderIds) {
+        const provider = streamingProviders.find((sp) => sp.id === pid);
+        if (!provider) continue;
+
+        if (userNotifiers.length > 0) {
+          const content = {
+            episodes: [] as never[],
+            movies: [] as never[],
+            date: today,
+            streamingAlerts: [
+              {
+                titleId,
+                title: titleRow.title,
+                posterUrl: titleRow.poster_url,
+                providerName: provider.name,
+              },
+            ],
+          };
+
+          for (const notifier of userNotifiers) {
+            const notifierProvider = getProvider(notifier.provider);
+            if (!notifierProvider) continue;
+            try {
+              await notifierProvider.send(notifier.config, content);
+              log.info("Sent streaming alert", {
+                userId,
+                titleId,
+                title: titleRow.title,
+                provider: provider.name,
+              });
+            } catch (err) {
+              const message = err instanceof Error ? err.message : String(err);
+              log.error("Failed to send streaming alert", {
+                notifierId: notifier.id,
+                userId,
+                titleId,
+                error: message,
+              });
+            }
+          }
+        }
+
+        // Mark as alerted regardless of whether we had notifiers
+        // (so we don't re-send if user adds a notifier later for already-available titles)
+        await markAlerted(userId, titleId, pid, provider.name);
+      }
+    }
+  }
+}

--- a/server/jobs/notifications.ts
+++ b/server/jobs/notifications.ts
@@ -7,7 +7,7 @@ import {
   disableNotifier,
 } from "../db/repository";
 import { getProvider } from "../notifications/registry";
-import { buildNotificationContent } from "../notifications/content";
+import { buildNotificationContent, buildWeeklyDigestContent } from "../notifications/content";
 import { SubscriptionExpiredError } from "../notifications/webpush";
 import { refreshNotificationSchedule } from "./schedule";
 
@@ -67,6 +67,46 @@ export async function registerNotificationJobs() {
             continue;
           }
 
+          // Weekly digest: only send if today matches the configured digest_day
+          if (notifier.digest_mode === "weekly") {
+            const tzInfo = timesByTimezone.get(notifier.timezone);
+            if (!tzInfo) continue;
+
+            const todayDayOfWeek = new Date(tzInfo.date + "T00:00:00Z").getUTCDay();
+            if (notifier.digest_day !== todayDayOfWeek) {
+              // Not the right day — skip without marking sent so we retry tomorrow
+              continue;
+            }
+
+            // Build content for the next 7 days
+            const endDate = new Date(tzInfo.date + "T00:00:00Z");
+            endDate.setUTCDate(endDate.getUTCDate() + 7);
+            const endDateStr = endDate.toISOString().slice(0, 10);
+
+            const content = await buildWeeklyDigestContent(
+              notifier.user_id,
+              tzInfo.date,
+              endDateStr
+            );
+
+            if (content.episodes.length === 0 && content.movies.length === 0) {
+              await markNotifierSent(notifier.id, notifier.todayDate);
+              continue;
+            }
+
+            await provider.send(notifier.config, content);
+            await markNotifierSent(notifier.id, notifier.todayDate);
+            log.info("Sent weekly digest notification", { provider: notifier.provider, userId: notifier.user_id });
+            continue;
+          }
+
+          // "off" mode: do nothing, just mark as sent to prevent re-firing
+          if (notifier.digest_mode === "off") {
+            await markNotifierSent(notifier.id, notifier.todayDate);
+            continue;
+          }
+
+          // Default daily behavior
           const content = await buildNotificationContent(
             notifier.user_id,
             notifier.todayDate

--- a/server/jobs/streaming-alerts.test.ts
+++ b/server/jobs/streaming-alerts.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, mock, spyOn } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import {
+  createUser,
+  upsertTitles,
+  trackTitle,
+  createNotifier,
+  getUnalertedProviders,
+} from "../db/repository";
+import { makeParsedTitle, makeParsedOffer } from "../test-utils/fixtures";
+
+// We import the internals we need to test. Since checkStreamingAlerts is not
+// exported, we test it indirectly via getUnalertedProviders state changes and
+// by verifying that the notification provider send() is called.
+import * as registry from "../notifications/registry";
+
+let userId: string;
+const TITLE_ID = "movie-streaming-test";
+const PROVIDER_ID = 8;
+const PROVIDER_NAME = "Netflix";
+let spies: ReturnType<typeof spyOn>[] = [];
+
+beforeEach(async () => {
+  setupTestDb();
+  userId = await createUser("streamalertuser", "hash");
+});
+
+afterEach(() => {
+  spies.forEach((s) => s.mockRestore());
+  spies = [];
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+describe("getStreamingAlertNotifiersForUser", () => {
+  it("returns notifiers with streaming_alerts_enabled=true", async () => {
+    const { getStreamingAlertNotifiersForUser } = await import("../db/repository/notifiers");
+    await createNotifier(userId, "discord", "Discord", { webhookUrl: "https://discord.com/api/webhooks/1/a" }, "09:00", "UTC");
+    const notifiers = await getStreamingAlertNotifiersForUser(userId);
+    expect(notifiers).toHaveLength(1);
+    expect(notifiers[0].provider).toBe("discord");
+  });
+
+  it("excludes notifiers with streaming_alerts_enabled=false", async () => {
+    const { getStreamingAlertNotifiersForUser } = await import("../db/repository/notifiers");
+    const id = await createNotifier(userId, "discord", "Discord", { webhookUrl: "https://discord.com/api/webhooks/1/a" }, "09:00", "UTC");
+    // Update to disable streaming alerts
+    const { updateNotifier } = await import("../db/repository/notifiers");
+    await updateNotifier(id, userId, { streamingAlertsEnabled: false });
+    const notifiers = await getStreamingAlertNotifiersForUser(userId);
+    expect(notifiers).toHaveLength(0);
+  });
+
+  it("excludes disabled notifiers", async () => {
+    const { getStreamingAlertNotifiersForUser } = await import("../db/repository/notifiers");
+    const id = await createNotifier(userId, "discord", "Discord", { webhookUrl: "https://discord.com/api/webhooks/1/a" }, "09:00", "UTC");
+    const { updateNotifier } = await import("../db/repository/notifiers");
+    await updateNotifier(id, userId, { enabled: false });
+    const notifiers = await getStreamingAlertNotifiersForUser(userId);
+    expect(notifiers).toHaveLength(0);
+  });
+});
+
+describe("streaming alert flow via sync", () => {
+  it("marks providers as alerted after sync and does not re-alert on next sync", async () => {
+    // Set up a title with a flatrate offer
+    await upsertTitles([
+      makeParsedTitle({
+        id: TITLE_ID,
+        title: "New on Netflix",
+        offers: [
+          makeParsedOffer({
+            titleId: TITLE_ID,
+            providerId: PROVIDER_ID,
+            providerName: PROVIDER_NAME,
+            monetizationType: "FLATRATE",
+          }),
+        ],
+      }),
+    ]);
+
+    // User tracks the title
+    await trackTitle(TITLE_ID, userId);
+
+    // User has a notifier with streaming alerts enabled
+    const sendFn = mock(async () => {});
+    spies.push(spyOn(registry, "getProvider").mockReturnValue({
+      name: "discord",
+      send: sendFn,
+      validateConfig: () => ({ valid: true }),
+    } as any));
+
+    await createNotifier(userId, "discord", "Discord", { webhookUrl: "https://discord.com/api/webhooks/1/a" }, "09:00", "UTC");
+
+    // Simulate what checkStreamingAlerts does by importing and calling it
+    // We use the internal module directly for white-box testing
+    const { checkStreamingAlerts } = await import("./check-streaming-alerts");
+    await checkStreamingAlerts([TITLE_ID]);
+
+    // Verify send was called once
+    expect(sendFn).toHaveBeenCalledTimes(1);
+    const content = (sendFn.mock.calls[0] as any[])[1] as any;
+    expect(content.streamingAlerts).toHaveLength(1);
+    expect(content.streamingAlerts[0].providerName).toBe(PROVIDER_NAME);
+
+    // After alerting, the provider should be marked
+    const unalerted = await getUnalertedProviders(userId, TITLE_ID, [PROVIDER_ID]);
+    expect(unalerted).toEqual([]);
+
+    // Second call should NOT send again
+    sendFn.mockClear();
+    await checkStreamingAlerts([TITLE_ID]);
+    expect(sendFn).toHaveBeenCalledTimes(0);
+  });
+
+  it("does not alert when title has no flatrate/free offers", async () => {
+    await upsertTitles([
+      makeParsedTitle({
+        id: TITLE_ID,
+        title: "Rental Only",
+        offers: [
+          makeParsedOffer({
+            titleId: TITLE_ID,
+            providerId: PROVIDER_ID,
+            providerName: PROVIDER_NAME,
+            monetizationType: "RENT",
+          }),
+        ],
+      }),
+    ]);
+
+    await trackTitle(TITLE_ID, userId);
+
+    const sendFn = mock(async () => {});
+    spies.push(spyOn(registry, "getProvider").mockReturnValue({
+      name: "discord",
+      send: sendFn,
+      validateConfig: () => ({ valid: true }),
+    } as any));
+
+    await createNotifier(userId, "discord", "Discord", { webhookUrl: "https://discord.com/api/webhooks/1/a" }, "09:00", "UTC");
+
+    const { checkStreamingAlerts } = await import("./check-streaming-alerts");
+    await checkStreamingAlerts([TITLE_ID]);
+
+    expect(sendFn).toHaveBeenCalledTimes(0);
+  });
+});

--- a/server/jobs/sync.ts
+++ b/server/jobs/sync.ts
@@ -3,6 +3,7 @@ import { registerHandler } from "./worker";
 import { getEnabledIntegrationsByProvider } from "../db/repository";
 import { syncPlexWatched } from "../plex/sync";
 import { syncPlexLibrary } from "../plex/library-sync";
+import { checkStreamingAlerts } from "./check-streaming-alerts";
 
 const log = logger.child({ module: "sync" });
 import { registerCron, enqueueJob, hasActiveJob } from "./queue";
@@ -24,8 +25,10 @@ export function registerSyncJobs() {
 
   registerHandler("sync-titles", async () => {
     const titles = await fetchNewReleases({ daysBack: CONFIG.DEFAULT_DAYS_BACK });
+    const titleIds = titles.map((t) => t.id);
     const count = await upsertTitles(titles);
     log.info("Synced titles from TMDB", { count });
+    await checkStreamingAlerts(titleIds);
   });
 
   registerHandler("sync-episodes", async () => {

--- a/server/notifications/content.test.ts
+++ b/server/notifications/content.test.ts
@@ -7,7 +7,7 @@ import {
   createUser,
   trackTitle,
 } from "../db/repository";
-import { buildNotificationContent } from "./content";
+import { buildNotificationContent, buildWeeklyDigestContent } from "./content";
 
 let userId: string;
 
@@ -122,5 +122,115 @@ describe("buildNotificationContent", () => {
 
     const otherContent = await buildNotificationContent(otherUserId, today);
     expect(otherContent.movies).toHaveLength(1);
+  });
+});
+
+describe("buildWeeklyDigestContent", () => {
+  it("returns episodes across the date range for tracked shows", async () => {
+    const startDate = "2026-04-07";
+    const endDate = "2026-04-14";
+
+    await upsertTitles([
+      makeParsedTitle({
+        id: "show-w1",
+        objectType: "SHOW",
+        title: "Weekly Show",
+        releaseDate: "2026-01-01",
+      }),
+    ]);
+    await trackTitle("show-w1", userId);
+
+    await upsertEpisodes([
+      {
+        title_id: "show-w1",
+        season_number: 1,
+        episode_number: 1,
+        name: "Episode One",
+        overview: null,
+        air_date: "2026-04-08",
+        still_path: null,
+      },
+      {
+        title_id: "show-w1",
+        season_number: 1,
+        episode_number: 2,
+        name: "Episode Two",
+        overview: null,
+        air_date: "2026-04-11",
+        still_path: null,
+      },
+    ]);
+
+    const content = await buildWeeklyDigestContent(userId, startDate, endDate);
+
+    expect(content.episodes).toHaveLength(2);
+    expect(content.episodes[0].showTitle).toBe("Weekly Show");
+    expect(content.date).toBe(startDate);
+  });
+
+  it("returns tracked movies releasing within the date range", async () => {
+    const startDate = "2026-04-07";
+    const endDate = "2026-04-14";
+
+    await upsertTitles([
+      makeParsedTitle({
+        id: "movie-w1",
+        objectType: "MOVIE",
+        title: "Week Movie",
+        releaseDate: "2026-04-10",
+        releaseYear: 2026,
+      }),
+    ]);
+    await trackTitle("movie-w1", userId);
+
+    const content = await buildWeeklyDigestContent(userId, startDate, endDate);
+
+    expect(content.movies).toHaveLength(1);
+    expect(content.movies[0].title).toBe("Week Movie");
+  });
+
+  it("excludes movies outside the date range", async () => {
+    const startDate = "2026-04-07";
+    const endDate = "2026-04-14";
+
+    await upsertTitles([
+      makeParsedTitle({
+        id: "movie-w2",
+        objectType: "MOVIE",
+        title: "Outside Range Movie",
+        releaseDate: "2026-04-15",
+        releaseYear: 2026,
+      }),
+    ]);
+    await trackTitle("movie-w2", userId);
+
+    const content = await buildWeeklyDigestContent(userId, startDate, endDate);
+
+    expect(content.movies).toHaveLength(0);
+  });
+
+  it("returns empty content when nothing is in range", async () => {
+    const content = await buildWeeklyDigestContent(userId, "2026-04-07", "2026-04-14");
+
+    expect(content.episodes).toHaveLength(0);
+    expect(content.movies).toHaveLength(0);
+  });
+
+  it("does not include untracked titles", async () => {
+    const startDate = "2026-04-07";
+    const endDate = "2026-04-14";
+
+    await upsertTitles([
+      makeParsedTitle({
+        id: "movie-w3",
+        objectType: "MOVIE",
+        title: "Untracked Week Movie",
+        releaseDate: "2026-04-10",
+      }),
+    ]);
+    // Intentionally NOT tracking
+
+    const content = await buildWeeklyDigestContent(userId, startDate, endDate);
+    expect(content.movies).toHaveLength(0);
   });
 });

--- a/server/notifications/content.ts
+++ b/server/notifications/content.ts
@@ -1,6 +1,7 @@
 import {
   getEpisodesByDateRange,
   getTrackedMoviesByReleaseDate,
+  getTrackedMoviesByReleaseDateRange,
 } from "../db/repository";
 import type { NotificationContent } from "./types";
 
@@ -47,4 +48,49 @@ export async function buildNotificationContent(
   }));
 
   return { episodes, movies, date };
+}
+
+/**
+ * Builds notification content covering a date range (e.g. next 7 days for weekly digest).
+ * startDate is inclusive, endDate is exclusive.
+ */
+export async function buildWeeklyDigestContent(
+  userId: string,
+  startDate: string,
+  endDate: string
+): Promise<NotificationContent> {
+  // Episodes airing in the range for tracked shows
+  const rawEpisodes = await getEpisodesByDateRange(startDate, endDate, userId);
+  const episodes = rawEpisodes
+    .filter((ep) => {
+      const mode = ep.notification_mode;
+      if (mode === "none") return false;
+      if (mode === "premieres_only") return ep.episode_number === 1;
+      return true; // "all" or null
+    })
+    .map((ep) => ({
+      showTitle: ep.show_title,
+      seasonNumber: ep.season_number,
+      episodeNumber: ep.episode_number,
+      episodeName: ep.name,
+      posterUrl: ep.poster_url,
+      offers: (ep.offers || []).map((o) => ({
+        providerName: o.provider_name,
+        providerIconUrl: o.provider_icon_url,
+      })),
+    }));
+
+  // Tracked movies releasing in the range
+  const rawMovies = await getTrackedMoviesByReleaseDateRange(startDate, endDate, userId);
+  const movies = rawMovies.map((m) => ({
+    title: m.title,
+    releaseYear: m.release_year,
+    posterUrl: m.poster_url,
+    offers: (m.offers || []).map((o) => ({
+      providerName: o.provider_name,
+      providerIconUrl: o.provider_icon_url,
+    })),
+  }));
+
+  return { episodes, movies, date: startDate };
 }

--- a/server/notifications/discord.ts
+++ b/server/notifications/discord.ts
@@ -53,9 +53,9 @@ export class DiscordProvider implements NotificationProvider {
 
   private buildEmbeds(content: NotificationContent) {
     const embeds: any[] = [];
-    const { episodes, movies, date } = content;
+    const { episodes, movies, date, streamingAlerts = [] } = content;
 
-    if (episodes.length === 0 && movies.length === 0) return [];
+    if (episodes.length === 0 && movies.length === 0 && streamingAlerts.length === 0) return [];
 
     // Header embed
     const parts: string[] = [];
@@ -66,11 +66,18 @@ export class DiscordProvider implements NotificationProvider {
       parts.push(`${movies.length} movie${movies.length !== 1 ? "s" : ""}`);
     }
 
-    embeds.push({
-      title: `📺 Releases for ${date}`,
-      description: `${parts.join(" and ")} releasing today`,
-      color: EMBED_COLOR,
-    });
+    if (streamingAlerts.length > 0 || parts.length > 0) {
+      const descParts: string[] = [];
+      if (parts.length > 0) descParts.push(`${parts.join(" and ")} releasing today`);
+      if (streamingAlerts.length > 0) {
+        descParts.push(`${streamingAlerts.length} title${streamingAlerts.length !== 1 ? "s" : ""} now streaming`);
+      }
+      embeds.push({
+        title: `📺 Releases for ${date}`,
+        description: descParts.join(" · "),
+        color: EMBED_COLOR,
+      });
+    }
 
     // Episode embeds (grouped by show)
     const showMap = new Map<
@@ -133,6 +140,21 @@ export class DiscordProvider implements NotificationProvider {
         embed.footer = { text: `Available on: ${providers}` };
       }
 
+      embeds.push(embed);
+    }
+
+    // Streaming alert embeds
+    for (const alert of streamingAlerts) {
+      const embed: any = {
+        title: `🎬 ${alert.title}`,
+        description: `Now available on **${alert.providerName}**`,
+        color: EMBED_COLOR,
+      };
+      if (alert.posterUrl) {
+        embed.thumbnail = {
+          url: `${CONFIG.TMDB_IMAGE_BASE_URL}/w185${alert.posterUrl}`,
+        };
+      }
       embeds.push(embed);
     }
 

--- a/server/notifications/types.ts
+++ b/server/notifications/types.ts
@@ -14,10 +14,18 @@ export interface NotificationMovie {
   offers: Array<{ providerName: string; providerIconUrl: string | null }>;
 }
 
+export interface NotificationStreamingAlert {
+  titleId: string;
+  title: string;
+  posterUrl: string | null;
+  providerName: string;
+}
+
 export interface NotificationContent {
   episodes: NotificationEpisode[];
   movies: NotificationMovie[];
   date: string;
+  streamingAlerts?: NotificationStreamingAlert[];
 }
 
 export interface NotificationProvider {

--- a/server/routes/import.test.ts
+++ b/server/routes/import.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, spyOn } from "bun:test";
+import { Hono } from "hono";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { makeParsedTitle } from "../test-utils/fixtures";
+import { createUser, createSession, getSessionWithUser } from "../db/repository";
+import { requireAuth } from "../middleware/auth";
+import * as resolver from "../imdb/resolver";
+import * as repository from "../db/repository";
+import type { AppEnv } from "../types";
+import { parseCsv, detectCsvFormat, extractImdbIdFromRow, type CsvFormat } from "./import";
+
+// ─── Auth helper ───────────────────────────────────────────────────────────
+
+function createMockAuth() {
+  return {
+    api: {
+      getSession: async ({ headers }: { headers: Headers }) => {
+        const cookieHeader = headers.get("cookie") || "";
+        const match = cookieHeader.match(/better-auth\.session_token=([^;]+)/);
+        const token = match?.[1];
+        if (!token) return null;
+        const user = await getSessionWithUser(token);
+        if (!user) return null;
+        return {
+          session: { id: "session-id", userId: user.id },
+          user: {
+            id: user.id,
+            name: user.display_name,
+            username: user.username,
+            role: user.role || (user.is_admin ? "admin" : "user"),
+          },
+        };
+      },
+    },
+  };
+}
+
+// ─── CSV unit tests ─────────────────────────────────────────────────────────
+
+describe("parseCsv", () => {
+  it("parses a simple CSV", () => {
+    const csv = "Name,Year\nInception,2010\nDune,2021";
+    const rows = parseCsv(csv);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toEqual({ Name: "Inception", Year: "2010" });
+    expect(rows[1]).toEqual({ Name: "Dune", Year: "2021" });
+  });
+
+  it("handles quoted fields with commas", () => {
+    const csv = `Title,Note\n"Hello, World",Test`;
+    const rows = parseCsv(csv);
+    expect(rows[0]["Title"]).toBe("Hello, World");
+  });
+
+  it("returns empty array for header-only CSV", () => {
+    const rows = parseCsv("Name,Year\n");
+    expect(rows).toHaveLength(0);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(parseCsv("")).toHaveLength(0);
+  });
+});
+
+describe("detectCsvFormat", () => {
+  it("detects Letterboxd format", () => {
+    const headers = ["Name", "Year", "Letterboxd URI", "Rating", "Watched Date"];
+    expect(detectCsvFormat(headers)).toBe("letterboxd");
+  });
+
+  it("detects IMDB format", () => {
+    const headers = ["Const", "Your Rating", "Date Rated", "Title", "Title Type"];
+    expect(detectCsvFormat(headers)).toBe("imdb");
+  });
+
+  it("detects Trakt format", () => {
+    const headers = ["imdb_id", "tmdb_id", "title", "type", "listed_at"];
+    expect(detectCsvFormat(headers)).toBe("trakt");
+  });
+
+  it("returns unknown for unrecognized headers", () => {
+    expect(detectCsvFormat(["foo", "bar", "baz"])).toBe("unknown");
+  });
+});
+
+describe("extractImdbIdFromRow", () => {
+  it("extracts IMDB ID from Letterboxd row via IMDB URI column", () => {
+    const row = {
+      Name: "Inception",
+      Year: "2010",
+      "Letterboxd URI": "https://letterboxd.com/film/inception/",
+      "IMDB URI": "https://www.imdb.com/title/tt1375666/",
+    };
+    expect(extractImdbIdFromRow(row, "letterboxd")).toBe("tt1375666");
+  });
+
+  it("extracts IMDB ID from IMDB row via Const column", () => {
+    const row = {
+      Const: "tt1375666",
+      "Your Rating": "9",
+      "Date Rated": "2024-01-01",
+      Title: "Inception",
+      "Title Type": "movie",
+    };
+    expect(extractImdbIdFromRow(row, "imdb")).toBe("tt1375666");
+  });
+
+  it("returns null for IMDB row with invalid Const value", () => {
+    const row = { Const: "nm0000093", "Your Rating": "9", "Date Rated": "", Title: "Brad Pitt", "Title Type": "name" };
+    expect(extractImdbIdFromRow(row, "imdb")).toBeNull();
+  });
+
+  it("extracts IMDB ID from Trakt row", () => {
+    const row = {
+      imdb_id: "tt1375666",
+      tmdb_id: "27205",
+      title: "Inception",
+      type: "movie",
+      listed_at: "2024-01-01",
+    };
+    expect(extractImdbIdFromRow(row, "trakt")).toBe("tt1375666");
+  });
+
+  it("returns null for Trakt row with empty imdb_id", () => {
+    const row = { imdb_id: "", tmdb_id: "27205", title: "Inception", type: "movie" };
+    expect(extractImdbIdFromRow(row, "trakt")).toBeNull();
+  });
+
+  it("returns null for unknown format", () => {
+    const row = { foo: "bar" };
+    expect(extractImdbIdFromRow(row, "unknown" as CsvFormat)).toBeNull();
+  });
+});
+
+// ─── HTTP endpoint tests ─────────────────────────────────────────────────────
+
+let app: Hono<AppEnv>;
+let userCookie: string;
+let spies: ReturnType<typeof spyOn>[] = [];
+
+beforeEach(async () => {
+  setupTestDb();
+
+  spies = [
+    spyOn(resolver, "resolveImdbUrl").mockResolvedValue(makeParsedTitle()),
+    spyOn(repository, "upsertTitles").mockImplementation(async () => 0),
+    spyOn(repository, "trackTitle").mockImplementation(async () => {}),
+  ];
+
+  const userId = await createUser("csvuser", "hash");
+  const token = await createSession(userId);
+  userCookie = `better-auth.session_token=${token}`;
+
+  const importApp = (await import("./import")).default;
+  app = new Hono<AppEnv>();
+  app.use("*", async (c, next) => {
+    c.set("auth", createMockAuth() as any);
+    await next();
+  });
+  app.use("/import/*", requireAuth);
+  app.use("/import", requireAuth);
+  app.route("/import", importApp);
+});
+
+afterEach(() => {
+  for (const spy of spies) spy.mockRestore();
+  spies = [];
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+function makeFormData(csvContent: string, filename = "test.csv"): FormData {
+  const form = new FormData();
+  form.append("file", new Blob([csvContent], { type: "text/csv" }), filename);
+  return form;
+}
+
+describe("POST /import/csv", () => {
+  it("returns 401 without auth", async () => {
+    const form = makeFormData("Const,Title\ntt1234567,Inception");
+    const res = await app.request("/import/csv", { method: "POST", body: form });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when file field is missing", async () => {
+    const res = await app.request("/import/csv", {
+      method: "POST",
+      headers: { Cookie: userCookie },
+      body: new FormData(),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Missing 'file'");
+  });
+
+  it("returns 400 for unrecognized CSV format", async () => {
+    const csv = "foo,bar\n1,2";
+    const form = makeFormData(csv);
+    const res = await app.request("/import/csv", {
+      method: "POST",
+      headers: { Cookie: userCookie },
+      body: form,
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Unrecognized CSV format");
+  });
+
+  it("imports a valid IMDB CSV", async () => {
+    const title = makeParsedTitle({ id: "movie-imdb-1", title: "Inception" });
+    (resolver.resolveImdbUrl as any).mockResolvedValueOnce(title);
+
+    const csv = "Const,Your Rating,Date Rated,Title,Title Type\ntt1375666,9,2024-01-01,Inception,movie";
+    const form = makeFormData(csv);
+    const res = await app.request("/import/csv", {
+      method: "POST",
+      headers: { Cookie: userCookie },
+      body: form,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.imported).toBe(1);
+    expect(body.failed).toBe(0);
+    expect(body.skipped).toBe(0);
+  });
+
+  it("imports a valid Trakt CSV", async () => {
+    const title = makeParsedTitle({ id: "movie-trakt-1", title: "Dune" });
+    (resolver.resolveImdbUrl as any).mockResolvedValueOnce(title);
+
+    const csv = "imdb_id,tmdb_id,title,type,listed_at\ntt1160419,438631,Dune,movie,2024-01-01";
+    const form = makeFormData(csv);
+    const res = await app.request("/import/csv", {
+      method: "POST",
+      headers: { Cookie: userCookie },
+      body: form,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.imported).toBe(1);
+    expect(body.failed).toBe(0);
+    expect(body.skipped).toBe(0);
+  });
+
+  it("imports a valid Letterboxd CSV (with IMDB URI)", async () => {
+    const title = makeParsedTitle({ id: "movie-lb-1", title: "Parasite" });
+    (resolver.resolveImdbUrl as any).mockResolvedValueOnce(title);
+
+    const csv = "Date,Name,Year,Letterboxd URI,Rating,Watched Date,IMDB URI\n2024-01-01,Parasite,2019,https://letterboxd.com/film/parasite-2019/,5,2024-01-01,https://www.imdb.com/title/tt6751668/";
+    const form = makeFormData(csv);
+    const res = await app.request("/import/csv", {
+      method: "POST",
+      headers: { Cookie: userCookie },
+      body: form,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.imported).toBe(1);
+    expect(body.failed).toBe(0);
+  });
+
+  it("counts rows without IMDB ID as skipped", async () => {
+    // Trakt row with empty imdb_id
+    const csv = "imdb_id,tmdb_id,title,type\n,438631,Dune,movie";
+    const form = makeFormData(csv);
+    const res = await app.request("/import/csv", {
+      method: "POST",
+      headers: { Cookie: userCookie },
+      body: form,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.skipped).toBe(1);
+    expect(body.imported).toBe(0);
+  });
+
+  it("counts rows where resolver returns null as failed", async () => {
+    (resolver.resolveImdbUrl as any).mockResolvedValueOnce(null);
+
+    const csv = "Const,Your Rating,Date Rated,Title,Title Type\ntt9999999,5,2024-01-01,Unknown,movie";
+    const form = makeFormData(csv);
+    const res = await app.request("/import/csv", {
+      method: "POST",
+      headers: { Cookie: userCookie },
+      body: form,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.failed).toBe(1);
+    expect(body.errors).toHaveLength(1);
+  });
+
+  it("returns errors array with details for failed rows", async () => {
+    (resolver.resolveImdbUrl as any).mockRejectedValueOnce(new Error("TMDB timeout"));
+
+    const csv = "Const,Your Rating,Date Rated,Title,Title Type\ntt0000001,5,2024-01-01,Ghost,movie";
+    const form = makeFormData(csv);
+    const res = await app.request("/import/csv", {
+      method: "POST",
+      headers: { Cookie: userCookie },
+      body: form,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.failed).toBe(1);
+    expect(body.errors[0]).toContain("TMDB timeout");
+  });
+});

--- a/server/routes/import.ts
+++ b/server/routes/import.ts
@@ -1,0 +1,244 @@
+import { Hono } from "hono";
+import { resolveImdbUrl } from "../imdb/resolver";
+import { upsertTitles, trackTitle } from "../db/repository";
+import type { AppEnv } from "../types";
+import { ok, err } from "./response";
+import { logger } from "../logger";
+
+const log = logger.child({ module: "import" });
+
+const MAX_ROWS = 500;
+const BATCH_SIZE = 10;
+const BATCH_DELAY_MS = 500;
+
+export type CsvFormat = "letterboxd" | "imdb" | "trakt" | "unknown";
+
+/**
+ * Parse a CSV string into an array of objects keyed by header row.
+ * Handles quoted fields (including fields containing commas and newlines).
+ */
+export function parseCsv(text: string): Record<string, string>[] {
+  const lines = splitCsvLines(text);
+  if (lines.length < 2) return [];
+
+  const headers = parseCsvRow(lines[0]).map((h) => h.trim());
+  const rows: Record<string, string>[] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    const values = parseCsvRow(line);
+    const row: Record<string, string> = {};
+    for (let j = 0; j < headers.length; j++) {
+      row[headers[j]] = values[j] ?? "";
+    }
+    rows.push(row);
+  }
+
+  return rows;
+}
+
+/** Split CSV text into logical lines, respecting quoted multi-line fields. */
+function splitCsvLines(text: string): string[] {
+  const lines: string[] = [];
+  let current = "";
+  let inQuote = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === '"') {
+      // Handle escaped quotes ""
+      if (inQuote && text[i + 1] === '"') {
+        current += '"';
+        i++;
+      } else {
+        inQuote = !inQuote;
+        current += ch;
+      }
+    } else if ((ch === "\n" || ch === "\r") && !inQuote) {
+      if (ch === "\r" && text[i + 1] === "\n") i++;
+      if (current.trim()) lines.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  if (current.trim()) lines.push(current);
+  return lines;
+}
+
+/** Parse a single CSV row into fields, handling quoted fields. */
+function parseCsvRow(line: string): string[] {
+  const fields: string[] = [];
+  let field = "";
+  let inQuote = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuote && line[i + 1] === '"') {
+        field += '"';
+        i++;
+      } else {
+        inQuote = !inQuote;
+      }
+    } else if (ch === "," && !inQuote) {
+      fields.push(field);
+      field = "";
+    } else {
+      field += ch;
+    }
+  }
+  fields.push(field);
+  return fields;
+}
+
+/** Detect CSV format from header names. */
+export function detectCsvFormat(headers: string[]): CsvFormat {
+  const set = new Set(headers.map((h) => h.trim()));
+  // Letterboxd: Name, Year, Letterboxd URI
+  if (set.has("Name") && set.has("Year") && set.has("Letterboxd URI")) {
+    return "letterboxd";
+  }
+  // IMDB: Const, Your Rating, Title Type
+  if (set.has("Const") && set.has("Your Rating") && set.has("Title Type")) {
+    return "imdb";
+  }
+  // Trakt: imdb_id, tmdb_id, title, type
+  if (set.has("imdb_id") && set.has("tmdb_id") && set.has("title") && set.has("type")) {
+    return "trakt";
+  }
+  return "unknown";
+}
+
+/**
+ * Extract an IMDB ID from a CSV row depending on the detected format.
+ * Returns null if the row doesn't have a valid IMDB ID.
+ */
+export function extractImdbIdFromRow(row: Record<string, string>, format: CsvFormat): string | null {
+  switch (format) {
+    case "letterboxd": {
+      // Letterboxd URI looks like https://letterboxd.com/film/...
+      // The IMDB ID isn't in the CSV directly, but some exports include it in
+      // an "IMDB URI" or "IMDb" column. Otherwise we use the Letterboxd URI
+      // column as identifier — but we can only resolve via IMDB ID.
+      // Letterboxd does export an "IMDB URI" column in watchlist/ratings CSVs.
+      const imdbUri = row["IMDB URI"] ?? row["IMDb URI"] ?? row["Imdb URI"] ?? "";
+      if (imdbUri) {
+        const match = imdbUri.match(/tt\d+/);
+        if (match) return match[0];
+      }
+      // Some Letterboxd exports embed IMDB ID in a separate column
+      const imdbId = row["IMDb ID"] ?? row["IMDB ID"] ?? row["imdb_id"] ?? "";
+      const idMatch = imdbId.match(/tt\d+/);
+      if (idMatch) return idMatch[0];
+      return null;
+    }
+    case "imdb": {
+      // "Const" column contains the IMDB ID (e.g. tt1234567)
+      const constVal = (row["Const"] ?? "").trim();
+      if (/^tt\d+$/.test(constVal)) return constVal;
+      return null;
+    }
+    case "trakt": {
+      const imdbId = (row["imdb_id"] ?? "").trim();
+      if (/^tt\d+$/.test(imdbId)) return imdbId;
+      return null;
+    }
+    default:
+      return null;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const app = new Hono<AppEnv>();
+
+app.post("/csv", async (c) => {
+  const user = c.get("user")!;
+
+  let formData: FormData;
+  try {
+    formData = await c.req.formData();
+  } catch {
+    return err(c, "Expected multipart form data with a 'file' field");
+  }
+
+  const fileField = formData.get("file");
+  if (!fileField || typeof fileField === "string") {
+    return err(c, "Missing 'file' field in form data");
+  }
+
+  const file = fileField as File;
+  let csvText: string;
+  try {
+    csvText = await file.text();
+  } catch {
+    return err(c, "Failed to read uploaded file");
+  }
+
+  const rows = parseCsv(csvText);
+  if (rows.length === 0) {
+    return err(c, "CSV file is empty or has no data rows");
+  }
+
+  const headers = Object.keys(rows[0]);
+  const format = detectCsvFormat(headers);
+  if (format === "unknown") {
+    return err(c, "Unrecognized CSV format. Supported formats: Letterboxd, IMDB, Trakt");
+  }
+
+  log.info("CSV import started", { format, totalRows: rows.length, userId: user.id });
+
+  const limitedRows = rows.slice(0, MAX_ROWS);
+  let imported = 0;
+  let failed = 0;
+  let skipped = 0;
+  const errors: string[] = [];
+
+  for (let batchStart = 0; batchStart < limitedRows.length; batchStart += BATCH_SIZE) {
+    if (batchStart > 0) {
+      await sleep(BATCH_DELAY_MS);
+    }
+
+    const batch = limitedRows.slice(batchStart, batchStart + BATCH_SIZE);
+
+    for (const row of batch) {
+      const imdbId = extractImdbIdFromRow(row, format);
+      if (!imdbId) {
+        skipped++;
+        continue;
+      }
+
+      try {
+        const title = await resolveImdbUrl(imdbId);
+        if (!title) {
+          failed++;
+          errors.push(`Could not resolve IMDB ID: ${imdbId}`);
+          continue;
+        }
+
+        await upsertTitles([title]);
+        await trackTitle(title.id, user.id);
+        imported++;
+        log.info("Imported title from CSV", { imdbId, titleId: title.id, title: title.title });
+      } catch (e: unknown) {
+        failed++;
+        const msg = e instanceof Error ? e.message : String(e);
+        errors.push(`Failed to import ${imdbId}: ${msg}`);
+        log.warn("Failed to import CSV row", { imdbId, err: msg });
+      }
+    }
+  }
+
+  const totalSkippedRows = rows.length > MAX_ROWS ? rows.length - MAX_ROWS : 0;
+  skipped += totalSkippedRows;
+
+  log.info("CSV import complete", { format, imported, failed, skipped, userId: user.id });
+
+  return ok(c, { imported, failed, skipped, errors });
+});
+
+export default app;

--- a/server/routes/notifiers.test.ts
+++ b/server/routes/notifiers.test.ts
@@ -408,6 +408,131 @@ describe("POST /notifiers/renew-subscription", () => {
   });
 });
 
+describe("digest_mode", () => {
+  it("creates a notifier with weekly digest_mode and digest_day", async () => {
+    const res = await app.request("/notifiers", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        ...validNotifier,
+        digest_mode: "weekly",
+        digest_day: 1,
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.notifier.digest_mode).toBe("weekly");
+    expect(body.notifier.digest_day).toBe(1);
+  });
+
+  it("creates a notifier with off digest_mode", async () => {
+    const res = await app.request("/notifiers", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        ...validNotifier,
+        digest_mode: "off",
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.notifier.digest_mode).toBe("off");
+    expect(body.notifier.digest_day).toBeNull();
+  });
+
+  it("creates a notifier with null digest_mode (daily behavior)", async () => {
+    const res = await app.request("/notifiers", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify(validNotifier),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.notifier.digest_mode).toBeNull();
+    expect(body.notifier.digest_day).toBeNull();
+  });
+
+  it("rejects weekly digest_mode without digest_day", async () => {
+    const res = await app.request("/notifiers", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        ...validNotifier,
+        digest_mode: "weekly",
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("digest_day");
+  });
+
+  it("rejects invalid digest_mode value", async () => {
+    const res = await app.request("/notifiers", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        ...validNotifier,
+        digest_mode: "monthly",
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("digest_mode");
+  });
+
+  it("rejects digest_day out of range", async () => {
+    const res = await app.request("/notifiers", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        ...validNotifier,
+        digest_mode: "weekly",
+        digest_day: 7,
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("digest_day");
+  });
+
+  it("updates digest_mode via PUT", async () => {
+    const createRes = await app.request("/notifiers", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify(validNotifier),
+    });
+    const { notifier } = await createRes.json();
+
+    const res = await app.request(`/notifiers/${notifier.id}`, {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ digest_mode: "weekly", digest_day: 5 }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.notifier.digest_mode).toBe("weekly");
+    expect(body.notifier.digest_day).toBe(5);
+  });
+
+  it("returns digest fields in notifier list", async () => {
+    await app.request("/notifiers", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        ...validNotifier,
+        digest_mode: "weekly",
+        digest_day: 3,
+      }),
+    });
+
+    const res = await app.request("/notifiers", { headers: headers() });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.notifiers[0].digest_mode).toBe("weekly");
+    expect(body.notifiers[0].digest_day).toBe(3);
+  });
+});
+
 describe("ownership enforcement", () => {
   it("user cannot access another user's notifier", async () => {
     // Create notifier as user 1

--- a/server/routes/notifiers.ts
+++ b/server/routes/notifiers.ts
@@ -34,6 +34,19 @@ function isValidTimezone(tz: string): boolean {
   }
 }
 
+const VALID_DIGEST_MODES = ["weekly", "off"] as const;
+type DigestMode = (typeof VALID_DIGEST_MODES)[number];
+
+function isValidDigestMode(mode: unknown): mode is DigestMode | null {
+  if (mode === null || mode === undefined) return true;
+  return VALID_DIGEST_MODES.includes(mode as DigestMode);
+}
+
+function isValidDigestDay(day: unknown): day is number | null {
+  if (day === null || day === undefined) return true;
+  return typeof day === "number" && Number.isInteger(day) && day >= 0 && day <= 6;
+}
+
 // GET / — list user's notifiers
 app.get("/", async (c) => {
   const user = c.get("user")!;
@@ -61,7 +74,7 @@ app.post("/", async (c) => {
   const user = c.get("user")!;
   const body = await c.req.json();
 
-  const { provider, config, notify_time, timezone } = body;
+  const { provider, config, notify_time, timezone, digest_mode, digest_day, streaming_alerts_enabled } = body;
 
   if (!provider || !config) {
     return err(c, "provider and config are required");
@@ -89,7 +102,19 @@ app.post("/", async (c) => {
     return err(c, "Invalid timezone");
   }
 
-  const id = await createNotifier(user.id, provider, name, config, time, tz);
+  if (!isValidDigestMode(digest_mode)) {
+    return err(c, "Invalid digest_mode. Must be 'weekly', 'off', or null");
+  }
+
+  if (!isValidDigestDay(digest_day)) {
+    return err(c, "Invalid digest_day. Must be 0-6 (0=Sunday) or null");
+  }
+
+  if (digest_mode === "weekly" && (digest_day === null || digest_day === undefined)) {
+    return err(c, "digest_day is required when digest_mode is 'weekly'");
+  }
+
+  const id = await createNotifier(user.id, provider, name, config, time, tz, digest_mode ?? null, digest_day ?? null, streaming_alerts_enabled !== false);
   await refreshNotificationSchedule();
   const notifier = await getNotifierById(id, user.id);
   return c.json({ notifier }, 201);
@@ -158,11 +183,32 @@ app.put("/:id", async (c) => {
     return err(c, "Invalid timezone");
   }
 
+  if ("digest_mode" in body && !isValidDigestMode(body.digest_mode)) {
+    return err(c, "Invalid digest_mode. Must be 'weekly', 'off', or null");
+  }
+
+  if ("digest_day" in body && !isValidDigestDay(body.digest_day)) {
+    return err(c, "Invalid digest_day. Must be 0-6 (0=Sunday) or null");
+  }
+
+  const digestMode = "digest_mode" in body ? body.digest_mode : undefined;
+  const digestDay = "digest_day" in body ? body.digest_day : undefined;
+
+  if (digestMode === "weekly" && (digestDay === null || digestDay === undefined)) {
+    // Check if existing notifier already has a digest_day set
+    if (existing.digest_day === null || existing.digest_day === undefined) {
+      return err(c, "digest_day is required when digest_mode is 'weekly'");
+    }
+  }
+
   await updateNotifier(id, user.id, {
     config: body.config,
     notifyTime: body.notify_time,
     timezone: body.timezone,
     enabled: body.enabled,
+    ...("digest_mode" in body ? { digestMode: body.digest_mode ?? null } : {}),
+    ...("digest_day" in body ? { digestDay: body.digest_day ?? null } : {}),
+    ...("streaming_alerts_enabled" in body ? { streamingAlertsEnabled: body.streaming_alerts_enabled !== false } : {}),
   });
   await refreshNotificationSchedule();
 

--- a/server/routes/watched.test.ts
+++ b/server/routes/watched.test.ts
@@ -324,3 +324,127 @@ describe("DELETE /watched/movies/:titleId", () => {
     expect(res.status).toBe(200);
   });
 });
+
+describe("Watch history logging", () => {
+  it("marking an episode watched logs a history entry", async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    await upsertTitles([makeParsedTitle({ id: "show-hist-1", objectType: "SHOW" })]);
+    await upsertEpisodes([
+      { title_id: "show-hist-1", season_number: 1, episode_number: 1, name: "Ep1", overview: null, air_date: today, still_path: null },
+    ]);
+    const episodeId = await getEpisodeId("show-hist-1", 1, 1);
+
+    const app = makeAuthedApp();
+    await app.request(`/watched/${episodeId}`, { method: "POST" });
+
+    const db = getRawDb();
+    const row = db.prepare("SELECT COUNT(*) as cnt FROM watch_history WHERE user_id = ? AND title_id = ? AND episode_id = ?")
+      .get(userId, "show-hist-1", episodeId) as { cnt: number };
+    expect(row.cnt).toBe(1);
+  });
+
+  it("marking the same episode watched twice increments play count to 2", async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    await upsertTitles([makeParsedTitle({ id: "show-hist-2", objectType: "SHOW" })]);
+    await upsertEpisodes([
+      { title_id: "show-hist-2", season_number: 1, episode_number: 1, name: "Ep1", overview: null, air_date: today, still_path: null },
+    ]);
+    const episodeId = await getEpisodeId("show-hist-2", 1, 1);
+
+    const app = makeAuthedApp();
+    await app.request(`/watched/${episodeId}`, { method: "POST" });
+    await app.request(`/watched/${episodeId}`, { method: "POST" });
+
+    const db = getRawDb();
+    const row = db.prepare("SELECT COUNT(*) as cnt FROM watch_history WHERE user_id = ? AND title_id = ?")
+      .get(userId, "show-hist-2") as { cnt: number };
+    expect(row.cnt).toBe(2);
+  });
+
+  it("marking a movie watched logs a history entry", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-hist-1", objectType: "MOVIE" })]);
+
+    const app = makeAuthedApp();
+    await app.request("/watched/movies/movie-hist-1", { method: "POST" });
+
+    const db = getRawDb();
+    const row = db.prepare("SELECT COUNT(*) as cnt FROM watch_history WHERE user_id = ? AND title_id = ?")
+      .get(userId, "movie-hist-1") as { cnt: number };
+    expect(row.cnt).toBe(1);
+  });
+
+  it("bulk watch logs history for each released episode", async () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const yesterdayStr = yesterday.toISOString().slice(0, 10);
+
+    await upsertTitles([makeParsedTitle({ id: "show-hist-bulk", objectType: "SHOW" })]);
+    await upsertEpisodes([
+      { title_id: "show-hist-bulk", season_number: 1, episode_number: 1, name: "Ep1", overview: null, air_date: yesterdayStr, still_path: null },
+      { title_id: "show-hist-bulk", season_number: 1, episode_number: 2, name: "Ep2", overview: null, air_date: yesterdayStr, still_path: null },
+    ]);
+    const ep1Id = await getEpisodeId("show-hist-bulk", 1, 1);
+    const ep2Id = await getEpisodeId("show-hist-bulk", 1, 2);
+
+    const app = makeAuthedApp();
+    await app.request("/watched/bulk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ episodeIds: [ep1Id, ep2Id], watched: true }),
+    });
+
+    const db = getRawDb();
+    const row = db.prepare("SELECT COUNT(*) as cnt FROM watch_history WHERE user_id = ? AND title_id = ?")
+      .get(userId, "show-hist-bulk") as { cnt: number };
+    expect(row.cnt).toBe(2);
+  });
+});
+
+describe("GET /watched/history/:titleId", () => {
+  it("returns empty history and 0 play count for a title with no watches", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-nowatch", objectType: "MOVIE" })]);
+
+    const app = makeAuthedApp();
+    const res = await app.request("/watched/history/movie-nowatch");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.playCount).toBe(0);
+    expect(body.history).toEqual([]);
+  });
+
+  it("returns correct history and play count after watching a movie", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-hist-get", objectType: "MOVIE" })]);
+
+    const app = makeAuthedApp();
+    await app.request("/watched/movies/movie-hist-get", { method: "POST" });
+    await app.request("/watched/movies/movie-hist-get", { method: "POST" });
+
+    const res = await app.request("/watched/history/movie-hist-get");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.playCount).toBe(2);
+    expect(body.history.length).toBe(2);
+    // Newest first
+    expect(new Date(body.history[0].watchedAt).getTime()).toBeGreaterThanOrEqual(
+      new Date(body.history[1].watchedAt).getTime()
+    );
+  });
+
+  it("history entries for episodes include episodeId", async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    await upsertTitles([makeParsedTitle({ id: "show-hist-ep", objectType: "SHOW" })]);
+    await upsertEpisodes([
+      { title_id: "show-hist-ep", season_number: 1, episode_number: 1, name: "Ep1", overview: null, air_date: today, still_path: null },
+    ]);
+    const episodeId = await getEpisodeId("show-hist-ep", 1, 1);
+
+    const app = makeAuthedApp();
+    await app.request(`/watched/${episodeId}`, { method: "POST" });
+
+    const res = await app.request("/watched/history/show-hist-ep");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.playCount).toBe(1);
+    expect(body.history[0].episodeId).toBe(episodeId);
+  });
+});

--- a/server/routes/watched.ts
+++ b/server/routes/watched.ts
@@ -1,5 +1,10 @@
 import { Hono } from "hono";
-import { watchEpisode, unwatchEpisode, watchEpisodesBulk, unwatchEpisodesBulk, getEpisodeAirDate, getReleasedEpisodeIds, watchTitle, unwatchTitle } from "../db/repository";
+import {
+  watchEpisode, unwatchEpisode, watchEpisodesBulk, unwatchEpisodesBulk,
+  getEpisodeAirDate, getReleasedEpisodeIds, watchTitle, unwatchTitle,
+  getEpisodeTitleId, getEpisodeTitleIds,
+} from "../db/repository";
+import { logWatch, getTitlePlayCount, getTitleWatchHistory } from "../db/repository/watch-history";
 import { localDateForTimezone } from "../utils/timezone";
 import type { AppEnv } from "../types";
 import { ok, err } from "./response";
@@ -28,11 +33,30 @@ app.post("/bulk", async (c) => {
       return err(c, "Cannot mark unreleased episodes as watched");
     }
     await watchEpisodesBulk(releasedIds, user.id);
+
+    // Log watch history for each released episode
+    const titleIdMap = await getEpisodeTitleIds(releasedIds);
+    for (const episodeId of releasedIds) {
+      const titleId = titleIdMap.get(episodeId);
+      if (titleId) {
+        await logWatch(user.id, titleId, episodeId);
+      }
+    }
   } else {
     await unwatchEpisodesBulk(episodeIds, user.id);
   }
 
   return ok(c, {});
+});
+
+app.get("/history/:titleId", async (c) => {
+  const user = c.get("user")!;
+  const titleId = c.req.param("titleId");
+  const [history, playCount] = await Promise.all([
+    getTitleWatchHistory(user.id, titleId),
+    getTitlePlayCount(user.id, titleId),
+  ]);
+  return ok(c, { history, playCount });
 });
 
 app.post("/:episodeId", async (c) => {
@@ -45,6 +69,13 @@ app.post("/:episodeId", async (c) => {
     return err(c, "Cannot mark an unreleased episode as watched");
   }
   await watchEpisode(episodeId, user.id);
+
+  // Log to watch history
+  const titleId = await getEpisodeTitleId(episodeId);
+  if (titleId) {
+    await logWatch(user.id, titleId, episodeId);
+  }
+
   return ok(c, {});
 });
 
@@ -62,6 +93,7 @@ app.post("/movies/:titleId", async (c) => {
   const user = c.get("user")!;
   const titleId = c.req.param("titleId");
   await watchTitle(titleId, user.id);
+  await logWatch(user.id, titleId);
   return ok(c, {});
 });
 

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -68,6 +68,7 @@ import healthRoutes from "./routes/health";
 import statsRoutes from "./routes/stats";
 import userSettingsRoutes from "./routes/user-settings";
 import feedRoutes from "./routes/feed";
+import importRoutes from "./routes/import";
 import type { AppEnv } from "./types";
 import { logger, requestLogger, resetLogLevel } from "./logger";
 import { patchConfig } from "./config";
@@ -325,6 +326,10 @@ function createApp(env: Env) {
   app.use("/api/integrations/*", requireAuth);
   app.use("/api/integrations", requireAuth);
   app.route("/api/integrations", integrationRoutes);
+
+  app.use("/api/import/*", requireAuth);
+  app.use("/api/import", requireAuth);
+  app.route("/api/import", importRoutes);
 
   app.use("/api/stats/*", requireAuth);
   app.use("/api/stats", requireAuth);


### PR DESCRIPTION
Implements four features. All changes share schema/API/settings UI files so they're batched in one PR.

## #369 — Weekly digest notifications
- `digest_mode` (`null`=daily, `"weekly"`, `"off"`) and `digest_day` (0–6) on notifiers
- `buildWeeklyDigestContent(userId, start, end)` collects episodes + movies over a date range
- Dispatch checks the notifier's day-of-week in its timezone before sending
- Settings UI: frequency dropdown + day-of-week selector per notifier

## #368 — Streaming availability alerts
- `streaming_alerts` table records `(user, title, provider)` pairs already notified — no duplicates
- `checkStreamingAlerts(titleIds)` job runs after each sync batch for tracked titles
- `streaming_alerts_enabled` toggle on each notifier (default on)
- Discord provider extended with streaming-alert embed format

## #364 — Rewatch tracking
- `watch_history` table logs every watch event with `watched_at` + optional note
- `logWatch()` called in all watched routes (single episode, bulk, movie)
- `GET /api/watched/history/:titleId` → `{ playCount, history[] }`
- Title detail page: "Watched N×" badge + collapsible watch history

## #365 — CSV import (Letterboxd, IMDB, Trakt)
- `POST /api/import/csv` auto-detects format from CSV headers
- Resolves IMDB IDs via existing resolver → upsert + track
- Batches of 10 with 500ms between batches; hard limit 500 rows
- Settings page: drag-and-drop file picker with per-service instructions + result summary

## DB migrations
| # | File | Feature |
|---|------|---------|
| 0022 | `notifier_digest_mode.sql` | Weekly digest |
| 0023 | `watch_history.sql` | Rewatch tracking |
| 0024 | `streaming_alerts.sql` | Streaming alerts |

## Test plan
- [ ] **Digest**: Create a notifier with frequency=Weekly, verify it only fires on the selected day
- [ ] **Streaming alerts**: Add a title, manually trigger a sync, verify a Discord notification is sent once (not again on next sync)
- [ ] **Rewatch**: Mark an episode watched twice, check `/api/watched/history/:titleId` returns play count = 2
- [ ] **Import**: Export a Letterboxd CSV, upload via Settings → Import, verify titles are tracked

1722 tests pass (`bun run check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)