### PR TITLE
feat: Signal mockup alignment follow-up

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useState } from "react";
-import { Routes, Route, NavLink, Link, Navigate, useLocation } from "react-router";
+import { Routes, Route, NavLink, Link, Navigate, useLocation, useNavigate } from "react-router";
 import { Toaster } from "sonner";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "./context/AuthContext";
@@ -52,14 +52,23 @@ const PersonPage = lazyWithRetry(() => import("./pages/PersonPage"));
 const ReelsPage = lazyWithRetry(() => import("./pages/ReelsPage"));
 const DiscoveryPage = lazyWithRetry(() => import("./pages/DiscoveryPage"));
 const InvitePage = lazyWithRetry(() => import("./pages/InvitePage"));
-const StatsPage = lazyWithRetry(() => import("./pages/StatsPage"));
 const AdminUsersPage = lazyWithRetry(() => import("./pages/AdminUsersPage"));
 const NotFoundPage = lazyWithRetry(() => import("./pages/NotFoundPage"));
 const MorePage = lazyWithRetry(() => import("./pages/MorePage"));
 
+function focusOrNavigateSearch(navigate: ReturnType<typeof useNavigate>, currentPath: string) {
+  if (currentPath === "/browse") {
+    const input = document.getElementById("search-input") as HTMLInputElement | null;
+    if (input) { input.focus(); input.select(); }
+  } else {
+    navigate("/browse?focus=search");
+  }
+}
+
 export default function App() {
   const { user, loading, logout } = useAuth();
   const location = useLocation();
+  const navigate = useNavigate();
   const { t } = useTranslation();
   const isReelsPage = location.pathname === "/reels";
   usePushSubscriptionSync();
@@ -67,13 +76,7 @@ export default function App() {
   const { theme } = useTheme();
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   useKeyboardShortcut("?", () => setShortcutsOpen((v) => !v));
-  useKeyboardShortcut("/", () => {
-    const input = document.getElementById("search-input") as HTMLInputElement | null;
-    if (input) {
-      input.focus();
-      input.select();
-    }
-  });
+  useKeyboardShortcut("/", () => focusOrNavigateSearch(navigate, location.pathname));
 
   return (
     <div
@@ -115,28 +118,22 @@ export default function App() {
             {user && (
               <>
                 <NavLink
-                  to="/tracked"
-                  className={({ isActive }) => navLinkClass(isActive)}
-                >
-                  {t("nav.tracked")}
-                </NavLink>
-                <NavLink
                   to="/calendar"
                   className={({ isActive }) => navLinkClass(isActive)}
                 >
                   {t("nav.calendar")}
                 </NavLink>
                 <NavLink
+                  to="/tracked"
+                  className={({ isActive }) => navLinkClass(isActive)}
+                >
+                  {t("nav.tracked")}
+                </NavLink>
+                <NavLink
                   to="/discovery"
                   className={({ isActive }) => navLinkClass(isActive)}
                 >
                   {t("nav.discovery")}
-                </NavLink>
-                <NavLink
-                  to="/stats"
-                  className={({ isActive }) => navLinkClass(isActive)}
-                >
-                  {t("nav.stats")}
                 </NavLink>
               </>
             )}
@@ -146,10 +143,7 @@ export default function App() {
           <button
             type="button"
             aria-label="Search (press / or ⌘K)"
-            onClick={() => {
-              const input = document.getElementById("search-input") as HTMLInputElement | null;
-              if (input) { input.focus(); input.select(); }
-            }}
+            onClick={() => focusOrNavigateSearch(navigate, location.pathname)}
             className="hidden sm:flex items-center gap-2 w-[260px] bg-white/[0.06] border border-white/[0.08] rounded-lg px-3 py-1.5 text-sm text-zinc-400 hover:bg-white/[0.1] transition-colors"
           >
             <span className="opacity-60 text-base leading-none">⌕</span>
@@ -211,7 +205,7 @@ export default function App() {
             <Route path="/more" element={<RequireAuth><MorePage /></RequireAuth>} />
             <Route path="/discovery" element={<RequireAuth><DiscoveryPage /></RequireAuth>} />
             <Route path="/invite" element={<RequireAuth><InvitePage /></RequireAuth>} />
-            <Route path="/stats" element={<RequireAuth><StatsPage /></RequireAuth>} />
+            <Route path="/stats" element={<Navigate to="/tracked?view=stats" replace />} />
             <Route path="/admin/users" element={<RequireAuth><AdminUsersPage /></RequireAuth>} />
             <Route path="/user/:username" element={<UserProfilePage />} />
             <Route path="/settings" element={<RequireAuth><SettingsPage /></RequireAuth>} />

--- a/frontend/src/components/BottomTabBar.tsx
+++ b/frontend/src/components/BottomTabBar.tsx
@@ -1,5 +1,5 @@
 import { NavLink } from "react-router";
-import { Clapperboard, Search, CalendarDays, Bookmark, MoreHorizontal, LogIn } from "lucide-react";
+import { Home, Search, CalendarDays, Bookmark, MoreHorizontal, LogIn } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../context/AuthContext";
 import { useApiCall } from "../hooks/useApiCall";
@@ -36,8 +36,8 @@ export default function BottomTabBar() {
         {user ? (
           <>
             <NavLink to="/reels" className={({ isActive }) => tabClass(isActive)}>
-              <Clapperboard size={ICON_SIZE} aria-hidden="true" />
-              <span className="text-[10px] font-semibold tracking-[0.02em]">{t("bottomNav.watch")}</span>
+              <Home size={ICON_SIZE} aria-hidden="true" />
+              <span className="text-[10px] font-semibold tracking-[0.02em]">{t("bottomNav.home")}</span>
             </NavLink>
 
             <NavLink to="/browse" className={({ isActive }) => tabClass(isActive)}>

--- a/frontend/src/components/HeroBanner.tsx
+++ b/frontend/src/components/HeroBanner.tsx
@@ -162,8 +162,9 @@ export default function HeroBanner({ episodes, onWatched }: { episodes: Episode[
         }}
       />
 
-      {/* Content overlay — bottom-left anchored */}
-      <div className="relative z-10 h-full flex items-end pb-12 px-8 sm:px-16">
+      {/* Content overlay — bottom-left anchored, text aligned to main container */}
+      <div className="relative z-10 h-full flex items-end pb-12">
+        <div className="max-w-7xl mx-auto px-4 w-full">
         <div className="max-w-[560px]">
           {/* Kicker */}
           <p className="font-mono text-[11px] font-semibold uppercase tracking-[0.15em] text-amber-400 mb-3">
@@ -223,6 +224,7 @@ export default function HeroBanner({ episodes, onWatched }: { episodes: Episode[
               ))}
             </div>
           )}
+        </div>
         </div>
 
         {/* Slide nav arrows — top-right of hero */}

--- a/frontend/src/components/SearchBar.test.tsx
+++ b/frontend/src/components/SearchBar.test.tsx
@@ -1,7 +1,12 @@
 import { describe, it, expect, mock, afterEach } from "bun:test";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
 import "../i18n";
 import SearchBar from "./SearchBar";
+
+function renderSearchBar(props: Parameters<typeof SearchBar>[0]) {
+  return render(<MemoryRouter><SearchBar {...props} /></MemoryRouter>);
+}
 
 afterEach(() => {
   cleanup();
@@ -11,7 +16,7 @@ describe("SearchBar", () => {
   it("renders input and search button", () => {
     const onSearch = mock(() => {});
     const onImdb = mock(() => {});
-    render(<SearchBar onSearch={onSearch} onImdb={onImdb} />);
+    renderSearchBar({ onSearch, onImdb });
 
     expect(screen.getByPlaceholderText("Search titles or paste IMDB link...")).toBeDefined();
     expect(screen.getByRole("button", { name: "Search" })).toBeDefined();
@@ -20,7 +25,7 @@ describe("SearchBar", () => {
   it("disables button when input is empty", () => {
     const onSearch = mock(() => {});
     const onImdb = mock(() => {});
-    render(<SearchBar onSearch={onSearch} onImdb={onImdb} />);
+    renderSearchBar({ onSearch, onImdb });
 
     const button = screen.getByRole("button", { name: "Search" });
     expect(button.hasAttribute("disabled")).toBe(true);
@@ -29,7 +34,7 @@ describe("SearchBar", () => {
   it("enables button when input has text", () => {
     const onSearch = mock(() => {});
     const onImdb = mock(() => {});
-    render(<SearchBar onSearch={onSearch} onImdb={onImdb} />);
+    renderSearchBar({ onSearch, onImdb });
 
     const input = screen.getByPlaceholderText("Search titles or paste IMDB link...");
     fireEvent.change(input, { target: { value: "Breaking Bad" } });
@@ -41,7 +46,7 @@ describe("SearchBar", () => {
   it("calls onSearch for regular text queries", () => {
     const onSearch = mock(() => {});
     const onImdb = mock(() => {});
-    render(<SearchBar onSearch={onSearch} onImdb={onImdb} />);
+    renderSearchBar({ onSearch, onImdb });
 
     const input = screen.getByPlaceholderText("Search titles or paste IMDB link...");
     fireEvent.change(input, { target: { value: "Breaking Bad" } });
@@ -54,7 +59,7 @@ describe("SearchBar", () => {
   it("calls onImdb for IMDB URLs", () => {
     const onSearch = mock(() => {});
     const onImdb = mock(() => {});
-    render(<SearchBar onSearch={onSearch} onImdb={onImdb} />);
+    renderSearchBar({ onSearch, onImdb });
 
     const input = screen.getByPlaceholderText("Search titles or paste IMDB link...");
     fireEvent.change(input, {
@@ -69,7 +74,7 @@ describe("SearchBar", () => {
   it("calls onImdb for bare IMDB IDs like tt0903747", () => {
     const onSearch = mock(() => {});
     const onImdb = mock(() => {});
-    render(<SearchBar onSearch={onSearch} onImdb={onImdb} />);
+    renderSearchBar({ onSearch, onImdb });
 
     const input = screen.getByPlaceholderText("Search titles or paste IMDB link...");
     fireEvent.change(input, { target: { value: "tt0903747" } });
@@ -82,7 +87,7 @@ describe("SearchBar", () => {
   it("does not submit when input is whitespace only", () => {
     const onSearch = mock(() => {});
     const onImdb = mock(() => {});
-    render(<SearchBar onSearch={onSearch} onImdb={onImdb} />);
+    renderSearchBar({ onSearch, onImdb });
 
     const input = screen.getByPlaceholderText("Search titles or paste IMDB link...");
     fireEvent.change(input, { target: { value: "   " } });
@@ -95,7 +100,7 @@ describe("SearchBar", () => {
   it("shows loading state when loading prop is true", () => {
     const onSearch = mock(() => {});
     const onImdb = mock(() => {});
-    render(<SearchBar onSearch={onSearch} onImdb={onImdb} loading={true} />);
+    renderSearchBar({ onSearch, onImdb, loading: true });
 
     expect(screen.getByRole("button", { name: "..." })).toBeDefined();
     expect(screen.getByRole("button", { name: "..." }).hasAttribute("disabled")).toBe(true);

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useSearchParams } from "react-router";
 import { useTranslation } from "react-i18next";
 
 interface Props {
@@ -12,6 +13,15 @@ const IMDB_REGEX = /imdb\.com\/title\/tt\d+/i;
 export default function SearchBar({ onSearch, onImdb, loading }: Props) {
   const [value, setValue] = useState("");
   const { t } = useTranslation();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (searchParams.get("focus") === "search") {
+      inputRef.current?.focus();
+      setSearchParams((p) => { p.delete("focus"); return p; }, { replace: true });
+    }
+  }, [searchParams, setSearchParams]);
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -28,6 +38,7 @@ export default function SearchBar({ onSearch, onImdb, loading }: Props) {
   return (
     <form onSubmit={handleSubmit} className="flex gap-2">
       <input
+        ref={inputRef}
         id="search-input"
         type="text"
         value={value}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -51,6 +51,7 @@
     "stats": "Stats"
   },
   "bottomNav": {
+    "home": "Home",
     "watch": "Home",
     "upcoming": "Upcoming",
     "browse": "Browse",

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -226,9 +226,9 @@ function MobileFeedHome({
                 <Link key={titleId} to={`/title/${titleId}`} className="w-[132px] shrink-0">
                   <div className="aspect-[2/3] rounded-[10px] overflow-hidden relative mb-2 bg-zinc-800">
                     {pUrl && <img src={pUrl} alt="" className="w-full h-full object-cover" loading="lazy" />}
-                    {/* Progress bar placeholder */}
+                    {/* Progress bar */}
                     <div className="absolute bottom-0 left-0 right-0 h-[3px] bg-black/40">
-                      <div className="h-full bg-amber-400" style={{ width: "30%" }} />
+                      <div className="h-full bg-amber-400" style={{ width: `${ep.total_episodes ? Math.round((ep.watched_episodes_count ?? 0) / ep.total_episodes * 100) : 0}%` }} />
                     </div>
                     {/* Unwatched badge */}
                     <div className="absolute top-1.5 right-1.5 bg-black/70 text-amber-400 text-[10px] font-bold font-mono px-1.5 py-0.5 rounded-full">

--- a/frontend/src/pages/MorePage.tsx
+++ b/frontend/src/pages/MorePage.tsx
@@ -113,7 +113,7 @@ export default function MorePage() {
           icon={<BarChart2 size={16} />}
           label="Stats"
           sub="Your watch history"
-          to="/stats"
+          to="/tracked?view=stats"
           isLast
         />
       </MoreGroup>

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -1,4 +1,3 @@
-import { useTranslation } from "react-i18next";
 import * as api from "../api";
 import type { StatsResponse } from "../types";
 import { useApiCall } from "../hooks/useApiCall";
@@ -106,14 +105,19 @@ function ShowStatusGrid({ showsByStatus }: { showsByStatus: StatsResponse["shows
   );
 }
 
-export default function StatsPage() {
+const LANGUAGE_NAMES: Record<string, string> = {
+  en: "English", ja: "Japanese", ko: "Korean", fr: "French", de: "German",
+  es: "Spanish", it: "Italian", pt: "Portuguese", zh: "Chinese", hi: "Hindi",
+  ar: "Arabic", ru: "Russian", tr: "Turkish", nl: "Dutch", sv: "Swedish",
+  da: "Danish", fi: "Finnish", no: "Norwegian", pl: "Polish", th: "Thai",
+};
+
+export function StatsView() {
   const { data, loading } = useApiCall(() => api.getStats(), []);
-  const { t: _t } = useTranslation();
 
   if (loading || !data) {
     return (
       <div className="space-y-6">
-        <h2 className="text-lg font-semibold">Stats</h2>
         <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
           {Array.from({ length: 5 }).map((_, i) => (
             <div key={i} className="bg-zinc-900 rounded-xl p-4 h-20 animate-pulse" />
@@ -127,17 +131,8 @@ export default function StatsPage() {
   const maxGenre = genres[0]?.count ?? 0;
   const maxLang = languages[0]?.count ?? 0;
 
-  const LANGUAGE_NAMES: Record<string, string> = {
-    en: "English", ja: "Japanese", ko: "Korean", fr: "French", de: "German",
-    es: "Spanish", it: "Italian", pt: "Portuguese", zh: "Chinese", hi: "Hindi",
-    ar: "Arabic", ru: "Russian", tr: "Turkish", nl: "Dutch", sv: "Swedish",
-    da: "Danish", fi: "Finnish", no: "Norwegian", pl: "Polish", th: "Thai",
-  };
-
   return (
     <div className="space-y-8 pb-8">
-      <h2 className="text-lg font-semibold">Stats</h2>
-
       {/* Overview */}
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
         <OverviewCard label="Movies Watched" value={overview.watched_movies} />
@@ -200,6 +195,15 @@ export default function StatsPage() {
           <ShowStatusGrid showsByStatus={shows_by_status} />
         </div>
       )}
+    </div>
+  );
+}
+
+export default function StatsPage() {
+  return (
+    <div className="space-y-8">
+      <h2 className="text-lg font-semibold">Stats</h2>
+      <StatsView />
     </div>
   );
 }

--- a/frontend/src/pages/TrackedPage.test.tsx
+++ b/frontend/src/pages/TrackedPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, mock, afterEach } from "bun:test";
-import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { render, screen, waitFor, cleanup, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import type { ReactNode } from "react";
 
@@ -128,6 +128,10 @@ describe("TrackedPage", () => {
 
     render(<TrackedPage />, { wrapper: Wrapper });
 
+    // Default view is list; switch to grid to see section headers
+    await waitFor(() => expect(screen.getByText("Grid")).toBeDefined());
+    fireEvent.click(screen.getByText("Grid"));
+
     await waitFor(() => {
       expect(screen.getByText("Currently Watching (1)")).toBeDefined();
       expect(screen.getByText("Caught Up (1)")).toBeDefined();
@@ -147,6 +151,9 @@ describe("TrackedPage", () => {
     );
 
     render(<TrackedPage />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByText("Grid")).toBeDefined());
+    fireEvent.click(screen.getByText("Grid"));
 
     await waitFor(() => {
       expect(screen.getByText("Currently Watching (1)")).toBeDefined();
@@ -176,6 +183,9 @@ describe("TrackedPage", () => {
     );
 
     render(<TrackedPage />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByText("Grid")).toBeDefined());
+    fireEvent.click(screen.getByText("Grid"));
 
     await waitFor(() => {
       expect(screen.getByText("Movies (2)")).toBeDefined();
@@ -210,6 +220,9 @@ describe("TrackedPage", () => {
 
     render(<TrackedPage />, { wrapper: Wrapper });
 
+    await waitFor(() => expect(screen.getByText("Grid")).toBeDefined());
+    fireEvent.click(screen.getByText("Grid"));
+
     await waitFor(() => {
       expect(screen.getByText("Unreleased (1)")).toBeDefined();
     });
@@ -224,6 +237,9 @@ describe("TrackedPage", () => {
     );
 
     render(<TrackedPage />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByText("Grid")).toBeDefined());
+    fireEvent.click(screen.getByText("Grid"));
 
     await waitFor(() => {
       expect(screen.getByText("Currently Watching (1)")).toBeDefined();

--- a/frontend/src/pages/TrackedPage.tsx
+++ b/frontend/src/pages/TrackedPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import * as api from "../api";
@@ -11,6 +11,7 @@ import { useGridNavigation } from "../hooks/useGridNavigation";
 import { useScrollRestoration } from "../hooks/useScrollRestoration";
 import { useIsMobile } from "../hooks/useIsMobile";
 import { PageHeader, Pill } from "../components/design";
+import { StatsView } from "./StatsPage";
 
 function TrackedStatsBand({ titles }: { titles: Title[] }) {
   const watching = titles.filter(t => t.show_status === 'watching' || t.user_status === 'watching').length;
@@ -80,7 +81,7 @@ export default function TrackedPage() {
   useGridNavigation();
 
   const [statusFilter, setStatusFilter] = useState<StatusTab>('all');
-  const [view, setView] = useState<'grid' | 'list'>('grid');
+  const [view, setView] = useState<'grid' | 'list' | 'stats'>('list');
   const [sort, setSort] = useState<SortKey>('last_aired');
 
   const { showGroups, movies } = useMemo(() => {
@@ -117,50 +118,55 @@ export default function TrackedPage() {
           <div className="flex items-center gap-2">
             <Pill active={view === 'grid'} onClick={() => setView('grid')}>Grid</Pill>
             <Pill active={view === 'list'} onClick={() => setView('list')}>List</Pill>
+            <Pill active={view === 'stats'} onClick={() => setView('stats')}>Stats</Pill>
           </div>
         }
       />
 
       {!loading && <TrackedStatsBand titles={allTitles} />}
 
-      <div className="flex items-center gap-0 border-b border-white/[0.06] mb-4 overflow-x-auto scrollbar-none">
-        {STATUS_TABS.map(tab => {
-          const count = tab.key === 'all' ? allTitles.length
-            : allTitles.filter(t => t.user_status === tab.key || (tab.key === 'watching' && t.show_status === 'watching') || (tab.key === 'completed' && t.show_status === 'completed')).length;
-          return (
-            <button
-              key={tab.key}
-              onClick={() => setStatusFilter(tab.key)}
-              className={`px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px ${
-                statusFilter === tab.key
-                  ? 'text-zinc-100 border-amber-400 font-semibold'
-                  : 'text-zinc-400 border-transparent hover:text-zinc-100'
-              }`}
-            >
-              {tab.label}
-              <span className="ml-2 font-mono text-[11px] text-zinc-500">{count}</span>
-            </button>
-          );
-        })}
-        <div className="flex-1" />
-        <select
-          value={sort}
-          onChange={(e) => setSort(e.target.value as SortKey)}
-          className="font-mono text-[11px] bg-white/[0.04] border border-white/[0.06] text-zinc-400 rounded-md px-3 py-1.5 cursor-pointer focus:outline-none mb-0.5"
-        >
-          <option value="last_aired">sort: last aired</option>
-          <option value="title">sort: title</option>
-          <option value="rating">sort: rating</option>
-          <option value="progress">sort: progress</option>
-        </select>
-      </div>
+      {view !== 'stats' && (
+        <div className="flex items-center gap-0 border-b border-white/[0.06] mb-4 overflow-x-auto scrollbar-none">
+          {STATUS_TABS.map(tab => {
+            const count = tab.key === 'all' ? allTitles.length
+              : allTitles.filter(t => t.user_status === tab.key || (tab.key === 'watching' && t.show_status === 'watching') || (tab.key === 'completed' && t.show_status === 'completed')).length;
+            return (
+              <button
+                key={tab.key}
+                onClick={() => setStatusFilter(tab.key)}
+                className={`px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px ${
+                  statusFilter === tab.key
+                    ? 'text-zinc-100 border-amber-400 font-semibold'
+                    : 'text-zinc-400 border-transparent hover:text-zinc-100'
+                }`}
+              >
+                {tab.label}
+                <span className="ml-2 font-mono text-[11px] text-zinc-500">{count}</span>
+              </button>
+            );
+          })}
+          <div className="flex-1" />
+          <select
+            value={sort}
+            onChange={(e) => setSort(e.target.value as SortKey)}
+            className="font-mono text-[11px] bg-white/[0.04] border border-white/[0.06] text-zinc-400 rounded-md px-3 py-1.5 cursor-pointer focus:outline-none mb-0.5"
+          >
+            <option value="last_aired">sort: last aired</option>
+            <option value="title">sort: title</option>
+            <option value="rating">sort: rating</option>
+            <option value="progress">sort: progress</option>
+          </select>
+        </div>
+      )}
 
-      {loading ? (
+      {view === 'stats' ? (
+        <StatsView />
+      ) : loading ? (
         <TitleGridSkeleton />
       ) : filteredTitles.length === 0 ? (
         <TitleList titles={[]} onTrackToggle={refetch} emptyMessage={t("tracked.empty")} />
       ) : view === 'list' ? (
-        <TrackedTable titles={sortedFilteredTitles} />
+        <TrackedTable titles={sortedFilteredTitles} onRefetch={refetch} />
       ) : statusFilter !== 'all' ? (
         <TitleList titles={sortedFilteredTitles} onTrackToggle={refetch} hideTypeBadge showProgressBar showStatusPicker showNotificationPicker showTags />
       ) : (
@@ -195,7 +201,59 @@ const STATUS_COLORS: Record<string, string> = {
   dropped: 'oklch(0.65 0.12 0)',
 };
 
-function TrackedTable({ titles }: { titles: Title[] }) {
+function RowActionsMenu({ title, onRefetch }: { title: Title; onRefetch: () => void }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const handleUntrack = async () => {
+    setOpen(false);
+    await api.untrackTitle(title.id);
+    onRefetch();
+  };
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen(!open)}
+        className="px-2 py-1 text-[11px] font-medium bg-white/[0.06] border border-white/[0.08] rounded text-zinc-400 hover:text-white transition-colors cursor-pointer"
+      >
+        ···
+      </button>
+      {open && (
+        <div className="absolute right-0 top-full mt-1 z-20 min-w-[160px] bg-zinc-800 border border-white/[0.08] rounded-lg shadow-xl py-1 text-sm">
+          {title.tmdb_url && (
+            <a
+              href={title.tmdb_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setOpen(false)}
+              className="block px-3 py-2 text-zinc-300 hover:bg-white/[0.06] transition-colors"
+            >
+              Open on TMDB ↗
+            </a>
+          )}
+          <button
+            onClick={() => { void handleUntrack(); }}
+            className="w-full text-left px-3 py-2 text-red-400 hover:bg-white/[0.06] transition-colors cursor-pointer"
+          >
+            Untrack
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TrackedTable({ titles, onRefetch }: { titles: Title[]; onRefetch: () => void }) {
   const isMobile = useIsMobile();
 
   if (isMobile) {
@@ -324,6 +382,7 @@ function TrackedTable({ titles }: { titles: Title[] }) {
                 >
                   Open
                 </Link>
+                <RowActionsMenu title={title} onRefetch={onRefetch} />
               </div>
             </div>
           );

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -70,6 +70,8 @@ export interface Episode {
   backdrop_url?: string | null;
   is_watched?: boolean;
   offers?: Offer[];
+  total_episodes?: number;
+  watched_episodes_count?: number;
 }
 
 // Search results come from the API directly with different shape

--- a/server/db/repository/episodes.ts
+++ b/server/db/repository/episodes.ts
@@ -175,6 +175,16 @@ export async function getUnwatchedEpisodes(userId: string, timezone = "UTC") {
         show_original_title: titles.originalTitle,
         poster_url: titles.posterUrl,
         backdrop_url: titles.backdropUrl,
+        total_episodes: sql<number>`(
+          SELECT COUNT(*) FROM episodes e2
+          WHERE e2.title_id = ${episodes.titleId}
+          AND e2.air_date IS NOT NULL AND e2.air_date <= ${today}
+        )`,
+        watched_episodes_count: sql<number>`(
+          SELECT COUNT(*) FROM watched_episodes we2
+          INNER JOIN episodes e3 ON e3.id = we2.episode_id
+          WHERE e3.title_id = ${episodes.titleId} AND we2.user_id = ${userId}
+        )`,
       })
       .from(episodes)
       .innerJoin(titles, eq(titles.id, episodes.titleId))


### PR DESCRIPTION
## Summary

- **Search**: top-bar button and `/` shortcut navigate to `/browse?focus=search`; `SearchBar` autofocuses on arrival
- **Hero banner**: text content now aligns with `max-w-7xl mx-auto px-4` container (same gutter as all other page sections)
- **Tracked default view**: changed from grid → list; Grid / List / Stats pill toggle added; Stats renders inline via extracted `StatsView` component
- **Tracked `···` menu**: each list row gets an actions dropdown (Untrack, Open on TMDB)
- **Stats route**: `/stats` redirects to `/tracked?view=stats`; Stats nav link removed from desktop top-bar and MorePage
- **Desktop nav order**: Home → Browse → Calendar → Tracked → Discovery
- **Mobile tab bar**: "Watch" renamed "Home", Clapperboard icon swapped for Home icon (route stays `/reels`)
- **Mobile progress bar**: continue-watching cards now compute real progress from `watched_episodes_count / total_episodes` (server query updated)

## Test plan

- [ ] Click top-bar search button from Home/Tracked/Calendar → lands on Browse with input focused
- [ ] Press `/` from a non-Browse page → same behaviour
- [ ] Hero banner text left-edge aligns with nav items at 1440px+
- [ ] Tracked opens in List view by default; Grid / List / Stats pills switch views correctly
- [ ] Tracked list row `···` opens menu; Untrack removes the title; TMDB link opens in new tab
- [ ] `/stats` redirects to `/tracked?view=stats`; Stats not in desktop nav
- [ ] Mobile tab bar first tab shows "Home" with home icon, navigates to `/reels`
- [ ] Mobile home continue-watching progress bars reflect actual progress (not all at 30%)
- [ ] `bun run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)