### PR TITLE
Add HomeRoute with mobile redirect to /reels

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,7 +37,7 @@ function lazyWithRetry(factory: () => Promise<{ default: React.ComponentType }>)
   );
 }
 
-const HomePage = lazyWithRetry(() => import("./pages/HomePage"));
+const HomeRoute = lazyWithRetry(() => import("./routes/HomeRoute"));
 const BrowsePage = lazyWithRetry(() => import("./pages/BrowsePage"));
 const TrackedPage = lazyWithRetry(() => import("./pages/TrackedPage"));
 const CalendarPage = lazyWithRetry(() => import("./pages/CalendarPage"));
@@ -201,7 +201,7 @@ export default function App() {
         {user && <NotificationPrompt />}
         <Suspense fallback={<div className="text-center py-12 text-zinc-500">Loading...</div>}>
           <Routes>
-            <Route path="/" element={<Page><HomePage /></Page>} />
+            <Route path="/" element={<HomeRoute />} />
             <Route path="/browse" element={<Page><BrowsePage /></Page>} />
             <Route path="/login" element={<Page><LoginPage /></Page>} />
             <Route path="/signup" element={<Page><SignupPage /></Page>} />

--- a/frontend/src/routes/HomeRoute.test.tsx
+++ b/frontend/src/routes/HomeRoute.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, mock, afterEach } from "bun:test";
+import { render, cleanup, waitFor } from "@testing-library/react";
+import { MemoryRouter, Routes, Route, useLocation } from "react-router";
+
+import "../i18n";
+
+let mockIsMobile = false;
+mock.module("../hooks/useIsMobile", () => ({
+  useIsMobile: () => mockIsMobile,
+}));
+
+const { default: HomeRoute } = await import("./HomeRoute");
+const { AuthContext } = await import("../context/AuthContext");
+
+const authedUser = { id: "1", username: "test", display_name: null, auth_provider: "local", is_admin: false };
+
+function makeAuth(overrides: Partial<{ user: unknown; loading: boolean }> = {}) {
+  return {
+    user: overrides.user ?? null,
+    providers: null,
+    loading: overrides.loading ?? false,
+    login: mock(() => Promise.resolve()),
+    signup: mock(() => Promise.resolve()),
+    logout: mock(() => Promise.resolve()),
+    refresh: mock(() => Promise.resolve()),
+  };
+}
+
+function LocationProbe() {
+  const loc = useLocation();
+  return <span data-testid="pathname">{loc.pathname}</span>;
+}
+
+function Harness({ authValue }: { authValue: ReturnType<typeof makeAuth> }) {
+  return (
+    <MemoryRouter initialEntries={["/"]}>
+      <AuthContext value={authValue as any}>
+        <LocationProbe />
+        <Routes>
+          <Route path="/" element={<HomeRoute />} />
+          <Route path="/reels" element={<div data-testid="reels-page">Reels</div>} />
+        </Routes>
+      </AuthContext>
+    </MemoryRouter>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  mockIsMobile = false;
+});
+
+describe("HomeRoute", () => {
+  it("redirects authenticated mobile users to /reels", async () => {
+    mockIsMobile = true;
+    const { getByTestId } = render(<Harness authValue={makeAuth({ user: authedUser })} />);
+
+    await waitFor(() => {
+      expect(getByTestId("pathname").textContent).toBe("/reels");
+    });
+  });
+
+  it("stays on / for authenticated desktop users", async () => {
+    mockIsMobile = false;
+    const { getByTestId } = render(<Harness authValue={makeAuth({ user: authedUser })} />);
+
+    // Give React a tick to process any pending effects; pathname should remain "/".
+    await new Promise((r) => setTimeout(r, 10));
+    expect(getByTestId("pathname").textContent).toBe("/");
+  });
+
+  it("stays on / for unauthenticated mobile users", async () => {
+    mockIsMobile = true;
+    const { getByTestId } = render(<Harness authValue={makeAuth({ user: null })} />);
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(getByTestId("pathname").textContent).toBe("/");
+  });
+
+  it("does not redirect while auth is loading, even on mobile", async () => {
+    mockIsMobile = true;
+    const { getByTestId } = render(
+      <Harness authValue={makeAuth({ user: authedUser, loading: true })} />,
+    );
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(getByTestId("pathname").textContent).toBe("/");
+  });
+});

--- a/frontend/src/routes/HomeRoute.tsx
+++ b/frontend/src/routes/HomeRoute.tsx
@@ -1,0 +1,21 @@
+import { lazy, Suspense } from "react";
+import { Navigate } from "react-router";
+import { useAuth } from "../context/AuthContext";
+import { useIsMobile } from "../hooks/useIsMobile";
+import ErrorBoundary from "../components/ErrorBoundary";
+
+const HomePage = lazy(() => import("../pages/HomePage"));
+
+export default function HomeRoute() {
+  const { user, loading } = useAuth();
+  const isMobile = useIsMobile();
+  if (loading) return null;
+  if (user && isMobile) return <Navigate to="/reels" replace />;
+  return (
+    <ErrorBoundary variant="inline">
+      <Suspense fallback={<div className="text-center py-12 text-zinc-500">Loading...</div>}>
+        <HomePage />
+      </Suspense>
+    </ErrorBoundary>
+  );
+}


### PR DESCRIPTION
## Summary
Refactored the home page routing logic into a dedicated `HomeRoute` component that intelligently redirects authenticated mobile users to the `/reels` page while keeping desktop users on the home page.

## Key Changes
- **Created `HomeRoute` component** (`frontend/src/routes/HomeRoute.tsx`): A new route wrapper that handles conditional navigation based on authentication status and device type
  - Redirects authenticated mobile users to `/reels`
  - Keeps authenticated desktop users and all unauthenticated users on the home page
  - Prevents redirects while auth is loading
  - Wraps `HomePage` with error boundary and suspense fallback

- **Updated App routing** (`frontend/src/App.tsx`): Changed the root route to use the new `HomeRoute` component instead of directly rendering `HomePage`

- **Added comprehensive test suite** (`frontend/src/routes/HomeRoute.test.tsx`): Full test coverage including:
  - Mobile authenticated user redirect to `/reels`
  - Desktop authenticated user stays on `/`
  - Unauthenticated mobile user stays on `/`
  - No redirect while auth is loading

## Implementation Details
- Uses `useAuth()` hook to check authentication status and loading state
- Uses `useIsMobile()` hook to detect mobile devices
- Implements proper loading state handling to prevent premature redirects
- Maintains error boundary and suspense patterns for robust error handling

https://claude.ai/code/session_01Fz9SKbgGJ3XQrE1NaVnU4x