### PR TITLE
Fix mobile pages not scrolling to top on navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "./context/AuthContext";
 import { useIsMobile } from "./hooks/useIsMobile";
 import RequireAuth from "./components/RequireAuth";
 import BottomTabBar from "./components/BottomTabBar";
+import ScrollToTop from "./components/ScrollToTop";
 import OfflineIndicator from "./components/OfflineIndicator";
 import InstallPrompt from "./components/InstallPrompt";
 import NotificationPrompt from "./components/NotificationPrompt";
@@ -175,6 +176,7 @@ export default function App() {
           </div>
         </div>
       </nav>
+      <ScrollToTop />
       <InstallPrompt />
       <main id="main-content" className={isReelsPage ? "" : "max-w-7xl mx-auto px-4 py-6 pb-20 sm:pb-6"}>
         {user && <NotificationPrompt />}

--- a/frontend/src/components/ScrollToTop.test.tsx
+++ b/frontend/src/components/ScrollToTop.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, mock, afterEach } from "bun:test";
+import { useEffect } from "react";
+import { render, cleanup } from "@testing-library/react";
+import { MemoryRouter, useNavigate } from "react-router";
+import ScrollToTop from "./ScrollToTop";
+
+const scrollToMock = mock(() => {});
+
+beforeEach(() => {
+  window.scrollTo = scrollToMock as unknown as typeof window.scrollTo;
+  scrollToMock.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// Helper component to trigger navigation
+function NavigateTo({ path }: { path: string }) {
+  const navigate = useNavigate();
+  useEffect(() => {
+    navigate(path);
+  }, [navigate, path]);
+  return null;
+}
+
+describe("ScrollToTop", () => {
+  it("scrolls to top on initial render", () => {
+    render(
+      <MemoryRouter initialEntries={["/title/123"]}>
+        <ScrollToTop />
+      </MemoryRouter>
+    );
+
+    expect(scrollToMock).toHaveBeenCalledWith(0, 0);
+  });
+
+  it("scrolls to top when pathname changes", () => {
+    const { unmount } = render(
+      <MemoryRouter initialEntries={["/title/123", "/title/456"]} initialIndex={0}>
+        <ScrollToTop />
+        <NavigateTo path="/title/456" />
+      </MemoryRouter>
+    );
+
+    // Called at least once for initial render
+    expect(scrollToMock.mock.calls.length).toBeGreaterThanOrEqual(1);
+    unmount();
+  });
+
+  it("renders nothing", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ScrollToTop />
+      </MemoryRouter>
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/frontend/src/components/ScrollToTop.tsx
+++ b/frontend/src/components/ScrollToTop.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router";
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
Add ScrollToTop component that resets scroll position to (0, 0) on every
route change, fixing the issue where detail pages (shows, seasons, cast,
etc.) opened in the middle of the page on mobile.

https://claude.ai/code/session_016sYyQDngwtiRPBmZ6JisHc