### PR TITLE
Replace UnwatchedCarousel with FullBleedCarousel component

### DIFF
--- a/frontend/src/components/EpisodeShowCard.tsx
+++ b/frontend/src/components/EpisodeShowCard.tsx
@@ -2,7 +2,6 @@ import { memo } from "react";
 import { Link } from "react-router";
 import { CheckCircle } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import ScrollableRow from "./ScrollableRow";
 import type { Episode } from "../types";
 import {
   formatEpisodeCode,
@@ -122,13 +121,5 @@ export function DeckCardWrapper({ episodeCount, children }: { episodeCount: numb
       )}
       <div className="relative">{children}</div>
     </div>
-  );
-}
-
-export function UnwatchedCarousel({ children }: { children: React.ReactNode }) {
-  return (
-    <ScrollableRow className="gap-3" scrollAmount={332} scrollSnap>
-      {children}
-    </ScrollableRow>
   );
 }

--- a/frontend/src/components/FullBleedCarousel.tsx
+++ b/frontend/src/components/FullBleedCarousel.tsx
@@ -24,6 +24,7 @@ export default function FullBleedCarousel({
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
+    el.scrollLeft = 0;
     updateScrollButtons();
     el.addEventListener("scroll", updateScrollButtons, { passive: true });
     const observer = new ResizeObserver(updateScrollButtons);

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -10,7 +10,7 @@ import { normalizeSearchTitle, DEFAULT_HOMEPAGE_LAYOUT } from "../types";
 import TitleList from "../components/TitleList";
 import { TitleGridSkeleton, EpisodeListSkeleton } from "../components/SkeletonComponents";
 import { groupByShow, formatUpcomingDate } from "../components/EpisodeComponents";
-import { EpisodeShowCard, DeckCardWrapper, UnwatchedCarousel } from "../components/EpisodeShowCard";
+import { EpisodeShowCard, DeckCardWrapper } from "../components/EpisodeShowCard";
 import HeroBanner from "../components/HeroBanner";
 import FullBleedCarousel from "../components/FullBleedCarousel";
 
@@ -302,7 +302,7 @@ export default function HomePage() {
                 {t("home.seeAll")} →
               </Link>
             </div>
-            <UnwatchedCarousel>
+            <FullBleedCarousel scrollAmount={144}>
               {recommendations.map((rec) => {
                 const posterSrc = rec.title.poster_url
                   ? `https://image.tmdb.org/t/p/w185${rec.title.poster_url}`
@@ -341,7 +341,7 @@ export default function HomePage() {
                   </Link>
                 );
               })}
-            </UnwatchedCarousel>
+            </FullBleedCarousel>
           </section>
         ) : null;
 
@@ -354,7 +354,7 @@ export default function HomePage() {
                 {noEpisodes ? t("home.noEpisodes") : t("home.noEpisodesToday")}
               </p>
             ) : (
-              <UnwatchedCarousel>
+              <FullBleedCarousel>
                 {Array.from(groupByShow(today).entries()).map(([titleId, eps]) => (
                   <div key={titleId} className="w-80 flex-shrink-0" style={{ scrollSnapAlign: "start" }}>
                     <DeckCardWrapper episodeCount={eps.length}>
@@ -365,7 +365,7 @@ export default function HomePage() {
                     </DeckCardWrapper>
                   </div>
                 ))}
-              </UnwatchedCarousel>
+              </FullBleedCarousel>
             )}
           </section>
         );
@@ -381,7 +381,7 @@ export default function HomePage() {
                 return (
                   <div key={date}>
                     <h3 className="text-sm font-medium text-zinc-500 mb-2">{dateLabel === "__TOMORROW__" ? t("episodes.tomorrow") : dateLabel}</h3>
-                    <UnwatchedCarousel>
+                    <FullBleedCarousel>
                       {Array.from(byShow.entries()).map(([titleId, showEps]) => (
                         <div key={titleId} className="w-80 flex-shrink-0" style={{ scrollSnapAlign: "start" }}>
                           <DeckCardWrapper episodeCount={showEps.length}>
@@ -392,7 +392,7 @@ export default function HomePage() {
                           </DeckCardWrapper>
                         </div>
                       ))}
-                    </UnwatchedCarousel>
+                    </FullBleedCarousel>
                   </div>
                 );
               })}


### PR DESCRIPTION
## Summary
Removed the `UnwatchedCarousel` component and replaced all its usages with the `FullBleedCarousel` component throughout the HomePage. This consolidates carousel functionality into a single, more flexible component.

## Key Changes
- **Removed `UnwatchedCarousel` component** from `EpisodeShowCard.tsx` and its import of `ScrollableRow`
- **Replaced all `UnwatchedCarousel` usages** in `HomePage.tsx` with `FullBleedCarousel`:
  - Recommendations section carousel (with explicit `scrollAmount={144}`)
  - Today's episodes carousel
  - Upcoming episodes carousels (grouped by date)
- **Enhanced `FullBleedCarousel`** with scroll position reset on mount by setting `el.scrollLeft = 0` in the useEffect hook

## Implementation Details
- The `UnwatchedCarousel` was a thin wrapper around `ScrollableRow` with fixed `scrollAmount={332}` and `scrollSnap={true}` props
- `FullBleedCarousel` now handles all carousel use cases with configurable `scrollAmount` prop (defaults to 332 based on existing usage)
- The scroll reset ensures consistent initial state when the carousel component mounts

https://claude.ai/code/session_01KPWo8EVkTMKNYAgCE7Xb8f