### PR TITLE
fix(security): metrics bearer guard + rate-limit write routes + cache sessions count

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -65,6 +65,11 @@ export const CONFIG = {
   // Sentry
   SENTRY_DSN: process.env.SENTRY_DSN || "",
 
+  // Prometheus metrics bearer token. If set, /metrics requires
+  // `Authorization: Bearer <token>`. If empty, /metrics is public
+  // (intended for home-lab deploys behind a trusted reverse proxy).
+  METRICS_TOKEN: process.env.METRICS_TOKEN || "",
+
   // Cache
   CACHE_BACKEND: (process.env.CACHE_BACKEND || "memory") as
     | "memory"

--- a/server/index.ts
+++ b/server/index.ts
@@ -204,9 +204,14 @@ app.use("/api/social/following/*", optionalAuth);
 app.use("/api/social/following", optionalAuth);
 app.route("/api/social", socialRoutes);
 
-// Ratings routes — optionalAuth base, POST/DELETE check auth internally
-app.use("/api/ratings/*", optionalAuth);
-app.use("/api/ratings", optionalAuth);
+// Rate limit write-heavy routes: 60 requests per minute per IP.
+// Applied before requireAuth so floods are rejected cheaply.
+const writeRateLimiter = rateLimiter({ limit: 60, windowMs: 60_000 });
+
+// Ratings routes — optionalAuth base, POST/DELETE check auth internally.
+// Rate-limit applies to all (reads + writes) so unauth scrapers get throttled too.
+app.use("/api/ratings/*", writeRateLimiter, optionalAuth);
+app.use("/api/ratings", writeRateLimiter, optionalAuth);
 app.route("/api/ratings", ratingsRoutes);
 
 // Recommendations routes
@@ -220,28 +225,29 @@ app.use("/api/invitations", requireAuth);
 app.route("/api/invitations", invitationsRoutes);
 
 // Protected routes
-app.use("/api/track/*", requireAuth);
-app.use("/api/track", requireAuth);
+app.use("/api/track/*", writeRateLimiter, requireAuth);
+app.use("/api/track", writeRateLimiter, requireAuth);
 app.route("/api/track", trackRoutes);
 
-app.use("/api/watched/*", requireAuth);
-app.use("/api/watched", requireAuth);
+app.use("/api/watched/*", writeRateLimiter, requireAuth);
+app.use("/api/watched", writeRateLimiter, requireAuth);
 app.route("/api/watched", watchedRoutes);
 
-app.use("/api/imdb/*", requireAuth);
-app.use("/api/imdb", requireAuth);
+app.use("/api/imdb/*", writeRateLimiter, requireAuth);
+app.use("/api/imdb", writeRateLimiter, requireAuth);
 app.route("/api/imdb", imdbRoutes);
 
-app.use("/api/notifiers/*", requireAuth);
-app.use("/api/notifiers", requireAuth);
+app.use("/api/notifiers/*", writeRateLimiter, requireAuth);
+app.use("/api/notifiers", writeRateLimiter, requireAuth);
 app.route("/api/notifiers", notifierRoutes);
 
-app.use("/api/integrations/*", requireAuth);
-app.use("/api/integrations", requireAuth);
+app.use("/api/integrations/*", writeRateLimiter, requireAuth);
+app.use("/api/integrations", writeRateLimiter, requireAuth);
 app.route("/api/integrations", integrationRoutes);
 
-app.use("/api/import/*", requireAuth);
-app.use("/api/import", requireAuth);
+// Import is more expensive per request — tighter cap.
+app.use("/api/import/*", rateLimiter({ limit: 10, windowMs: 60_000 }), requireAuth);
+app.use("/api/import", rateLimiter({ limit: 10, windowMs: 60_000 }), requireAuth);
 app.route("/api/import", importRoutes);
 
 app.use("/api/stats/*", requireAuth);

--- a/server/routes/metrics.test.ts
+++ b/server/routes/metrics.test.ts
@@ -2,13 +2,16 @@ import { describe, it, expect, beforeEach, afterAll } from "bun:test";
 import { Hono } from "hono";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
 import { resetMetrics, httpRequestsTotal, jobsTotal } from "../metrics";
-import metricsApp from "./metrics";
+import { CONFIG } from "../config";
+import metricsApp, { __resetSessionsCountCache } from "./metrics";
 
 let app: Hono;
 
 beforeEach(() => {
   setupTestDb();
   resetMetrics();
+  __resetSessionsCountCache();
+  CONFIG.METRICS_TOKEN = "";
   app = new Hono();
   app.route("/metrics", metricsApp);
 });
@@ -67,5 +70,41 @@ describe("GET /metrics", () => {
     const res = await app.request("/metrics");
     const body = await res.text();
     expect(body.endsWith("\n")).toBe(true);
+  });
+
+  describe("METRICS_TOKEN bearer guard", () => {
+    it("rejects requests without a bearer token when METRICS_TOKEN is set", async () => {
+      CONFIG.METRICS_TOKEN = "secret";
+      try {
+        const res = await app.request("/metrics");
+        expect(res.status).toBe(401);
+      } finally {
+        CONFIG.METRICS_TOKEN = "";
+      }
+    });
+
+    it("rejects requests with a wrong bearer token", async () => {
+      CONFIG.METRICS_TOKEN = "secret";
+      try {
+        const res = await app.request("/metrics", {
+          headers: { authorization: "Bearer nope" },
+        });
+        expect(res.status).toBe(401);
+      } finally {
+        CONFIG.METRICS_TOKEN = "";
+      }
+    });
+
+    it("allows requests with the correct bearer token", async () => {
+      CONFIG.METRICS_TOKEN = "secret";
+      try {
+        const res = await app.request("/metrics", {
+          headers: { authorization: "Bearer secret" },
+        });
+        expect(res.status).toBe(200);
+      } finally {
+        CONFIG.METRICS_TOKEN = "";
+      }
+    });
   });
 });

--- a/server/routes/metrics.ts
+++ b/server/routes/metrics.ts
@@ -1,22 +1,51 @@
 import { Hono } from "hono";
 import { getRawDb } from "../db/bun-db";
 import { activeSessionsGauge, renderMetrics } from "../metrics";
+import { CONFIG } from "../config";
 
 const app = new Hono();
 
-// GET /metrics — Prometheus text format metrics
-// Public endpoint (protect via reverse proxy or METRICS_TOKEN env var if needed)
-app.get("/", (c) => {
-  // Query active (non-expired) session count on-demand
+// Cache the sessions count so Prometheus scrape traffic doesn't trigger a
+// COUNT(*) on every poll. 10 seconds is shorter than typical scrape intervals
+// so freshness stays useful, while still amortizing the query.
+const SESSIONS_COUNT_CACHE_MS = 10_000;
+let sessionsCountCache: { value: number; ts: number } | null = null;
+
+function getSessionsCount(): number {
+  const now = Date.now();
+  if (sessionsCountCache && now - sessionsCountCache.ts < SESSIONS_COUNT_CACHE_MS) {
+    return sessionsCountCache.value;
+  }
   const db = getRawDb();
   const row = db
     .prepare("SELECT COUNT(*) as count FROM sessions WHERE expires_at > datetime('now')")
     .get() as { count: number } | null;
-  activeSessionsGauge.set({}, row?.count ?? 0);
+  const value = row?.count ?? 0;
+  sessionsCountCache = { value, ts: now };
+  return value;
+}
+
+// GET /metrics — Prometheus text format metrics
+// Public unless METRICS_TOKEN is set, in which case a bearer token is required.
+app.get("/", (c) => {
+  if (CONFIG.METRICS_TOKEN) {
+    const header = c.req.header("authorization") ?? "";
+    const expected = `Bearer ${CONFIG.METRICS_TOKEN}`;
+    if (header !== expected) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+  }
+
+  activeSessionsGauge.set({}, getSessionsCount());
 
   return new Response(renderMetrics(), {
     headers: { "Content-Type": "text/plain; version=0.0.4; charset=utf-8" },
   });
 });
+
+/** @internal exposed for tests */
+export function __resetSessionsCountCache() {
+  sessionsCountCache = null;
+}
 
 export default app;


### PR DESCRIPTION
## Summary
Three REVIEW.md hardenings rolled into one PR, all in the same area:

**P1-2 — \`/metrics\` bearer guard**
If \`METRICS_TOKEN\` env var is set, \`/metrics\` requires \`Authorization: Bearer <token>\`. If unset, the endpoint stays public (so home-lab Prometheus scrapes keep working). Three new tests cover missing/wrong/correct token.

**P1-3 — Rate-limit write-heavy routes**
Previously only \`/api/auth/*\`, \`/api/search/*\`, and \`/api/sync/*\` were rate-limited. Now \`/api/track\`, \`/api/watched\`, \`/api/notifiers\`, \`/api/imdb\`, \`/api/integrations\`, \`/api/ratings\` get a 60 req/min bucket. \`/api/import\` (CSV upload, expensive per request) gets a tighter 10 req/min bucket. Limiters mount before \`requireAuth\` so floods are rejected cheaply.

**P2-11 — Cache sessions count**
The \`active_sessions\` gauge ran a \`COUNT(*)\` on every Prometheus scrape. Caches the result for 10 s to amortize DB load as the sessions table grows.

## Test plan
- [x] \`bun run check\` passes locally (1789 tests, 0 failures — +3 new tests)
- [ ] CI green on GitHub Actions
- [ ] On merge, verify home-lab deploys: \`curl /metrics\` still returns 200 (since \`METRICS_TOKEN\` defaults to empty). If set, confirm 401 without header.
- [ ] Confirm watchlist POSTs still work under normal user load (60/min is generous).

🤖 Generated with [Claude Code](https://claude.com/claude-code)