### PR TITLE
Use clientWidth for scroll amount instead of fixed prop

### DIFF
--- a/frontend/src/components/AgendaCalendar.tsx
+++ b/frontend/src/components/AgendaCalendar.tsx
@@ -776,7 +776,7 @@ export default function AgendaCalendar({
 
                       {/* All episode cards in a single row */}
                       {dayEpisodes.length > 0 && (
-                        <ScrollableRow className="flex-wrap lg:flex-nowrap gap-3" scrollAmount={332}>
+                        <ScrollableRow className="flex-wrap lg:flex-nowrap gap-3">
                           {dayEpisodes.map((ep) => {
                             const showEps = episodesByShow.get(ep.title_id) ?? [ep];
                             const imgUrl = getEpisodeCardImageUrl(ep);

--- a/frontend/src/components/FullBleedCarousel.test.tsx
+++ b/frontend/src/components/FullBleedCarousel.test.tsx
@@ -93,7 +93,7 @@ describe("FullBleedCarousel", () => {
     const scrollByMock = mock(() => {});
 
     const { container } = render(
-      <FullBleedCarousel scrollAmount={332}>
+      <FullBleedCarousel>
         <div>Item</div>
       </FullBleedCarousel>,
     );
@@ -109,17 +109,17 @@ describe("FullBleedCarousel", () => {
     const buttons = container.querySelectorAll("button");
     expect(buttons.length).toBe(2);
 
-    // Click left button
+    // Click left button — scrolls by clientWidth (400)
     fireEvent.click(buttons[0]);
     expect(scrollByMock).toHaveBeenCalledWith({
-      left: -332,
+      left: -400,
       behavior: "smooth",
     });
 
-    // Click right button
+    // Click right button — scrolls by clientWidth (400)
     fireEvent.click(buttons[1]);
     expect(scrollByMock).toHaveBeenCalledWith({
-      left: 332,
+      left: 400,
       behavior: "smooth",
     });
   });

--- a/frontend/src/components/FullBleedCarousel.tsx
+++ b/frontend/src/components/FullBleedCarousel.tsx
@@ -2,13 +2,10 @@ import { useRef, useState, useCallback, useEffect } from "react";
 
 interface FullBleedCarouselProps {
   children: React.ReactNode;
-  /** Pixels to scroll per click. Defaults to 332 (320 card + 12 gap). */
-  scrollAmount?: number;
 }
 
 export default function FullBleedCarousel({
   children,
-  scrollAmount = 332,
 }: FullBleedCarouselProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
@@ -43,8 +40,9 @@ export default function FullBleedCarousel({
   const scroll = (direction: "left" | "right") => {
     const el = scrollRef.current;
     if (!el) return;
+    const amount = el.clientWidth;
     el.scrollBy({
-      left: direction === "left" ? -scrollAmount : scrollAmount,
+      left: direction === "left" ? -amount : amount,
       behavior: "smooth",
     });
   };

--- a/frontend/src/components/ScrollableRow.test.tsx
+++ b/frontend/src/components/ScrollableRow.test.tsx
@@ -64,7 +64,7 @@ describe("ScrollableRow", () => {
     const scrollByMock = mock(() => {});
 
     const { container } = render(
-      <ScrollableRow scrollAmount={200}>
+      <ScrollableRow>
         <div>Item</div>
       </ScrollableRow>,
     );
@@ -82,17 +82,17 @@ describe("ScrollableRow", () => {
     const buttons = container.querySelectorAll("button");
     expect(buttons.length).toBe(2);
 
-    // Click right button
+    // Click right button — scrolls by clientWidth (400)
     fireEvent.click(buttons[1]);
     expect(scrollByMock).toHaveBeenCalledWith({
-      left: 200,
+      left: 400,
       behavior: "smooth",
     });
 
-    // Click left button
+    // Click left button — scrolls by clientWidth (400)
     fireEvent.click(buttons[0]);
     expect(scrollByMock).toHaveBeenCalledWith({
-      left: -200,
+      left: -400,
       behavior: "smooth",
     });
   });

--- a/frontend/src/components/ScrollableRow.tsx
+++ b/frontend/src/components/ScrollableRow.tsx
@@ -4,8 +4,6 @@ interface ScrollableRowProps {
   children: React.ReactNode;
   /** CSS classes for the inner flex container (controls gap, padding, etc.) */
   className?: string;
-  /** Pixels to scroll per click. Defaults to 332 (320 + 12). */
-  scrollAmount?: number;
   /** Enable scroll-snap-type: x mandatory. Defaults to false. */
   scrollSnap?: boolean;
 }
@@ -13,7 +11,6 @@ interface ScrollableRowProps {
 export default function ScrollableRow({
   children,
   className,
-  scrollAmount = 332,
   scrollSnap = false,
 }: ScrollableRowProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -43,8 +40,9 @@ export default function ScrollableRow({
   const scroll = (direction: "left" | "right") => {
     const el = scrollRef.current;
     if (!el) return;
+    const amount = el.clientWidth;
     el.scrollBy({
-      left: direction === "left" ? -scrollAmount : scrollAmount,
+      left: direction === "left" ? -amount : amount,
       behavior: "smooth",
     });
   };

--- a/frontend/src/pages/EpisodeDetailPage.tsx
+++ b/frontend/src/pages/EpisodeDetailPage.tsx
@@ -201,7 +201,7 @@ export default function EpisodeDetailPage() {
       {allCast.length > 0 && (
         <section className="space-y-3">
           <h2 className="text-lg font-semibold text-white">Cast</h2>
-          <ScrollableRow className="gap-4 pb-2" scrollAmount={128}>
+          <ScrollableRow className="gap-4 pb-2">
             {allCast.slice(0, 20).map((c) => (
               <PersonCard key={c.id} id={c.id} name={c.name} role={c.character} profilePath={c.profile_path} />
             ))}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -302,7 +302,7 @@ export default function HomePage() {
                 {t("home.seeAll")} →
               </Link>
             </div>
-            <FullBleedCarousel scrollAmount={144}>
+            <FullBleedCarousel>
               {recommendations.map((rec) => {
                 const posterSrc = rec.title.poster_url
                   ? `https://image.tmdb.org/t/p/w185${rec.title.poster_url}`

--- a/frontend/src/pages/PersonPage.tsx
+++ b/frontend/src/pages/PersonPage.tsx
@@ -189,7 +189,7 @@ export default function PersonPage() {
       {castCredits.length > 0 && (
         <section className="space-y-3">
           <h2 className="text-lg font-semibold text-white">Acting ({castCredits.length})</h2>
-          <ScrollableRow className="gap-4 pb-2" scrollAmount={160}>
+          <ScrollableRow className="gap-4 pb-2">
             {castCredits.map((c) => (
               <CreditCard key={`cast-${c.id}-${c.character}`} credit={c} subtitle={c.character} />
             ))}
@@ -201,7 +201,7 @@ export default function PersonPage() {
       {crewCredits.length > 0 && (
         <section className="space-y-3">
           <h2 className="text-lg font-semibold text-white">Crew ({crewCredits.length})</h2>
-          <ScrollableRow className="gap-4 pb-2" scrollAmount={160}>
+          <ScrollableRow className="gap-4 pb-2">
             {crewCredits.map((c) => (
               <CreditCard key={`crew-${c.id}-${c.job}`} credit={c} subtitle={c.job} />
             ))}

--- a/frontend/src/pages/SeasonDetailPage.tsx
+++ b/frontend/src/pages/SeasonDetailPage.tsx
@@ -321,7 +321,7 @@ export default function SeasonDetailPage() {
       {tmdb?.credits?.cast && tmdb.credits.cast.length > 0 && (
         <section className="space-y-3">
           <h2 className="text-lg font-semibold text-white">Season Cast</h2>
-          <ScrollableRow className="gap-4 pb-2" scrollAmount={128}>
+          <ScrollableRow className="gap-4 pb-2">
             {tmdb.credits.cast.slice(0, 15).map((c) => (
               <PersonCard key={c.id} id={c.id} name={c.name} role={c.character} profilePath={c.profile_path} />
             ))}

--- a/frontend/src/pages/TitleDetailPage.tsx
+++ b/frontend/src/pages/TitleDetailPage.tsx
@@ -418,7 +418,7 @@ function MovieDetail({ data }: { data: MovieDetailsResponse }) {
 
       {cast.length > 0 && (
         <Section title="Cast">
-          <ScrollableRow className="gap-4 pb-2" scrollAmount={128}>
+          <ScrollableRow className="gap-4 pb-2">
             {cast.map((c: CastMember) => (
               <PersonCard key={c.id} id={c.id} name={c.name} role={c.character} profilePath={c.profile_path} />
             ))}
@@ -698,7 +698,7 @@ function ShowDetail({ data }: { data: ShowDetailsResponse }) {
 
       {cast.length > 0 && (
         <Section title="Cast">
-          <ScrollableRow className="gap-4 pb-2" scrollAmount={128}>
+          <ScrollableRow className="gap-4 pb-2">
             {cast.map((c: CastMember) => (
               <PersonCard key={c.id} id={c.id} name={c.name} role={c.character} profilePath={c.profile_path} />
             ))}


### PR DESCRIPTION
## Summary
Removed the `scrollAmount` prop from `FullBleedCarousel` and `ScrollableRow` components, replacing it with dynamic scroll behavior that uses the element's `clientWidth` for each scroll action. This makes the scroll amount responsive to the actual container size rather than relying on hardcoded values.

## Key Changes
- **FullBleedCarousel**: Removed `scrollAmount` prop (defaulted to 332) and now uses `el.clientWidth` to determine scroll distance
- **ScrollableRow**: Removed `scrollAmount` prop (defaulted to 332) and now uses `el.clientWidth` to determine scroll distance
- **Updated all usages**: Removed `scrollAmount` prop from all component instances across:
  - `PersonPage.tsx` (cast/crew sections)
  - `TitleDetailPage.tsx` (cast sections in movie and show details)
  - `EpisodeDetailPage.tsx` (cast section)
  - `SeasonDetailPage.tsx` (season cast section)
  - `HomePage.tsx` (recommendations carousel)
  - `AgendaCalendar.tsx` (episode cards)
- **Updated tests**: Modified test expectations to reflect the new behavior (scrolling by 400px, which is the mocked `clientWidth`)

## Implementation Details
The scroll amount is now calculated dynamically at scroll time using `el.clientWidth`, making the carousel/scrollable row behavior responsive to container resizing. This eliminates the need for consumers to calculate and pass in appropriate scroll amounts, simplifying the API and making the components more adaptable to different layouts.

https://claude.ai/code/session_01TaYcnHQe39qdjjGvUksF28