### PR TITLE
Fix scroll snap overriding initial scroll position in carousel

### DIFF
--- a/frontend/src/components/FullBleedCarousel.test.tsx
+++ b/frontend/src/components/FullBleedCarousel.test.tsx
@@ -37,8 +37,10 @@ describe("FullBleedCarousel", () => {
     const style = scrollDiv.getAttribute("style") ?? "";
     expect(style).toContain("scroll-padding-left");
     expect(style).toContain("scroll-padding-right");
-    // The scroll-padding values should use the same expression as the padding values
-    expect(style).toContain("scroll-snap-type");
+    // scroll-snap-type is NOT in the inline style — it is set imperatively
+    // after scrollLeft = 0 via requestAnimationFrame to prevent mandatory
+    // snap from overriding the initial scroll position
+    expect(style).not.toContain("scroll-snap-type");
   });
 
   it("hides scroll buttons when content does not overflow", () => {

--- a/frontend/src/components/FullBleedCarousel.tsx
+++ b/frontend/src/components/FullBleedCarousel.tsx
@@ -26,10 +26,15 @@ export default function FullBleedCarousel({
     if (!el) return;
     el.scrollLeft = 0;
     updateScrollButtons();
+    // Enable snap AFTER position is set so mandatory snap doesn't override it
+    const rafId = requestAnimationFrame(() => {
+      el.style.scrollSnapType = "x mandatory";
+    });
     el.addEventListener("scroll", updateScrollButtons, { passive: true });
     const observer = new ResizeObserver(updateScrollButtons);
     observer.observe(el);
     return () => {
+      cancelAnimationFrame(rafId);
       el.removeEventListener("scroll", updateScrollButtons);
       observer.disconnect();
     };
@@ -57,7 +62,6 @@ export default function FullBleedCarousel({
         ref={scrollRef}
         className="flex overflow-x-auto gap-3 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
         style={{
-          scrollSnapType: "x mandatory",
           paddingLeft: edgePad,
           paddingRight: edgePad,
           // Ensure snap points account for the padding so the first card is reachable


### PR DESCRIPTION
## Summary
Fixed an issue in FullBleedCarousel where the `scroll-snap-type: x mandatory` CSS property was preventing the carousel from scrolling to its initial position (scrollLeft = 0). The snap behavior now activates after the initial scroll position is set.

## Key Changes
- Moved `scrollSnapType` from inline style to imperative assignment via `requestAnimationFrame`
- The snap type is now set after `scrollLeft = 0` to prevent mandatory snap from overriding the initial position
- Updated the cleanup function to cancel the pending animation frame
- Updated test expectations to reflect that `scroll-snap-type` is no longer in the inline style

## Implementation Details
The issue occurred because CSS `scroll-snap-type: mandatory` was being applied simultaneously with the JavaScript scroll position change, causing the browser's snap behavior to override the intended scroll position. By deferring the snap type assignment to the next animation frame (after the scroll position is already set), we ensure the initial position takes precedence while still enabling snap behavior for user interactions.

https://claude.ai/code/session_01AWJqygmkQQnpJXMfvvrMmV