### PR TITLE
feat: mobile Signal redesign — floating dock, More screen, and per-page layouts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@better-auth/passkey": "^1.5.6",
+        "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@fontsource-variable/plus-jakarta-sans": "^5.2.8",
         "@sentry/react": "^10.43.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -395,6 +396,8 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
+    "@fontsource-variable/jetbrains-mono": ["@fontsource-variable/jetbrains-mono@5.2.8", "", {}, "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q=="],
 
     "@fontsource-variable/plus-jakarta-sans": ["@fontsource-variable/plus-jakarta-sans@5.2.8", "", {}, "sha512-iQecBizIdZxezODNHzOn4SvvRMrZL/S8k4MEXGDynCmUrImVW0VmX+tIAMqnADwH4haXlHSXqMgU6+kcfBQJdw=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@base-ui/react": "^1.2.0",
     "@better-auth/passkey": "^1.5.6",
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@fontsource-variable/plus-jakarta-sans": "^5.2.8",
     "@sentry/react": "^10.43.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -2,17 +2,18 @@ import { describe, it, expect } from "bun:test";
 import { navLinkClass } from "./nav-utils";
 
 describe("navLinkClass", () => {
-  it("returns desktop active classes", () => {
+  it("returns desktop active classes with underline indicator", () => {
     const result = navLinkClass(true);
-    expect(result).toContain("px-4 py-2");
-    expect(result).toContain("bg-amber-500 text-zinc-950");
+    expect(result).toContain("border-amber-400");
+    expect(result).toContain("text-zinc-100");
     expect(result).not.toContain("block w-full");
+    expect(result).not.toContain("bg-amber-500");
   });
 
   it("returns desktop inactive classes", () => {
     const result = navLinkClass(false);
-    expect(result).toContain("px-4 py-2");
-    expect(result).toContain("text-zinc-400 hover:text-white hover:bg-zinc-800");
+    expect(result).toContain("text-zinc-400");
+    expect(result).toContain("border-transparent");
     expect(result).not.toContain("bg-amber-500");
   });
 
@@ -20,7 +21,7 @@ describe("navLinkClass", () => {
     const result = navLinkClass(true, true);
     expect(result).toContain("block w-full px-3 py-2.5");
     expect(result).toContain("bg-amber-500 text-zinc-950");
-    expect(result).not.toContain("px-4 py-2");
+    expect(result).not.toContain("border-amber-400");
   });
 
   it("returns mobile inactive classes", () => {
@@ -30,15 +31,12 @@ describe("navLinkClass", () => {
     expect(result).not.toContain("bg-amber-500");
   });
 
-  it("always includes common classes", () => {
+  it("desktop always includes common classes", () => {
     for (const isActive of [true, false]) {
-      for (const mobile of [true, false]) {
-        const result = navLinkClass(isActive, mobile);
-        expect(result).toContain("rounded-lg");
-        expect(result).toContain("text-sm");
-        expect(result).toContain("font-medium");
-        expect(result).toContain("transition-colors");
-      }
+      const result = navLinkClass(isActive);
+      expect(result).toContain("text-sm");
+      expect(result).toContain("transition-colors");
+      expect(result).toContain("border-b-2");
     }
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -99,12 +99,16 @@ export default function App() {
       </a>
       {/* Hide top nav on reels page for mobile */}
       <nav aria-label="Main navigation" className={`bg-zinc-950/80 backdrop-blur-xl border-b border-white/[0.06] sticky top-0 z-50 safe-top ${isReelsPage ? "hidden sm:block" : ""}`}>
-        <div className="max-w-7xl mx-auto px-4 flex items-center justify-between h-14">
-          <Link to="/" className="text-lg font-bold text-white tracking-tight hover:text-amber-400 transition-colors">
-            Remindarr
+        <div className="max-w-7xl mx-auto px-4 flex items-center gap-8 h-14">
+          {/* Logo */}
+          <Link to="/" className="flex items-center gap-2 shrink-0 hover:opacity-90 transition-opacity">
+            <div className="w-6 h-6 rounded-md bg-amber-400 flex items-center justify-center font-extrabold text-sm text-black leading-none select-none">
+              R
+            </div>
+            <span className="text-base font-bold text-white tracking-tight">Remindarr</span>
           </Link>
           {/* Desktop nav links */}
-          <div className="hidden sm:flex gap-1">
+          <div className="hidden sm:flex items-center gap-6">
             <NavLink
               to="/"
               end
@@ -141,6 +145,21 @@ export default function App() {
               </>
             )}
           </div>
+          <div className="flex-1" />
+          {/* ⌘K search trigger */}
+          <button
+            type="button"
+            aria-label="Search (press / or ⌘K)"
+            onClick={() => {
+              const input = document.getElementById("search-input") as HTMLInputElement | null;
+              if (input) { input.focus(); input.select(); }
+            }}
+            className="hidden sm:flex items-center gap-2 w-[260px] bg-white/[0.06] border border-white/[0.08] rounded-lg px-3 py-1.5 text-sm text-zinc-400 hover:bg-white/[0.1] transition-colors"
+          >
+            <span className="opacity-60 text-base leading-none">⌕</span>
+            <span className="flex-1 text-left text-[13px]">Search titles, people…</span>
+            <span className="font-mono text-[11px] opacity-60">⌘K</span>
+          </button>
           {/* Desktop user section */}
           <div className="hidden sm:flex items-center gap-3">
             {loading ? null : user ? (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,12 +51,12 @@ const SeasonDetailPage = lazyWithRetry(() => import("./pages/SeasonDetailPage"))
 const EpisodeDetailPage = lazyWithRetry(() => import("./pages/EpisodeDetailPage"));
 const PersonPage = lazyWithRetry(() => import("./pages/PersonPage"));
 const ReelsPage = lazyWithRetry(() => import("./pages/ReelsPage"));
-const UpcomingPage = lazyWithRetry(() => import("./pages/UpcomingPage"));
 const DiscoveryPage = lazyWithRetry(() => import("./pages/DiscoveryPage"));
 const InvitePage = lazyWithRetry(() => import("./pages/InvitePage"));
 const StatsPage = lazyWithRetry(() => import("./pages/StatsPage"));
 const AdminUsersPage = lazyWithRetry(() => import("./pages/AdminUsersPage"));
 const NotFoundPage = lazyWithRetry(() => import("./pages/NotFoundPage"));
+const MorePage = lazyWithRetry(() => import("./pages/MorePage"));
 
 function MobileHomeRedirect() {
   const { user, loading } = useAuth();
@@ -208,7 +208,8 @@ export default function App() {
             <Route path="/tracked" element={<RequireAuth><TrackedPage /></RequireAuth>} />
             <Route path="/calendar" element={<RequireAuth><CalendarPage /></RequireAuth>} />
             <Route path="/reels" element={<RequireAuth><ReelsPage /></RequireAuth>} />
-            <Route path="/upcoming" element={<RequireAuth><UpcomingPage /></RequireAuth>} />
+            <Route path="/upcoming" element={<RequireAuth><Navigate to="/calendar" replace /></RequireAuth>} />
+            <Route path="/more" element={<RequireAuth><MorePage /></RequireAuth>} />
             <Route path="/discovery" element={<RequireAuth><DiscoveryPage /></RequireAuth>} />
             <Route path="/invite" element={<RequireAuth><InvitePage /></RequireAuth>} />
             <Route path="/stats" element={<RequireAuth><StatsPage /></RequireAuth>} />

--- a/frontend/src/components/BottomTabBar.test.tsx
+++ b/frontend/src/components/BottomTabBar.test.tsx
@@ -41,11 +41,11 @@ describe("BottomTabBar", () => {
   it("renders 5 tabs when user is authenticated", () => {
     render(<BottomTabBar />, { wrapper: Wrapper });
 
-    expect(screen.getByText("Watch")).toBeDefined();
-    expect(screen.getByText("Upcoming")).toBeDefined();
-    expect(screen.getByText("Discovery")).toBeDefined();
+    expect(screen.getByText("Home")).toBeDefined();
     expect(screen.getByText("Browse")).toBeDefined();
-    expect(screen.getByText("Profile")).toBeDefined();
+    expect(screen.getByText("Calendar")).toBeDefined();
+    expect(screen.getByText("Tracked")).toBeDefined();
+    expect(screen.getByText("More")).toBeDefined();
   });
 
   it("renders Browse and Sign In when user is not authenticated", () => {
@@ -60,10 +60,10 @@ describe("BottomTabBar", () => {
 
     expect(screen.getByText("Browse")).toBeDefined();
     expect(screen.getByText("Sign In")).toBeDefined();
-    expect(screen.queryByText("Watch")).toBeNull();
-    expect(screen.queryByText("Upcoming")).toBeNull();
-    expect(screen.queryByText("Discovery")).toBeNull();
-    expect(screen.queryByText("Profile")).toBeNull();
+    expect(screen.queryByText("Home")).toBeNull();
+    expect(screen.queryByText("Calendar")).toBeNull();
+    expect(screen.queryByText("Tracked")).toBeNull();
+    expect(screen.queryByText("More")).toBeNull();
   });
 
   it("renders nothing while auth is loading", () => {
@@ -91,10 +91,10 @@ describe("BottomTabBar", () => {
     const links = screen.getAllByRole("link");
     const hrefs = links.map((link) => link.getAttribute("href"));
     expect(hrefs).toContain("/reels");
-    expect(hrefs).toContain("/upcoming");
-    expect(hrefs).toContain("/discovery");
     expect(hrefs).toContain("/browse");
-    expect(hrefs).toContain("/user/test");
+    expect(hrefs).toContain("/calendar");
+    expect(hrefs).toContain("/tracked");
+    expect(hrefs).toContain("/more");
   });
 
   it("links to correct routes when not authenticated", () => {

--- a/frontend/src/components/BottomTabBar.tsx
+++ b/frontend/src/components/BottomTabBar.tsx
@@ -1,12 +1,11 @@
 import { NavLink } from "react-router";
-import { Clapperboard, Clock, Search, Sparkles, User, LogIn } from "lucide-react";
+import { Clapperboard, Search, CalendarDays, Bookmark, MoreHorizontal, LogIn } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../context/AuthContext";
-import { bottomTabClass } from "../nav-utils";
 import { useApiCall } from "../hooks/useApiCall";
 import * as api from "../api";
 
-const ICON_SIZE = 20;
+const ICON_SIZE = 22;
 
 export default function BottomTabBar() {
   const { user, loading } = useAuth();
@@ -21,24 +20,44 @@ export default function BottomTabBar() {
 
   if (loading) return null;
 
+  const tabClass = (isActive: boolean) =>
+    `flex flex-col items-center justify-center flex-1 gap-1 py-2 transition-colors ${
+      isActive ? "text-amber-400" : "text-zinc-500"
+    }`;
+
   return (
-    <nav aria-label="Mobile navigation" className="fixed bottom-0 left-0 right-0 z-50 bg-zinc-950/90 backdrop-blur-xl border-t border-white/[0.06] sm:hidden safe-bottom">
-      <div className="flex justify-around">
+    <nav
+      aria-label="Mobile navigation"
+      className="fixed left-3 right-3 bottom-[18px] z-50 sm:hidden"
+    >
+      <div
+        className="flex items-center bg-zinc-900/[0.72] backdrop-blur-xl backdrop-saturate-150 border border-white/[0.08] rounded-3xl shadow-[0_10px_30px_rgba(0,0,0,0.6)] px-1.5"
+      >
         {user ? (
           <>
-            <NavLink to="/reels" className={({ isActive }) => bottomTabClass(isActive)}>
+            <NavLink to="/reels" className={({ isActive }) => tabClass(isActive)}>
               <Clapperboard size={ICON_SIZE} aria-hidden="true" />
-              <span className="text-[10px] mt-0.5">{t("bottomNav.watch")}</span>
+              <span className="text-[10px] font-semibold tracking-[0.02em]">{t("bottomNav.watch")}</span>
             </NavLink>
 
-            <NavLink to="/upcoming" className={({ isActive }) => bottomTabClass(isActive)}>
-              <Clock size={ICON_SIZE} aria-hidden="true" />
-              <span className="text-[10px] mt-0.5">{t("bottomNav.upcoming")}</span>
+            <NavLink to="/browse" className={({ isActive }) => tabClass(isActive)}>
+              <Search size={ICON_SIZE} aria-hidden="true" />
+              <span className="text-[10px] font-semibold tracking-[0.02em]">{t("bottomNav.browse")}</span>
             </NavLink>
 
-            <NavLink to="/discovery" className={({ isActive }) => bottomTabClass(isActive)}>
+            <NavLink to="/calendar" className={({ isActive }) => tabClass(isActive)}>
+              <CalendarDays size={ICON_SIZE} aria-hidden="true" />
+              <span className="text-[10px] font-semibold tracking-[0.02em]">{t("bottomNav.calendar")}</span>
+            </NavLink>
+
+            <NavLink to="/tracked" className={({ isActive }) => tabClass(isActive)}>
+              <Bookmark size={ICON_SIZE} aria-hidden="true" />
+              <span className="text-[10px] font-semibold tracking-[0.02em]">{t("bottomNav.tracked")}</span>
+            </NavLink>
+
+            <NavLink to="/more" className={({ isActive }) => tabClass(isActive)}>
               <div className="relative">
-                <Sparkles size={ICON_SIZE} aria-hidden="true" />
+                <MoreHorizontal size={ICON_SIZE} aria-hidden="true" />
                 {unreadCount > 0 && (
                   <span
                     data-testid="unread-badge"
@@ -49,29 +68,19 @@ export default function BottomTabBar() {
                   </span>
                 )}
               </div>
-              <span className="text-[10px] mt-0.5">{t("bottomNav.discovery")}</span>
-            </NavLink>
-
-            <NavLink to="/browse" className={({ isActive }) => bottomTabClass(isActive)}>
-              <Search size={ICON_SIZE} aria-hidden="true" />
-              <span className="text-[10px] mt-0.5">{t("bottomNav.browse")}</span>
-            </NavLink>
-
-            <NavLink to={`/user/${user.username}`} className={({ isActive }) => bottomTabClass(isActive)}>
-              <User size={ICON_SIZE} aria-hidden="true" />
-              <span className="text-[10px] mt-0.5">{t("bottomNav.profile")}</span>
+              <span className="text-[10px] font-semibold tracking-[0.02em]">{t("bottomNav.more")}</span>
             </NavLink>
           </>
         ) : (
           <>
-            <NavLink to="/browse" className={({ isActive }) => bottomTabClass(isActive)}>
+            <NavLink to="/browse" className={({ isActive }) => tabClass(isActive)}>
               <Search size={ICON_SIZE} aria-hidden="true" />
-              <span className="text-[10px] mt-0.5">{t("bottomNav.browse")}</span>
+              <span className="text-[10px] font-semibold tracking-[0.02em]">{t("bottomNav.browse")}</span>
             </NavLink>
 
-            <NavLink to="/login" className={({ isActive }) => bottomTabClass(isActive)}>
+            <NavLink to="/login" className={({ isActive }) => tabClass(isActive)}>
               <LogIn size={ICON_SIZE} aria-hidden="true" />
-              <span className="text-[10px] mt-0.5">{t("bottomNav.signIn")}</span>
+              <span className="text-[10px] font-semibold tracking-[0.02em]">{t("bottomNav.signIn")}</span>
             </NavLink>
           </>
         )}

--- a/frontend/src/components/CategoryBar.tsx
+++ b/frontend/src/components/CategoryBar.tsx
@@ -1,3 +1,5 @@
+import { Pill } from "../components/design";
+
 export type BrowseCategory = "new_releases" | "popular" | "upcoming" | "top_rated";
 
 const CATEGORIES: { value: BrowseCategory; label: string }[] = [
@@ -14,19 +16,15 @@ interface Props {
 
 export default function CategoryBar({ category, onCategoryChange }: Props) {
   return (
-    <div className="flex gap-1 bg-zinc-800/50 rounded-lg p-1">
+    <div className="flex gap-2">
       {CATEGORIES.map((c) => (
-        <button
+        <Pill
           key={c.value}
+          active={category === c.value}
           onClick={() => onCategoryChange(c.value)}
-          className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors cursor-pointer ${
-            category === c.value
-              ? "bg-amber-500/15 text-amber-400"
-              : "text-zinc-400 hover:text-white"
-          }`}
         >
           {c.label}
-        </button>
+        </Pill>
       ))}
     </div>
   );

--- a/frontend/src/components/EpisodeShowCard.tsx
+++ b/frontend/src/components/EpisodeShowCard.tsx
@@ -46,8 +46,8 @@ export const EpisodeShowCard = memo(function EpisodeShowCard({
           <div className="w-full aspect-video bg-gradient-to-b from-zinc-800 to-zinc-950" />
         )}
         {episodeCount > 1 && (
-          <span className="absolute top-2 right-2 bg-black/70 text-white text-xs font-bold px-2 py-0.5 rounded-full">
-            {episodeCount}
+          <span className="absolute top-2 right-2 bg-black/75 backdrop-blur-sm text-zinc-100 font-mono text-[11px] font-semibold px-2 py-0.5 rounded-full">
+            {episodeCount} new
           </span>
         )}
       </Link>
@@ -113,13 +113,13 @@ export function DeckCardWrapper({ episodeCount, children }: { episodeCount: numb
     <div className="relative pb-2">
       {/* Second offset layer (deepest) */}
       {episodeCount > 2 && (
-        <div className="absolute inset-0 translate-y-2 scale-[0.97] opacity-40 bg-zinc-900 rounded-xl pointer-events-none" />
+        <div className="absolute inset-0 translate-y-3 scale-[0.96] opacity-35 bg-zinc-800 border border-white/[0.06] rounded-xl pointer-events-none" />
       )}
       {/* First offset layer */}
       {episodeCount > 1 && (
-        <div className="absolute inset-0 translate-y-1 scale-[0.985] opacity-60 bg-zinc-900 rounded-xl pointer-events-none" />
+        <div className="absolute inset-0 translate-y-1.5 scale-[0.98] opacity-60 bg-zinc-800 border border-white/[0.06] rounded-xl pointer-events-none" />
       )}
-      <div className="relative">{children}</div>
+      <div className="relative border border-white/[0.06] rounded-xl overflow-hidden">{children}</div>
     </div>
   );
 }

--- a/frontend/src/components/HeroBanner.tsx
+++ b/frontend/src/components/HeroBanner.tsx
@@ -94,7 +94,6 @@ export default function HeroBanner({ episodes }: { episodes: Episode[] }) {
   if (slides.length === 0) return null;
 
   const current = slides[activeIndex];
-  const currentPosterUrl = current.featured.poster_url;
 
   return (
     <div
@@ -149,143 +148,75 @@ export default function HeroBanner({ episodes }: { episodes: Episode[] }) {
         }}
       />
 
-      {/* Content overlay */}
-      <div className="relative z-10 h-full max-w-[1920px] mx-auto flex">
-        {/* Continue Watching card (left side) */}
-        {current.sidebar.length > 0 && (
-          <div className="w-72 shrink-0 flex items-center px-4">
-            <div className="w-full bg-zinc-900/80 backdrop-blur-sm rounded-xl p-4">
-              <p className="text-xs uppercase tracking-widest text-zinc-400 font-medium mb-3">
-                Continue Watching
-              </p>
-              <div className="space-y-1">
-                {current.sidebar.map((item) => {
-                  const slideIdx = slides.findIndex(
-                    (s) => s.featured.title_id === item.titleId
-                  );
-                  return (
-                    <button
-                      key={item.titleId}
-                      onClick={() => goTo(slideIdx)}
-                      className={`w-full flex items-center gap-3 px-2 py-1.5 rounded-lg transition-colors cursor-pointer ${
-                        slideIdx === activeIndex
-                          ? "bg-white/15"
-                          : "hover:bg-white/10"
-                      }`}
-                    >
-                      {item.posterUrl ? (
-                        <img
-                          src={item.posterUrl}
-                          alt={item.showTitle}
-                          className="w-8 h-12 rounded object-cover shrink-0"
-                          loading="lazy"
-                        />
-                      ) : (
-                        <div className="w-8 h-12 rounded bg-zinc-700 shrink-0" />
-                      )}
-                      <div className="min-w-0 text-left">
-                        <p className="text-sm font-semibold text-white truncate">
-                          {item.showTitle}
-                        </p>
-                        <p className="text-xs text-zinc-400 truncate">
-                          {item.episodeCode}
-                        </p>
-                      </div>
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-          </div>
-        )}
+      {/* Content overlay — bottom-left anchored */}
+      <div className="relative z-10 h-full flex items-end pb-12 px-8 sm:px-16">
+        <div className="max-w-[560px]">
+          {/* Kicker */}
+          <p className="font-mono text-[11px] font-semibold uppercase tracking-[0.15em] text-amber-400 mb-3">
+            Continue watching
+            {current.remainingCount > 0 && ` · ${current.remainingCount} unwatched`}
+          </p>
 
-        {/* Poster + text info */}
-        <div className="flex items-center gap-6 px-8">
-          {/* Show poster */}
-          {currentPosterUrl && (
-            <Link
-              to={`/title/${current.featured.title_id}`}
-              className="shrink-0"
-            >
-              <img
-                src={currentPosterUrl}
-                alt={current.featured.show_title}
-                className="h-[300px] rounded-lg shadow-2xl object-cover"
-                style={{ aspectRatio: "2/3" }}
-              />
-            </Link>
-          )}
+          {/* Title */}
+          <Link to={`/title/${current.featured.title_id}`} className="group">
+            <h2 className="text-5xl sm:text-[56px] font-extrabold tracking-[-0.03em] leading-none text-white group-hover:text-amber-300 transition-colors mb-4">
+              {current.featured.show_title}
+            </h2>
+          </Link>
 
           {/* Episode info */}
-          <div
-            className="flex flex-col justify-center max-w-md"
-            style={{ textShadow: "0 1px 4px rgba(0,0,0,0.6)" }}
-          >
-            <p className="text-xs uppercase tracking-widest text-amber-400 font-medium mb-2">
-              Currently Watching
-            </p>
+          <p className="text-base text-zinc-300 leading-relaxed mb-6 line-clamp-2">
+            {formatEpisodeCode(current.featured)}
+            {current.featured.name && ` · ${current.featured.name}`}
+            {current.featured.overview && ` — ${current.featured.overview}`}
+          </p>
+
+          {/* Actions */}
+          <div className="flex items-center gap-3 flex-wrap">
             <Link
               to={`/title/${current.featured.title_id}`}
-              className="group"
+              className="bg-amber-400 hover:bg-amber-300 text-black font-bold text-sm px-5 py-2.5 rounded-lg transition-colors"
             >
-              <h2 className="text-4xl font-bold text-white group-hover:text-amber-300 transition-colors">
-                {current.featured.show_title}
-              </h2>
+              ▶ Watch now
             </Link>
-            <p className="text-xl text-zinc-200 mt-2">
-              {formatEpisodeCode(current.featured)}
-              {current.featured.name && ` · ${current.featured.name}`}
-            </p>
-            {current.featured.overview && (
-              <p className="text-zinc-300 mt-3 line-clamp-3 max-w-xl">
-                {current.featured.overview}
-              </p>
-            )}
-            <p className="text-sm text-amber-300 mt-4">
-              {current.remainingCount} episode
-              {current.remainingCount !== 1 ? "s" : ""} remaining
-            </p>
-            <div className="mt-3">
-              <WatchButtonGroup offers={current.featured.offers ?? []} variant="inline" maxVisible={4} />
-            </div>
+            <WatchButtonGroup offers={current.featured.offers ?? []} variant="inline" maxVisible={2} />
           </div>
+
+          {/* Slide dots */}
+          {slides.length > 1 && (
+            <div className="flex gap-2 mt-6">
+              {slides.map((_, i) => (
+                <button
+                  key={i}
+                  onClick={() => goTo(i)}
+                  className={`h-1 rounded-full transition-all cursor-pointer ${
+                    i === activeIndex ? "w-6 bg-amber-400" : "w-2 bg-white/30 hover:bg-white/50"
+                  }`}
+                />
+              ))}
+            </div>
+          )}
         </div>
+
+        {/* Slide nav arrows — top-right of hero */}
+        {slides.length > 1 && (
+          <div className="absolute top-6 right-6 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+            <button
+              onClick={() => goTo(activeIndex - 1)}
+              className="bg-black/50 hover:bg-black/70 text-white rounded-full w-9 h-9 flex items-center justify-center cursor-pointer"
+            >
+              <ChevronLeft size={18} />
+            </button>
+            <button
+              onClick={() => goTo(activeIndex + 1)}
+              className="bg-black/50 hover:bg-black/70 text-white rounded-full w-9 h-9 flex items-center justify-center cursor-pointer"
+            >
+              <ChevronRight size={18} />
+            </button>
+          </div>
+        )}
       </div>
 
-      {/* Navigation arrows */}
-      {slides.length > 1 && (
-        <>
-          <button
-            onClick={() => goTo(activeIndex - 1)}
-            className="absolute left-3 top-1/2 -translate-y-1/2 z-20 bg-black/50 hover:bg-black/70 text-white rounded-full w-9 h-9 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
-          >
-            <ChevronLeft size={20} />
-          </button>
-          <button
-            onClick={() => goTo(activeIndex + 1)}
-            className="absolute right-3 top-1/2 -translate-y-1/2 z-20 bg-black/50 hover:bg-black/70 text-white rounded-full w-9 h-9 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
-          >
-            <ChevronRight size={20} />
-          </button>
-        </>
-      )}
-
-      {/* Navigation dots */}
-      {slides.length > 1 && (
-        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-20 flex gap-2">
-          {slides.map((_, i) => (
-            <button
-              key={i}
-              onClick={() => goTo(i)}
-              className={`w-2 h-2 rounded-full transition-colors cursor-pointer ${
-                i === activeIndex
-                  ? "bg-amber-400"
-                  : "bg-white/30 hover:bg-white/50"
-              }`}
-            />
-          ))}
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/src/components/ReelsCard.tsx
+++ b/frontend/src/components/ReelsCard.tsx
@@ -7,7 +7,7 @@ import ReelsUndoBar from "./ReelsUndoBar";
 function formatEpisodeCode(ep: Episode): string {
   const s = String(ep.season_number).padStart(2, "0");
   const e = String(ep.episode_number).padStart(2, "0");
-  return `S${s}E${e}`;
+  return `S${s}·E${e}`;
 }
 
 function formatAirDate(dateStr: string | null): string | null {
@@ -53,6 +53,11 @@ export default function ReelsCard({ episode, caughtUp, onMarkWatched, index, tot
   const airDateFormatted = formatAirDate(episode.air_date);
   const isNew = isToday(episode.air_date);
 
+  // Pick first provider name from offers for the chip
+  const providerName = episode.offers && episode.offers.length > 0
+    ? episode.offers[0].provider_name
+    : null;
+
   return (
     <div className="dark-section snap-start snap-always w-full relative flex-shrink-0 overflow-hidden" style={{ height: "calc(100dvh - env(safe-area-inset-top, 0px))" }}>
       {/* Background image */}
@@ -70,20 +75,32 @@ export default function ReelsCard({ episode, caughtUp, onMarkWatched, index, tot
       {/* Gradient overlay */}
       <div className="absolute inset-0 bg-gradient-to-b from-black/30 via-transparent to-black/90" />
 
-      {/* Position indicator */}
+      {/* Top-left: episode/provider/runtime chips */}
+      {!caughtUp && (
+        <div className="absolute top-4 left-4 z-10 flex items-center gap-1.5 flex-wrap">
+          <span className="bg-amber-400 text-black text-[10px] font-bold font-mono px-2 py-0.5 rounded-full leading-tight tracking-wide">
+            {formatEpisodeCode(episode)}
+          </span>
+          {providerName && (
+            <span className="bg-white/[0.12] text-white text-[10px] font-semibold font-mono px-2 py-0.5 rounded-full leading-tight border border-white/[0.1]">
+              {providerName.toUpperCase()}
+            </span>
+          )}
+          {isNew && (
+            <span className="bg-emerald-500 text-white text-[10px] font-bold px-2 py-0.5 rounded-full leading-tight">
+              NEW
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Top-right: position indicator */}
       <div className="absolute top-4 right-4 z-10 bg-black/50 px-3 py-1 rounded-full text-xs text-white/80">
         {index + 1} / {total}
       </div>
 
-      {/* Swipe hint */}
-      {!caughtUp && (
-        <div className="absolute top-4 left-4 z-10 bg-black/30 px-2 py-1 rounded-full text-[10px] text-white/50">
-          Swipe left for season
-        </div>
-      )}
-
       {/* Bottom content */}
-      <div className="absolute bottom-0 left-0 right-0 p-6 pb-20 sm:pb-4 z-10">
+      <div className="absolute bottom-0 left-0 right-0 p-6 pb-24 sm:pb-6 z-10">
         {caughtUp ? (
           <div className="text-center py-8">
             <div className="inline-flex items-center gap-2 bg-green-500/20 text-green-400 px-4 py-2 rounded-full text-lg font-semibold mb-2">
@@ -99,34 +116,26 @@ export default function ReelsCard({ episode, caughtUp, onMarkWatched, index, tot
           </div>
         ) : (
           <>
-            {/* Show title - linked */}
+            {/* Show title — mono amber kicker */}
             <Link to={`/title/${episode.title_id}`}>
-              <h2 className="text-2xl font-bold text-white mb-1 drop-shadow-lg hover:text-amber-300 transition-colors">
+              <div className="font-mono text-[11px] uppercase tracking-[0.15em] text-amber-400 font-semibold mb-2 drop-shadow hover:opacity-80 transition-opacity">
                 {episode.show_title}
+              </div>
+            </Link>
+
+            {/* Episode name — large */}
+            <Link to={`/title/${episode.title_id}/season/${episode.season_number}/episode/${episode.episode_number}`}>
+              <h2 className="text-[30px] font-extrabold tracking-[-0.02em] leading-[1.05] text-white mb-2 drop-shadow-lg hover:text-amber-300 transition-colors">
+                {episode.name ?? formatEpisodeCode(episode)}
               </h2>
             </Link>
 
-            {/* Episode code + name - linked */}
-            <Link to={`/title/${episode.title_id}/season/${episode.season_number}/episode/${episode.episode_number}`}>
-              <p className="text-base text-white/90 font-medium mb-1 drop-shadow hover:text-amber-300 transition-colors">
-                {formatEpisodeCode(episode)}
-                {episode.name && ` · ${episode.name}`}
-              </p>
-            </Link>
-
-            {/* Air date + NEW badge */}
-            <div className="flex items-center gap-2 mb-2">
-              {airDateFormatted && (
-                <span className="text-sm text-white/60 drop-shadow">
-                  {airDateFormatted}
-                </span>
-              )}
-              {isNew && (
-                <span className="bg-emerald-500 text-white text-xs font-semibold px-2 py-0.5 rounded-full">
-                  NEW
-                </span>
-              )}
-            </div>
+            {/* Meta line */}
+            {airDateFormatted && (
+              <div className="font-mono text-[12px] text-zinc-300 mb-3 drop-shadow">
+                {airDateFormatted}
+              </div>
+            )}
 
             {/* Overview */}
             {episode.overview && (
@@ -134,6 +143,11 @@ export default function ReelsCard({ episode, caughtUp, onMarkWatched, index, tot
                 {episode.overview}
               </p>
             )}
+
+            {/* 3px progress bar (placeholder — no progress data on Episode type) */}
+            <div className="h-[3px] bg-white/[0.1] rounded-full mb-4 overflow-hidden">
+              <div className="h-full w-0 bg-amber-400 rounded-full" />
+            </div>
 
             {/* Watch on provider button */}
             <div className="mb-2">

--- a/frontend/src/components/TitleCard.tsx
+++ b/frontend/src/components/TitleCard.tsx
@@ -18,9 +18,11 @@ interface Props {
   showStatusPicker?: boolean;
   showNotificationPicker?: boolean;
   showTags?: boolean;
+  showProviderBadge?: boolean;
+  showRating?: boolean;
 }
 
-const TitleCard = memo(function TitleCard({ title, onTrackToggle, showVisibilityToggle, onVisibilityToggle, hideTypeBadge, showProgressBar, showStatusPicker, showNotificationPicker, showTags }: Props) {
+const TitleCard = memo(function TitleCard({ title, onTrackToggle, showVisibilityToggle, onVisibilityToggle, hideTypeBadge, showProgressBar, showStatusPicker, showNotificationPicker, showTags, showProviderBadge, showRating }: Props) {
   const [prevTitleId, setPrevTitleId] = useState(title.id);
   const [userStatus, setUserStatus] = useState(title.user_status ?? null);
   const [notifMode, setNotifMode] = useState(title.notification_mode ?? null);
@@ -53,7 +55,12 @@ const TitleCard = memo(function TitleCard({ title, onTrackToggle, showVisibility
             </div>
           )}
         </Link>
-        {!hideTypeBadge && title.object_type === "SHOW" && (
+        {showProviderBadge && title.offers?.[0]?.provider_name && (
+          <span className="absolute top-2 left-2 bg-black/70 backdrop-blur-sm text-zinc-100 font-mono text-[10px] font-semibold px-2 py-0.5 rounded">
+            {title.offers[0].provider_name}
+          </span>
+        )}
+        {!hideTypeBadge && !showProviderBadge && title.object_type === "SHOW" && (
           <span className="absolute top-2 left-2 bg-amber-500 text-black text-[10px] font-bold px-1.5 py-0.5 rounded">
             TV
           </span>
@@ -126,9 +133,14 @@ const TitleCard = memo(function TitleCard({ title, onTrackToggle, showVisibility
             />
           </div>
         )}
-        {title.imdb_score && !showVisibilityToggle && (
+        {title.imdb_score && !showVisibilityToggle && !showRating && (
           <span className="absolute top-2 right-2 bg-yellow-500 text-black text-[11px] font-bold px-1.5 py-0.5 rounded">
             {title.imdb_score.toFixed(1)}
+          </span>
+        )}
+        {showRating && (title.imdb_score ?? title.tmdb_score) && (
+          <span className="absolute bottom-2 right-2 bg-black/70 backdrop-blur-sm text-amber-400 font-mono text-[10px] font-bold px-1.5 py-0.5 rounded">
+            ★ {(title.imdb_score ?? title.tmdb_score)?.toFixed(1)}
           </span>
         )}
         {showVisibilityToggle && (

--- a/frontend/src/components/TitleList.tsx
+++ b/frontend/src/components/TitleList.tsx
@@ -4,7 +4,7 @@ import type { Title } from "../types";
 import TitleCard from "./TitleCard";
 
 /** Number of columns at each responsive breakpoint */
-const BREAKPOINT_COLS = { base: 2, sm: 3, md: 4, lg: 5, xl: 6 };
+const BREAKPOINT_COLS = { base: 3, sm: 3, md: 4, lg: 5, xl: 6 };
 
 /** Auto-virtualize when list exceeds this many items (4 rows × 6 cols at xl) */
 const VIRTUAL_THRESHOLD = 24;
@@ -140,7 +140,7 @@ export default function TitleList({
                 transform: `translateY(${virtualRow.start - rowVirtualizer.options.scrollMargin}px)`,
               }}
             >
-              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4 pb-4">
+              <div className="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-2 sm:gap-4 pb-4">
                 {(rows[virtualRow.index] ?? []).map((title) => (
                   <TitleCard key={title.id} title={title} {...cardProps} />
                 ))}
@@ -151,7 +151,7 @@ export default function TitleList({
       ) : (
         <div
           data-testid="title-grid"
-          className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4"
+          className="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-2 sm:gap-4"
         >
           {displayTitles.map((title) => (
             <TitleCard key={title.id} title={title} {...cardProps} />

--- a/frontend/src/components/design/Chip.tsx
+++ b/frontend/src/components/design/Chip.tsx
@@ -1,0 +1,23 @@
+import { cn } from "@/lib/utils";
+
+interface ChipProps {
+  children: React.ReactNode;
+  variant?: "default" | "amber" | "outline";
+  className?: string;
+}
+
+export function Chip({ children, variant = "default", className }: ChipProps) {
+  return (
+    <span
+      className={cn(
+        "inline-block font-mono text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 rounded",
+        variant === "default" && "bg-white/[0.08] text-zinc-300",
+        variant === "amber" && "bg-amber-400 text-black",
+        variant === "outline" && "bg-transparent border border-amber-400/40 text-amber-400",
+        className
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/frontend/src/components/design/Kicker.tsx
+++ b/frontend/src/components/design/Kicker.tsx
@@ -1,0 +1,21 @@
+import { cn } from "@/lib/utils";
+
+interface KickerProps {
+  children: React.ReactNode;
+  className?: string;
+  color?: "amber" | "zinc";
+}
+
+export function Kicker({ children, className, color = "amber" }: KickerProps) {
+  return (
+    <div
+      className={cn(
+        "font-mono text-[11px] font-semibold uppercase tracking-[0.15em] mb-3",
+        color === "amber" ? "text-amber-400" : "text-zinc-500",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/design/PageHeader.tsx
+++ b/frontend/src/components/design/PageHeader.tsx
@@ -1,0 +1,28 @@
+import { Kicker } from "./Kicker";
+import { cn } from "@/lib/utils";
+
+interface PageHeaderProps {
+  kicker: string;
+  title: string;
+  right?: React.ReactNode;
+  className?: string;
+}
+
+export function PageHeader({ kicker, title, right, className }: PageHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "px-6 md:px-16 pt-10 pb-6 flex items-end justify-between gap-4",
+        className
+      )}
+    >
+      <div>
+        <Kicker>{kicker}</Kicker>
+        <h1 className="text-4xl md:text-[44px] font-extrabold tracking-[-0.03em] leading-none text-zinc-100">
+          {title}
+        </h1>
+      </div>
+      {right && <div className="flex items-center gap-2 shrink-0">{right}</div>}
+    </div>
+  );
+}

--- a/frontend/src/components/design/Pill.tsx
+++ b/frontend/src/components/design/Pill.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@/lib/utils";
+
+interface PillProps {
+  children: React.ReactNode;
+  active?: boolean;
+  onClick?: () => void;
+  className?: string;
+}
+
+export function Pill({ children, active, onClick, className }: PillProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "rounded-full px-3 py-1.5 text-xs font-semibold whitespace-nowrap transition-colors",
+        active
+          ? "bg-amber-400 text-black border-transparent"
+          : "bg-white/[0.04] border border-white/[0.08] text-zinc-300 hover:text-zinc-100 hover:bg-white/[0.08]",
+        className
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/components/design/index.ts
+++ b/frontend/src/components/design/index.ts
@@ -1,0 +1,4 @@
+export { Kicker } from "./Kicker";
+export { Pill } from "./Pill";
+export { Chip } from "./Chip";
+export { PageHeader } from "./PageHeader";

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,6 +2,7 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 @import "@fontsource-variable/plus-jakarta-sans";
+@import "@fontsource-variable/jetbrains-mono";
 
 @custom-variant dark (&:is(.dark *));
 
@@ -45,6 +46,7 @@
 
 @theme inline {
     --font-sans: 'Plus Jakarta Sans Variable', sans-serif;
+    --font-mono: 'JetBrains Mono Variable', ui-monospace, Menlo, monospace;
     --color-sidebar-ring: var(--sidebar-ring);
     --color-sidebar-border: var(--sidebar-border);
     --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -50,11 +50,13 @@
     "stats": "Stats"
   },
   "bottomNav": {
-    "watch": "Watch",
+    "watch": "Home",
     "upcoming": "Upcoming",
     "browse": "Browse",
     "calendar": "Calendar",
+    "tracked": "Tracked",
     "discovery": "Discovery",
+    "more": "More",
     "profile": "Profile",
     "signIn": "Sign In",
     "unreadRecommendations_one": "{{count}} unread recommendation",

--- a/frontend/src/nav-utils.ts
+++ b/frontend/src/nav-utils.ts
@@ -1,6 +1,14 @@
 export function navLinkClass(isActive: boolean, mobile = false): string {
-  return `${mobile ? "block w-full px-3 py-2.5" : "px-4 py-2"} rounded-lg text-sm font-medium transition-colors ${
-    isActive ? "bg-amber-500 text-zinc-950 font-medium" : "text-zinc-400 hover:text-white hover:bg-zinc-800"
+  if (mobile) {
+    return `block w-full px-3 py-2.5 rounded-lg text-sm font-medium transition-colors ${
+      isActive ? "bg-amber-500 text-zinc-950 font-medium" : "text-zinc-400 hover:text-white hover:bg-zinc-800"
+    }`;
+  }
+  // Desktop: underline active indicator (matches V1 Signal design)
+  return `px-1 py-2 text-sm font-medium transition-colors border-b-2 leading-none ${
+    isActive
+      ? "text-zinc-100 border-amber-400 font-semibold"
+      : "text-zinc-400 border-transparent hover:text-zinc-100"
   }`;
 }
 

--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -10,6 +10,7 @@ import * as api from "../api";
 import type { Title } from "../types";
 import { normalizeSearchTitle } from "../types";
 import { useGridNavigation } from "../hooks/useGridNavigation";
+import { PageHeader } from "../components/design";
 
 const VALID_CATEGORIES: BrowseCategory[] = ["new_releases", "popular", "upcoming", "top_rated"];
 
@@ -233,6 +234,7 @@ export default function BrowsePage() {
 
   return (
     <div className="space-y-6">
+      <PageHeader kicker="Browse catalog" title="Browse" className="px-0 pt-4 pb-4" />
       <SearchBar onSearch={handleSearch} onImdb={handleImdb} loading={searchLoading} />
 
 
@@ -334,7 +336,7 @@ export default function BrowsePage() {
       {searchResults !== null ? (
         <div className="space-y-3">
           <div className="flex items-center justify-between">
-            <h2 className="text-lg font-semibold">{t("browse.searchResults", { count: searchResults.length })}</h2>
+            <h2 className="text-xl font-bold tracking-[-0.01em]">{t("browse.searchResults", { count: searchResults.length })}</h2>
             <button
               onClick={clearSearch}
               className="text-sm text-zinc-400 hover:text-white cursor-pointer"
@@ -346,7 +348,7 @@ export default function BrowsePage() {
         </div>
       ) : (
         <div>
-          <h2 className="text-lg font-semibold mb-4">{t(CATEGORY_LABEL_KEYS[category])}</h2>
+          <h2 className="text-xl font-bold tracking-[-0.01em] mb-4">{t(CATEGORY_LABEL_KEYS[category])}</h2>
           {category === "new_releases" ? (
             <NewReleases
               type={type}

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -25,12 +25,11 @@ import AgendaCalendar, {
   typeFilters,
   formatMonth,
   formatDateKey,
-  getItemHeroUrl,
-  pickFeaturedItem,
   getCellBorderColor,
   useCalendarParam,
   ViewToggle,
 } from "../components/AgendaCalendar";
+import { PageHeader } from "../components/design";
 
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -527,62 +526,73 @@ function GridCalendar({
     }
   };
 
+  const monthTitle = currentMonth.toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+  });
+
+  const headerRight = (
+    <div className="flex items-center gap-2">
+      <button
+        onClick={prevMonth}
+        className="p-1.5 rounded-lg hover:bg-zinc-800 text-zinc-400 hover:text-white transition-colors cursor-pointer"
+      >
+        <ChevronLeftIcon className="size-5" />
+      </button>
+      <button
+        onClick={() => setMonthParam(formatMonth(new Date()))}
+        className="px-3 py-1.5 rounded-lg text-sm font-medium text-zinc-400 hover:text-white hover:bg-zinc-800 transition-colors cursor-pointer"
+      >
+        Today
+      </button>
+      <button
+        onClick={nextMonth}
+        className="p-1.5 rounded-lg hover:bg-zinc-800 text-zinc-400 hover:text-white transition-colors cursor-pointer"
+      >
+        <ChevronRightIcon className="size-5" />
+      </button>
+      <div className="w-px h-5 bg-white/10 mx-1" />
+      {typeFilters.map((f) => (
+        <button
+          key={f.value}
+          onClick={() => setTypeFilter(f.value)}
+          className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
+            typeFilter === f.value
+              ? "bg-amber-500 text-zinc-950"
+              : "text-zinc-400 hover:text-white hover:bg-zinc-800"
+          }`}
+        >
+          {f.label}
+        </button>
+      ))}
+      <button
+        onClick={() => setHideWatched((v) => !v)}
+        className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
+          hideWatched
+            ? "bg-amber-500 text-zinc-950"
+            : "text-zinc-400 hover:text-white hover:bg-zinc-800"
+        }`}
+        title={hideWatched ? "Show watched" : "Hide watched"}
+      >
+        {hideWatched ? (
+          <EyeOffIcon className="size-4" />
+        ) : (
+          <EyeIcon className="size-4" />
+        )}
+      </button>
+      <ViewToggle viewMode={viewMode} onViewModeChange={onViewModeChange} />
+    </div>
+  );
+
   return (
     <div className="space-y-4">
       {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-        <div className="flex items-center gap-3">
-          <button
-            onClick={prevMonth}
-            className="p-1.5 rounded-lg hover:bg-zinc-800 text-zinc-400 hover:text-white transition-colors cursor-pointer"
-          >
-            <ChevronLeftIcon className="size-5" />
-          </button>
-          <h2 className="text-lg font-semibold w-44 text-center">
-            {currentMonth.toLocaleDateString("en-US", {
-              month: "long",
-              year: "numeric",
-            })}
-          </h2>
-          <button
-            onClick={nextMonth}
-            className="p-1.5 rounded-lg hover:bg-zinc-800 text-zinc-400 hover:text-white transition-colors cursor-pointer"
-          >
-            <ChevronRightIcon className="size-5" />
-          </button>
-        </div>
-        <div className="flex items-center gap-2">
-          {typeFilters.map((f) => (
-            <button
-              key={f.value}
-              onClick={() => setTypeFilter(f.value)}
-              className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
-                typeFilter === f.value
-                  ? "bg-amber-500 text-zinc-950"
-                  : "text-zinc-400 hover:text-white hover:bg-zinc-800"
-              }`}
-            >
-              {f.label}
-            </button>
-          ))}
-          <button
-            onClick={() => setHideWatched((v) => !v)}
-            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
-              hideWatched
-                ? "bg-amber-500 text-zinc-950"
-                : "text-zinc-400 hover:text-white hover:bg-zinc-800"
-            }`}
-            title={hideWatched ? "Show watched" : "Hide watched"}
-          >
-            {hideWatched ? (
-              <EyeOffIcon className="size-4" />
-            ) : (
-              <EyeIcon className="size-4" />
-            )}
-          </button>
-          <ViewToggle viewMode={viewMode} onViewModeChange={onViewModeChange} />
-        </div>
-      </div>
+      <PageHeader
+        kicker="Month view · your timezone"
+        title={monthTitle}
+        right={headerRight}
+        className="px-0 pt-4 pb-4"
+      />
 
       {/* Stats bar */}
       {!loading && <MonthStatsBar episodes={stats.episodes} titles={stats.titles} />}
@@ -597,7 +607,7 @@ function GridCalendar({
             {WEEKDAYS.map((d) => (
               <div
                 key={d}
-                className="px-2 py-2 text-center text-xs font-medium text-zinc-500 uppercase"
+                className="px-2 py-2 text-center font-mono text-[11px] text-zinc-500 font-semibold uppercase tracking-[0.15em]"
               >
                 {d}
               </div>
@@ -608,12 +618,12 @@ function GridCalendar({
           {weeks.map((week, wi) => (
             <div
               key={wi}
-              className="grid grid-cols-7 border-b border-white/[0.06] last:border-b-0"
+              className="grid grid-cols-7 gap-px bg-white/[0.06]"
             >
               {week.map((day, di) => {
                 if (!day) {
                   return (
-                    <div key={di} className="min-h-28 bg-zinc-950/50" />
+                    <div key={di} className="min-h-28 bg-zinc-950" />
                   );
                 }
                 const dateKey = formatDateKey(day);
@@ -622,84 +632,67 @@ function GridCalendar({
                 const isSelected = dateKey === selectedDate;
                 const borderColor = getCellBorderColor(dayItems);
 
-                // Pick featured item for card display
-                const featured = dayItems.length > 0 ? pickFeaturedItem(dayItems) : null;
-                const featuredImageUrl = featured ? getItemHeroUrl(featured) : null;
-
                 return (
                   <button
                     key={di}
                     onClick={() =>
                       setSelectedDate(isSelected ? "" : dateKey)
                     }
-                    className={`min-h-36 p-1.5 text-left transition-colors cursor-pointer border-r border-white/[0.06] last:border-r-0 ${
+                    className={`min-h-36 p-1.5 text-left transition-colors cursor-pointer bg-zinc-950 ${
                       borderColor ? `border-l-2 ${borderColor}` : ""
                     } ${
                       isSelected
                         ? "bg-amber-500/10 ring-1 ring-inset ring-amber-500"
                         : dayItems.length > 0
                           ? "hover:bg-zinc-900/60"
-                          : "hover:bg-zinc-950/80"
-                    } ${isToday ? "ring-2 ring-inset ring-amber-500/40" : ""}`}
+                          : "hover:bg-zinc-900/30"
+                    } ${isToday ? "outline-2 outline-amber-400 outline-offset-[-2px] relative z-10" : ""}`}
                   >
-                    <div
-                      className={`text-xs font-medium mb-1 ${
-                        isToday
-                          ? "bg-amber-500 text-zinc-950 rounded-full size-5 flex items-center justify-center"
-                          : "text-zinc-400 pl-0.5"
-                      }`}
-                    >
-                      {day.getDate()}
+                    <div className="flex items-center mb-1">
+                      {isToday ? (
+                        <>
+                          <span className="font-mono text-[13px] text-amber-400 font-bold">
+                            {day.getDate()}
+                          </span>
+                          <span className="font-mono text-[9px] ml-1 tracking-widest text-amber-400 opacity-80">TODAY</span>
+                        </>
+                      ) : (
+                        <span className="font-mono text-[13px] text-zinc-400 pl-0.5">
+                          {day.getDate()}
+                        </span>
+                      )}
                     </div>
 
-                    {/* Mini card — episode still + title + code */}
-                    {featured && (
-                      <div className="space-y-1">
-                        <div className="relative rounded-sm overflow-hidden">
-                          {featuredImageUrl ? (
-                            <img
-                              src={featuredImageUrl}
-                              alt=""
-                              className="w-full aspect-video object-cover"
-                              loading="lazy"
-                            />
-                          ) : (
-                            <div className="w-full aspect-video bg-gradient-to-b from-zinc-800 to-zinc-950" />
-                          )}
-                          {dayItems.length > 1 && (
-                            <span className="absolute top-1 right-1 bg-black/70 text-white text-[10px] font-bold px-1.5 py-0.5 rounded-full">
-                              +{dayItems.length - 1}
-                            </span>
-                          )}
-                        </div>
-                        <div className="min-w-0">
-                          <p className="text-xs font-medium text-white truncate">
-                            {featured.type === "episode"
-                              ? featured.data.show_title
-                              : featured.data.title}
-                          </p>
-                          <p className="text-xs truncate">
-                            {featured.type === "episode" ? (
-                              <>
-                                <span className="text-amber-400 font-medium">
-                                  {formatEpisodeCode(featured.data)}
-                                </span>
-                                {featured.data.name && (
-                                  <span className="text-zinc-400"> · {featured.data.name}</span>
-                                )}
-                              </>
-                            ) : (
-                              <span className={
-                                featured.data.object_type === "MOVIE"
-                                  ? "text-blue-400"
-                                  : "text-purple-400"
-                              }>
-                                {featured.data.object_type === "MOVIE" ? "Movie" : "Show"}
-                                {featured.data.release_year && ` · ${featured.data.release_year}`}
-                              </span>
-                            )}
-                          </p>
-                        </div>
+                    {/* Episode + title pills */}
+                    {dayItems.length > 0 && (
+                      <div className="space-y-0.5">
+                        {dayItems.slice(0, 3).map((item, idx) => {
+                          const isEp = item.type === "episode";
+                          const label = isEp
+                            ? item.data.show_title
+                            : item.type === "title"
+                              ? item.data.title
+                              : "";
+                          const prefix = isEp
+                            ? `S${item.data.season_number}E${item.data.episode_number} `
+                            : item.type === "title"
+                              ? (item.data.object_type === "MOVIE" ? "FILM " : "SHOW ")
+                              : "";
+                          return (
+                            <div
+                              key={idx}
+                              className="bg-amber-400/10 text-amber-400 border-l-2 border-amber-400 px-1.5 py-0.5 rounded-sm text-[10px] font-medium leading-tight overflow-hidden text-ellipsis whitespace-nowrap"
+                            >
+                              <span className="font-mono">{prefix}</span>
+                              {label}
+                            </div>
+                          );
+                        })}
+                        {dayItems.length > 3 && (
+                          <div className="text-[10px] text-zinc-500 pl-1.5">
+                            +{dayItems.length - 3} more
+                          </div>
+                        )}
                       </div>
                     )}
                   </button>

--- a/frontend/src/pages/DiscoveryPage.test.tsx
+++ b/frontend/src/pages/DiscoveryPage.test.tsx
@@ -136,6 +136,12 @@ describe("DiscoveryPage", () => {
 
     render(<DiscoveryPage />, { wrapper: Wrapper });
 
+    // Switch to Activity tab where RecommendationCard feed is rendered
+    await waitFor(() => {
+      expect(screen.getByText("Activity")).toBeDefined();
+    });
+    fireEvent.click(screen.getByText("Activity"));
+
     await waitFor(() => {
       expect(screen.getByText("Movie r1")).toBeDefined();
       expect(screen.getByText("Show R2")).toBeDefined();
@@ -199,6 +205,12 @@ describe("DiscoveryPage", () => {
 
     render(<DiscoveryPage />, { wrapper: Wrapper });
 
+    // Switch to Activity tab where RecommendationCard with "Dismiss" button is rendered
+    await waitFor(() => {
+      expect(screen.getByText("Activity")).toBeDefined();
+    });
+    fireEvent.click(screen.getByText("Activity"));
+
     await waitFor(() => {
       expect(screen.getByText("Movie r1")).toBeDefined();
     });
@@ -253,12 +265,18 @@ describe("DiscoveryPage", () => {
 
     render(<DiscoveryPage />, { wrapper: Wrapper });
 
+    // Switch to Activity tab where RecommendationCard renders type badges via i18n
+    await waitFor(() => {
+      expect(screen.getByText("Activity")).toBeDefined();
+    });
+    fireEvent.click(screen.getByText("Activity"));
+
     await waitFor(() => {
       expect(screen.getByText("A Movie")).toBeDefined();
       expect(screen.getByText("A Show")).toBeDefined();
     });
 
-    // Check type badges
+    // Check type badges (t("discovery.movie") = "Movie", t("discovery.tv") = "TV Show")
     const movieBadges = screen.getAllByText("Movie");
     const tvBadges = screen.getAllByText("TV Show");
     expect(movieBadges.length).toBeGreaterThanOrEqual(1);

--- a/frontend/src/pages/DiscoveryPage.tsx
+++ b/frontend/src/pages/DiscoveryPage.tsx
@@ -6,6 +6,7 @@ import * as api from "../api";
 import type { Recommendation } from "../types";
 import { useApiCall } from "../hooks/useApiCall";
 import { Skeleton } from "../components/ui/skeleton";
+import { PageHeader, Kicker, Pill } from "../components/design";
 
 function formatRelativeTime(dateStr: string): string {
   const now = Date.now();
@@ -166,9 +167,143 @@ function RecommendationCard({
   );
 }
 
+function HeroCard({
+  rec,
+  onTrack,
+  onDismiss,
+}: {
+  rec: Recommendation;
+  onTrack: (rec: Recommendation) => void;
+  onDismiss: (rec: Recommendation) => void;
+}) {
+  const { t } = useTranslation();
+  const posterSrc = rec.title.poster_url
+    ? `https://image.tmdb.org/t/p/w342${rec.title.poster_url}`
+    : null;
+
+  const senderName = rec.from_user.display_name ?? rec.from_user.username;
+
+  return (
+    <div className="bg-zinc-900 border border-white/[0.06] rounded-2xl p-6 mb-8 grid grid-cols-[200px_1fr] sm:grid-cols-[240px_1fr] gap-6 items-start">
+      {/* Poster */}
+      <div className="aspect-[2/3] rounded-lg overflow-hidden">
+        {posterSrc ? (
+          <img
+            src={posterSrc}
+            alt={rec.title.title}
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          <div className="w-full h-full bg-zinc-800" />
+        )}
+      </div>
+
+      {/* Info */}
+      <div className="flex flex-col gap-3 min-w-0">
+        <Kicker>Pick of the week</Kicker>
+
+        <h2 className="font-bold text-2xl text-zinc-100 leading-tight">
+          {rec.title.title}
+        </h2>
+
+        <p className="text-zinc-300 text-sm leading-relaxed line-clamp-4">
+          {rec.title.object_type === "SHOW" ? "TV Series" : "Movie"}
+        </p>
+
+        {/* "Why you'll like it" tag — from sender */}
+        {senderName && (
+          <div className="flex items-center gap-1.5 text-xs text-zinc-400">
+            <span className="text-amber-400">&#10022;</span>
+            <span>
+              Recommended by <span className="text-zinc-200 font-medium">{senderName}</span>
+            </span>
+            {rec.message && (
+              <span className="text-zinc-500 italic truncate max-w-[200px]">
+                &ldquo;{rec.message}&rdquo;
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex flex-wrap gap-2 mt-1">
+          <button
+            onClick={() => onTrack(rec)}
+            className="inline-flex items-center justify-center px-4 py-2 rounded-lg text-sm font-semibold bg-amber-500 text-zinc-950 hover:bg-amber-400 transition-colors cursor-pointer"
+          >
+            {t("discovery.track")}
+          </button>
+          <Link
+            to={`/title/${rec.title.id}`}
+            className="inline-flex items-center justify-center px-4 py-2 rounded-lg text-sm font-semibold bg-white/[0.06] border border-white/[0.08] text-zinc-300 hover:text-zinc-100 hover:bg-white/[0.1] transition-colors"
+          >
+            View details
+          </Link>
+          <button
+            onClick={() => onDismiss(rec)}
+            className="inline-flex items-center justify-center px-4 py-2 rounded-lg text-sm font-semibold text-zinc-500 hover:text-zinc-300 transition-colors cursor-pointer"
+          >
+            Not interested
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RailCard({
+  rec,
+  onTrack,
+  onDismiss,
+}: {
+  rec: Recommendation;
+  onTrack: (rec: Recommendation) => void;
+  onDismiss: (rec: Recommendation) => void;
+}) {
+  const { t } = useTranslation();
+  const posterSrc = rec.title.poster_url
+    ? `https://image.tmdb.org/t/p/w185${rec.title.poster_url}`
+    : null;
+
+  return (
+    <div className="w-[140px] shrink-0 flex flex-col gap-2">
+      <Link to={`/title/${rec.title.id}`} className="block aspect-[2/3] rounded-lg overflow-hidden bg-zinc-800">
+        {posterSrc ? (
+          <img
+            src={posterSrc}
+            alt={rec.title.title}
+            className="w-full h-full object-cover hover:scale-105 transition-transform duration-200"
+            loading="lazy"
+          />
+        ) : (
+          <div className="w-full h-full bg-zinc-800" />
+        )}
+      </Link>
+      <p className="text-xs text-zinc-300 font-medium line-clamp-2 leading-snug">
+        {rec.title.title}
+      </p>
+      <div className="flex gap-1">
+        <button
+          onClick={() => onTrack(rec)}
+          className="flex-1 py-1 rounded text-[10px] font-semibold bg-amber-500 text-zinc-950 hover:bg-amber-400 transition-colors cursor-pointer"
+        >
+          {t("discovery.track")}
+        </button>
+        <button
+          onClick={() => onDismiss(rec)}
+          className="flex-1 py-1 rounded text-[10px] font-semibold bg-zinc-700 text-zinc-400 hover:bg-zinc-600 transition-colors cursor-pointer"
+        >
+          {t("discovery.dismiss")}
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export default function DiscoveryPage() {
   const { t } = useTranslation();
   const [recommendations, setRecommendations] = useState<Recommendation[]>([]);
+  const [tab, setTab] = useState<"foryou" | "activity">("foryou");
 
   const { loading, error } = useApiCall(
     () => api.getRecommendations(),
@@ -222,15 +357,26 @@ export default function DiscoveryPage() {
     }
   }, [t]);
 
+  const heroRec = recommendations[0];
+  const railRecs = recommendations.slice(1);
+
   return (
-    <div className="space-y-4">
-      <div className="flex items-center gap-2">
-        <h2 className="text-lg font-semibold">{t("discovery.title")}</h2>
-        {unreadCount > 0 && (
-          <span className="inline-flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full bg-amber-500 text-zinc-950 text-xs font-bold">
-            {unreadCount}
-          </span>
-        )}
+    <div className="space-y-0">
+      <PageHeader kicker="Based on what you watch" title="For you" className="px-0 pt-4 pb-4" />
+
+      {/* Tab toggle */}
+      <div className="flex gap-2 mb-6">
+        <Pill active={tab === "foryou"} onClick={() => setTab("foryou")}>
+          For you
+        </Pill>
+        <Pill active={tab === "activity"} onClick={() => setTab("activity")}>
+          Activity
+          {unreadCount > 0 && (
+            <span className="ml-1.5 inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full bg-amber-500 text-zinc-950 text-[9px] font-bold">
+              {unreadCount}
+            </span>
+          )}
+        </Pill>
       </div>
 
       {loading ? (
@@ -239,22 +385,59 @@ export default function DiscoveryPage() {
         <div className="bg-red-900/50 border border-red-800 text-red-200 px-4 py-2 rounded-lg text-sm">
           {error}
         </div>
-      ) : recommendations.length === 0 ? (
-        <p className="text-zinc-500 text-sm py-8 text-center">
-          {t("discovery.empty")}
-        </p>
-      ) : (
-        <div className="space-y-3">
-          {recommendations.map((rec) => (
-            <RecommendationCard
-              key={rec.id}
-              rec={rec}
+      ) : tab === "foryou" ? (
+        recommendations.length === 0 ? (
+          <p className="text-zinc-500 text-sm py-8 text-center">
+            {t("discovery.empty")}
+          </p>
+        ) : (
+          <div>
+            {/* Hero card — first recommendation */}
+            <HeroCard
+              rec={heroRec}
               onTrack={handleTrack}
               onDismiss={handleDismiss}
-              onMarkRead={handleMarkRead}
             />
-          ))}
-        </div>
+
+            {/* Horizontal rail — remaining recommendations */}
+            {railRecs.length > 0 && (
+              <div>
+                <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-3">
+                  More recommendations
+                </p>
+                <div className="flex gap-4 overflow-x-auto pb-2 -mx-1 px-1">
+                  {railRecs.map((rec) => (
+                    <RailCard
+                      key={rec.id}
+                      rec={rec}
+                      onTrack={handleTrack}
+                      onDismiss={handleDismiss}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )
+      ) : (
+        /* Activity tab — original feed */
+        recommendations.length === 0 ? (
+          <p className="text-zinc-500 text-sm py-8 text-center">
+            {t("discovery.empty")}
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {recommendations.map((rec) => (
+              <RecommendationCard
+                key={rec.id}
+                rec={rec}
+                onTrack={handleTrack}
+                onDismiss={handleDismiss}
+                onMarkRead={handleMarkRead}
+              />
+            ))}
+          </div>
+        )
       )}
     </div>
   );

--- a/frontend/src/pages/DiscoveryPage.tsx
+++ b/frontend/src/pages/DiscoveryPage.tsx
@@ -184,9 +184,9 @@ function HeroCard({
   const senderName = rec.from_user.display_name ?? rec.from_user.username;
 
   return (
-    <div className="bg-zinc-900 border border-white/[0.06] rounded-2xl p-6 mb-8 grid grid-cols-[200px_1fr] sm:grid-cols-[240px_1fr] gap-6 items-start">
+    <div className="bg-zinc-900 border border-white/[0.06] rounded-2xl p-6 mb-8 grid grid-cols-1 sm:grid-cols-[240px_1fr] gap-6 items-start">
       {/* Poster */}
-      <div className="aspect-[2/3] rounded-lg overflow-hidden">
+      <div className="aspect-[2/3] rounded-lg overflow-hidden max-w-[200px] sm:max-w-none mx-auto sm:mx-0">
         {posterSrc ? (
           <img
             src={posterSrc}
@@ -266,7 +266,7 @@ function RailCard({
     : null;
 
   return (
-    <div className="w-[140px] shrink-0 flex flex-col gap-2">
+    <div className="w-[118px] sm:w-[140px] shrink-0 flex flex-col gap-2">
       <Link to={`/title/${rec.title.id}`} className="block aspect-[2/3] rounded-lg overflow-hidden bg-zinc-800">
         {posterSrc ? (
           <img

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -277,8 +277,11 @@ describe("HomePage — authenticated recommendations", () => {
       expect(screen.getByText("Recommended for You")).toBeDefined();
     });
 
-    const seeAllLink = screen.getByText(/See all/).closest("a");
-    expect(seeAllLink?.getAttribute("href")).toBe("/discovery");
+    // Multiple "See all" links may exist (e.g. today section also has one).
+    // Find the specific link pointing to /discovery.
+    const seeAllLinks = screen.getAllByText(/See all/).map((el) => el.closest("a"));
+    const discoveryLink = seeAllLinks.find((a) => a?.getAttribute("href") === "/discovery");
+    expect(discoveryLink).toBeDefined();
   });
 
   it("links recommendation cards to title detail page", async () => {

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -13,6 +13,7 @@ import { groupByShow, formatUpcomingDate } from "../components/EpisodeComponents
 import { EpisodeShowCard, DeckCardWrapper } from "../components/EpisodeShowCard";
 import HeroBanner from "../components/HeroBanner";
 import FullBleedCarousel from "../components/FullBleedCarousel";
+import { Kicker } from "../components/design";
 
 export interface UnwatchedCardEntry {
   episode: Episode;
@@ -217,9 +218,12 @@ export default function HomePage() {
 
         {/* Popular titles */}
         <section>
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-xl font-bold text-white">{t("landing.popularNow")}</h2>
-            <Link to="/browse" className="text-sm text-amber-400 hover:text-amber-300 transition-colors">
+          <div className="flex items-baseline justify-between mb-4">
+            <div>
+              <Kicker>Browse</Kicker>
+              <h2 className="text-xl font-bold tracking-[-0.01em]">{t("landing.popularNow")}</h2>
+            </div>
+            <Link to="/browse" className="font-mono text-xs text-amber-400 hover:text-amber-300 transition-colors">
               {t("landing.discoverMore")} →
             </Link>
           </div>
@@ -261,16 +265,22 @@ export default function HomePage() {
               <HeroBanner episodes={unwatched} />
             </div>
             <section key="unwatched">
-              <div className="flex items-center gap-3 mb-4">
-                <h2 className="text-xl font-bold text-white">{t("home.unwatched")}</h2>
-                <Link
-                  to="/reels"
-                  className="flex items-center gap-1 text-xs text-zinc-400 hover:text-amber-400 transition-colors sm:hidden"
-                  title="Full-screen reels view"
-                >
-                  <Maximize2 size={14} />
-                  {t("home.reels")}
-                </Link>
+              <div className="flex items-baseline justify-between mb-4">
+                <div>
+                  <Kicker>Up next</Kicker>
+                  <div className="flex items-center gap-3">
+                    <h2 className="text-xl font-bold tracking-[-0.01em]">{t("home.unwatched")}</h2>
+                    <Link
+                      to="/reels"
+                      className="flex items-center gap-1 text-xs text-zinc-400 hover:text-amber-400 transition-colors sm:hidden"
+                      title="Full-screen reels view"
+                    >
+                      <Maximize2 size={14} />
+                      {t("home.reels")}
+                    </Link>
+                  </div>
+                </div>
+                <Link to="/upcoming" className="font-mono text-xs text-amber-400 hover:text-amber-300 transition-colors">{t("home.seeAll")} →</Link>
               </div>
               <FullBleedCarousel>
                 {unwatchedCards.map((card) => (
@@ -296,9 +306,12 @@ export default function HomePage() {
       case "recommendations":
         return recommendations.length > 0 ? (
           <section key="recommendations">
-            <div className="flex items-center justify-between mb-4">
-              <h2 className="text-xl font-bold text-white">{t("home.recommendedForYou")}</h2>
-              <Link to="/discovery" className="text-sm text-amber-400 hover:text-amber-300 transition-colors">
+            <div className="flex items-baseline justify-between mb-4">
+              <div>
+                <Kicker>From friends</Kicker>
+                <h2 className="text-xl font-bold tracking-[-0.01em]">{t("home.recommendedForYou")}</h2>
+              </div>
+              <Link to="/discovery" className="font-mono text-xs text-amber-400 hover:text-amber-300 transition-colors">
                 {t("home.seeAll")} →
               </Link>
             </div>
@@ -348,7 +361,13 @@ export default function HomePage() {
       case "today":
         return (
           <section key="today">
-            <h2 className="text-xl font-bold text-white mb-4">{t("home.today")}</h2>
+            <div className="flex items-baseline justify-between mb-4">
+              <div>
+                <Kicker>Airing tonight</Kicker>
+                <h2 className="text-xl font-bold tracking-[-0.01em]">{t("home.today")}</h2>
+              </div>
+              <Link to="/calendar" className="font-mono text-xs text-amber-400 hover:text-amber-300 transition-colors">{t("home.seeAll")} →</Link>
+            </div>
             {today.length === 0 ? (
               <p className="text-zinc-500 text-sm">
                 {noEpisodes ? t("home.noEpisodes") : t("home.noEpisodesToday")}
@@ -373,14 +392,20 @@ export default function HomePage() {
       case "upcoming":
         return upcoming.length > 0 ? (
           <section key="upcoming">
-            <h2 className="text-lg font-semibold text-zinc-300 mb-4">{t("home.comingUp")}</h2>
+            <div className="flex items-baseline justify-between mb-4">
+              <div>
+                <Kicker>This week</Kicker>
+                <h2 className="text-xl font-bold tracking-[-0.01em]">{t("home.comingUp")}</h2>
+              </div>
+              <Link to="/calendar" className="font-mono text-xs text-amber-400 hover:text-amber-300 transition-colors">Open calendar →</Link>
+            </div>
             <div className="space-y-4">
               {Array.from(upcomingByDate.entries()).map(([date, eps]) => {
                 const byShow = groupByShow(eps);
                 const dateLabel = formatUpcomingDate(date);
                 return (
                   <div key={date}>
-                    <h3 className="text-sm font-medium text-zinc-500 mb-2">{dateLabel === "__TOMORROW__" ? t("episodes.tomorrow") : dateLabel}</h3>
+                    <h3 className="font-mono text-[11px] uppercase tracking-[0.12em] text-zinc-500 mb-2">{dateLabel === "__TOMORROW__" ? t("episodes.tomorrow") : dateLabel}</h3>
                     <FullBleedCarousel>
                       {Array.from(byShow.entries()).map(([titleId, showEps]) => (
                         <div key={titleId} className="w-80 flex-shrink-0" style={{ scrollSnapAlign: "start" }}>

--- a/frontend/src/pages/MorePage.tsx
+++ b/frontend/src/pages/MorePage.tsx
@@ -1,0 +1,148 @@
+import { Link, useNavigate } from "react-router";
+import { ChevronRight, Sparkles, BarChart2, User, Settings, LogOut } from "lucide-react";
+import { useAuth } from "../context/AuthContext";
+
+function MoreGroup({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="mb-4">
+      <div className="px-5 pb-2 font-mono text-[10px] uppercase tracking-[0.15em] text-zinc-500 font-semibold">
+        {label}
+      </div>
+      <div className="mx-4 bg-zinc-900 border border-white/[0.05] rounded-2xl overflow-hidden">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function MoreRow({
+  icon,
+  label,
+  sub,
+  to,
+  onClick,
+  danger,
+  isLast,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  sub?: string;
+  to?: string;
+  onClick?: () => void;
+  danger?: boolean;
+  isLast?: boolean;
+}) {
+  const inner = (
+    <div className={`flex items-center gap-3 px-4 py-3.5 ${!isLast ? "border-b border-white/[0.04]" : ""}`}>
+      <div className="w-8 h-8 rounded-lg bg-white/[0.06] flex items-center justify-center shrink-0 text-zinc-400">
+        {icon}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className={`text-sm font-medium ${danger ? "text-red-400" : "text-zinc-100"}`}>
+          {label}
+        </div>
+        {sub && (
+          <div className="font-mono text-[11px] text-zinc-500 mt-0.5">{sub}</div>
+        )}
+      </div>
+      {!danger && (
+        <ChevronRight size={16} className="text-zinc-600 shrink-0" />
+      )}
+    </div>
+  );
+
+  if (to) {
+    return <Link to={to}>{inner}</Link>;
+  }
+  return (
+    <button type="button" onClick={onClick} className="w-full text-left cursor-pointer">
+      {inner}
+    </button>
+  );
+}
+
+export default function MorePage() {
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
+
+  if (!user) return null;
+
+  const initials = (user.display_name ?? user.username)
+    .split(" ")
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? "")
+    .join("");
+
+  const handleLogout = async () => {
+    await logout();
+    navigate("/login", { replace: true });
+  };
+
+  return (
+    <div className="pb-32 pt-4">
+      {/* Profile card */}
+      <div className="mx-4 mb-6">
+        <Link
+          to={`/user/${user.username}`}
+          className="flex items-center gap-3 bg-zinc-900 border border-white/[0.05] rounded-2xl p-4 hover:bg-zinc-900/80 transition-colors"
+        >
+          <div className="w-12 h-12 rounded-full bg-[oklch(0.6_0.1_250)] flex items-center justify-center font-extrabold text-lg text-black shrink-0">
+            {initials}
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="text-[15px] font-bold truncate">
+              {user.display_name ?? user.username}
+            </div>
+            <div className="font-mono text-[11px] text-zinc-500">
+              @{user.username}
+            </div>
+          </div>
+          <ChevronRight size={16} className="text-zinc-600 shrink-0" />
+        </Link>
+      </div>
+
+      {/* Discover */}
+      <MoreGroup label="Discover">
+        <MoreRow
+          icon={<Sparkles size={16} />}
+          label="Discovery"
+          sub="Recommendations for you"
+          to="/discovery"
+        />
+        <MoreRow
+          icon={<BarChart2 size={16} />}
+          label="Stats"
+          sub="Your watch history"
+          to="/stats"
+          isLast
+        />
+      </MoreGroup>
+
+      {/* Account */}
+      <MoreGroup label="Account">
+        <MoreRow
+          icon={<User size={16} />}
+          label="Profile"
+          to={`/user/${user.username}`}
+        />
+        <MoreRow
+          icon={<Settings size={16} />}
+          label="Settings"
+          to="/settings"
+          isLast
+        />
+      </MoreGroup>
+
+      {/* Session */}
+      <MoreGroup label="Session">
+        <MoreRow
+          icon={<LogOut size={16} />}
+          label="Sign out"
+          onClick={handleLogout}
+          danger
+          isLast
+        />
+      </MoreGroup>
+    </div>
+  );
+}

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -210,14 +210,18 @@ describe("Settings tabs", () => {
   it("renders tab list with expected tabs for non-admin user", async () => {
     render(<SettingsPage />, { wrapper: Wrapper });
 
+    // Wait for the sidebar nav to be rendered — all tabs appear as <button> elements in the sidebar
     await waitFor(() => {
-      expect(screen.getByText("Account")).toBeDefined();
+      const navButtons = screen.getAllByRole("button", { name: "Account" });
+      expect(navButtons.length).toBeGreaterThanOrEqual(1);
     });
 
-    expect(screen.getByText("Appearance")).toBeDefined();
-    expect(screen.getByText("Notifications")).toBeDefined();
-    expect(screen.getByText("Integrations")).toBeDefined();
-    expect(screen.queryByText("Admin")).toBeNull();
+    // Sidebar nav buttons for each tab should exist
+    expect(screen.getAllByRole("button", { name: "Appearance" }).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByRole("button", { name: "Notifications" }).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByRole("button", { name: "Integrations" }).length).toBeGreaterThanOrEqual(1);
+    // Admin tab should not appear for non-admin users
+    expect(screen.queryByRole("button", { name: "Admin" })).toBeNull();
   });
 
   it("shows account tab content by default", async () => {
@@ -227,15 +231,17 @@ describe("Settings tabs", () => {
       expect(screen.getByText("Profile Visibility")).toBeDefined();
     });
 
-    // Appearance-tab content should not be rendered (base-ui only renders active panel)
+    // Appearance-tab content should not be rendered (conditional rendering)
     expect(screen.queryByText("Homepage Layout")).toBeNull();
   });
 
   it("shows notifications tab content when ?tab=notifications", async () => {
     render(<SettingsPage />, { wrapper: WrapperWithPath("/settings?tab=notifications") });
 
+    // The notifications card title and the sidebar button both say "Notifications" —
+    // use the SettingsCard subtitle which is unique to the notifications tab content
     await waitFor(() => {
-      expect(screen.getByText("Notifications")).toBeDefined();
+      expect(screen.getByText("How and when you receive alerts")).toBeDefined();
     });
 
     // Account-tab content should not be rendered

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -69,17 +69,17 @@ export default function SettingsPage() {
     <div className="max-w-7xl mx-auto">
       <PageHeader kicker="Your preferences" title="Settings" className="px-0 pt-4 pb-4" />
 
-      <div className="grid grid-cols-1 sm:grid-cols-[240px_1fr] gap-8">
-        {/* Sidebar */}
-        <nav className="flex flex-col gap-0.5">
+      <div className="grid grid-cols-1 sm:grid-cols-[240px_1fr] gap-6 sm:gap-8">
+        {/* Sidebar — pill row on mobile, vertical list on desktop */}
+        <nav className="flex sm:flex-col gap-1 overflow-x-auto scrollbar-none pb-1 sm:pb-0">
           {TABS.map((tab) => (
             <button
               key={tab.value}
               onClick={() => setTab(tab.value)}
-              className={`w-full text-left px-[14px] py-[10px] text-sm font-medium transition-colors rounded-r-md border-l-2 ${
+              className={`shrink-0 sm:w-full text-left px-3 sm:px-[14px] py-2 sm:py-[10px] text-sm font-medium transition-colors rounded-lg sm:rounded-r-md sm:border-l-2 whitespace-nowrap ${
                 activeTab === tab.value
-                  ? "bg-amber-400/10 text-zinc-100 border-amber-400"
-                  : "text-zinc-400 border-transparent hover:text-zinc-100 hover:bg-white/[0.04]"
+                  ? "bg-amber-400/10 text-zinc-100 sm:border-amber-400 border border-amber-400/40"
+                  : "text-zinc-400 sm:border-transparent hover:text-zinc-100 hover:bg-white/[0.04] border border-white/[0.06] sm:border-transparent"
               }`}
             >
               {tab.label}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { Link, useSearchParams } from "react-router";
 import { useTranslation } from "react-i18next";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "../components/ui/tabs";
 import { SUPPORTED_LANGUAGES, setLanguage } from "../i18n";
 import { useAuth } from "../context/AuthContext";
 import * as api from "../api";
@@ -12,9 +11,22 @@ import { isPushSupported, subscribeToPush, unsubscribeFromPush, getExistingSubsc
 import { authClient } from "../lib/auth-client";
 import { UserPlus, GripVertical, Eye, EyeOff } from "lucide-react";
 import ThemePicker from "../components/ThemePicker";
+import { PageHeader } from "../components/design";
 
 const VALID_TABS = ["account", "appearance", "notifications", "integrations", "admin"] as const;
 type SettingsTab = (typeof VALID_TABS)[number];
+
+function SettingsCard({ title, subtitle, children }: { title: string; subtitle?: string; children: React.ReactNode }) {
+  return (
+    <div className="bg-zinc-900 border border-white/[0.06] rounded-xl p-6 mb-4">
+      <div className="mb-5">
+        <div className="text-[17px] font-bold tracking-[-0.01em] mb-1">{title}</div>
+        {subtitle && <div className="text-sm text-zinc-500">{subtitle}</div>}
+      </div>
+      {children}
+    </div>
+  );
+}
 
 export default function SettingsPage() {
   const { user } = useAuth();
@@ -29,8 +41,8 @@ export default function SettingsPage() {
       ? (rawTab as SettingsTab)
       : "account";
 
-  function handleTabChange(value: string | number) {
-    const tab = String(value) as SettingsTab;
+  function setTab(value: string) {
+    const tab = value as SettingsTab;
     setSearchParams(
       (prev) => {
         const next = new URLSearchParams(prev);
@@ -45,57 +57,84 @@ export default function SettingsPage() {
     );
   }
 
+  const TABS = [
+    { value: "account", label: t("settings.tabs.account") },
+    { value: "appearance", label: t("settings.tabs.appearance") },
+    { value: "notifications", label: t("settings.tabs.notifications") },
+    { value: "integrations", label: t("settings.tabs.integrations") },
+    ...(user.is_admin ? [{ value: "admin", label: t("settings.tabs.admin") }] : []),
+  ];
+
   return (
     <div className="max-w-7xl mx-auto">
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold text-white">{t("settings.title")}</h1>
-        <Link to={`/user/${user.username}`} className="text-sm text-amber-500 hover:text-amber-400 transition-colors">
-          {t("settings.viewProfile")}
-        </Link>
-      </div>
+      <PageHeader kicker="Your preferences" title="Settings" className="px-0 pt-4 pb-4" />
 
-      <Tabs value={activeTab} onValueChange={handleTabChange}>
-        <TabsList>
-          <TabsTrigger value="account">{t("settings.tabs.account")}</TabsTrigger>
-          <TabsTrigger value="appearance">{t("settings.tabs.appearance")}</TabsTrigger>
-          <TabsTrigger value="notifications">{t("settings.tabs.notifications")}</TabsTrigger>
-          <TabsTrigger value="integrations">{t("settings.tabs.integrations")}</TabsTrigger>
-          {user.is_admin && (
-            <TabsTrigger value="admin">{t("settings.tabs.admin")}</TabsTrigger>
+      <div className="grid grid-cols-1 sm:grid-cols-[240px_1fr] gap-8">
+        {/* Sidebar */}
+        <nav className="flex flex-col gap-0.5">
+          {TABS.map((tab) => (
+            <button
+              key={tab.value}
+              onClick={() => setTab(tab.value)}
+              className={`w-full text-left px-[14px] py-[10px] text-sm font-medium transition-colors rounded-r-md border-l-2 ${
+                activeTab === tab.value
+                  ? "bg-amber-400/10 text-zinc-100 border-amber-400"
+                  : "text-zinc-400 border-transparent hover:text-zinc-100 hover:bg-white/[0.04]"
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </nav>
+
+        {/* Content */}
+        <div>
+          {activeTab === "account" && (
+            <>
+              <SettingsCard title="Account" subtitle="Your profile and login credentials">
+                <UserSection />
+                <PasskeySection />
+              </SettingsCard>
+              <SettingsCard title={t("settings.profileVisibility")} subtitle="Control who can see your watchlist">
+                <ProfileVisibilitySection />
+              </SettingsCard>
+              <SettingsCard title="Social" subtitle="Invite friends and share your activity">
+                <SocialSection />
+              </SettingsCard>
+            </>
           )}
-        </TabsList>
 
-        <TabsContent value="account">
-          <UserSection />
-          <PasskeySection />
-          <ProfileVisibilitySection />
-          <SocialSection />
-        </TabsContent>
+          {activeTab === "appearance" && (
+            <SettingsCard title="Appearance" subtitle="Theme and display preferences">
+              <ThemeSection />
+              <HomepageLayoutSection />
+            </SettingsCard>
+          )}
 
-        <TabsContent value="appearance">
-          <ThemeSection />
-          <HomepageLayoutSection />
-        </TabsContent>
+          {activeTab === "notifications" && (
+            <SettingsCard title="Notifications" subtitle="How and when you receive alerts">
+              {isPushSupported() && <PushNotificationsSection />}
+              <NotificationsSection />
+            </SettingsCard>
+          )}
 
-        <TabsContent value="notifications">
-          {isPushSupported() && <PushNotificationsSection />}
-          <NotificationsSection />
-        </TabsContent>
+          {activeTab === "integrations" && (
+            <SettingsCard title="Integrations" subtitle="Connected services and data sources">
+              <PlexSection />
+              <CalendarFeedSection />
+              <WatchlistSection />
+              <CsvImportSection />
+            </SettingsCard>
+          )}
 
-        <TabsContent value="integrations">
-          <PlexSection />
-          <CalendarFeedSection />
-          <WatchlistSection />
-          <CsvImportSection />
-        </TabsContent>
-
-        {user.is_admin && (
-          <TabsContent value="admin">
-            <BackgroundJobsSection />
-            <AdminSection />
-          </TabsContent>
-        )}
-      </Tabs>
+          {activeTab === "admin" && user.is_admin && (
+            <SettingsCard title="Admin" subtitle="Server and user management">
+              <BackgroundJobsSection />
+              <AdminSection />
+            </SettingsCard>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/TitleDetailPage.tsx
+++ b/frontend/src/pages/TitleDetailPage.tsx
@@ -25,6 +25,7 @@ import VisibilityButton from "../components/VisibilityButton";
 import ShareButton from "../components/ShareButton";
 import RecommendButton from "../components/RecommendButton";
 import { getProviderColor } from "../data/providerColors";
+import { Kicker, Chip } from "../components/design";
 
 const TMDB_IMG = "https://image.tmdb.org/t/p";
 
@@ -54,6 +55,13 @@ function formatRuntime(minutes: number | null | undefined): string {
 function formatCurrency(value: number): string {
   if (!value) return "—";
   return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(value);
+}
+
+function isToday(dateStr: string | null | undefined): boolean {
+  if (!dateStr) return false;
+  const d = new Date(dateStr.includes("T") ? dateStr : dateStr + "T00:00:00");
+  const now = new Date();
+  return d.getFullYear() === now.getFullYear() && d.getMonth() === now.getMonth() && d.getDate() === now.getDate();
 }
 
 // ─── Sub-components ──────────────────────────────────────────────────────────
@@ -291,7 +299,10 @@ function MovieDetail({ data }: { data: MovieDetailsResponse }) {
               {tmdb?.tagline && (
                 <p className="text-sm text-amber-400 italic mb-1">{tmdb.tagline}</p>
               )}
-              <h1 className="text-3xl font-bold text-white">{tmdb?.title || title.title}</h1>
+              <Kicker className="mb-2">
+                Movie{title.release_year ? ` · ${title.release_year}` : ""}{title.offers[0]?.provider_name ? ` · ${title.offers[0].provider_name}` : ""}
+              </Kicker>
+              <h1 className="text-[56px] leading-tight font-bold text-white">{tmdb?.title || title.title}</h1>
               {(() => {
                 const displayTitle = tmdb?.title || title.title;
                 const originalTitle = tmdb?.original_title || title.original_title;
@@ -323,11 +334,14 @@ function MovieDetail({ data }: { data: MovieDetailsResponse }) {
               )}
             </div>
 
-            {genres.length > 0 && (
+            {(genres.length > 0 || title.imdb_score) && (
               <div className="flex flex-wrap gap-2">
                 {genres.map((g) => (
-                  <span key={g} className="bg-zinc-800 text-zinc-300 px-2.5 py-1 rounded-full text-xs">{g}</span>
+                  <Chip key={g} variant="default">{g}</Chip>
                 ))}
+                {title.imdb_score && (
+                  <Chip variant="amber">★ {title.imdb_score.toFixed(1)}</Chip>
+                )}
               </div>
             )}
 
@@ -378,6 +392,30 @@ function MovieDetail({ data }: { data: MovieDetailsResponse }) {
             )}
           </div>
         </div>
+      </div>
+
+      {/* Metadata strip */}
+      <div className="dark-section -mx-4 px-6 sm:px-12 py-5 flex flex-wrap gap-x-10 gap-y-3 border-b border-white/[0.06]">
+        {[
+          { label: 'TYPE', value: 'Movie' },
+          title.runtime_minutes
+            ? { label: 'RUNTIME', value: `${title.runtime_minutes} min` }
+            : null,
+          tmdb?.status
+            ? { label: 'STATUS', value: tmdb.status }
+            : null,
+          title.offers[0]?.provider_name
+            ? { label: 'NETWORK', value: title.offers[0].provider_name }
+            : null,
+          title.imdb_score
+            ? { label: 'IMDB', value: `★ ${title.imdb_score.toFixed(1)}` }
+            : null,
+        ].filter(Boolean).map(cell => (
+          <div key={cell!.label}>
+            <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-500 mb-1">{cell!.label}</div>
+            <div className="font-mono text-[13px] font-semibold text-zinc-100">{cell!.value}</div>
+          </div>
+        ))}
       </div>
 
       {/* Overview */}
@@ -598,7 +636,10 @@ function ShowDetail({ data }: { data: ShowDetailsResponse }) {
               {tmdb?.tagline && (
                 <p className="text-sm text-amber-400 italic mb-1">{tmdb.tagline}</p>
               )}
-              <h1 className="text-3xl font-bold text-white">{tmdb?.name || title.title}</h1>
+              <Kicker className="mb-2">
+                TV Show{title.release_year ? ` · ${title.release_year}` : ""}{title.offers[0]?.provider_name ? ` · ${title.offers[0].provider_name}` : ""}
+              </Kicker>
+              <h1 className="text-[56px] leading-tight font-bold text-white">{tmdb?.name || title.title}</h1>
               {(() => {
                 const displayTitle = tmdb?.name || title.title;
                 const originalTitle = tmdb?.original_name || title.original_title;
@@ -642,11 +683,14 @@ function ShowDetail({ data }: { data: ShowDetailsResponse }) {
               )}
             </div>
 
-            {genres.length > 0 && (
+            {(genres.length > 0 || title.imdb_score) && (
               <div className="flex flex-wrap gap-2">
                 {genres.map((g) => (
-                  <span key={g} className="bg-zinc-800 text-zinc-300 px-2.5 py-1 rounded-full text-xs">{g}</span>
+                  <Chip key={g} variant="default">{g}</Chip>
                 ))}
+                {title.imdb_score && (
+                  <Chip variant="amber">★ {title.imdb_score.toFixed(1)}</Chip>
+                )}
               </div>
             )}
 
@@ -667,6 +711,39 @@ function ShowDetail({ data }: { data: ShowDetailsResponse }) {
             </div>
           </div>
         </div>
+      </div>
+
+      {/* Metadata strip */}
+      <div className="dark-section -mx-4 px-6 sm:px-12 py-5 flex flex-wrap gap-x-10 gap-y-3 border-b border-white/[0.06]">
+        {[
+          { label: 'TYPE', value: 'TV Show' },
+          tmdb?.status
+            ? { label: 'STATUS', value: tmdb.status }
+            : null,
+          tmdb?.number_of_seasons != null
+            ? { label: 'SEASONS', value: String(tmdb.number_of_seasons) }
+            : null,
+          tmdb?.number_of_episodes != null
+            ? { label: 'EPISODES', value: String(tmdb.number_of_episodes) }
+            : null,
+          title.next_episode_air_date
+            ? { label: 'NEXT EP', value: formatDate(title.next_episode_air_date) }
+            : null,
+          title.offers[0]?.provider_name
+            ? { label: 'NETWORK', value: title.offers[0].provider_name }
+            : null,
+          tmdb?.episode_run_time?.[0]
+            ? { label: 'AVG RUNTIME', value: `${tmdb.episode_run_time[0]} min` }
+            : null,
+          title.imdb_score
+            ? { label: 'IMDB', value: `★ ${title.imdb_score.toFixed(1)}` }
+            : null,
+        ].filter(Boolean).map(cell => (
+          <div key={cell!.label}>
+            <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-500 mb-1">{cell!.label}</div>
+            <div className="font-mono text-[13px] font-semibold text-zinc-100">{cell!.value}</div>
+          </div>
+        ))}
       </div>
 
       {/* Overview */}
@@ -710,35 +787,47 @@ function ShowDetail({ data }: { data: ShowDetailsResponse }) {
       {seasons.length > 0 && (
         <Section title="Seasons">
           <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
-            {seasons.map((s: SeasonSummary) => (
-              <Link
-                key={s.season_number}
-                to={`/title/${title.id}/season/${s.season_number}`}
-                className="bg-zinc-900 rounded-xl overflow-hidden border border-white/[0.06] hover:border-amber-500/50 transition-colors group"
-              >
-                <div className="aspect-[2/3] bg-zinc-800">
-                  {s.poster_path ? (
-                    <img
-                      src={`${TMDB_IMG}/w342${s.poster_path}`}
-                      alt={s.name}
-                      className="w-full h-full object-cover"
-                      loading="lazy"
-                    />
-                  ) : (
-                    <div className="w-full h-full flex items-center justify-center text-zinc-600 text-sm">
-                      Season {s.season_number}
+            {seasons.map((s: SeasonSummary) => {
+              const airingToday = isToday(s.air_date);
+              return (
+                <Link
+                  key={s.season_number}
+                  to={`/title/${title.id}/season/${s.season_number}`}
+                  className={`rounded-xl overflow-hidden border transition-colors group ${
+                    airingToday
+                      ? "bg-amber-400/[0.06] border-amber-400/25 hover:border-amber-400/50"
+                      : "bg-zinc-900 border-white/[0.06] hover:border-amber-500/50"
+                  }`}
+                >
+                  <div className="aspect-[2/3] bg-zinc-800">
+                    {s.poster_path ? (
+                      <img
+                        src={`${TMDB_IMG}/w342${s.poster_path}`}
+                        alt={s.name}
+                        className="w-full h-full object-cover"
+                        loading="lazy"
+                      />
+                    ) : (
+                      <div className="w-full h-full flex items-center justify-center text-zinc-600 text-sm">
+                        Season {s.season_number}
+                      </div>
+                    )}
+                  </div>
+                  <div className="p-3">
+                    <div className="flex items-center gap-1.5">
+                      <h3 className="text-sm font-medium text-white group-hover:text-amber-400 transition-colors truncate">{s.name}</h3>
+                      {airingToday && (
+                        <span className="font-mono text-[10px] text-amber-400 tracking-[0.12em] uppercase shrink-0">AIRING NOW</span>
+                      )}
                     </div>
-                  )}
-                </div>
-                <div className="p-3">
-                  <h3 className="text-sm font-medium text-white group-hover:text-amber-400 transition-colors truncate">{s.name}</h3>
-                  <p className="text-xs text-zinc-500 mt-0.5">
-                    {s.episode_count} episode{s.episode_count !== 1 ? "s" : ""}
-                    {s.air_date && ` · ${s.air_date.slice(0, 4)}`}
-                  </p>
-                </div>
-              </Link>
-            ))}
+                    <p className="text-xs text-zinc-500 mt-0.5">
+                      {s.episode_count} episode{s.episode_count !== 1 ? "s" : ""}
+                      {s.air_date && ` · ${s.air_date.slice(0, 4)}`}
+                    </p>
+                  </div>
+                </Link>
+              );
+            })}
           </div>
         </Section>
       )}

--- a/frontend/src/pages/TitleDetailPage.tsx
+++ b/frontend/src/pages/TitleDetailPage.tsx
@@ -302,7 +302,7 @@ function MovieDetail({ data }: { data: MovieDetailsResponse }) {
               <Kicker className="mb-2">
                 Movie{title.release_year ? ` · ${title.release_year}` : ""}{title.offers[0]?.provider_name ? ` · ${title.offers[0].provider_name}` : ""}
               </Kicker>
-              <h1 className="text-[56px] leading-tight font-bold text-white">{tmdb?.title || title.title}</h1>
+              <h1 className="text-[30px] sm:text-[56px] leading-tight font-bold text-white">{tmdb?.title || title.title}</h1>
               {(() => {
                 const displayTitle = tmdb?.title || title.title;
                 const originalTitle = tmdb?.original_title || title.original_title;
@@ -639,7 +639,7 @@ function ShowDetail({ data }: { data: ShowDetailsResponse }) {
               <Kicker className="mb-2">
                 TV Show{title.release_year ? ` · ${title.release_year}` : ""}{title.offers[0]?.provider_name ? ` · ${title.offers[0].provider_name}` : ""}
               </Kicker>
-              <h1 className="text-[56px] leading-tight font-bold text-white">{tmdb?.name || title.title}</h1>
+              <h1 className="text-[30px] sm:text-[56px] leading-tight font-bold text-white">{tmdb?.name || title.title}</h1>
               {(() => {
                 const displayTitle = tmdb?.name || title.title;
                 const originalTitle = tmdb?.original_name || title.original_title;

--- a/frontend/src/pages/TrackedPage.test.tsx
+++ b/frontend/src/pages/TrackedPage.test.tsx
@@ -152,11 +152,17 @@ describe("TrackedPage", () => {
       expect(screen.getByText("Currently Watching (1)")).toBeDefined();
     });
 
-    // These sections should not exist
-    expect(screen.queryByText(/Caught Up/)).toBeNull();
-    expect(screen.queryByText(/Not Started/)).toBeNull();
-    expect(screen.queryByText(/Unreleased/)).toBeNull();
-    expect(screen.queryByText(/Completed/)).toBeNull();
+    // These section headers (h3) should not exist — note that status filter tab buttons
+    // like "Completed" and "Watching" are always rendered but as tab buttons, not group headers.
+    // Group headers use the pattern "Label (count)" so we check for those specific patterns.
+    expect(screen.queryByText("Caught Up (0)")).toBeNull();
+    expect(screen.queryByText(/^Caught Up \(/)).toBeNull();
+    expect(screen.queryByText("Not Started (0)")).toBeNull();
+    expect(screen.queryByText(/^Not Started \(/)).toBeNull();
+    expect(screen.queryByText("Unreleased (0)")).toBeNull();
+    expect(screen.queryByText(/^Unreleased \(/)).toBeNull();
+    expect(screen.queryByText("Completed (0)")).toBeNull();
+    expect(screen.queryByText(/^Completed \(/)).toBeNull();
   });
 
   it("shows movies in their own section after shows", async () => {
@@ -188,8 +194,9 @@ describe("TrackedPage", () => {
 
     render(<TrackedPage />, { wrapper: Wrapper });
 
+    // The new header uses a PageHeader kicker showing "Your library · N title(s)"
     await waitFor(() => {
-      expect(screen.getByText("Tracked Titles (3)")).toBeDefined();
+      expect(screen.getByText("Your library · 3 titles")).toBeDefined();
     });
   });
 

--- a/frontend/src/pages/TrackedPage.tsx
+++ b/frontend/src/pages/TrackedPage.tsx
@@ -89,7 +89,7 @@ export default function TrackedPage() {
 
       {!loading && <TrackedStatsBand titles={allTitles} />}
 
-      <div className="flex gap-0 border-b border-white/[0.06] mb-4">
+      <div className="flex gap-0 border-b border-white/[0.06] mb-4 overflow-x-auto scrollbar-none">
         {STATUS_TABS.map(tab => {
           const count = tab.key === 'all' ? allTitles.length
             : allTitles.filter(t => t.user_status === tab.key || (tab.key === 'watching' && t.show_status === 'watching') || (tab.key === 'completed' && t.show_status === 'completed')).length;

--- a/frontend/src/pages/TrackedPage.tsx
+++ b/frontend/src/pages/TrackedPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import * as api from "../api";
 import type { Title } from "../types";
@@ -8,17 +8,58 @@ import { useApiCall } from "../hooks/useApiCall";
 import { groupShowsByStatus } from "../lib/groupShows";
 import { useGridNavigation } from "../hooks/useGridNavigation";
 import { useScrollRestoration } from "../hooks/useScrollRestoration";
+import { PageHeader } from "../components/design";
+
+function TrackedStatsBand({ titles }: { titles: Title[] }) {
+  const watching = titles.filter(t => t.show_status === 'watching' || t.user_status === 'watching').length;
+  const completed = titles.filter(t => t.show_status === 'completed' || t.user_status === 'completed').length;
+  const scored = titles.filter(t => t.imdb_score || t.tmdb_score);
+  const avgScore = scored.length > 0
+    ? (scored.reduce((sum, t) => sum + (t.imdb_score ?? t.tmdb_score ?? 0), 0) / scored.length).toFixed(1)
+    : null;
+  const stats = [
+    { label: 'Currently watching', value: String(watching), sub: `of ${titles.length} tracked` },
+    { label: 'Completed', value: String(completed), sub: 'shows & movies' },
+    { label: 'Avg score', value: avgScore ? `★ ${avgScore}` : '—', sub: scored.length > 0 ? `across ${scored.length} rated` : 'no ratings yet' },
+    { label: 'Total tracked', value: String(titles.length), sub: 'titles in library' },
+  ];
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+      {stats.map(s => (
+        <div key={s.label} className="bg-zinc-900 border border-white/[0.06] rounded-xl p-4">
+          <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-500 mb-2">{s.label}</div>
+          <div className="flex items-baseline gap-2">
+            <div className="text-3xl font-extrabold tracking-[-0.03em] leading-none">{s.value}</div>
+            <div className="font-mono text-[11px] text-zinc-500">{s.sub}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const STATUS_TABS = [
+  { key: 'all', label: 'All' },
+  { key: 'watching', label: 'Watching' },
+  { key: 'completed', label: 'Completed' },
+  { key: 'on_hold', label: 'On Hold' },
+  { key: 'plan_to_watch', label: 'Planning' },
+  { key: 'dropped', label: 'Dropped' },
+] as const;
+type StatusTab = (typeof STATUS_TABS)[number]['key'];
 
 export default function TrackedPage() {
   const { data, loading, refetch } = useApiCall(() => api.getTrackedTitles(), []);
-  const titles: Title[] = useMemo(() => data?.titles ?? [], [data]);
+  const allTitles: Title[] = useMemo(() => data?.titles ?? [], [data]);
   useScrollRestoration("tracked", !loading);
   const { t } = useTranslation();
   useGridNavigation();
 
+  const [statusFilter, setStatusFilter] = useState<StatusTab>('all');
+
   const { showGroups, movies } = useMemo(() => {
-    const shows = titles.filter((t) => t.object_type === "SHOW");
-    const movieList = titles
+    const shows = allTitles.filter((t) => t.object_type === "SHOW");
+    const movieList = allTitles
       .filter((t) => t.object_type === "MOVIE")
       .sort((a, b) => {
         if (!a.tracked_at && !b.tracked_at) return 0;
@@ -27,15 +68,54 @@ export default function TrackedPage() {
         return b.tracked_at.localeCompare(a.tracked_at);
       });
     return { showGroups: groupShowsByStatus(shows), movies: movieList };
-  }, [titles]);
+  }, [allTitles]);
+
+  const filteredTitles = useMemo(() => {
+    if (statusFilter === 'all') return allTitles;
+    return allTitles.filter(t =>
+      t.user_status === statusFilter ||
+      (statusFilter === 'watching' && t.show_status === 'watching') ||
+      (statusFilter === 'completed' && t.show_status === 'completed')
+    );
+  }, [allTitles, statusFilter]);
 
   return (
     <div className="space-y-4">
-      <h2 className="text-lg font-semibold">{t("tracked.title", { count: titles.length })}</h2>
+      <PageHeader
+        kicker={`Your library · ${allTitles.length} title${allTitles.length === 1 ? '' : 's'}`}
+        title="Tracked"
+        className="px-0 pt-4 pb-4"
+      />
+
+      {!loading && <TrackedStatsBand titles={allTitles} />}
+
+      <div className="flex gap-0 border-b border-white/[0.06] mb-4">
+        {STATUS_TABS.map(tab => {
+          const count = tab.key === 'all' ? allTitles.length
+            : allTitles.filter(t => t.user_status === tab.key || (tab.key === 'watching' && t.show_status === 'watching') || (tab.key === 'completed' && t.show_status === 'completed')).length;
+          return (
+            <button
+              key={tab.key}
+              onClick={() => setStatusFilter(tab.key)}
+              className={`px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px ${
+                statusFilter === tab.key
+                  ? 'text-zinc-100 border-amber-400 font-semibold'
+                  : 'text-zinc-400 border-transparent hover:text-zinc-100'
+              }`}
+            >
+              {tab.label}
+              <span className="ml-2 font-mono text-[11px] text-zinc-500">{count}</span>
+            </button>
+          );
+        })}
+      </div>
+
       {loading ? (
         <TitleGridSkeleton />
-      ) : titles.length === 0 ? (
+      ) : filteredTitles.length === 0 ? (
         <TitleList titles={[]} onTrackToggle={refetch} emptyMessage={t("tracked.empty")} />
+      ) : statusFilter !== 'all' ? (
+        <TitleList titles={filteredTitles} onTrackToggle={refetch} hideTypeBadge showProgressBar showStatusPicker showNotificationPicker showTags />
       ) : (
         <div className="space-y-6">
           {showGroups.map((group) => (


### PR DESCRIPTION
## Summary

- **Floating liquid-glass tab bar** (`BottomTabBar`): replaces edge-to-edge bar with a rounded-3xl floating dock (`bg-zinc-900/72 backdrop-blur-xl shadow`), restructured from 5 old tabs to **Home · Browse · Calendar · Tracked · More**. Unread badge moves from Discovery to the More tab.
- **New `/more` screen** (`MorePage.tsx`): iOS-style grouped list with profile card, Discover group (Discovery, Stats), Account group (Profile, Settings), and Session group (Sign out). Wired as a `RequireAuth` route.
- **`/upcoming` redirect**: `/upcoming` now redirects to `/calendar` (route retained for deep links from notifications/emails). Removes unused `UpcomingPage` import from `App.tsx`.
- **ReelsCard restyle**: amber mono kicker for show title, 30px `font-extrabold` episode name, episode code + provider + NEW chips in top-left, 3px amber progress bar. No action rail per design scope decision.
- **TitleList 3-column mobile grid**: `BREAKPOINT_COLS.base` updated from 2 → 3 so virtualized row chunking matches the CSS `grid-cols-3` on mobile.
- **TitleDetailPage responsive title**: `text-[30px] sm:text-[56px]` for both movie and show heroes.
- **DiscoveryPage**: HeroCard stacks vertically on mobile (`grid-cols-1 sm:grid-cols-[240px_1fr]`); RailCard shrinks to `w-[118px]` on mobile.
- **SettingsPage**: sidebar nav renders as a horizontal scrolling pill row on mobile (`flex-row gap-1 overflow-x-auto` on `<sm`).
- **TrackedPage**: status tab bar gets `overflow-x-auto scrollbar-none` so all tabs are reachable on narrow screens.

## Test plan

- [x] `bun run check` — 1786 tests pass, 0 lint errors
- [x] Tab bar visible on every mobile route with active tab amber-highlighted
- [x] `/more` — profile card, grouped links, sign out
- [x] `/browse` — kicker + title + 3-column grid on mobile
- [x] `/calendar` — agenda view, Calendar tab amber
- [x] `/tracked` — 2×2 stats grid, horizontal status pills
- [x] `/settings` — horizontal pill tab row on mobile
- [x] Title Detail — 30px mobile title, backdrop hero

🤖 Generated with [Claude Code](https://claude.com/claude-code)