### PR TITLE
fix: include today's episodes in unwatched list and Reels mode

### DIFF
--- a/server/db/repository/episodes.test.ts
+++ b/server/db/repository/episodes.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
+import { makeParsedTitle } from "../../test-utils/fixtures";
+import { upsertTitles, createUser, trackTitle, upsertEpisodes, watchEpisode } from "../repository";
+import { getUnwatchedEpisodes } from "./episodes";
+
+let userId: string;
+
+beforeEach(async () => {
+  setupTestDb();
+  userId = await createUser("testuser", "hash");
+  await upsertTitles([makeParsedTitle({ id: "show-1", objectType: "SHOW", title: "Test Show" })]);
+  await trackTitle("show-1", userId);
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+describe("getUnwatchedEpisodes", () => {
+  it("includes episodes that aired today", async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    await upsertEpisodes([
+      {
+        title_id: "show-1",
+        season_number: 1,
+        episode_number: 1,
+        name: "Today Episode",
+        overview: null,
+        air_date: today,
+        still_path: null,
+      },
+    ]);
+
+    const results = await getUnwatchedEpisodes(userId);
+    expect(results.some((e) => e.air_date === today)).toBe(true);
+  });
+
+  it("excludes future episodes", async () => {
+    const tomorrow = new Date(Date.now() + 86400000).toISOString().slice(0, 10);
+    await upsertEpisodes([
+      {
+        title_id: "show-1",
+        season_number: 1,
+        episode_number: 2,
+        name: "Future Episode",
+        overview: null,
+        air_date: tomorrow,
+        still_path: null,
+      },
+    ]);
+
+    const results = await getUnwatchedEpisodes(userId);
+    expect(results.some((e) => e.air_date === tomorrow)).toBe(false);
+  });
+
+  it("excludes episodes already watched", async () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+    await upsertEpisodes([
+      {
+        title_id: "show-1",
+        season_number: 1,
+        episode_number: 3,
+        name: "Watched Episode",
+        overview: null,
+        air_date: yesterday,
+        still_path: null,
+      },
+    ]);
+
+    const [episode] = await getUnwatchedEpisodes(userId);
+    await watchEpisode(episode.id, userId);
+
+    const after = await getUnwatchedEpisodes(userId);
+    expect(after.some((e) => e.id === episode.id)).toBe(false);
+  });
+});

--- a/server/db/repository/episodes.ts
+++ b/server/db/repository/episodes.ts
@@ -1,4 +1,4 @@
-import { eq, and, sql, gte, lt, asc, inArray } from "drizzle-orm";
+import { eq, and, sql, gte, lt, lte, asc, inArray } from "drizzle-orm";
 import { getDb } from "../schema";
 import { titles, episodes, tracked, watchedEpisodes } from "../schema";
 import { traceDbQuery } from "../../tracing";
@@ -184,7 +184,7 @@ export async function getUnwatchedEpisodes(userId: string, timezone = "UTC") {
       )
       .where(
         and(
-          lt(episodes.airDate, today),
+          lte(episodes.airDate, today),
           sql`NOT EXISTS(
             SELECT 1 FROM watched_episodes we
             WHERE we.episode_id = ${episodes.id} AND we.user_id = ${userId}


### PR DESCRIPTION
## Summary
- `getUnwatchedEpisodes` used `lt(episodes.airDate, today)` (strict `<`), silently excluding episodes that air on the current day
- Changed to `lte` so episodes released today are immediately visible in the unwatched list and Reels mode
- Added `server/db/repository/episodes.test.ts` with regression tests covering the today-boundary, future exclusion, and watched exclusion cases

## Test plan
- [ ] The Boys S05E03 (air_date 2026-04-15) now appears in the unwatched list and Reels mode
- [ ] Future episodes are still excluded
- [ ] Watched episodes are still excluded
- [ ] `bun run check` passes (1783 tests, no type errors, no lint warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)