### PR TITLE
perf(db): add user_id index on tracked table

### DIFF
--- a/drizzle/0028_tracked_user_id_index.sql
+++ b/drizzle/0028_tracked_user_id_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_tracked_user_id ON tracked(user_id);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1744761600000,
       "tag": "0027_episode_ratings",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "6",
+      "when": 1745021200000,
+      "tag": "0028_tracked_user_id_index",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -133,6 +133,6 @@ describe("fixSkippedMigrations", () => {
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(28);
+    expect(migrations.cnt).toBe(29);
   });
 });

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -238,7 +238,10 @@ export const tracked = sqliteTable(
     userStatus: text("user_status"),
     notificationMode: text("notification_mode"),
   },
-  (table) => [primaryKey({ columns: [table.titleId, table.userId] })]
+  (table) => [
+    primaryKey({ columns: [table.titleId, table.userId] }),
+    index("idx_tracked_user_id").on(table.userId),
+  ]
 );
 
 export const watchedEpisodes = sqliteTable(


### PR DESCRIPTION
## Summary
The \`tracked\` table has a composite PK \`(title_id, user_id)\` which does not serve the hot "all titles tracked by user X" query efficiently (title_id is the leading column). Add a secondary \`idx_tracked_user_id\` so watchlist reads stay O(log n) as the table grows.

- Add the index in \`server/db/schema.ts\`
- Add hand-written drizzle migration \`0028_tracked_user_id_index.sql\` (matches the curation pattern of the other 27 migrations; drizzle-kit generate needs a TTY we don't have here)
- Bump the expected migration count in \`server/db/bun-db.test.ts\`

Part of REVIEW.md follow-ups (P1-5).

## Test plan
- [x] \`bun run check\` passes locally (1786 tests, 0 failures)
- [x] Migration is idempotent (\`CREATE INDEX IF NOT EXISTS\`)
- [ ] CI green on GitHub Actions
- [ ] On merge, production Bun deployments run migration 0028 on next startup; CF D1 deployments apply via \`bun run db:migrate:cf\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)