### PR TITLE
fix: suppress spurious AUTH_CANCELLED error on passkey sign-in

### DIFF
--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, mock, afterEach, beforeEach } from "bun:test";
+import { render, screen, waitFor, cleanup, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+import "../i18n";
+
+type PasskeyError = { code?: string; message?: string; status?: number };
+type PasskeyResult = { data: unknown; error: PasskeyError | null };
+type SessionResult = { data: { user: { id: string; name?: string; username?: string; role?: string | null } } | null };
+
+let mockPasskeySignIn: (opts?: { autoFill?: boolean }) => Promise<PasskeyResult>;
+let mockGetSession: () => Promise<SessionResult>;
+
+mock.module("../lib/auth-client", () => ({
+  authClient: {
+    getSession: () => mockGetSession(),
+    signIn: {
+      passkey: (opts?: { autoFill?: boolean }) => mockPasskeySignIn(opts),
+      username: mock(() => Promise.resolve({ data: null, error: null })),
+      social: mock(() => {}),
+    },
+    signUp: { email: mock(() => Promise.resolve({})) },
+    signOut: mock(() => Promise.resolve()),
+  },
+}));
+
+// Mock useAuth directly so this test is immune to AuthContext mock.module
+// leakage from sibling test files.
+mock.module("../context/AuthContext", () => ({
+  useAuth: () => ({
+    user: null,
+    providers: { local: true, oidc: null, passkey: true },
+    loading: false,
+    login: () => Promise.resolve(),
+    signup: () => Promise.resolve(),
+    logout: () => Promise.resolve(),
+    refresh: () => Promise.resolve(),
+  }),
+  AuthContext: { Provider: ({ children }: { children: React.ReactNode }) => children },
+}));
+
+const { default: LoginPage } = await import("./LoginPage");
+
+const originalPublicKeyCredential = (globalThis as unknown as { PublicKeyCredential?: unknown }).PublicKeyCredential;
+
+beforeEach(() => {
+  // Make isWebAuthnSupported() true without triggering conditional mediation.
+  (globalThis as unknown as { PublicKeyCredential: unknown }).PublicKeyCredential = {
+    isConditionalMediationAvailable: () => Promise.resolve(false),
+  };
+  mockGetSession = () => Promise.resolve({ data: null });
+});
+
+afterEach(() => {
+  cleanup();
+  if (originalPublicKeyCredential === undefined) {
+    delete (globalThis as unknown as { PublicKeyCredential?: unknown }).PublicKeyCredential;
+  } else {
+    (globalThis as unknown as { PublicKeyCredential: unknown }).PublicKeyCredential = originalPublicKeyCredential;
+  }
+});
+
+describe("LoginPage passkey sign-in", () => {
+  it("does not show an error when the passkey prompt is cancelled (AUTH_CANCELLED)", async () => {
+    mockPasskeySignIn = () =>
+      Promise.resolve({
+        data: null,
+        error: { code: "AUTH_CANCELLED", message: "AUTH_CANCELLED", status: 400 },
+      });
+
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>
+    );
+
+    const button = await screen.findByRole("button", { name: /sign in with passkey/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect((button as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    expect(screen.queryByText(/AUTH_CANCELLED/)).toBeNull();
+  });
+
+  it("shows a real error message when passkey sign-in fails for other reasons", async () => {
+    mockPasskeySignIn = () =>
+      Promise.resolve({
+        data: null,
+        error: { code: "INVALID_CHALLENGE", message: "Challenge expired", status: 400 },
+      });
+
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>
+    );
+
+    const button = await screen.findByRole("button", { name: /sign in with passkey/i });
+    fireEvent.click(button);
+
+    expect(await screen.findByText(/Challenge expired/)).toBeDefined();
+  });
+
+  it("falls back to the localized message when error message is empty", async () => {
+    mockPasskeySignIn = () =>
+      Promise.resolve({
+        data: null,
+        error: { code: "UNKNOWN", message: "", status: 400 },
+      });
+
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>
+    );
+
+    const button = await screen.findByRole("button", { name: /sign in with passkey/i });
+    fireEvent.click(button);
+
+    expect(await screen.findByText(/Passkey sign-in failed/i)).toBeDefined();
+  });
+});

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -38,9 +38,11 @@ export default function LoginPage() {
     if (oidcError) setError(t("login.loginFailed", { error: oidcError }));
   }, [searchParams, t]);
 
-  // Enable passkey autofill (conditional UI)
+  // Enable passkey autofill (conditional UI) — only when the username field is
+  // visible, otherwise the pending ceremony has nothing to attach to and can
+  // conflict with an explicit passkey button click (surfaces as AUTH_CANCELLED).
   useEffect(() => {
-    if (!passkeyAvailable) return;
+    if (!passkeyAvailable || !showLocalLogin) return;
     let cancelled = false;
     (async () => {
       try {
@@ -60,7 +62,7 @@ export default function LoginPage() {
       }
     })();
     return () => { cancelled = true; };
-  }, [passkeyAvailable, navigate, refresh]);
+  }, [passkeyAvailable, showLocalLogin, navigate, refresh]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -89,7 +91,14 @@ export default function LoginPage() {
     try {
       const result = await authClient.signIn.passkey();
       if (result?.error) {
-        throw new Error(String(result.error.message || t("login.passkeyFailed")));
+        // better-auth maps every WebAuthn failure (user cancel, timeout,
+        // conditional-UI conflict) to AUTH_CANCELLED — treat it as a silent
+        // dismissal and show other errors normally.
+        const code = (result.error as { code?: string }).code;
+        const message = result.error.message ? String(result.error.message) : "";
+        if (code === "AUTH_CANCELLED" || message === "AUTH_CANCELLED") return;
+        setError(message || t("login.passkeyFailed"));
+        return;
       }
       const session = await authClient.getSession();
       if (session.data?.user) {


### PR DESCRIPTION
better-auth's passkey client wraps every WebAuthn failure — user cancel,
timeout, or a conditional-UI conflict with autofill — into a soft result
{ error: { code: "AUTH_CANCELLED" } } instead of throwing NotAllowedError.
The existing handler re-threw it as a plain Error, so the catch's
`err.name !== "NotAllowedError"` filter didn't match and the raw code was
displayed to the user.

Inspect result.error directly and silently return on AUTH_CANCELLED.
Also gate the conditional-mediation autofill effect on showLocalLogin so
it only runs when a webauthn-autocomplete input is actually visible,
eliminating the autofill/explicit-request conflict that was triggering
the cancel in the first place.