### PR TITLE
chore: add Firefox/Webkit to Playwright and document job-restart policy

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,6 +16,14 @@ export default defineConfig({
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
     },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+    },
   ],
   webServer: {
     command: "cd frontend && bun run dev",

--- a/server/jobs/worker.ts
+++ b/server/jobs/worker.ts
@@ -72,6 +72,10 @@ export async function processJobs() {
 }
 
 export function startWorker() {
+  // Cron runs missed during downtime are not backfilled: `recoverStaleJobs`
+  // only re-queues jobs that were already claimed when the process died, and
+  // `tickCrons` computes the next run from "now" rather than "last run".
+  // This is intentional — it prevents restart storms after long outages.
   recoverStaleJobs();
 
   // Poll for pending jobs


### PR DESCRIPTION
## Summary
- Extend \`playwright.config.ts\` with firefox and webkit projects. The PWA, passkey, and service-worker flows benefit from cross-browser coverage — Safari/WebKit in particular surfaces its own bugs.
- Add a comment in \`server/jobs/worker.ts\` documenting the intentional no-backfill-on-restart policy: cron runs missed during downtime are not replayed, preventing restart storms after long outages.

Part of the REVIEW.md follow-ups (P2-3, P2-10).

## Test plan
- [x] \`bun run check\` passes locally (1786 tests, 0 failures)
- [ ] CI green on GitHub Actions
- [ ] Optional follow-up: run \`bun run test:e2e\` locally to confirm firefox+webkit are installed; if not, add to README deploy/dev docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)