### PR TITLE
Redesign season episode list with pill tabs and per-row actions

### DIFF
--- a/frontend/src/pages/SeasonDetailPage.test.tsx
+++ b/frontend/src/pages/SeasonDetailPage.test.tsx
@@ -251,6 +251,50 @@ describe("SeasonDetailPage", () => {
     expect(options[1].textContent).toBe("Season 2");
   });
 
+  it("shows AIRING NOW indicator for episodes airing today", async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    mockGetSeasonDetails.mockImplementation(() => Promise.resolve({
+      title: { id: "tv-100", title: "Test Show", is_tracked: true },
+      tmdb: {
+        id: 1, name: "Season 1", overview: "Overview", air_date: "2024-01-01", poster_path: null, season_number: 1, vote_average: 8.0,
+        episodes: [
+          { id: 101, name: "Today Ep", overview: "Airing today", air_date: today, episode_number: 1, season_number: 1, still_path: null, runtime: 45, vote_average: 0, guest_stars: [], crew: [] },
+          { id: 102, name: "Other Ep", overview: "Not today", air_date: "2024-01-08", episode_number: 2, season_number: 1, still_path: null, runtime: 42, vote_average: 0, guest_stars: [], crew: [] },
+        ],
+        credits: { cast: [], crew: [] },
+      },
+      seasonNumber: 1, country: "US", seasons: defaultSeasons,
+    }));
+
+    render(<SeasonDetailPage />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByText("Today Ep")).toBeDefined());
+
+    const airingLabels = screen.getAllByText(/airing now/i);
+    expect(airingLabels.length).toBe(1);
+  });
+
+  it("renders watched count summary", async () => {
+    render(<SeasonDetailPage />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByText("Pilot")).toBeDefined());
+
+    // 1 watched (episode 2), 2 released/tracked; 3 total episodes; 2 remaining
+    await waitFor(() => {
+      expect(screen.getByText(/1 of 3 watched · 2 remaining/i)).toBeDefined();
+    });
+  });
+
+  it("renders padded two-digit episode numbers", async () => {
+    render(<SeasonDetailPage />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByText("Pilot")).toBeDefined());
+
+    expect(screen.getByText("01")).toBeDefined();
+    expect(screen.getByText("02")).toBeDefined();
+    expect(screen.getByText("03")).toBeDefined();
+  });
+
   it("does not render season selector when only one season", async () => {
     mockGetSeasonDetails.mockImplementation(() => Promise.resolve({
       title: { id: "tv-100", title: "Test Show", is_tracked: true },

--- a/frontend/src/pages/SeasonDetailPage.test.tsx
+++ b/frontend/src/pages/SeasonDetailPage.test.tsx
@@ -237,18 +237,15 @@ describe("SeasonDetailPage", () => {
     });
   });
 
-  it("renders season selector when multiple seasons exist", async () => {
+  it("renders season pill tabs when multiple seasons exist", async () => {
     render(<SeasonDetailPage />, { wrapper: Wrapper });
 
     await waitFor(() => expect(screen.getByText("Pilot")).toBeDefined());
 
-    const selector = screen.getByRole("combobox");
-    expect(selector).toBeDefined();
-
-    const options = screen.getAllByRole("option");
-    expect(options).toHaveLength(2);
-    expect(options[0].textContent).toBe("Season 1");
-    expect(options[1].textContent).toBe("Season 2");
+    const s1 = screen.getByRole("button", { name: "Season 1" });
+    const s2 = screen.getByRole("button", { name: "Season 2" });
+    expect(s1.getAttribute("aria-pressed")).toBe("true");
+    expect(s2.getAttribute("aria-pressed")).toBe("false");
   });
 
   it("shows AIRING NOW indicator for episodes airing today", async () => {
@@ -295,7 +292,7 @@ describe("SeasonDetailPage", () => {
     expect(screen.getByText("03")).toBeDefined();
   });
 
-  it("does not render season selector when only one season", async () => {
+  it("does not render season pill tabs when only one season", async () => {
     mockGetSeasonDetails.mockImplementation(() => Promise.resolve({
       title: { id: "tv-100", title: "Test Show", is_tracked: true },
       tmdb: {
@@ -313,7 +310,23 @@ describe("SeasonDetailPage", () => {
 
     await waitFor(() => expect(screen.getByText("Pilot")).toBeDefined());
 
-    const selector = screen.queryByRole("combobox");
-    expect(selector).toBeNull();
+    expect(screen.queryByRole("button", { name: "Season 1" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Season 2" })).toBeNull();
+  });
+
+  it("renders per-row overflow menu and opens on click", async () => {
+    render(<SeasonDetailPage />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByText("Pilot")).toBeDefined());
+
+    const moreButtons = screen.getAllByLabelText(/more actions/i);
+    expect(moreButtons.length).toBe(3);
+
+    await act(async () => {
+      fireEvent.click(moreButtons[0]);
+    });
+
+    expect(screen.getByRole("menuitem", { name: /view details/i })).toBeDefined();
+    expect(screen.getByRole("menuitem", { name: /share/i })).toBeDefined();
   });
 });

--- a/frontend/src/pages/SeasonDetailPage.tsx
+++ b/frontend/src/pages/SeasonDetailPage.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useParams, Link, useNavigate } from "react-router";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
+import { CheckCircle, Circle, MoreHorizontal, Share2 } from "lucide-react";
 import ScrollableRow from "../components/ScrollableRow";
 import * as api from "../api";
 import type { SeasonDetailsResponse, RatingValue } from "../types";
@@ -9,7 +10,6 @@ import PersonCard from "../components/PersonCard";
 import { DetailPageSkeleton } from "../components/SkeletonComponents";
 import { useApiCall } from "../hooks/useApiCall";
 import { useAuth } from "../context/AuthContext";
-import { WatchedIcon } from "../components/EpisodeComponents";
 import ShareButton from "../components/ShareButton";
 
 const TMDB_IMG = "https://image.tmdb.org/t/p";
@@ -160,21 +160,7 @@ export default function SeasonDetailPage() {
       <div className="flex items-center gap-2 text-sm text-zinc-400">
         <Link to={`/title/${title.id}`} className="hover:text-white transition-colors">{title.title}</Link>
         <span className="text-zinc-600">/</span>
-        {seasons && seasons.length > 1 ? (
-          <select
-            value={seasonNumber}
-            onChange={(e) => navigate(`/title/${title.id}/season/${e.target.value}`)}
-            className="bg-zinc-800 text-white text-sm rounded-lg border border-white/[0.06] px-2 py-1 focus:border-amber-500/50 focus:outline-none cursor-pointer"
-          >
-            {seasons.map((s) => (
-              <option key={s.season_number} value={s.season_number} className="bg-zinc-900">
-                {s.name}
-              </option>
-            ))}
-          </select>
-        ) : (
-          <span className="text-white">{tmdb?.name || `Season ${seasonNumber}`}</span>
-        )}
+        <span className="text-white">{tmdb?.name || `Season ${seasonNumber}`}</span>
       </div>
 
       {/* Header */}
@@ -221,7 +207,30 @@ export default function SeasonDetailPage() {
       {episodes.length > 0 && (
         <section className="space-y-3">
           <div className="flex items-center justify-between gap-3 flex-wrap">
-            <h2 className="text-lg font-semibold text-white">{t("season.episodes", "Episodes")}</h2>
+            <div className="flex items-center gap-3 flex-wrap">
+              <h2 className="text-lg font-semibold text-white">{t("season.episodes", "Episodes")}</h2>
+              {seasons && seasons.length > 1 && (
+                <div className="flex items-center gap-1.5 flex-wrap">
+                  {seasons.map((s) => {
+                    const active = s.season_number === seasonNumber;
+                    return (
+                      <button
+                        key={s.season_number}
+                        onClick={() => navigate(`/title/${title.id}/season/${s.season_number}`)}
+                        className={`px-3 py-1 rounded-full text-xs font-semibold transition-colors cursor-pointer whitespace-nowrap ${
+                          active
+                            ? "bg-amber-400 text-black"
+                            : "bg-white/[0.04] text-zinc-300 border border-white/[0.08] hover:border-white/20"
+                        }`}
+                        aria-pressed={active}
+                      >
+                        {s.name}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
             <div className="flex items-center gap-4">
               {hasStatus && releasedWithStatus.length > 0 && (
                 <span className="text-[11px] font-mono text-zinc-500 tracking-wide whitespace-nowrap">
@@ -348,18 +357,28 @@ export default function SeasonDetailPage() {
                       )}
                     </div>
 
-                    {/* Watched toggle */}
+                    {/* Watched pill */}
                     {hasStatus && (
                       <div className="shrink-0 self-center">
-                        <WatchedIcon
+                        <EpisodeWatchedPill
                           watched={watched}
-                          onClick={() => toggleWatched(ep.episode_number)}
-                          disabled={!released || !status}
-                          size="md"
-                          compactOnMobile
+                          released={released}
+                          hasStatus={!!status}
+                          onToggle={() => toggleWatched(ep.episode_number)}
                         />
                       </div>
                     )}
+
+                    {/* Overflow menu */}
+                    <div className="shrink-0 self-center">
+                      <EpisodeOverflowMenu
+                        titleId={title.id}
+                        seasonNumber={seasonNumber}
+                        episodeNumber={ep.episode_number}
+                        episodeName={ep.name}
+                        showTitle={title.title}
+                      />
+                    </div>
                   </div>
                 </div>
               );
@@ -378,6 +397,152 @@ export default function SeasonDetailPage() {
             ))}
           </ScrollableRow>
         </section>
+      )}
+    </div>
+  );
+}
+
+function EpisodeWatchedPill({
+  watched,
+  released,
+  hasStatus,
+  onToggle,
+}: {
+  watched: boolean;
+  released: boolean;
+  hasStatus: boolean;
+  onToggle: () => void;
+}) {
+  const { t } = useTranslation();
+  const disabled = !released || !hasStatus;
+
+  if (disabled) {
+    return (
+      <span
+        role="img"
+        aria-label={t("episodes.notYetReleased", "Not yet released")}
+        className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-[11px] font-semibold bg-zinc-800/50 text-zinc-600 border-zinc-800 cursor-not-allowed opacity-60"
+      >
+        <Circle size={12} aria-hidden="true" />
+        <span className="hidden sm:inline">{t("episodes.watch", "Watch")}</span>
+      </span>
+    );
+  }
+
+  return (
+    <button
+      onClick={(e) => {
+        e.stopPropagation();
+        onToggle();
+      }}
+      aria-pressed={watched}
+      aria-label={
+        watched
+          ? t("episodes.markAsUnwatched", "Mark as unwatched")
+          : t("episodes.markAsWatched", "Mark as watched")
+      }
+      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-[11px] font-semibold cursor-pointer transition-colors ${
+        watched
+          ? "bg-amber-400/15 text-amber-400 border-amber-400/30 hover:bg-amber-400/25"
+          : "bg-white/[0.06] text-zinc-300 border-white/[0.08] hover:bg-white/10 hover:text-white"
+      }`}
+    >
+      {watched ? <CheckCircle size={12} aria-hidden="true" /> : <Circle size={12} aria-hidden="true" />}
+      <span className="hidden sm:inline">
+        {watched ? t("episodes.watched", "Watched") : t("episodes.markWatchedShort", "Mark")}
+      </span>
+    </button>
+  );
+}
+
+function EpisodeOverflowMenu({
+  titleId,
+  seasonNumber,
+  episodeNumber,
+  episodeName,
+  showTitle,
+}: {
+  titleId: string;
+  seasonNumber: number;
+  episodeNumber: number;
+  episodeName: string;
+  showTitle: string;
+}) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const handleShare = async () => {
+    setOpen(false);
+    const shareUrl = `${window.location.origin}/title/${titleId}/season/${seasonNumber}/episode/${episodeNumber}`;
+    const shareTitle = `${showTitle} — S${String(seasonNumber).padStart(2, "0")}E${String(episodeNumber).padStart(2, "0")} · ${episodeName}`;
+    try {
+      if (navigator.share) {
+        await navigator.share({ title: shareTitle, url: shareUrl });
+      } else {
+        await navigator.clipboard.writeText(shareUrl);
+        toast.success(t("share.copied", "Link copied"));
+      }
+    } catch {
+      // user cancelled or copy failed — stay quiet
+    }
+  };
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((o) => !o);
+        }}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={t("episodes.moreActions", "More actions")}
+        className="inline-flex items-center justify-center w-8 h-8 rounded-md text-zinc-500 hover:text-white hover:bg-white/[0.06] cursor-pointer transition-colors"
+      >
+        <MoreHorizontal size={16} aria-hidden="true" />
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-full mt-1 z-20 min-w-[180px] rounded-lg border border-white/[0.08] bg-zinc-900 shadow-xl py-1"
+        >
+          <button
+            role="menuitem"
+            onClick={() => {
+              setOpen(false);
+              navigate(`/title/${titleId}/season/${seasonNumber}/episode/${episodeNumber}`);
+            }}
+            className="w-full text-left px-3 py-2 text-[13px] text-zinc-200 hover:bg-white/[0.06] cursor-pointer transition-colors"
+          >
+            {t("episodes.viewDetails", "View details")}
+          </button>
+          <button
+            role="menuitem"
+            onClick={handleShare}
+            className="w-full flex items-center gap-2 text-left px-3 py-2 text-[13px] text-zinc-200 hover:bg-white/[0.06] cursor-pointer transition-colors"
+          >
+            <Share2 size={13} aria-hidden="true" />
+            {t("share.share", "Share")}
+          </button>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/pages/SeasonDetailPage.tsx
+++ b/frontend/src/pages/SeasonDetailPage.tsx
@@ -21,10 +21,17 @@ function formatDate(dateStr: string | null | undefined): string {
   return d.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
 }
 
+function todayISO(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
 function isReleased(airDate: string | null | undefined): boolean {
   if (!airDate) return false;
-  const today = new Date().toISOString().slice(0, 10);
-  return airDate <= today;
+  return airDate <= todayISO();
+}
+
+function isAiringToday(airDate: string | null | undefined): boolean {
+  return !!airDate && airDate === todayISO();
 }
 
 type EpisodeStatus = { id: number; is_watched: boolean };
@@ -213,103 +220,147 @@ export default function SeasonDetailPage() {
       {/* Episode List */}
       {episodes.length > 0 && (
         <section className="space-y-3">
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between gap-3 flex-wrap">
             <h2 className="text-lg font-semibold text-white">{t("season.episodes", "Episodes")}</h2>
-            {hasStatus && releasedWithStatus.length > 0 && (
-              <button
-                onClick={toggleAllWatched}
-                className="text-sm text-zinc-400 hover:text-white transition-colors cursor-pointer"
-              >
-                {allReleasedWatched
-                  ? t("episodes.markAllUnwatched", "Mark all unwatched")
-                  : t("episodes.markAllWatched", "Mark all watched")}
-              </button>
-            )}
+            <div className="flex items-center gap-4">
+              {hasStatus && releasedWithStatus.length > 0 && (
+                <span className="text-[11px] font-mono text-zinc-500 tracking-wide whitespace-nowrap">
+                  {releasedWithStatus.filter((ep) => statusMap.get(ep.episode_number)?.is_watched).length} of {episodes.length} watched · {episodes.length - releasedWithStatus.filter((ep) => statusMap.get(ep.episode_number)?.is_watched).length} remaining
+                </span>
+              )}
+              {hasStatus && releasedWithStatus.length > 0 && (
+                <button
+                  onClick={toggleAllWatched}
+                  className="text-sm text-zinc-400 hover:text-white transition-colors cursor-pointer"
+                >
+                  {allReleasedWatched
+                    ? t("episodes.markAllUnwatched", "Mark all unwatched")
+                    : t("episodes.markAllWatched", "Mark all watched")}
+                </button>
+              )}
+            </div>
           </div>
-          <div className="space-y-2">
+          <div className="flex flex-col gap-1.5">
             {episodes.map((ep) => {
               const status = statusMap.get(ep.episode_number);
               const released = isReleased(ep.air_date);
+              const airingToday = isAiringToday(ep.air_date);
+              const watched = status?.is_watched ?? false;
+              const ratingCounts = episodeRatings[ep.episode_number];
+              const totalRatings = ratingCounts
+                ? ratingCounts.HATE + ratingCounts.DISLIKE + ratingCounts.LIKE + ratingCounts.LOVE
+                : 0;
 
               return (
                 <div
                   key={ep.episode_number}
-                  className="flex items-center gap-3 bg-zinc-900 rounded-xl border border-white/[0.06] hover:border-amber-500/50 transition-colors p-3 group"
+                  className={`rounded-[10px] border transition-colors group ${
+                    airingToday
+                      ? "bg-amber-400/[0.06] border-amber-400/25"
+                      : "bg-zinc-900 border-white/[0.05] hover:border-white/10"
+                  }`}
                 >
-                  {/* Episode link */}
-                  <Link
-                    to={`/title/${title.id}/season/${seasonNumber}/episode/${ep.episode_number}`}
-                    className="flex gap-3 sm:gap-4 flex-1 min-w-0"
-                  >
-                    {/* Episode still */}
-                    <div className="w-24 sm:w-36 shrink-0 aspect-video bg-zinc-800 rounded-lg overflow-hidden">
-                      {ep.still_path ? (
-                        <img
-                          src={`${TMDB_IMG}/w300${ep.still_path}`}
-                          alt={ep.name}
-                          className="w-full h-full object-cover"
-                          loading="lazy"
-                        />
-                      ) : (
-                        <div className="w-full h-full flex items-center justify-center text-zinc-600 text-xs">
-                          E{String(ep.episode_number).padStart(2, "0")}
-                        </div>
-                      )}
+                  <div className="flex items-stretch sm:items-center gap-3 sm:gap-5 p-3 sm:p-4">
+                    {/* Episode number */}
+                    <div
+                      className={`shrink-0 w-8 sm:w-10 self-center text-[22px] leading-none font-mono font-extrabold tabular-nums tracking-tight text-center ${
+                        watched ? "text-zinc-600" : "text-zinc-100"
+                      }`}
+                    >
+                      {String(ep.episode_number).padStart(2, "0")}
                     </div>
 
-                    {/* Episode info */}
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-start justify-between gap-2">
-                        <div>
-                          <h3 className="text-sm font-medium text-white group-hover:text-amber-400 transition-colors">
-                            <span className="text-zinc-500 mr-1">{ep.episode_number}.</span>
+                    <Link
+                      to={`/title/${title.id}/season/${seasonNumber}/episode/${ep.episode_number}`}
+                      className="flex flex-1 min-w-0 gap-3 sm:gap-5 items-stretch sm:items-center"
+                    >
+                      {/* Still */}
+                      <div className="shrink-0 w-24 sm:w-[180px] aspect-video bg-zinc-800 rounded-md overflow-hidden self-center">
+                        {ep.still_path ? (
+                          <img
+                            src={`${TMDB_IMG}/w300${ep.still_path}`}
+                            alt={ep.name}
+                            className="w-full h-full object-cover"
+                            loading="lazy"
+                          />
+                        ) : (
+                          <div className="w-full h-full flex items-center justify-center text-zinc-600 text-[11px] font-mono">
+                            E{String(ep.episode_number).padStart(2, "0")}
+                          </div>
+                        )}
+                      </div>
+
+                      {/* Title + description */}
+                      <div className="flex-1 min-w-0 self-center">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <h3
+                            className={`text-sm font-semibold transition-colors group-hover:text-amber-400 ${
+                              watched ? "text-zinc-400" : "text-zinc-100"
+                            }`}
+                          >
                             {ep.name}
                           </h3>
-                          <div className="flex items-center gap-2 text-xs text-zinc-500 mt-0.5">
-                            {ep.air_date && <span>{formatDate(ep.air_date)}</span>}
-                            {ep.runtime && (
-                              <>
-                                <span className="text-zinc-700">·</span>
-                                <span>{ep.runtime}m</span>
-                              </>
-                            )}
-                            {ep.vote_average > 0 && (
-                              <>
-                                <span className="text-zinc-700">·</span>
-                                <span className="text-yellow-500">{ep.vote_average.toFixed(1)}</span>
-                              </>
-                            )}
-                            {(() => {
-                              const r = episodeRatings[ep.episode_number];
-                              const total = r ? (r.HATE + r.DISLIKE + r.LIKE + r.LOVE) : 0;
-                              return total > 0 ? (
-                                <>
-                                  <span className="text-zinc-700">·</span>
-                                  <span className="text-pink-400">{total} {total === 1 ? "rating" : "ratings"}</span>
-                                </>
-                              ) : null;
-                            })()}
-                          </div>
+                          {airingToday && (
+                            <span className="text-[10px] font-mono font-semibold tracking-[0.15em] text-amber-400">
+                              AIRING NOW
+                            </span>
+                          )}
+                        </div>
+                        {ep.overview && (
+                          <p className="hidden sm:block text-xs text-zinc-500 mt-1 line-clamp-2 leading-snug">
+                            {ep.overview}
+                          </p>
+                        )}
+                        {/* Mobile-only meta row */}
+                        <div className="sm:hidden flex items-center gap-2 mt-1 text-[11px] font-mono text-zinc-400">
+                          {ep.air_date && <span>{formatDate(ep.air_date)}</span>}
+                          {ep.runtime && (
+                            <>
+                              <span className="text-zinc-700">·</span>
+                              <span>{ep.runtime} min</span>
+                            </>
+                          )}
+                          {ep.vote_average > 0 && (
+                            <>
+                              <span className="text-zinc-700">·</span>
+                              <span className="text-amber-400">★ {ep.vote_average.toFixed(1)}</span>
+                            </>
+                          )}
                         </div>
                       </div>
-                      {ep.overview && (
-                        <p className="text-xs text-zinc-400 mt-1 line-clamp-2">{ep.overview}</p>
+                    </Link>
+
+                    {/* Desktop: air date column */}
+                    <div className="hidden sm:block shrink-0 w-[110px] text-xs font-mono text-zinc-400">
+                      {ep.air_date ? formatDate(ep.air_date) : "—"}
+                    </div>
+
+                    {/* Desktop: runtime + rating column */}
+                    <div className="hidden sm:block shrink-0 w-[100px] text-xs font-mono text-zinc-400">
+                      <div>{ep.runtime ? `${ep.runtime} min` : "—"}</div>
+                      {ep.vote_average > 0 && (
+                        <div className="text-amber-400 mt-0.5">★ {ep.vote_average.toFixed(1)}</div>
+                      )}
+                      {totalRatings > 0 && (
+                        <div className="text-pink-400 mt-0.5">
+                          {totalRatings} {totalRatings === 1 ? "rating" : "ratings"}
+                        </div>
                       )}
                     </div>
-                  </Link>
 
-                  {/* Watched icon */}
-                  {hasStatus && (
-                    <div className="flex-shrink-0">
-                      <WatchedIcon
-                        watched={status?.is_watched ?? false}
-                        onClick={() => toggleWatched(ep.episode_number)}
-                        disabled={!released || !status}
-                        size="md"
-                        compactOnMobile
-                      />
-                    </div>
-                  )}
+                    {/* Watched toggle */}
+                    {hasStatus && (
+                      <div className="shrink-0 self-center">
+                        <WatchedIcon
+                          watched={watched}
+                          onClick={() => toggleWatched(ep.episode_number)}
+                          disabled={!released || !status}
+                          size="md"
+                          compactOnMobile
+                        />
+                      </div>
+                    )}
+                  </div>
                 </div>
               );
             })}


### PR DESCRIPTION
## Summary
Redesigned the episode list UI on the season detail page with a modern layout featuring season navigation pills, improved episode cards with better metadata display, and per-row action menus.

## Key Changes

- **Season Navigation**: Replaced dropdown selector with pill-style button tabs for season switching, displayed inline with the episodes heading
- **Episode Card Redesign**: 
  - Restructured layout with prominent two-digit episode numbers on the left
  - Moved metadata (air date, runtime, ratings) to dedicated columns on desktop
  - Added "AIRING NOW" indicator for episodes airing today
  - Improved mobile responsiveness with condensed metadata row
- **Watched Status UI**: Replaced `WatchedIcon` component with new `EpisodeWatchedPill` component featuring circle/check icons and better visual states
- **Per-Row Actions**: Added `EpisodeOverflowMenu` component with "View details" and "Share" options for each episode
- **Episode Summary**: Added watched count display (e.g., "1 of 3 watched · 2 remaining") in the episodes header
- **Helper Functions**: Added `todayISO()` and `isAiringToday()` utility functions for date comparisons
- **Accessibility**: Improved ARIA labels and semantic HTML for menu interactions

## Implementation Details

- Season pills use `aria-pressed` to indicate active state with amber highlight
- Episode overflow menu uses a ref-based click-outside handler to close when clicking elsewhere
- Share functionality supports native Web Share API with clipboard fallback
- Desktop layout uses flexbox columns for air date, runtime, and ratings metadata
- Mobile layout consolidates metadata into a single monospace row below episode title

https://claude.ai/code/session_01WoECjH8S1UE93CqhBrKRw4