### PR TITLE
refactor(frontend): fetch helpers + per-route ErrorBoundary

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { Toaster } from "sonner";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "./context/AuthContext";
 import RequireAuth from "./components/RequireAuth";
+import ErrorBoundary from "./components/ErrorBoundary";
 import BottomTabBar from "./components/BottomTabBar";
 import ScrollToTop from "./components/ScrollToTop";
 import OfflineIndicator from "./components/OfflineIndicator";
@@ -55,6 +56,12 @@ const InvitePage = lazyWithRetry(() => import("./pages/InvitePage"));
 const AdminUsersPage = lazyWithRetry(() => import("./pages/AdminUsersPage"));
 const NotFoundPage = lazyWithRetry(() => import("./pages/NotFoundPage"));
 const MorePage = lazyWithRetry(() => import("./pages/MorePage"));
+
+// Wraps a route element in an inline ErrorBoundary so a single page crash
+// shows a contained fallback instead of taking down the whole shell.
+function Page({ children }: { children: React.ReactNode }) {
+  return <ErrorBoundary variant="inline">{children}</ErrorBoundary>;
+}
 
 function focusOrNavigateSearch(navigate: ReturnType<typeof useNavigate>, currentPath: string) {
   if (currentPath === "/browse") {
@@ -194,27 +201,27 @@ export default function App() {
         {user && <NotificationPrompt />}
         <Suspense fallback={<div className="text-center py-12 text-zinc-500">Loading...</div>}>
           <Routes>
-            <Route path="/" element={<HomePage />} />
-            <Route path="/browse" element={<BrowsePage />} />
-            <Route path="/login" element={<LoginPage />} />
-            <Route path="/signup" element={<SignupPage />} />
-            <Route path="/tracked" element={<RequireAuth><TrackedPage /></RequireAuth>} />
-            <Route path="/calendar" element={<RequireAuth><CalendarPage /></RequireAuth>} />
-            <Route path="/reels" element={<RequireAuth><ReelsPage /></RequireAuth>} />
+            <Route path="/" element={<Page><HomePage /></Page>} />
+            <Route path="/browse" element={<Page><BrowsePage /></Page>} />
+            <Route path="/login" element={<Page><LoginPage /></Page>} />
+            <Route path="/signup" element={<Page><SignupPage /></Page>} />
+            <Route path="/tracked" element={<RequireAuth><Page><TrackedPage /></Page></RequireAuth>} />
+            <Route path="/calendar" element={<RequireAuth><Page><CalendarPage /></Page></RequireAuth>} />
+            <Route path="/reels" element={<RequireAuth><Page><ReelsPage /></Page></RequireAuth>} />
             <Route path="/upcoming" element={<RequireAuth><Navigate to="/calendar" replace /></RequireAuth>} />
-            <Route path="/more" element={<RequireAuth><MorePage /></RequireAuth>} />
-            <Route path="/discovery" element={<RequireAuth><DiscoveryPage /></RequireAuth>} />
-            <Route path="/invite" element={<RequireAuth><InvitePage /></RequireAuth>} />
+            <Route path="/more" element={<RequireAuth><Page><MorePage /></Page></RequireAuth>} />
+            <Route path="/discovery" element={<RequireAuth><Page><DiscoveryPage /></Page></RequireAuth>} />
+            <Route path="/invite" element={<RequireAuth><Page><InvitePage /></Page></RequireAuth>} />
             <Route path="/stats" element={<Navigate to="/tracked?view=stats" replace />} />
-            <Route path="/admin/users" element={<RequireAuth><AdminUsersPage /></RequireAuth>} />
-            <Route path="/user/:username" element={<UserProfilePage />} />
-            <Route path="/settings" element={<RequireAuth><SettingsPage /></RequireAuth>} />
-            <Route path="/profile" element={<ProfilePage />} />
-            <Route path="/title/:id" element={<TitleDetailPage />} />
-            <Route path="/title/:id/season/:season" element={<SeasonDetailPage />} />
-            <Route path="/title/:id/season/:season/episode/:episode" element={<EpisodeDetailPage />} />
-            <Route path="/person/:personId" element={<PersonPage />} />
-            <Route path="*" element={<NotFoundPage />} />
+            <Route path="/admin/users" element={<RequireAuth><Page><AdminUsersPage /></Page></RequireAuth>} />
+            <Route path="/user/:username" element={<Page><UserProfilePage /></Page>} />
+            <Route path="/settings" element={<RequireAuth><Page><SettingsPage /></Page></RequireAuth>} />
+            <Route path="/profile" element={<Page><ProfilePage /></Page>} />
+            <Route path="/title/:id" element={<Page><TitleDetailPage /></Page>} />
+            <Route path="/title/:id/season/:season" element={<Page><SeasonDetailPage /></Page>} />
+            <Route path="/title/:id/season/:season/episode/:episode" element={<Page><EpisodeDetailPage /></Page>} />
+            <Route path="/person/:personId" element={<Page><PersonPage /></Page>} />
+            <Route path="*" element={<Page><NotFoundPage /></Page>} />
           </Routes>
         </Suspense>
       </main>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -28,11 +28,13 @@ import type {
 
 const BASE = "/api";
 
-async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
-  const res = await fetch(`${BASE}${url}`, {
-    headers: { "Content-Type": "application/json" },
-    ...options,
-  });
+/**
+ * Low-level fetch used by every helper. Shares 401-handling (dispatching the
+ * `auth:unauthorized` CustomEvent that `AuthContext` listens for) and
+ * error-body parsing across JSON, blob, and form-data callers.
+ */
+async function doFetch(url: string, options: RequestInit): Promise<Response> {
+  const res = await fetch(`${BASE}${url}`, options);
   if (res.status === 401) {
     window.dispatchEvent(new CustomEvent("auth:unauthorized"));
     throw new Error("Authentication required");
@@ -41,6 +43,26 @@ async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
     const err = await res.json().catch(() => ({ error: res.statusText }));
     throw new Error(err.error || `Request failed: ${res.status}`);
   }
+  return res;
+}
+
+async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await doFetch(url, {
+    headers: { "Content-Type": "application/json" },
+    ...options,
+  });
+  return res.json();
+}
+
+/** Fetches a binary response. Returns the raw Response so callers can read the
+ *  blob and headers (e.g. Content-Disposition for downloads). */
+async function fetchBlob(url: string, options?: RequestInit): Promise<Response> {
+  return doFetch(url, { credentials: "include", ...options });
+}
+
+/** Posts multipart form data and parses the JSON response. */
+async function fetchForm<T>(url: string, form: FormData): Promise<T> {
+  const res = await doFetch(url, { method: "POST", body: form });
   return res.json();
 }
 
@@ -146,8 +168,7 @@ export async function getTrackedTitles(): Promise<{ titles: (Title & { public: b
 }
 
 export async function exportWatchlist(): Promise<void> {
-  const res = await fetch(`${BASE}/track/export`, { credentials: "include" });
-  if (!res.ok) throw new Error("Export failed");
+  const res = await fetchBlob("/track/export");
   const blob = await res.blob();
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
@@ -170,16 +191,7 @@ export async function importWatchlist(file: File): Promise<{ success: boolean; i
 export async function importCsv(file: File): Promise<{ imported: number; failed: number; skipped: number; errors: string[] }> {
   const form = new FormData();
   form.append("file", file);
-  const res = await fetch(`${BASE}/import/csv`, { method: "POST", body: form });
-  if (res.status === 401) {
-    window.dispatchEvent(new CustomEvent("auth:unauthorized"));
-    throw new Error("Authentication required");
-  }
-  if (!res.ok) {
-    const e = await res.json().catch(() => ({ error: res.statusText }));
-    throw new Error(e.error || `Request failed: ${res.status}`);
-  }
-  return res.json();
+  return fetchForm("/import/csv", form);
 }
 
 // ─── User Profile ──────────────────────────────────────────────────────────

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -5,6 +5,12 @@ const log = logger.child({ module: "error-boundary" });
 
 interface Props {
   children: ReactNode;
+  /**
+   * "page" (default) — full-screen fallback used at the app root.
+   * "inline" — compact fallback suitable for per-route wrapping inside the
+   *   main content area, so a single page crash doesn't nuke the shell.
+   */
+  variant?: "page" | "inline";
 }
 
 interface State {
@@ -39,8 +45,13 @@ export default class ErrorBoundary extends Component<Props, State> {
 
   render() {
     if (this.state.hasError) {
+      const variant = this.props.variant ?? "page";
+      const outerClass =
+        variant === "inline"
+          ? "py-12 px-4 flex items-center justify-center"
+          : "min-h-screen bg-zinc-950 flex items-center justify-center p-4";
       return (
-        <div className="min-h-screen bg-zinc-950 flex items-center justify-center p-4">
+        <div className={outerClass}>
           <div className="max-w-md w-full bg-zinc-900 border border-red-800 rounded-lg p-6 text-center">
             <h1 className="text-xl font-bold text-red-400 mb-2">
               Something went wrong


### PR DESCRIPTION
## Summary
Two REVIEW.md follow-ups in the frontend.

**P2-5 — \`frontend/src/api.ts\`**
- Extract a shared \`doFetch()\` core that owns 401 dispatch and error-body parsing.
- \`fetchJson\` uses it; add \`fetchBlob\` (returns raw \`Response\` for blob + headers access) and \`fetchForm\` (POST \`FormData\`, parses JSON).
- \`exportWatchlist\` and \`importCsv\` drop their bespoke \`fetch()\` + duplicated 401 handling and call the helpers instead.

**P2-6 — Per-route ErrorBoundary**
- Add a \`variant="inline"\` mode to \`ErrorBoundary\` with a compact, in-page fallback (vs the full-screen variant used at the app root in \`main.tsx\`).
- Wrap every route element in an inline boundary via a tiny \`<Page>\` helper in \`App.tsx\`. A single page crash now shows a contained fallback inside \`<main>\` instead of taking down the whole shell (nav, tabs, settings link, etc.).

## Test plan
- [x] \`bun run check\` passes locally (1786 tests, 0 failures)
- [ ] CI green on GitHub Actions
- [ ] Visually verify: throw an error from a page (e.g. temporarily \`throw new Error()\` in HomePage) — should show inline fallback, nav and BottomTabBar should remain.
- [ ] Export + CSV import still work end-to-end (401 handling unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)