### PR TITLE
Prevent vertical scrollbar in FullBleedCarousel

### DIFF
--- a/frontend/src/components/FullBleedCarousel.test.tsx
+++ b/frontend/src/components/FullBleedCarousel.test.tsx
@@ -27,6 +27,16 @@ describe("FullBleedCarousel", () => {
     expect(getByTestId("child-2")).toBeDefined();
   });
 
+  it("hides vertical overflow so horizontal scroll container does not produce a vertical scrollbar", () => {
+    const { container } = render(
+      <FullBleedCarousel>
+        <div>Item</div>
+      </FullBleedCarousel>,
+    );
+    const scrollDiv = container.querySelector(".overflow-x-auto") as HTMLDivElement;
+    expect(scrollDiv.className).toContain("overflow-y-hidden");
+  });
+
   it("applies scroll-padding matching padding so snap respects the inset", () => {
     const { container } = render(
       <FullBleedCarousel>

--- a/frontend/src/components/FullBleedCarousel.tsx
+++ b/frontend/src/components/FullBleedCarousel.tsx
@@ -63,7 +63,7 @@ export default function FullBleedCarousel({
       {/* Scroll container: pad content to align with body */}
       <div
         ref={scrollRef}
-        className="flex overflow-x-auto gap-3 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
+        className="flex overflow-x-auto overflow-y-hidden gap-3 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
         style={{
           paddingLeft: edgePad,
           paddingRight: edgePad,


### PR DESCRIPTION
## Summary
Added `overflow-y-hidden` class to the horizontal scroll container in FullBleedCarousel to prevent unwanted vertical scrollbars from appearing.

## Changes
- Added `overflow-y-hidden` utility class to the scroll container's className in FullBleedCarousel component
- Added corresponding test case to verify the overflow-y-hidden class is applied

## Details
The FullBleedCarousel component uses a horizontal scroll container that was previously only hiding the horizontal scrollbar. By adding `overflow-y-hidden`, we ensure that vertical overflow is also hidden, preventing the browser from displaying a vertical scrollbar when content might otherwise trigger one. This maintains a cleaner UI and prevents layout shifts caused by scrollbar appearance.

https://claude.ai/code/session_01UpoKSyrCPtdqddTKT4dPAQ