### PR TITLE
Fix reels season panel showing wrong show on swipe

### DIFF
--- a/frontend/src/pages/ReelsPage.tsx
+++ b/frontend/src/pages/ReelsPage.tsx
@@ -76,7 +76,6 @@ export default function ReelsPage() {
   const touchStartRef = useRef<{ x: number; y: number } | null>(null);
 
   // Track visible card index for swipe context
-  const [visibleCardIndex, setVisibleCardIndex] = useState(0);
   const visibleCardIndexRef = useRef(0);
 
   useEffect(() => {
@@ -104,7 +103,6 @@ export default function ReelsPage() {
       if (cardHeight === 0) return;
       const index = Math.round(container.scrollTop / cardHeight);
       visibleCardIndexRef.current = index;
-      setVisibleCardIndex(index);
     }
 
     container.addEventListener("scroll", onScroll, { passive: true });
@@ -178,13 +176,13 @@ export default function ReelsPage() {
     // Only trigger on horizontal swipe (dx > 80px, and more horizontal than vertical)
     if (dx < -80 && Math.abs(dx) > Math.abs(dy) * 1.5) {
       // Swipe left -> open season panel
-      const card = cardsRef.current[visibleCardIndex];
+      const card = cardsRef.current[visibleCardIndexRef.current];
       if (card && !card.caughtUp) {
         const currentEp = card.episodes[card.currentIndex];
         setSeasonPanel({ card, seasonNumber: currentEp.season_number });
       }
     }
-  }, [visibleCardIndex]);
+  }, []);
 
   const markWatched = useCallback(async (titleId: string) => {
     const card = cardsRef.current.find((c) => c.titleId === titleId);


### PR DESCRIPTION
The handleTouchEnd callback captured visibleCardIndex from React state,
which could be stale due to async setState timing. When a user scrolled
to a different card and swiped left before the state update propagated,
the season panel would open for the wrong show.

Switch to reading visibleCardIndexRef.current which is updated
synchronously in the scroll handler, ensuring the correct card is
always referenced. Also remove the now-unused visibleCardIndex state
variable.

https://claude.ai/code/session_01Y1i292trPt34jTxj2HU3Q1