### PR TITLE
feat(design): Signal mockup follow-up polish

### DIFF
--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -255,7 +255,11 @@ export default function BrowsePage() {
 
   return (
     <div className="space-y-6">
-      <PageHeader kicker="Browse catalog" title="Browse" className="px-0 pt-4 pb-4" />
+      <PageHeader
+        kicker={searchResults !== null ? `Search · ${searchResults.length} result${searchResults.length === 1 ? "" : "s"}` : "Catalog · discover titles"}
+        title="Browse"
+        className="px-0 pt-4 pb-4"
+      />
       <SearchBar onSearch={handleSearch} onImdb={handleImdb} loading={searchLoading} />
 
 

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -744,7 +744,7 @@ function GridCalendar({
     <div className="space-y-4">
       {/* Header */}
       <PageHeader
-        kicker="Month view · your timezone"
+        kicker={`Month view · ${Intl.DateTimeFormat().resolvedOptions().timeZone}`}
         title={monthTitle}
         right={headerRight}
         className="px-0 pt-4 pb-4"
@@ -856,6 +856,27 @@ function GridCalendar({
               })}
             </div>
           ))}
+        </div>
+      )}
+
+      {/* Legend */}
+      {!loading && (
+        <div className="flex flex-wrap items-center gap-x-5 gap-y-2 font-mono text-[11px] text-zinc-500 pt-1">
+          <div className="flex items-center gap-1.5">
+            <span className="text-amber-400">●</span>
+            <span>Tracked · airing</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span style={{ color: "oklch(0.72 0.13 220)" }}>●</span>
+            <span>Followed · new episode</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span style={{ color: "oklch(0.72 0.15 140)" }}>●</span>
+            <span>Premiere</span>
+          </div>
+          <div className="ml-auto">
+            {stats.episodes} episode{stats.episodes === 1 ? "" : "s"} this month
+          </div>
         </div>
       )}
 

--- a/frontend/src/pages/DiscoveryPage.tsx
+++ b/frontend/src/pages/DiscoveryPage.tsx
@@ -6,7 +6,7 @@ import * as api from "../api";
 import type { Recommendation } from "../types";
 import { useApiCall } from "../hooks/useApiCall";
 import { Skeleton } from "../components/ui/skeleton";
-import { PageHeader, Kicker, Pill } from "../components/design";
+import { PageHeader, Kicker, Pill, Chip } from "../components/design";
 
 function formatRelativeTime(dateStr: string): string {
   const now = Date.now();
@@ -182,11 +182,12 @@ function HeroCard({
     : null;
 
   const senderName = rec.from_user.display_name ?? rec.from_user.username;
+  const typeLabel = rec.title.object_type === "SHOW" ? "TV Series" : "Movie";
 
   return (
-    <div className="bg-zinc-900 border border-white/[0.06] rounded-2xl p-6 mb-8 grid grid-cols-1 sm:grid-cols-[240px_1fr] gap-6 items-start">
+    <div className="bg-zinc-900 border border-white/[0.06] rounded-2xl p-6 mb-8 grid grid-cols-1 sm:grid-cols-[280px_1fr] lg:grid-cols-[360px_1fr] gap-6 sm:gap-8 items-stretch">
       {/* Poster */}
-      <div className="aspect-[2/3] rounded-lg overflow-hidden max-w-[200px] sm:max-w-none mx-auto sm:mx-0">
+      <div className="aspect-[2/3] rounded-[10px] overflow-hidden max-w-[220px] sm:max-w-none mx-auto sm:mx-0 shadow-2xl">
         {posterSrc ? (
           <img
             src={posterSrc}
@@ -199,49 +200,54 @@ function HeroCard({
       </div>
 
       {/* Info */}
-      <div className="flex flex-col gap-3 min-w-0">
-        <Kicker>Pick of the week</Kicker>
+      <div className="flex flex-col min-w-0 py-2">
+        <Kicker>Pick of the week{senderName ? ` · from @${rec.from_user.username}` : ""}</Kicker>
 
-        <h2 className="font-bold text-2xl text-zinc-100 leading-tight">
+        <h2 className="text-[30px] sm:text-[36px] lg:text-[44px] font-extrabold tracking-[-0.03em] leading-[1.02] text-zinc-100 mb-3.5">
           {rec.title.title}
         </h2>
 
-        <p className="text-zinc-300 text-sm leading-relaxed line-clamp-4">
-          {rec.title.object_type === "SHOW" ? "TV Series" : "Movie"}
-        </p>
+        <div className="flex flex-wrap gap-2 mb-4">
+          <Chip variant="default">{typeLabel}</Chip>
+        </div>
 
-        {/* "Why you'll like it" tag — from sender */}
-        {senderName && (
-          <div className="flex items-center gap-1.5 text-xs text-zinc-400">
-            <span className="text-amber-400">&#10022;</span>
-            <span>
-              Recommended by <span className="text-zinc-200 font-medium">{senderName}</span>
-            </span>
-            {rec.message && (
-              <span className="text-zinc-500 italic truncate max-w-[200px]">
-                &ldquo;{rec.message}&rdquo;
-              </span>
+        {/* "Why you'll like it" — featuring sender message */}
+        {(rec.message || senderName) && (
+          <div className="bg-white/[0.04] border border-white/[0.06] rounded-lg p-3.5 mb-5">
+            <div className="font-mono text-[10px] uppercase tracking-[0.15em] text-zinc-500 font-semibold mb-2">
+              Why you'll like it
+            </div>
+            {rec.message ? (
+              <p className="text-sm text-zinc-300 italic leading-relaxed mb-2">&ldquo;{rec.message}&rdquo;</p>
+            ) : null}
+            {senderName && (
+              <div className="flex flex-wrap gap-1.5 items-center">
+                <span className="text-[11px] px-2.5 py-1 rounded-full bg-amber-400/[0.08] text-amber-400 border border-amber-400/[0.18] font-medium">
+                  Recommended by
+                </span>
+                <span className="text-xs text-zinc-200 font-medium">{senderName}</span>
+              </div>
             )}
           </div>
         )}
 
         {/* Actions */}
-        <div className="flex flex-wrap gap-2 mt-1">
+        <div className="flex flex-wrap gap-2.5 mt-auto">
           <button
             onClick={() => onTrack(rec)}
-            className="inline-flex items-center justify-center px-4 py-2 rounded-lg text-sm font-semibold bg-amber-500 text-zinc-950 hover:bg-amber-400 transition-colors cursor-pointer"
+            className="inline-flex items-center justify-center px-5 py-2.5 rounded-lg text-sm font-bold bg-amber-400 text-black hover:bg-amber-300 transition-colors cursor-pointer"
           >
             {t("discovery.track")}
           </button>
           <Link
             to={`/title/${rec.title.id}`}
-            className="inline-flex items-center justify-center px-4 py-2 rounded-lg text-sm font-semibold bg-white/[0.06] border border-white/[0.08] text-zinc-300 hover:text-zinc-100 hover:bg-white/[0.1] transition-colors"
+            className="inline-flex items-center justify-center px-[18px] py-2.5 rounded-lg text-sm font-semibold bg-white/[0.08] border border-white/[0.14] text-zinc-100 hover:bg-white/[0.14] transition-colors"
           >
             View details
           </Link>
           <button
             onClick={() => onDismiss(rec)}
-            className="inline-flex items-center justify-center px-4 py-2 rounded-lg text-sm font-semibold text-zinc-500 hover:text-zinc-300 transition-colors cursor-pointer"
+            className="inline-flex items-center justify-center px-[14px] py-2.5 rounded-lg text-sm font-semibold text-zinc-500 border border-white/[0.08] hover:text-zinc-300 hover:border-white/[0.16] transition-colors cursor-pointer"
           >
             Not interested
           </button>

--- a/frontend/src/pages/TitleDetailPage.tsx
+++ b/frontend/src/pages/TitleDetailPage.tsx
@@ -303,7 +303,7 @@ function MovieDetail({ data }: { data: MovieDetailsResponse }) {
               <Kicker className="mb-2">
                 Movie{title.release_year ? ` · ${title.release_year}` : ""}{title.offers[0]?.provider_name ? ` · ${title.offers[0].provider_name}` : ""}
               </Kicker>
-              <h1 className="text-[30px] sm:text-[56px] leading-tight font-bold text-white">{tmdb?.title || title.title}</h1>
+              <h1 className="text-[30px] sm:text-[56px] lg:text-[64px] leading-none tracking-[-0.035em] font-extrabold text-white">{tmdb?.title || title.title}</h1>
               {(() => {
                 const displayTitle = tmdb?.title || title.title;
                 const originalTitle = tmdb?.original_title || title.original_title;
@@ -702,7 +702,7 @@ function ShowDetail({ data }: { data: ShowDetailsResponse }) {
                 <Kicker className="mb-2">
                   TV Show{title.release_year ? ` · ${title.release_year}` : ""}{title.offers[0]?.provider_name ? ` · ${title.offers[0].provider_name}` : ""}
                 </Kicker>
-                <h1 className="text-[30px] sm:text-[56px] leading-tight font-bold text-white">{tmdb?.name || title.title}</h1>
+                <h1 className="text-[30px] sm:text-[56px] lg:text-[64px] leading-none tracking-[-0.035em] font-extrabold text-white">{tmdb?.name || title.title}</h1>
                 {(() => {
                   const displayTitle = tmdb?.name || title.title;
                   const originalTitle = tmdb?.original_name || title.original_title;

--- a/frontend/src/pages/TrackedPage.tsx
+++ b/frontend/src/pages/TrackedPage.tsx
@@ -29,10 +29,10 @@ function TrackedStatsBand({ titles }: { titles: Title[] }) {
   return (
     <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
       {stats.map(s => (
-        <div key={s.label} className="bg-zinc-900 border border-white/[0.06] rounded-xl p-4">
-          <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-500 mb-2">{s.label}</div>
+        <div key={s.label} className="bg-zinc-900 border border-white/[0.06] rounded-xl p-[18px]">
+          <div className="font-mono text-[10px] uppercase tracking-[0.15em] text-zinc-500 font-semibold mb-2">{s.label}</div>
           <div className="flex items-baseline gap-2">
-            <div className="text-3xl font-extrabold tracking-[-0.03em] leading-none">{s.value}</div>
+            <div className="text-[30px] sm:text-[36px] font-extrabold tracking-[-0.03em] leading-none">{s.value}</div>
             <div className="font-mono text-[11px] text-zinc-500">{s.sub}</div>
           </div>
         </div>


### PR DESCRIPTION
Tighten remaining gaps vs the Signal V1 Full App & Mobile designs:

- BrowsePage kicker shows result/catalog context instead of generic "Browse catalog"
- CalendarPage kicker uses the actual IANA timezone, plus a mono legend band
  (Tracked · airing / Followed / Premiere) with episode-count tally
- TitleDetailPage hero title scales to 64px on lg with tighter letter-spacing
- TrackedPage stats values scale to 36px on sm with tighter mono kickers
- DiscoveryPage HeroCard gets the 44px title, bigger poster column, and a
  proper "Why you'll like it" panel with sender attribution

https://claude.ai/code/session_015qhpfZMEDqYioyq57hF2zZ