### PR TITLE
fix(security): harden admin bootstrap + guard bare /api/user/settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ frontend/dist/
 *.db-shm
 *.db-wal
 
+# Initial admin bootstrap password (written once on first launch)
+admin-password.txt
+
 # Environment
 .env
 .env.*

--- a/server/index.ts
+++ b/server/index.ts
@@ -49,6 +49,8 @@ import { createAuthWithOidc, type BetterAuthInstance } from "./auth/better-auth"
 import { migrateAuthData } from "./db/migrate-auth";
 import { validateStartup } from "./startup-validation";
 import { createCache, initCache } from "./cache";
+import fs from "node:fs";
+import path from "node:path";
 
 // Validate required configuration before anything else
 validateStartup();
@@ -71,8 +73,33 @@ if (await getUserCount() === 0) {
   const hash = await platform.hashPassword(password);
   const adminId = await createUser("admin", hash, "Admin", "local", undefined, true);
   migrateTrackedData(adminId);
-  logger.info("Admin account created", { username: "admin" });
-  console.log(`\n  Default admin password: ${password}\n  Change it after first login.\n`);
+
+  // Write the password to a file next to the DB rather than stdout so that
+  // log aggregators don't permanently archive the initial secret. Chmod 600
+  // on POSIX; on Windows we fall back to the default ACL.
+  const passwordFile = path.resolve(
+    path.dirname(CONFIG.DB_PATH === ":memory:" ? "./remindarr.db" : CONFIG.DB_PATH),
+    "admin-password.txt"
+  );
+  try {
+    fs.writeFileSync(
+      passwordFile,
+      `Default admin password: ${password}\nChange it after first login, then delete this file.\n`,
+      { mode: 0o600 }
+    );
+    logger.warn("Admin account created — default password written to file", {
+      username: "admin",
+      passwordFile,
+    });
+  } catch (err) {
+    // If we can't write the file (read-only FS, permissions), fall back to
+    // the structured log so the operator can still recover the password.
+    logger.warn("Admin account created — could not write password file, logging instead", {
+      username: "admin",
+      password,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 }
 
 // Create auth instance (singleton for Bun)
@@ -222,6 +249,7 @@ app.use("/api/stats", requireAuth);
 app.route("/api/stats", statsRoutes);
 
 app.use("/api/user/settings/*", requireAuth);
+app.use("/api/user/settings", requireAuth);
 app.route("/api/user/settings", userSettingsRoutes);
 
 // Calendar feed — /calendar.ics is public (token-authenticated); /token endpoints require session


### PR DESCRIPTION
## Summary
Two small but material security hardening changes from REVIEW.md.

**P0-1 — Admin password stdout**
The first-launch admin bootstrap in \`server/index.ts\` printed the generated default password via \`console.log\`, which means any log aggregator permanently archives the secret. Instead, write it to \`admin-password.txt\` (mode \`0o600\`) next to the DB and log a structured pointer at WARN. If the filesystem is read-only, fall back to a structured log so the operator can still recover it.

**P0-2 — Bare /api/user/settings path**
\`app.use("/api/user/settings/*", requireAuth)\` only covers \`/settings/...\` — the bare path \`/api/user/settings\` was falling back to the parent \`/api/user/*\` \`optionalAuth\` block. Add the bare \`app.use\` mount to pair the trailing-slash-less exact path.

Also adds \`admin-password.txt\` to \`.gitignore\`.

## Test plan
- [x] \`bun run check\` passes locally (1786 tests, 0 failures)
- [ ] CI green on GitHub Actions
- [ ] On a fresh deploy, verify: \`admin-password.txt\` is created with the generated password, logs show the WARN pointer but not the secret itself, and \`curl /api/user/settings\` (no cookie) returns 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)