### PR TITLE
Fix virtual scrolling offset calculation in TitleList

### DIFF
--- a/frontend/src/components/TitleList.tsx
+++ b/frontend/src/components/TitleList.tsx
@@ -137,7 +137,7 @@ export default function TitleList({
                 top: 0,
                 left: 0,
                 width: "100%",
-                transform: `translateY(${virtualRow.start}px)`,
+                transform: `translateY(${virtualRow.start - rowVirtualizer.options.scrollMargin}px)`,
               }}
             >
               <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4 pb-4">


### PR DESCRIPTION
## Summary
Fixed the virtual scrolling transform calculation in TitleList to account for the scroll margin offset, ensuring proper alignment of virtualized rows.

## Key Changes
- Updated the `translateY` transform calculation to subtract `rowVirtualizer.options.scrollMargin` from `virtualRow.start`
- This ensures that virtualized rows are positioned correctly relative to the scroll container's margin

## Implementation Details
The scroll margin offset was not being accounted for in the transform calculation, which could cause misalignment between the virtual scroll position and the actual rendered content. By subtracting the scroll margin from the start position, the rows now render at the correct visual position within the scrollable area.

https://claude.ai/code/session_013X5WfLYNKnfdHW9Mb4jxRo