### PR TITLE
Fix carousel scroll amount to account for padding

### DIFF
--- a/frontend/src/components/FullBleedCarousel.test.tsx
+++ b/frontend/src/components/FullBleedCarousel.test.tsx
@@ -89,8 +89,21 @@ describe("FullBleedCarousel", () => {
     expect(buttons.length).toBe(1);
   });
 
-  it("calls scrollBy with correct values when arrow buttons are clicked", () => {
+  it("calls scrollBy with visible content width (clientWidth minus padding)", () => {
     const scrollByMock = mock(() => {});
+
+    const originalGetComputedStyle = window.getComputedStyle;
+    window.getComputedStyle = ((el: Element) => {
+      const real = originalGetComputedStyle(el);
+      return new Proxy(real, {
+        get(target, prop) {
+          if (prop === "paddingLeft") return "80px";
+          if (prop === "paddingRight") return "80px";
+          const val = Reflect.get(target, prop);
+          return typeof val === "function" ? val.bind(target) : val;
+        },
+      });
+    }) as typeof window.getComputedStyle;
 
     const { container } = render(
       <FullBleedCarousel>
@@ -109,18 +122,20 @@ describe("FullBleedCarousel", () => {
     const buttons = container.querySelectorAll("button");
     expect(buttons.length).toBe(2);
 
-    // Click left button — scrolls by clientWidth (400)
+    // Click left button — scrolls by visible content width (400 - 80 - 80 = 240)
     fireEvent.click(buttons[0]);
     expect(scrollByMock).toHaveBeenCalledWith({
-      left: -400,
+      left: -240,
       behavior: "smooth",
     });
 
-    // Click right button — scrolls by clientWidth (400)
+    // Click right button — scrolls by visible content width (400 - 80 - 80 = 240)
     fireEvent.click(buttons[1]);
     expect(scrollByMock).toHaveBeenCalledWith({
-      left: 400,
+      left: 240,
       behavior: "smooth",
     });
+
+    window.getComputedStyle = originalGetComputedStyle;
   });
 });

--- a/frontend/src/components/FullBleedCarousel.tsx
+++ b/frontend/src/components/FullBleedCarousel.tsx
@@ -40,7 +40,10 @@ export default function FullBleedCarousel({
   const scroll = (direction: "left" | "right") => {
     const el = scrollRef.current;
     if (!el) return;
-    const amount = el.clientWidth;
+    const style = getComputedStyle(el);
+    const padLeft = parseFloat(style.paddingLeft) || 0;
+    const padRight = parseFloat(style.paddingRight) || 0;
+    const amount = el.clientWidth - padLeft - padRight;
     el.scrollBy({
       left: direction === "left" ? -amount : amount,
       behavior: "smooth",


### PR DESCRIPTION
## Summary
Updated the FullBleedCarousel component to calculate scroll distance based on visible content width rather than the full clientWidth, accounting for horizontal padding.

## Key Changes
- Modified the `scroll` function in `FullBleedCarousel.tsx` to subtract left and right padding from `clientWidth` when determining scroll amount
- Updated the corresponding test to mock `getComputedStyle` and verify the correct scroll distance is calculated (clientWidth minus padding)
- Added test cleanup to restore the original `getComputedStyle` function

## Implementation Details
The scroll amount is now calculated as: `clientWidth - paddingLeft - paddingRight`

This ensures that when users click the carousel navigation arrows, the component scrolls by the actual visible content width rather than the full element width, providing more intuitive navigation behavior when padding is present.

https://claude.ai/code/session_012eHHtdov7cfSQoDtBu6oGS