### PR TITLE
feat(sentry): wire Sentry releases into CF deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,7 +54,11 @@ BETTER_AUTH_SECRET=
 # VAPID_SUBJECT=mailto:admin@example.com
 
 # ── Sentry (optional) ───────────────────────────────────────────────────────
+# Server DSN — Bun deploys use remindarr-be, CF Workers use remindarr-cf.
 # SENTRY_DSN=
+# Frontend DSN — remindarr-fe project. Baked into the bundle at build time
+# (Vite loads from .env / .env.production at repo root).
+# VITE_SENTRY_DSN=
 
 # ── Prometheus metrics (optional) ───────────────────────────────────────────
 # If set, /metrics requires `Authorization: Bearer <token>`.

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ admin-password.txt
 .env.*
 !.env.example
 
+# Sentry CLI auth
+.sentryclirc
+
 # OS
 .DS_Store
 Thumbs.db

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@happy-dom/global-registrator": "^20.8.4",
         "@playwright/test": "^1.54.0",
+        "@sentry/cli": "^3.4.0",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -682,6 +683,24 @@
     "@sentry/browser": ["@sentry/browser@10.45.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.45.0", "@sentry-internal/feedback": "10.45.0", "@sentry-internal/replay": "10.45.0", "@sentry-internal/replay-canvas": "10.45.0", "@sentry/core": "10.45.0" } }, "sha512-e/a8UMiQhqqv706McSIcG6XK+AoQf9INthi2pD+giZfNRTzXTdqHzUT5OIO5hg8Am6eF63nDJc+vrYNPhzs51Q=="],
 
     "@sentry/bun": ["@sentry/bun@10.45.0", "", { "dependencies": { "@sentry/core": "10.45.0", "@sentry/node": "10.45.0" } }, "sha512-f9+24fp1Ew09qcqQ2DMKo0Dh/4WIE8G4D3/CLh8pgdwjP8A+5cvTQLcdUsqZll361P4jmXS+ZEi5KlmPv/ddGw=="],
+
+    "@sentry/cli": ["@sentry/cli@3.4.0", "", { "dependencies": { "progress": "^2.0.3", "proxy-from-env": "^1.1.0", "undici": "^6.22.0", "which": "^2.0.2" }, "optionalDependencies": { "@sentry/cli-darwin": "3.4.0", "@sentry/cli-linux-arm": "3.4.0", "@sentry/cli-linux-arm64": "3.4.0", "@sentry/cli-linux-i686": "3.4.0", "@sentry/cli-linux-x64": "3.4.0", "@sentry/cli-win32-arm64": "3.4.0", "@sentry/cli-win32-i686": "3.4.0", "@sentry/cli-win32-x64": "3.4.0" }, "bin": { "sentry-cli": "bin/sentry-cli" } }, "sha512-be0utAcAnxQ3PMDVvaVygAScwoyZzz49Z2N30J9EKYWvEITPsc7venDE9D8w1I3Xz7K3eS7j/v4A0XPcrpGnQA=="],
+
+    "@sentry/cli-darwin": ["@sentry/cli-darwin@3.4.0", "", { "os": "darwin" }, "sha512-U86DkrN4jS5nE7n9vW20wY//Hjpc75QhwJhN0W3dFcSFfZ/GoHpgDxnGBqrwOgOZWdWh7a+iRYxz2wTsQH/sdg=="],
+
+    "@sentry/cli-linux-arm": ["@sentry/cli-linux-arm@3.4.0", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm" }, "sha512-xfmCN0zRKaMso1xydgg+/Ja5OxEOJRjVERLU516CsQLip7psyQYZ81sjm4prDBwIxKmNLhLwntCH2q6CSxIjGg=="],
+
+    "@sentry/cli-linux-arm64": ["@sentry/cli-linux-arm64@3.4.0", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm64" }, "sha512-17E6HqoVEr3i8JTsk6ZE/oM8qGB+QMW/3h59OLcLOPiPJgNQ0yUhozEsVz4OqO4D1ZDrfamEmJ4EGJk0DjwfMQ=="],
+
+    "@sentry/cli-linux-i686": ["@sentry/cli-linux-i686@3.4.0", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "ia32" }, "sha512-vlRcoYLqUJqgXZujiKBeme7tW6N4BInrV0g3IpmtHwkjPj1Hu8/ocZ03GHMT401TxfNz0O+eoWAlNQ5lS6bMWQ=="],
+
+    "@sentry/cli-linux-x64": ["@sentry/cli-linux-x64@3.4.0", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "x64" }, "sha512-geBJ2WVTFnO0DCvkwCu8iJqpLl9ds6PVvciQK3cTV8cQCM4MOae7cdE21fLXPXO1QdSnzvSW4vf85f8noe48Ow=="],
+
+    "@sentry/cli-win32-arm64": ["@sentry/cli-win32-arm64@3.4.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-wZktHXuAXkhWky+QNsYuDxUeEDYwdQPm/INJqS9/8Yojojr2AQFK/UydZmdzJ7a3lGe0dqhGFb69V0fPVvMc9A=="],
+
+    "@sentry/cli-win32-i686": ["@sentry/cli-win32-i686@3.4.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-R4yx5U51ndh40o5TToNczGyJ4eOsKaDgtoOBJMW/SmRST3mnomKiFqR0ITmifacPuL909R4US4v619pRDLDk4g=="],
+
+    "@sentry/cli-win32-x64": ["@sentry/cli-win32-x64@3.4.0", "", { "os": "win32", "cpu": "x64" }, "sha512-9OU+XWvj7fo30ZjBfBXa6eD2RqJUeulPZVhWl+wc3gSP8B5H7VDZoZfBPd8jpKlzMoCn6gdF4HN2m4Rnqf84RA=="],
 
     "@sentry/cloudflare": ["@sentry/cloudflare@10.46.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@sentry/core": "10.46.0" }, "peerDependencies": { "@cloudflare/workers-types": "^4.x" }, "optionalPeers": ["@cloudflare/workers-types"] }, "sha512-gN+S56kStf8jvutSQ+RCkapB8YgVXAmXLddDsbO8Oz5G1ts7Af6QLqSS4FoSGF/JLdV8QFMmBLBhx0P/KD3ngw=="],
 
@@ -1577,9 +1596,13 @@
 
     "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
 
+    "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
+
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
@@ -1832,6 +1855,8 @@
     "typescript-eslint": ["typescript-eslint@8.57.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.57.1", "@typescript-eslint/parser": "8.57.1", "@typescript-eslint/typescript-estree": "8.57.1", "@typescript-eslint/utils": "8.57.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-fLvZWf+cAGw3tqMCYzGIU6yR8K+Y9NT2z23RwOjlNFF2HwSB3KhdEFI5lSBv8tNmFkkBShSjsCjzx1vahZfISA=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
+
+    "undici": ["undici@6.25.0", "", {}, "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 

--- a/frontend/src/instrument.ts
+++ b/frontend/src/instrument.ts
@@ -8,6 +8,7 @@ if (dsn) {
 
     Sentry.init({
       dsn,
+      release: import.meta.env.VITE_SENTRY_RELEASE,
       integrations: [
         Sentry.browserTracingIntegration(),
         Sentry.replayIntegration(),

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -55,6 +55,7 @@ export default defineConfig({
     },
   },
   build: {
+    sourcemap: true,
     rollupOptions: {
       output: {
         manualChunks: {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "db:push": "bunx drizzle-kit push",
     "db:studio": "bunx drizzle-kit studio",
     "db:migrate:cf": "bunx wrangler d1 migrations apply remindarr --remote",
-    "deploy:cf": "bun run db:migrate:cf && bunx wrangler deploy",
+    "sentry:release:new": "bunx sentry-cli releases new -p remindarr-cf -p remindarr-fe \"$VERSION\"",
+    "sentry:release:upload-maps": "bunx sentry-cli sourcemaps inject frontend/dist && bunx sentry-cli sourcemaps upload --project remindarr-fe --release=\"$VERSION\" frontend/dist",
+    "sentry:release:finalize": "bunx sentry-cli releases set-commits \"$VERSION\" --auto && bunx sentry-cli releases finalize \"$VERSION\"",
+    "deploy:cf": "bun run db:migrate:cf && export VERSION=$(bunx sentry-cli releases propose-version) && export VITE_SENTRY_RELEASE=\"$VERSION\" && bun run build && bun run sentry:release:new && bun run sentry:release:upload-maps && bunx wrangler deploy --var SENTRY_RELEASE:\"$VERSION\" && bun run sentry:release:finalize",
     "deploy:cf:version": "bun run db:migrate:cf && bunx wrangler versions upload"
   },
   "dependencies": {
@@ -36,6 +39,7 @@
   "devDependencies": {
     "@happy-dom/global-registrator": "^20.8.4",
     "@playwright/test": "^1.54.0",
+    "@sentry/cli": "^3.4.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -93,6 +93,7 @@ interface Env {
   LOG_LEVEL?: string;
   CORS_ORIGIN?: string;
   SENTRY_DSN?: string;
+  SENTRY_RELEASE?: string;
   OIDC_ISSUER_URL?: string;
   OIDC_CLIENT_ID?: string;
   OIDC_CLIENT_SECRET?: string;
@@ -509,6 +510,7 @@ const handler = {
 export default withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    release: env.SENTRY_RELEASE,
     tracesSampleRate: 1.0,
     sendDefaultPii: false,
   }),


### PR DESCRIPTION
## Summary
- Wire `release` (git SHA) into both `@sentry/cloudflare` and `@sentry/react` inits so issues group by version
- Teach `bun run deploy:cf` the full release lifecycle: propose-version → build with `VITE_SENTRY_RELEASE` → `releases new -p remindarr-cf -p remindarr-fe` → source-map upload for `remindarr-fe` → `wrangler deploy --var SENTRY_RELEASE` → `set-commits --auto` → `finalize`
- Enable `build.sourcemap` so the maps that get uploaded actually exist
- Add `@sentry/cli` as a dev dep (reached via `bunx sentry-cli`) so Workers Builds picks it up without a separate install step

Cloudflare Workers Builds already runs `bun run deploy:cf` on push-to-master (confirmed via the Workers Builds API — 682 builds, last one from #438). So this ships automatically once merged.

**Out of scope, deliberately punted:**
- Worker source maps uploaded to Sentry — Cloudflare's own symbolication covers Worker stack traces with `upload_source_maps = true` in `wrangler.toml`; follow-up.
- Docker release flow (`remindarr-be`) — separate pipeline, untouched.
- Swap to `@sentry/vite-plugin` — cleaner long-term but diverges from Sentry's onboarding snippet.

## Required before merging
Add these build-env vars in Cloudflare dashboard → Workers → `remindarr` → Settings → Variables and Secrets → **Build variables**:

| Name | Value | Type |
|---|---|---|
| `SENTRY_AUTH_TOKEN` | rotated token | Secret |
| `SENTRY_ORG` | `matija-maric` | Plain |
| `SENTRY_URL` | `https://de.sentry.io/` | Plain |
| `VITE_SENTRY_DSN` | remindarr-fe DSN | Plain |

`SENTRY_URL` is load-bearing — the org is in the EU region; without it, `sentry-cli` defaults to US and uploads 404. Without `SENTRY_AUTH_TOKEN`, the first post-merge deploy fails at `releases new`.

Also rotate the previously-exposed auth token before pasting it into Cloudflare.

## Test plan
- [ ] Set the four build-env vars in Cloudflare
- [ ] Rotate the exposed Sentry auth token
- [ ] Merge → confirm CF Workers Build succeeds (dashboard or Workers Builds API)
- [ ] Sentry → Releases → remindarr-cf and remindarr-fe both show the merge commit SHA with commits linked
- [ ] Trigger a test error post-deploy; issue should carry the release tag and show symbolicated frontend stack frames

🤖 Generated with [Claude Code](https://claude.com/claude-code)