### PR TITLE
Fix episode pill alignment on mobile screens

### DIFF
--- a/frontend/src/pages/SeasonDetailPage.tsx
+++ b/frontend/src/pages/SeasonDetailPage.tsx
@@ -421,7 +421,7 @@ function EpisodeWatchedPill({
       <span
         role="img"
         aria-label={t("episodes.notYetReleased", "Not yet released")}
-        className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-[11px] font-semibold bg-zinc-800/50 text-zinc-600 border-zinc-800 cursor-not-allowed opacity-60"
+        className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-[11px] font-semibold bg-zinc-800/50 text-zinc-600 border-zinc-800 cursor-not-allowed opacity-60 sm:w-[108px] sm:justify-center"
       >
         <Circle size={12} aria-hidden="true" />
         <span className="hidden sm:inline">{t("episodes.watch", "Watch")}</span>
@@ -441,7 +441,7 @@ function EpisodeWatchedPill({
           ? t("episodes.markAsUnwatched", "Mark as unwatched")
           : t("episodes.markAsWatched", "Mark as watched")
       }
-      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-[11px] font-semibold cursor-pointer transition-colors ${
+      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-[11px] font-semibold cursor-pointer transition-colors sm:w-[108px] sm:justify-center ${
         watched
           ? "bg-amber-400/15 text-amber-400 border-amber-400/30 hover:bg-amber-400/25"
           : "bg-white/[0.06] text-zinc-300 border-white/[0.08] hover:bg-white/10 hover:text-white"


### PR DESCRIPTION
## Summary
Updated the styling of episode watch status pills to ensure consistent alignment and sizing on small screens (sm breakpoint and up).

## Key Changes
- Added responsive width (`sm:w-[108px]`) and center justification (`sm:justify-center`) to the "Not yet released" episode pill
- Applied the same responsive styling to the watched/unwatched toggle pill for consistency

## Implementation Details
Both pills now use Tailwind's `sm:` breakpoint utilities to:
- Set a fixed width of 108px on small screens and larger
- Center-align the content within the pill using flexbox justify-center

This ensures the pills maintain a uniform appearance and don't shift layout when the text label appears on larger screens.

https://claude.ai/code/session_01AgPUHSf8tmwwsrPcSzFdSo