### PR TITLE
chore(db): audit and unify FK onDelete behavior (#442)

### DIFF
--- a/drizzle/0029_unify_fk_ondelete.sql
+++ b/drizzle/0029_unify_fk_ondelete.sql
@@ -1,0 +1,161 @@
+-- Audit and unify FK onDelete behavior across schema.
+-- SQLite cannot ALTER existing FK constraints, so each affected table is
+-- rebuilt via the standard copy / drop / rename pattern. Indexes are
+-- recreated after the rename.
+--
+-- Summary of FK changes:
+--   offers.title_id        -> titles.id         ON DELETE CASCADE
+--   offers.provider_id     -> providers.id      ON DELETE RESTRICT
+--   scores.title_id        -> titles.id         ON DELETE CASCADE
+--   tracked.title_id       -> titles.id         ON DELETE CASCADE (was no action)
+--   watched_titles.title_id-> titles.id         ON DELETE CASCADE (was no action)
+--   ratings.title_id       -> titles.id         ON DELETE CASCADE (was no action)
+--   recommendations.title_id -> titles.id       ON DELETE CASCADE (was no action)
+--   invitations.used_by_id -> users.id          ON DELETE SET NULL (was no action)
+PRAGMA foreign_keys=OFF;
+--> statement-breakpoint
+-- ─── offers ──────────────────────────────────────────────────────────────────
+CREATE TABLE __new_offers (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `title_id` text,
+  `provider_id` integer,
+  `monetization_type` text,
+  `presentation_type` text,
+  `price_value` real,
+  `price_currency` text,
+  `url` text,
+  `deep_link` text,
+  `available_to` text,
+  FOREIGN KEY (`title_id`) REFERENCES `titles`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`provider_id`) REFERENCES `providers`(`id`) ON UPDATE no action ON DELETE restrict
+);
+--> statement-breakpoint
+INSERT INTO __new_offers SELECT * FROM offers;
+--> statement-breakpoint
+DROP TABLE offers;
+--> statement-breakpoint
+ALTER TABLE __new_offers RENAME TO offers;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_offers_title_id` ON `offers` (`title_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_offers_provider_id` ON `offers` (`provider_id`);
+--> statement-breakpoint
+-- ─── scores ──────────────────────────────────────────────────────────────────
+CREATE TABLE __new_scores (
+  `title_id` text PRIMARY KEY NOT NULL,
+  `imdb_score` real,
+  `imdb_votes` integer,
+  `tmdb_score` real,
+  FOREIGN KEY (`title_id`) REFERENCES `titles`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO __new_scores SELECT * FROM scores;
+--> statement-breakpoint
+DROP TABLE scores;
+--> statement-breakpoint
+ALTER TABLE __new_scores RENAME TO scores;
+--> statement-breakpoint
+-- ─── tracked ─────────────────────────────────────────────────────────────────
+CREATE TABLE __new_tracked (
+  `title_id` text NOT NULL,
+  `user_id` text NOT NULL,
+  `tracked_at` text DEFAULT (datetime('now')),
+  `notes` text,
+  `public` integer DEFAULT 1 NOT NULL,
+  `user_status` text,
+  `notification_mode` text,
+  PRIMARY KEY(`title_id`, `user_id`),
+  FOREIGN KEY (`title_id`) REFERENCES `titles`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO __new_tracked SELECT title_id, user_id, tracked_at, notes, public, user_status, notification_mode FROM tracked;
+--> statement-breakpoint
+DROP TABLE tracked;
+--> statement-breakpoint
+ALTER TABLE __new_tracked RENAME TO tracked;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_tracked_user_id` ON `tracked` (`user_id`);
+--> statement-breakpoint
+-- ─── watched_titles ──────────────────────────────────────────────────────────
+CREATE TABLE __new_watched_titles (
+  `title_id` text NOT NULL,
+  `user_id` text NOT NULL,
+  `watched_at` text DEFAULT (datetime('now')),
+  PRIMARY KEY(`title_id`, `user_id`),
+  FOREIGN KEY (`title_id`) REFERENCES `titles`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO __new_watched_titles SELECT * FROM watched_titles;
+--> statement-breakpoint
+DROP TABLE watched_titles;
+--> statement-breakpoint
+ALTER TABLE __new_watched_titles RENAME TO watched_titles;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_watched_titles_user_id` ON `watched_titles` (`user_id`);
+--> statement-breakpoint
+-- ─── ratings ─────────────────────────────────────────────────────────────────
+CREATE TABLE __new_ratings (
+  `user_id` text NOT NULL,
+  `title_id` text NOT NULL,
+  `rating` text NOT NULL,
+  `created_at` text DEFAULT (datetime('now')),
+  PRIMARY KEY(`user_id`, `title_id`),
+  FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`title_id`) REFERENCES `titles`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO __new_ratings SELECT * FROM ratings;
+--> statement-breakpoint
+DROP TABLE ratings;
+--> statement-breakpoint
+ALTER TABLE __new_ratings RENAME TO ratings;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_ratings_title` ON `ratings` (`title_id`);
+--> statement-breakpoint
+-- ─── recommendations ─────────────────────────────────────────────────────────
+CREATE TABLE __new_recommendations (
+  `id` text PRIMARY KEY NOT NULL,
+  `from_user_id` text NOT NULL,
+  `title_id` text NOT NULL,
+  `message` text,
+  `created_at` text DEFAULT (datetime('now')),
+  FOREIGN KEY (`from_user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`title_id`) REFERENCES `titles`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO __new_recommendations SELECT * FROM recommendations;
+--> statement-breakpoint
+DROP TABLE recommendations;
+--> statement-breakpoint
+ALTER TABLE __new_recommendations RENAME TO recommendations;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `idx_recommendations_from_title` ON `recommendations` (`from_user_id`, `title_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_recommendations_from_user` ON `recommendations` (`from_user_id`);
+--> statement-breakpoint
+-- ─── invitations ─────────────────────────────────────────────────────────────
+CREATE TABLE __new_invitations (
+  `id` text PRIMARY KEY NOT NULL,
+  `code` text NOT NULL,
+  `created_by_id` text NOT NULL,
+  `used_by_id` text,
+  `created_at` text DEFAULT (datetime('now')),
+  `used_at` text,
+  `expires_at` text NOT NULL,
+  FOREIGN KEY (`created_by_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`used_by_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+INSERT INTO __new_invitations SELECT * FROM invitations;
+--> statement-breakpoint
+DROP TABLE invitations;
+--> statement-breakpoint
+ALTER TABLE __new_invitations RENAME TO invitations;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `invitations_code_unique` ON `invitations` (`code`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_invitations_code` ON `invitations` (`code`);
+--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1745021200000,
       "tag": "0028_tracked_user_id_index",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "6",
+      "when": 1745107600000,
+      "tag": "0029_unify_fk_ondelete",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/0002_unify_fk_ondelete.sql
+++ b/migrations/0002_unify_fk_ondelete.sql
@@ -1,0 +1,161 @@
+-- Audit and unify FK onDelete behavior across schema.
+-- SQLite cannot ALTER existing FK constraints, so each affected table is
+-- rebuilt via the standard copy / drop / rename pattern. Indexes are
+-- recreated after the rename.
+--
+-- Summary of FK changes:
+--   offers.title_id        -> titles.id         ON DELETE CASCADE
+--   offers.provider_id     -> providers.id      ON DELETE RESTRICT
+--   scores.title_id        -> titles.id         ON DELETE CASCADE
+--   tracked.title_id       -> titles.id         ON DELETE CASCADE (was no action)
+--   watched_titles.title_id-> titles.id         ON DELETE CASCADE (was no action)
+--   ratings.title_id       -> titles.id         ON DELETE CASCADE (was no action)
+--   recommendations.title_id -> titles.id       ON DELETE CASCADE (was no action)
+--   invitations.used_by_id -> users.id          ON DELETE SET NULL (was no action)
+PRAGMA foreign_keys=OFF;
+--> statement-breakpoint
+-- ─── offers ──────────────────────────────────────────────────────────────────
+CREATE TABLE __new_offers (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `title_id` text,
+  `provider_id` integer,
+  `monetization_type` text,
+  `presentation_type` text,
+  `price_value` real,
+  `price_currency` text,
+  `url` text,
+  `deep_link` text,
+  `available_to` text,
+  FOREIGN KEY (`title_id`) REFERENCES `titles`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`provider_id`) REFERENCES `providers`(`id`) ON UPDATE no action ON DELETE restrict
+);
+--> statement-breakpoint
+INSERT INTO __new_offers SELECT * FROM offers;
+--> statement-breakpoint
+DROP TABLE offers;
+--> statement-breakpoint
+ALTER TABLE __new_offers RENAME TO offers;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_offers_title_id` ON `offers` (`title_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_offers_provider_id` ON `offers` (`provider_id`);
+--> statement-breakpoint
+-- ─── scores ──────────────────────────────────────────────────────────────────
+CREATE TABLE __new_scores (
+  `title_id` text PRIMARY KEY NOT NULL,
+  `imdb_score` real,
+  `imdb_votes` integer,
+  `tmdb_score` real,
+  FOREIGN KEY (`title_id`) REFERENCES `titles`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO __new_scores SELECT * FROM scores;
+--> statement-breakpoint
+DROP TABLE scores;
+--> statement-breakpoint
+ALTER TABLE __new_scores RENAME TO scores;
+--> statement-breakpoint
+-- ─── tracked ─────────────────────────────────────────────────────────────────
+CREATE TABLE __new_tracked (
+  `title_id` text NOT NULL,
+  `user_id` text NOT NULL,
+  `tracked_at` text DEFAULT (datetime('now')),
+  `notes` text,
+  `public` integer DEFAULT 1 NOT NULL,
+  `user_status` text,
+  `notification_mode` text,
+  PRIMARY KEY(`title_id`, `user_id`),
+  FOREIGN KEY (`title_id`) REFERENCES `titles`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO __new_tracked SELECT title_id, user_id, tracked_at, notes, public, user_status, notification_mode FROM tracked;
+--> statement-breakpoint
+DROP TABLE tracked;
+--> statement-breakpoint
+ALTER TABLE __new_tracked RENAME TO tracked;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_tracked_user_id` ON `tracked` (`user_id`);
+--> statement-breakpoint
+-- ─── watched_titles ──────────────────────────────────────────────────────────
+CREATE TABLE __new_watched_titles (
+  `title_id` text NOT NULL,
+  `user_id` text NOT NULL,
+  `watched_at` text DEFAULT (datetime('now')),
+  PRIMARY KEY(`title_id`, `user_id`),
+  FOREIGN KEY (`title_id`) REFERENCES `titles`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO __new_watched_titles SELECT * FROM watched_titles;
+--> statement-breakpoint
+DROP TABLE watched_titles;
+--> statement-breakpoint
+ALTER TABLE __new_watched_titles RENAME TO watched_titles;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_watched_titles_user_id` ON `watched_titles` (`user_id`);
+--> statement-breakpoint
+-- ─── ratings ─────────────────────────────────────────────────────────────────
+CREATE TABLE __new_ratings (
+  `user_id` text NOT NULL,
+  `title_id` text NOT NULL,
+  `rating` text NOT NULL,
+  `created_at` text DEFAULT (datetime('now')),
+  PRIMARY KEY(`user_id`, `title_id`),
+  FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`title_id`) REFERENCES `titles`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO __new_ratings SELECT * FROM ratings;
+--> statement-breakpoint
+DROP TABLE ratings;
+--> statement-breakpoint
+ALTER TABLE __new_ratings RENAME TO ratings;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_ratings_title` ON `ratings` (`title_id`);
+--> statement-breakpoint
+-- ─── recommendations ─────────────────────────────────────────────────────────
+CREATE TABLE __new_recommendations (
+  `id` text PRIMARY KEY NOT NULL,
+  `from_user_id` text NOT NULL,
+  `title_id` text NOT NULL,
+  `message` text,
+  `created_at` text DEFAULT (datetime('now')),
+  FOREIGN KEY (`from_user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`title_id`) REFERENCES `titles`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO __new_recommendations SELECT * FROM recommendations;
+--> statement-breakpoint
+DROP TABLE recommendations;
+--> statement-breakpoint
+ALTER TABLE __new_recommendations RENAME TO recommendations;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `idx_recommendations_from_title` ON `recommendations` (`from_user_id`, `title_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_recommendations_from_user` ON `recommendations` (`from_user_id`);
+--> statement-breakpoint
+-- ─── invitations ─────────────────────────────────────────────────────────────
+CREATE TABLE __new_invitations (
+  `id` text PRIMARY KEY NOT NULL,
+  `code` text NOT NULL,
+  `created_by_id` text NOT NULL,
+  `used_by_id` text,
+  `created_at` text DEFAULT (datetime('now')),
+  `used_at` text,
+  `expires_at` text NOT NULL,
+  FOREIGN KEY (`created_by_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`used_by_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+INSERT INTO __new_invitations SELECT * FROM invitations;
+--> statement-breakpoint
+DROP TABLE invitations;
+--> statement-breakpoint
+ALTER TABLE __new_invitations RENAME TO invitations;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `invitations_code_unique` ON `invitations` (`code`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_invitations_code` ON `invitations` (`code`);
+--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -133,6 +133,6 @@ describe("fixSkippedMigrations", () => {
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(29);
+    expect(migrations.cnt).toBe(30);
   });
 });

--- a/server/db/schema.test.ts
+++ b/server/db/schema.test.ts
@@ -1,0 +1,243 @@
+import { describe, test, expect, beforeEach, afterAll } from "bun:test";
+import { eq } from "drizzle-orm";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { makeParsedTitle } from "../test-utils/fixtures";
+import {
+  createUser,
+  upsertTitles,
+  upsertEpisodes,
+  trackTitle,
+  watchTitle,
+  watchEpisode,
+  rateTitle,
+  createNotifier,
+  createRecommendation,
+  logWatch,
+  deleteUser,
+} from "./repository";
+import {
+  tracked,
+  watchedEpisodes,
+  watchedTitles,
+  notifiers,
+  recommendations,
+  offers,
+  episodes,
+  ratings,
+  watchHistory,
+} from "./schema";
+import { getDb } from "./schema";
+import { getRawDb } from "./bun-db";
+
+describe("FK onDelete behavior", () => {
+  beforeEach(() => {
+    setupTestDb();
+  });
+
+  afterAll(() => {
+    teardownTestDb();
+  });
+
+  test("test database has foreign keys enabled", () => {
+    const raw = getRawDb();
+    const row = raw.prepare("PRAGMA foreign_keys").get() as { foreign_keys: number };
+    expect(row.foreign_keys).toBe(1);
+  });
+
+  test("deleting a user cascades to tracked, watched_episodes, notifiers, recommendations", async () => {
+    const userId = await createUser("alice", "hash");
+    const otherUserId = await createUser("bob", "hash");
+
+    await upsertTitles([
+      makeParsedTitle({ id: "movie-1", title: "Movie 1" }),
+      makeParsedTitle({ id: "show-1", objectType: "SHOW", title: "Show 1" }),
+    ]);
+    await upsertEpisodes([
+      {
+        title_id: "show-1",
+        season_number: 1,
+        episode_number: 1,
+        name: "Pilot",
+        overview: null,
+        air_date: "2020-01-01",
+        still_path: null,
+      },
+    ]);
+
+    // Look up the generated episode id
+    const db = getDb();
+    const ep = await db.select({ id: episodes.id }).from(episodes).get();
+    expect(ep).toBeDefined();
+    const episodeId = ep!.id;
+
+    // Create user-owned rows
+    await trackTitle("movie-1", userId);
+    await watchTitle("movie-1", userId);
+    await watchEpisode(episodeId, userId);
+    await createNotifier(userId, "discord", "Test", { webhook: "x" }, "09:00", "UTC");
+    await createRecommendation(userId, "movie-1", "Watch this");
+
+    // Create rows for a second user that must survive deletion of the first
+    await trackTitle("movie-1", otherUserId);
+    await watchEpisode(episodeId, otherUserId);
+
+    // Delete the first user
+    await deleteUser(userId);
+
+    // Every user-owned row for the deleted user should be gone
+    const trackedRows = await db.select().from(tracked).where(eq(tracked.userId, userId)).all();
+    expect(trackedRows).toHaveLength(0);
+
+    const watchedEpRows = await db
+      .select()
+      .from(watchedEpisodes)
+      .where(eq(watchedEpisodes.userId, userId))
+      .all();
+    expect(watchedEpRows).toHaveLength(0);
+
+    const watchedTitleRows = await db
+      .select()
+      .from(watchedTitles)
+      .where(eq(watchedTitles.userId, userId))
+      .all();
+    expect(watchedTitleRows).toHaveLength(0);
+
+    const notifierRows = await db
+      .select()
+      .from(notifiers)
+      .where(eq(notifiers.userId, userId))
+      .all();
+    expect(notifierRows).toHaveLength(0);
+
+    const recRows = await db
+      .select()
+      .from(recommendations)
+      .where(eq(recommendations.fromUserId, userId))
+      .all();
+    expect(recRows).toHaveLength(0);
+
+    // Other user's rows are untouched
+    const otherTracked = await db
+      .select()
+      .from(tracked)
+      .where(eq(tracked.userId, otherUserId))
+      .all();
+    expect(otherTracked).toHaveLength(1);
+  });
+
+  test("deleting a title cascades to offers, episodes, tracked, watched_titles, ratings, recommendations", async () => {
+    const userId = await createUser("alice", "hash");
+
+    await upsertTitles([makeParsedTitle({ id: "show-x", objectType: "SHOW", title: "Show X" })]);
+
+    // offers: insert directly (requires a provider row)
+    const raw = getRawDb();
+    raw.prepare("INSERT INTO providers (id, name) VALUES (?, ?)").run(99, "TestProvider");
+    const db = getDb();
+    await db
+      .insert(offers)
+      .values({
+        titleId: "show-x",
+        providerId: 99,
+        monetizationType: "FLATRATE",
+        url: "https://example.com",
+      })
+      .run();
+
+    await upsertEpisodes([
+      {
+        title_id: "show-x",
+        season_number: 1,
+        episode_number: 1,
+        name: "Pilot",
+        overview: null,
+        air_date: "2020-01-01",
+        still_path: null,
+      },
+    ]);
+
+    await trackTitle("show-x", userId);
+    await watchTitle("show-x", userId);
+    await rateTitle(userId, "show-x", "LOVE");
+    await createRecommendation(userId, "show-x", "Check this out");
+
+    // Delete the title
+    await db.run("DELETE FROM titles WHERE id = 'show-x'");
+
+    const offersRows = await db.select().from(offers).where(eq(offers.titleId, "show-x")).all();
+    expect(offersRows).toHaveLength(0);
+
+    const epRows = await db.select().from(episodes).where(eq(episodes.titleId, "show-x")).all();
+    expect(epRows).toHaveLength(0);
+
+    const trackedRows = await db.select().from(tracked).where(eq(tracked.titleId, "show-x")).all();
+    expect(trackedRows).toHaveLength(0);
+
+    const watchedTitleRows = await db
+      .select()
+      .from(watchedTitles)
+      .where(eq(watchedTitles.titleId, "show-x"))
+      .all();
+    expect(watchedTitleRows).toHaveLength(0);
+
+    const ratingRows = await db.select().from(ratings).where(eq(ratings.titleId, "show-x")).all();
+    expect(ratingRows).toHaveLength(0);
+
+    const recRows = await db
+      .select()
+      .from(recommendations)
+      .where(eq(recommendations.titleId, "show-x"))
+      .all();
+    expect(recRows).toHaveLength(0);
+  });
+
+  test("deleting an episode cascades to watched_episodes and sets watch_history.episode_id to null", async () => {
+    const userId = await createUser("alice", "hash");
+
+    await upsertTitles([makeParsedTitle({ id: "show-y", objectType: "SHOW", title: "Show Y" })]);
+    await upsertEpisodes([
+      {
+        title_id: "show-y",
+        season_number: 1,
+        episode_number: 1,
+        name: "Pilot",
+        overview: null,
+        air_date: "2020-01-01",
+        still_path: null,
+      },
+    ]);
+
+    const db = getDb();
+    const ep = await db
+      .select({ id: episodes.id })
+      .from(episodes)
+      .where(eq(episodes.titleId, "show-y"))
+      .get();
+    expect(ep).toBeDefined();
+    const episodeId = ep!.id;
+
+    await watchEpisode(episodeId, userId);
+    await logWatch(userId, "show-y", episodeId);
+
+    // Delete the episode row
+    await db.run("DELETE FROM episodes WHERE id = " + episodeId);
+
+    // watched_episodes should be gone (cascade)
+    const weRows = await db
+      .select()
+      .from(watchedEpisodes)
+      .where(eq(watchedEpisodes.episodeId, episodeId))
+      .all();
+    expect(weRows).toHaveLength(0);
+
+    // watch_history row should survive with episode_id set to null
+    const historyRows = await db
+      .select()
+      .from(watchHistory)
+      .where(eq(watchHistory.userId, userId))
+      .all();
+    expect(historyRows).toHaveLength(1);
+    expect(historyRows[0].episodeId).toBeNull();
+    expect(historyRows[0].titleId).toBe("show-y");
+  });
+});

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -69,8 +69,10 @@ export const offers = sqliteTable(
   "offers",
   {
     id: integer("id").primaryKey({ autoIncrement: true }),
-    titleId: text("title_id").references(() => titles.id),
-    providerId: integer("provider_id").references(() => providers.id),
+    titleId: text("title_id").references(() => titles.id, { onDelete: "cascade" }),
+    // onDelete: restrict — providers are a reference/enum-like table seeded from TMDB
+    // and are not user-deletable; block deletion if offers reference them.
+    providerId: integer("provider_id").references(() => providers.id, { onDelete: "restrict" }),
     monetizationType: text("monetization_type"),
     presentationType: text("presentation_type"),
     priceValue: real("price_value"),
@@ -88,7 +90,7 @@ export const offers = sqliteTable(
 export const scores = sqliteTable("scores", {
   titleId: text("title_id")
     .primaryKey()
-    .references(() => titles.id),
+    .references(() => titles.id, { onDelete: "cascade" }),
   imdbScore: real("imdb_score"),
   imdbVotes: integer("imdb_votes"),
   tmdbScore: real("tmdb_score"),
@@ -228,7 +230,7 @@ export const tracked = sqliteTable(
   {
     titleId: text("title_id")
       .notNull()
-      .references(() => titles.id),
+      .references(() => titles.id, { onDelete: "cascade" }),
     userId: text("user_id")
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
@@ -266,7 +268,7 @@ export const watchedTitles = sqliteTable(
   {
     titleId: text("title_id")
       .notNull()
-      .references(() => titles.id),
+      .references(() => titles.id, { onDelete: "cascade" }),
     userId: text("user_id")
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
@@ -365,7 +367,7 @@ export const ratings = sqliteTable(
   "ratings",
   {
     userId: text("user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
-    titleId: text("title_id").notNull().references(() => titles.id),
+    titleId: text("title_id").notNull().references(() => titles.id, { onDelete: "cascade" }),
     rating: text("rating").notNull(), // 'HATE', 'DISLIKE', 'LIKE', 'LOVE'
     createdAt: text("created_at").default(sql`(datetime('now'))`),
   },
@@ -380,7 +382,7 @@ export const recommendations = sqliteTable(
   {
     id: text("id").primaryKey(),
     fromUserId: text("from_user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
-    titleId: text("title_id").notNull().references(() => titles.id),
+    titleId: text("title_id").notNull().references(() => titles.id, { onDelete: "cascade" }),
     message: text("message"),
     createdAt: text("created_at").default(sql`(datetime('now'))`),
   },
@@ -408,7 +410,8 @@ export const invitations = sqliteTable(
     id: text("id").primaryKey(),
     code: text("code").notNull().unique(),
     createdById: text("created_by_id").notNull().references(() => users.id, { onDelete: "cascade" }),
-    usedById: text("used_by_id").references(() => users.id),
+    // onDelete: set null — preserves invite audit trail after the redeeming user is deleted.
+    usedById: text("used_by_id").references(() => users.id, { onDelete: "set null" }),
     createdAt: text("created_at").default(sql`(datetime('now'))`),
     usedAt: text("used_at"),
     expiresAt: text("expires_at").notNull(),


### PR DESCRIPTION
## Summary

- Makes every `.references(...)` in `server/db/schema.ts` explicit about its `onDelete` behavior. Content-owned rows (`offers`, `scores`, `tracked`, `watched_titles`, `ratings`, `recommendations`) cascade when their parent title is deleted. `offers.provider_id` is now `RESTRICT` (providers are seeded reference data, not user-deletable) with an explanatory comment. `invitations.used_by_id` is `SET NULL` so an invite audit trail survives deletion of the redeeming user.
- Adds drizzle migration `0029_unify_fk_ondelete.sql` and a byte-identical D1 migration `migrations/0002_unify_fk_ondelete.sql`. Since SQLite cannot alter FK constraints in place, each affected table is rebuilt via the copy / drop / rename pattern bracketed by `PRAGMA foreign_keys=OFF/ON`. All prior indexes on those tables are recreated after the rename. Tables rebuilt: `offers`, `scores`, `tracked`, `watched_titles`, `ratings`, `recommendations`, `invitations`.
- Adds `server/db/schema.test.ts` with three deletion-behavior tests plus one guard test asserting FK enforcement is actually on in the test DB.

## Test plan

- [x] `bun test server/db/schema.test.ts` — 4/4 pass (includes guard that `PRAGMA foreign_keys` returns 1)
- [x] `bun test server/db/bun-db.test.ts` — 2/2 pass; migration-count assertion bumped from 29 to 30
- [x] `bunx tsc --noEmit` (server) — clean
- [x] `cd frontend && bunx tsc -b --noEmit` — clean
- [x] `bun run lint` — unchanged from master
- [x] Full `bun run check` — only pre-existing `HomeRoute` frontend failures (mock.module leak between test files, unrelated to this PR; passes in isolation)

Closes #442

Generated with [Claude Code](https://claude.com/claude-code)