### PR TITLE
docs(readme): add Deploy section with CF Workers + reverse-proxy notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A self-hosted app for tracking streaming media releases. Browse, search, and get
 
 ## Quick Start
 
-The easiest way to run Remindarr is with Docker.
+The easiest way to run Remindarr is with Docker. A Cloudflare Workers deploy is also supported — see [Deploy](#deploy) below.
 
 **1. Get a TMDB API key** at [themoviedb.org](https://www.themoviedb.org/settings/api) (free).
 
@@ -46,6 +46,55 @@ docker compose up -d
 ```
 
 The app is available at `http://localhost:3000`.
+
+## Deploy
+
+### Docker (recommended for self-hosted)
+
+The `ghcr.io/matijamaric/remindarr:latest` image is a multi-stage build with a non-root user, a healthcheck against `/api/health`, and a `/app/data` volume for the SQLite database. Use the `docker-compose.yml` snippet above or run it directly:
+
+```bash
+docker run -d \
+  -p 3000:3000 \
+  -v remindarr-data:/app/data \
+  -e DB_PATH=/app/data/remindarr.db \
+  -e TMDB_API_KEY=... \
+  -e BASE_URL=https://remindarr.example.com \
+  -e BETTER_AUTH_SECRET=... \
+  ghcr.io/matijamaric/remindarr:latest
+```
+
+For notifications, OIDC, backups, and every other variable see [`docs/configuration.md`](docs/configuration.md) or the committed [`.env.example`](.env.example) template.
+
+### Reverse proxy + `X-Forwarded-For`
+
+The rate limiter and IP-based session logging key on the `x-forwarded-for` header. **Deploy behind a reverse proxy that sets this header reliably** (Caddy, nginx, Traefik, Cloudflare, etc.) — otherwise rate-limit keys fall back to `"anonymous"` and are trivially poolable. If the app is exposed directly to the internet, add a proxy or tighten limits per your threat model. See [REVIEW.md finding P1-4](REVIEW.md) for detail.
+
+### Cloudflare Workers
+
+Remindarr ships with a [`wrangler.toml`](wrangler.toml) and a [`server/worker.ts`](server/worker.ts) entry point so the same code deploys to Workers + D1 + KV.
+
+```bash
+# Create D1 database + KV namespace (one-time)
+wrangler d1 create remindarr
+wrangler kv:namespace create CACHE_KV
+
+# Apply migrations
+bun run db:migrate:cf
+
+# Set secrets
+wrangler secret put TMDB_API_KEY
+wrangler secret put BETTER_AUTH_SECRET
+# ...and OIDC_CLIENT_SECRET / SENTRY_DSN / VAPID_* as needed
+
+# Deploy
+bun run deploy:cf
+```
+
+Runtime differences vs the Bun deploy:
+- In-memory job worker is replaced by Workers cron triggers (configured in `wrangler.toml`).
+- Cache defaults to KV; set `CACHE_BACKEND=kv` for both Bun and Workers.
+- Session IP detection uses `cf-connecting-ip` in addition to `x-forwarded-for`.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
Extend the README with the missing deploy guidance from REVIEW.md (P1-4, P2-2).

- Add a Deploy section covering Docker (\`docker run\` snippet) and Cloudflare Workers (D1 + KV setup, migrations, \`wrangler secret\` flow).
- Document that the rate limiter keys on \`x-forwarded-for\`, so production deploys **must** terminate at a trusted reverse proxy that sets the header reliably — otherwise rate-limit keys fall back to \`\"anonymous\"\` and are pool-able.
- Link to the new committed \`.env.example\` template as a complement to \`docs/configuration.md\`.

## Test plan
- [x] \`bun run check\` passes locally (1786 tests)
- [ ] CI green on GitHub Actions
- [ ] Human review: verify the CF Workers steps are accurate for a fresh deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)