### PR TITLE
feat(server): zod validation at route boundaries (#441)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,14 @@ Inventory is large (~45 components). Broad groups:
 - New notification providers must guard on `streamingAlerts.length` before rendering streaming-alert content
 - The Bun route wiring in `server/index.ts` and the CF route wiring in `server/worker.ts` must stay in sync
 
+### Route validation
+- Use zod + `zValidator` from `server/lib/validator.ts` for request shape validation at the route boundary.
+- Schemas are defined at the top of the route file (or a sibling `*-schemas.ts` for large surfaces) and applied as middleware: `app.post("/", zValidator("json", schema), handler)`.
+- Validation failures return HTTP 400 with `{ error: "Validation failed", issues: ZodIssue[] }`. Successful requests are not changed.
+- Supported targets: `"json"`, `"query"`, `"param"`, `"form"`, `"header"`, `"cookie"`. For multipart `File` uploads, parse `FormData` manually and feed into `schema.safeParse(...)` (see `server/routes/import.ts`) — `instanceof File` is unreliable in the Bun test env, duck-type the upload instead.
+- Provider- or business-level validation (e.g. notifier `validateConfig`, timezone semantics, uniqueness) runs AFTER zod inside the handler. Zod only validates shape/types.
+- Tests for every migrated route should include a `describe("validation", ...)` block asserting `res.status === 400` and that the response body exposes an `issues` array.
+
 ### API Routes
 Grouped by middleware. All routes are under `/api` except `/metrics`.
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "remindarr",
       "dependencies": {
         "@better-auth/passkey": "^1.5.6",
+        "@hono/zod-validator": "^0.7.6",
         "@sentry/bun": "^10.43.0",
         "@sentry/cloudflare": "^10.46.0",
         "@simplewebauthn/server": "^13.3.0",
@@ -14,6 +15,7 @@
         "drizzle-orm": "^0.45.1",
         "hono": "^4.4.0",
         "web-push": "^3.6.7",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@happy-dom/global-registrator": "^20.8.4",
@@ -407,6 +409,8 @@
     "@hexagon/base64": ["@hexagon/base64@1.1.28", "", {}, "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
+
+    "@hono/zod-validator": ["@hono/zod-validator@0.7.6", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -518,7 +518,7 @@ function GridCalendar({
   const month = currentMonth.getMonth();
 
   useEffect(() => {
-    setLoading(true); // eslint-disable-line react-hooks/set-state-in-effect -- reset before async load
+    setLoading(true);
     getCalendarTitles({
       month: formatMonth(currentMonth),
       type: typeFilter || undefined,

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@better-auth/passkey": "^1.5.6",
+    "@hono/zod-validator": "^0.7.6",
     "@sentry/bun": "^10.43.0",
     "@sentry/cloudflare": "^10.46.0",
     "@simplewebauthn/server": "^13.3.0",
@@ -35,7 +36,8 @@
     "cron-parser": "^4.9.0",
     "drizzle-orm": "^0.45.1",
     "hono": "^4.4.0",
-    "web-push": "^3.6.7"
+    "web-push": "^3.6.7",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@happy-dom/global-registrator": "^20.8.4",

--- a/server/lib/validator.ts
+++ b/server/lib/validator.ts
@@ -1,0 +1,40 @@
+import { zValidator as baseValidator } from "@hono/zod-validator";
+import type { ValidationTargets } from "hono";
+import type { ZodType } from "zod";
+
+/**
+ * Standard route validator.
+ *
+ * Wraps `@hono/zod-validator` so that every validation failure returns a
+ * uniform JSON error shape compatible with the rest of the API:
+ *
+ *   { error: "Validation failed", issues: ZodIssue[] }
+ *
+ * Usage:
+ *
+ *   import { zValidator } from "../lib/validator";
+ *   import { z } from "zod";
+ *
+ *   const schema = z.object({ titleId: z.string().min(1) });
+ *   app.post("/", zValidator("json", schema), async (c) => {
+ *     const body = c.req.valid("json");
+ *     // ...
+ *   });
+ *
+ * Provider/business-level validation that goes beyond shape (e.g. checking
+ * timezone strings, provider-specific configs) should run inside the handler
+ * AFTER this validator has accepted the payload.
+ */
+export function zValidator<
+  T extends keyof ValidationTargets,
+  S extends ZodType,
+>(target: T, schema: S) {
+  return baseValidator(target, schema, (result, c) => {
+    if (!result.success) {
+      return c.json(
+        { error: "Validation failed", issues: result.error.issues },
+        400,
+      );
+    }
+  });
+}

--- a/server/routes/admin.test.ts
+++ b/server/routes/admin.test.ts
@@ -183,15 +183,13 @@ describe("PUT /admin/settings", () => {
     expect(res.status).toBe(403);
   });
 
-  it("handles invalid JSON gracefully", async () => {
+  it("rejects invalid JSON body", async () => {
     const res = await app.request("/admin/settings", {
       method: "PUT",
       headers: { Cookie: adminCookie, "Content-Type": "application/json" },
       body: "not json",
     });
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.oidc_configured).toBeDefined();
+    expect(res.status).toBe(400);
   });
 });
 
@@ -262,6 +260,46 @@ describe("GET /admin/users/:id", () => {
       headers: { Cookie: adminCookie },
     });
     expect(res.status).toBe(404);
+  });
+});
+
+describe("validation", () => {
+  it("rejects PUT /settings when OIDC value is a non-string", async () => {
+    const res = await app.request("/admin/settings", {
+      method: "PUT",
+      headers: { Cookie: adminCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ oidc_issuer_url: 123 }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects PUT /users/:id/role with invalid enum", async () => {
+    const userId = await createUser("zodcheck", "hash");
+    const res = await app.request(`/admin/users/${userId}/role`, {
+      method: "PUT",
+      headers: { Cookie: adminCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ role: "superadmin" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects PUT /users/:id/role without role field", async () => {
+    const userId = await createUser("zodcheck2", "hash");
+    const res = await app.request(`/admin/users/${userId}/role`, {
+      method: "PUT",
+      headers: { Cookie: adminCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
   });
 });
 

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { z } from "zod";
 import {
   getSetting,
   setSetting,
@@ -19,8 +20,31 @@ import { CONFIG } from "../config";
 import type { AppEnv } from "../types";
 import { ok } from "./response";
 import { logger } from "../logger";
+import { zValidator } from "../lib/validator";
 
 const log = logger.child({ module: "admin" });
+
+const OIDC_SETTING_KEYS = [
+  "oidc_issuer_url",
+  "oidc_client_id",
+  "oidc_client_secret",
+  "oidc_redirect_uri",
+  "oidc_admin_claim",
+  "oidc_admin_value",
+] as const;
+
+// PUT /settings only accepts whitelisted OIDC keys. Values must be string|null
+// (null or empty string deletes the setting). Unknown keys are ignored, which
+// preserves the existing behavior before validation was added.
+const updateSettingsSchema = z
+  .object(Object.fromEntries(
+    OIDC_SETTING_KEYS.map((k) => [k, z.string().nullable().optional()]),
+  ) as Record<(typeof OIDC_SETTING_KEYS)[number], z.ZodOptional<z.ZodNullable<z.ZodString>>>)
+  .passthrough();
+
+const updateRoleSchema = z.object({
+  role: z.enum(["admin", "user"]),
+});
 
 /**
  * Callback to recreate the auth instance after OIDC settings change.
@@ -33,8 +57,6 @@ export function setOnOidcSettingsChanged(cb: () => Promise<void>) {
 }
 
 const app = new Hono<AppEnv>();
-
-const OIDC_SETTING_KEYS = ["oidc_issuer_url", "oidc_client_id", "oidc_client_secret", "oidc_redirect_uri", "oidc_admin_claim", "oidc_admin_value"];
 
 // GET /api/admin/settings
 app.get("/settings", async (c) => {
@@ -76,13 +98,13 @@ app.get("/settings", async (c) => {
 });
 
 // PUT /api/admin/settings
-app.put("/settings", async (c) => {
-  const body = await c.req.json().catch(() => ({}));
+app.put("/settings", zValidator("json", updateSettingsSchema), async (c) => {
+  const body = c.req.valid("json") as Partial<Record<(typeof OIDC_SETTING_KEYS)[number], string | null>>;
 
   for (const key of OIDC_SETTING_KEYS) {
     if (key in body) {
       const value = body[key];
-      if (value === "" || value === null) {
+      if (value === "" || value === null || value === undefined) {
         await deleteSetting(key);
       } else {
         await setSetting(key, value);
@@ -134,7 +156,7 @@ app.get("/users/:id", async (c) => {
 });
 
 // PUT /api/admin/users/:id/role  { role: "admin" | "user" }
-app.put("/users/:id/role", async (c) => {
+app.put("/users/:id/role", zValidator("json", updateRoleSchema), async (c) => {
   const id = c.req.param("id");
   const actingUser = c.get("user")!;
 
@@ -142,17 +164,14 @@ app.put("/users/:id/role", async (c) => {
     return c.json({ error: "Cannot change your own role" }, 400);
   }
 
-  const body = await c.req.json<{ role: string }>();
-  if (body.role !== "admin" && body.role !== "user") {
-    return c.json({ error: "role must be 'admin' or 'user'" }, 400);
-  }
+  const { role } = c.req.valid("json");
 
   const target = await getUserById(id);
   if (!target) return c.json({ error: "User not found" }, 404);
 
-  await updateUserAdmin(id, body.role === "admin");
-  log.info("Admin role changed", { targetUserId: id, newRole: body.role, by: actingUser.id });
-  return ok(c, { message: `User role updated to ${body.role}` });
+  await updateUserAdmin(id, role === "admin");
+  log.info("Admin role changed", { targetUserId: id, newRole: role, by: actingUser.id });
+  return ok(c, { message: `User role updated to ${role}` });
 });
 
 // PUT /api/admin/users/:id/ban  { reason?: string }

--- a/server/routes/import.test.ts
+++ b/server/routes/import.test.ts
@@ -192,7 +192,9 @@ describe("POST /import/csv", () => {
     });
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toContain("Missing 'file'");
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+    expect(body.issues.length).toBeGreaterThan(0);
   });
 
   it("returns 400 for unrecognized CSV format", async () => {
@@ -290,6 +292,22 @@ describe("POST /import/csv", () => {
     const body = await res.json();
     expect(body.failed).toBe(1);
     expect(body.errors).toHaveLength(1);
+  });
+
+  it("rejects oversized file via validation", async () => {
+    // Build a file just over the 5 MB limit
+    const oneMb = "x".repeat(1024 * 1024);
+    const csvContent = "Const,Title\n" + oneMb.repeat(6);
+    const form = makeFormData(csvContent);
+    const res = await app.request("/import/csv", {
+      method: "POST",
+      headers: { Cookie: userCookie },
+      body: form,
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
   });
 
   it("returns errors array with details for failed rows", async () => {

--- a/server/routes/import.ts
+++ b/server/routes/import.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { z } from "zod";
 import { resolveImdbUrl } from "../imdb/resolver";
 import { upsertTitles, trackTitle } from "../db/repository";
 import type { AppEnv } from "../types";
@@ -11,6 +12,32 @@ const MAX_ROWS = 500;
 const BATCH_SIZE = 10;
 const BATCH_DELAY_MS = 500;
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
+
+// `@hono/zod-validator` does not cleanly handle multipart `File` objects, so
+// we parse the FormData manually and then validate the shape via zod. This
+// keeps the 400 response shape consistent with the shared `zValidator`.
+//
+// Note: `instanceof File` is unreliable across Bun runtimes (happy-dom can
+// replace the global `File` in test setup), so we duck-type the upload field
+// instead: must look like a `Blob`/`File` and have a numeric `size`.
+const uploadedFileSchema = z
+  .custom<Blob>(
+    (v) =>
+      typeof v === "object" &&
+      v !== null &&
+      typeof (v as Blob).size === "number" &&
+      typeof (v as Blob).text === "function" &&
+      typeof (v as Blob).arrayBuffer === "function",
+    { message: "Missing 'file' field in form data" },
+  )
+  .refine((f) => f.size > 0, { message: "File is empty" })
+  .refine((f) => f.size <= MAX_FILE_SIZE, {
+    message: `File too large. Maximum allowed size is ${MAX_FILE_SIZE / (1024 * 1024)} MB.`,
+  });
+
+const uploadSchema = z.object({
+  file: uploadedFileSchema,
+});
 
 export type CsvFormat = "letterboxd" | "imdb" | "trakt" | "unknown";
 
@@ -167,15 +194,15 @@ app.post("/csv", async (c) => {
     return err(c, "Expected multipart form data with a 'file' field");
   }
 
-  const fileField = formData.get("file");
-  if (!fileField || typeof fileField === "string") {
-    return err(c, "Missing 'file' field in form data");
+  const parsed = uploadSchema.safeParse({ file: formData.get("file") });
+  if (!parsed.success) {
+    return c.json(
+      { error: "Validation failed", issues: parsed.error.issues },
+      400,
+    );
   }
 
-  const file = fileField as File;
-  if (file.size > MAX_FILE_SIZE) {
-    return err(c, "File too large. Maximum allowed size is 5 MB.");
-  }
+  const { file } = parsed.data;
   let csvText: string;
   try {
     csvText = await file.text();

--- a/server/routes/notifiers.test.ts
+++ b/server/routes/notifiers.test.ts
@@ -463,7 +463,9 @@ describe("digest_mode", () => {
     });
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toContain("digest_day");
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+    expect(body.issues.some((i: { path: unknown[] }) => i.path.includes("digest_day"))).toBe(true);
   });
 
   it("rejects invalid digest_mode value", async () => {
@@ -477,7 +479,9 @@ describe("digest_mode", () => {
     });
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toContain("digest_mode");
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+    expect(body.issues.some((i: { path: unknown[] }) => i.path.includes("digest_mode"))).toBe(true);
   });
 
   it("rejects digest_day out of range", async () => {
@@ -492,7 +496,9 @@ describe("digest_mode", () => {
     });
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toContain("digest_day");
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+    expect(body.issues.some((i: { path: unknown[] }) => i.path.includes("digest_day"))).toBe(true);
   });
 
   it("updates digest_mode via PUT", async () => {
@@ -530,6 +536,56 @@ describe("digest_mode", () => {
     const body = await res.json();
     expect(body.notifiers[0].digest_mode).toBe("weekly");
     expect(body.notifiers[0].digest_day).toBe(3);
+  });
+});
+
+describe("validation", () => {
+  it("rejects POST / when provider is missing", async () => {
+    const res = await app.request("/notifiers", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ config: {}, notify_time: "09:00", timezone: "UTC" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects POST / when notify_time is malformed", async () => {
+    const res = await app.request("/notifiers", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ ...validNotifier, notify_time: "9am" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects POST / when timezone is invalid", async () => {
+    const res = await app.request("/notifiers", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ ...validNotifier, timezone: "Not/AZone" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects POST /renew-subscription when endpoint is empty", async () => {
+    const res = await app.request("/notifiers/renew-subscription", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ endpoint: "", p256dh: "x", auth: "y" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
   });
 });
 

--- a/server/routes/notifiers.ts
+++ b/server/routes/notifiers.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { z } from "zod";
 import type { AppEnv } from "../types";
 import {
   createNotifier,
@@ -14,16 +15,9 @@ import { getVapidPublicKey } from "../notifications/vapid";
 import { SubscriptionExpiredError } from "../notifications/webpush";
 import Sentry from "../sentry";
 import { ok, err } from "./response";
+import { zValidator } from "../lib/validator";
 
 const app = new Hono<AppEnv>();
-
-function isValidTime(time: string): boolean {
-  const match = time.match(/^(\d{2}):(\d{2})$/);
-  if (!match) return false;
-  const h = parseInt(match[1], 10);
-  const m = parseInt(match[2], 10);
-  return h >= 0 && h <= 23 && m >= 0 && m <= 59;
-}
 
 function isValidTimezone(tz: string): boolean {
   try {
@@ -34,18 +28,47 @@ function isValidTimezone(tz: string): boolean {
   }
 }
 
-const VALID_DIGEST_MODES = ["weekly", "off"] as const;
-type DigestMode = (typeof VALID_DIGEST_MODES)[number];
+const HHMM = /^([01]\d|2[0-3]):[0-5]\d$/;
+const timezoneSchema = z.string().refine(isValidTimezone, { message: "Invalid timezone" });
+const digestModeSchema = z.enum(["weekly", "off"]);
+const digestDaySchema = z.number().int().min(0).max(6);
 
-function isValidDigestMode(mode: unknown): mode is DigestMode | null {
-  if (mode === null || mode === undefined) return true;
-  return VALID_DIGEST_MODES.includes(mode as DigestMode);
-}
+const createNotifierSchema = z
+  .object({
+    provider: z.string().min(1),
+    config: z.record(z.string(), z.string()),
+    notify_time: z.string().regex(HHMM, { message: "Invalid time format. Use HH:MM (24h)" }).default("09:00"),
+    timezone: timezoneSchema.default("UTC"),
+    digest_mode: digestModeSchema.nullish(),
+    digest_day: digestDaySchema.nullish(),
+    streaming_alerts_enabled: z.boolean().optional(),
+  })
+  .refine(
+    (v) => v.digest_mode !== "weekly" || (v.digest_day !== undefined && v.digest_day !== null),
+    {
+      message: "digest_day is required when digest_mode is 'weekly'",
+      path: ["digest_day"],
+    },
+  );
 
-function isValidDigestDay(day: unknown): day is number | null {
-  if (day === null || day === undefined) return true;
-  return typeof day === "number" && Number.isInteger(day) && day >= 0 && day <= 6;
-}
+const updateNotifierSchema = z
+  .object({
+    provider: z.string().min(1).optional(),
+    config: z.record(z.string(), z.string()).optional(),
+    notify_time: z.string().regex(HHMM, { message: "Invalid time format. Use HH:MM (24h)" }).optional(),
+    timezone: timezoneSchema.optional(),
+    enabled: z.boolean().optional(),
+    digest_mode: digestModeSchema.nullish(),
+    digest_day: digestDaySchema.nullish(),
+    streaming_alerts_enabled: z.boolean().optional(),
+  })
+  .passthrough();
+
+const renewSubscriptionSchema = z.object({
+  endpoint: z.string().min(1),
+  p256dh: z.string().min(1),
+  auth: z.string().min(1),
+});
 
 // GET / — list user's notifiers
 app.get("/", async (c) => {
@@ -70,15 +93,19 @@ app.get("/vapid-public-key", async (c) => {
 });
 
 // POST / — create notifier
-app.post("/", async (c) => {
+app.post("/", zValidator("json", createNotifierSchema), async (c) => {
   const user = c.get("user")!;
-  const body = await c.req.json();
+  const body = c.req.valid("json");
 
-  const { provider, config, notify_time, timezone, digest_mode, digest_day, streaming_alerts_enabled } = body;
-
-  if (!provider || !config) {
-    return err(c, "provider and config are required");
-  }
+  const {
+    provider,
+    config,
+    notify_time,
+    timezone,
+    digest_mode,
+    digest_day,
+    streaming_alerts_enabled,
+  } = body;
 
   const name = provider.charAt(0).toUpperCase() + provider.slice(1);
 
@@ -87,45 +114,32 @@ app.post("/", async (c) => {
     return err(c, `Unknown provider: ${provider}. Available: ${getAvailableProviders().join(", ")}`);
   }
 
+  // Provider-specific config validation (beyond zod's shape validation)
   const validation = providerImpl.validateConfig(config);
   if (!validation.valid) {
     return err(c, validation.error ?? "Invalid config");
   }
 
-  const time = notify_time || "09:00";
-  if (!isValidTime(time)) {
-    return err(c, "Invalid time format. Use HH:MM (24h)");
-  }
-
-  const tz = timezone || "UTC";
-  if (!isValidTimezone(tz)) {
-    return err(c, "Invalid timezone");
-  }
-
-  if (!isValidDigestMode(digest_mode)) {
-    return err(c, "Invalid digest_mode. Must be 'weekly', 'off', or null");
-  }
-
-  if (!isValidDigestDay(digest_day)) {
-    return err(c, "Invalid digest_day. Must be 0-6 (0=Sunday) or null");
-  }
-
-  if (digest_mode === "weekly" && (digest_day === null || digest_day === undefined)) {
-    return err(c, "digest_day is required when digest_mode is 'weekly'");
-  }
-
-  const id = await createNotifier(user.id, provider, name, config, time, tz, digest_mode ?? null, digest_day ?? null, streaming_alerts_enabled !== false);
+  const id = await createNotifier(
+    user.id,
+    provider,
+    name,
+    config,
+    notify_time,
+    timezone,
+    digest_mode ?? null,
+    digest_day ?? null,
+    streaming_alerts_enabled !== false,
+  );
   await refreshNotificationSchedule();
   const notifier = await getNotifierById(id, user.id);
   return c.json({ notifier }, 201);
 });
 
 // POST /renew-subscription — update webpush subscription config after SW update
-app.post("/renew-subscription", async (c) => {
+app.post("/renew-subscription", zValidator("json", renewSubscriptionSchema), async (c) => {
   const user = c.get("user")!;
-  const body = await c.req.json();
-
-  const { endpoint, p256dh, auth } = body;
+  const { endpoint, p256dh, auth } = c.req.valid("json");
 
   const providerImpl = getProvider("webpush");
   if (!providerImpl) {
@@ -154,17 +168,17 @@ app.post("/renew-subscription", async (c) => {
 });
 
 // PUT /:id — update notifier
-app.put("/:id", async (c) => {
+app.put("/:id", zValidator("json", updateNotifierSchema), async (c) => {
   const user = c.get("user")!;
   const id = c.req.param("id");
-  const body = await c.req.json();
+  const body = c.req.valid("json");
 
   const existing = await getNotifierById(id, user.id);
   if (!existing) {
     return err(c, "Notifier not found", 404);
   }
 
-  // Validate config if provided
+  // Validate config if provided (provider-specific)
   if (body.config) {
     const provider = getProvider(body.provider || existing.provider);
     if (provider) {
@@ -173,22 +187,6 @@ app.put("/:id", async (c) => {
         return err(c, validation.error ?? "Invalid config");
       }
     }
-  }
-
-  if (body.notify_time && !isValidTime(body.notify_time)) {
-    return err(c, "Invalid time format. Use HH:MM (24h)");
-  }
-
-  if (body.timezone && !isValidTimezone(body.timezone)) {
-    return err(c, "Invalid timezone");
-  }
-
-  if ("digest_mode" in body && !isValidDigestMode(body.digest_mode)) {
-    return err(c, "Invalid digest_mode. Must be 'weekly', 'off', or null");
-  }
-
-  if ("digest_day" in body && !isValidDigestDay(body.digest_day)) {
-    return err(c, "Invalid digest_day. Must be 0-6 (0=Sunday) or null");
   }
 
   const digestMode = "digest_mode" in body ? body.digest_mode : undefined;
@@ -208,7 +206,9 @@ app.put("/:id", async (c) => {
     enabled: body.enabled,
     ...("digest_mode" in body ? { digestMode: body.digest_mode ?? null } : {}),
     ...("digest_day" in body ? { digestDay: body.digest_day ?? null } : {}),
-    ...("streaming_alerts_enabled" in body ? { streamingAlertsEnabled: body.streaming_alerts_enabled !== false } : {}),
+    ...("streaming_alerts_enabled" in body
+      ? { streamingAlertsEnabled: body.streaming_alerts_enabled !== false }
+      : {}),
   });
   await refreshNotificationSchedule();
 

--- a/server/routes/ratings.test.ts
+++ b/server/routes/ratings.test.ts
@@ -134,7 +134,8 @@ describe("POST /ratings/:titleId", () => {
     });
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toContain("Invalid rating value");
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
   });
 
   it("returns 400 for missing rating value", async () => {
@@ -148,7 +149,8 @@ describe("POST /ratings/:titleId", () => {
     });
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toContain("Invalid rating value");
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
   });
 
   it("returns 401 without auth", async () => {
@@ -320,5 +322,44 @@ describe("GET /ratings/:titleId", () => {
     expect(body.user_rating).toBeNull();
     expect(body.aggregated).toEqual({ HATE: 0, DISLIKE: 0, LIKE: 0, LOVE: 0 });
     expect(body.friends_ratings).toHaveLength(0);
+  });
+});
+
+describe("validation", () => {
+  it("rejects POST /:titleId with unknown rating enum value", async () => {
+    const res = await app.request("/ratings/movie-123", {
+      method: "POST",
+      headers: { ...authHeaders(userAToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ rating: "OKAY" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+    expect(body.issues.length).toBeGreaterThan(0);
+  });
+
+  it("rejects POST /episode/:episodeId when episodeId is not numeric", async () => {
+    const res = await app.request("/ratings/episode/abc", {
+      method: "POST",
+      headers: { ...authHeaders(userAToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ rating: "LIKE" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects POST /episode/:episodeId with review over 500 chars", async () => {
+    const res = await app.request("/ratings/episode/1", {
+      method: "POST",
+      headers: { ...authHeaders(userAToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ rating: "LIKE", review: "x".repeat(501) }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
   });
 });

--- a/server/routes/ratings.ts
+++ b/server/routes/ratings.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { z } from "zod";
 import {
   rateTitle,
   unrateTitle,
@@ -16,29 +17,52 @@ import type { RatingValue } from "../db/repository";
 import type { AppEnv } from "../types";
 import { logger } from "../logger";
 import { ok, err } from "./response";
+import { zValidator } from "../lib/validator";
 
 const log = logger.child({ module: "ratings" });
 
-const VALID_RATINGS: RatingValue[] = ["HATE", "DISLIKE", "LIKE", "LOVE"];
+export const VALID_RATINGS = ["HATE", "DISLIKE", "LIKE", "LOVE"] as const;
+const ratingEnum = z.enum(VALID_RATINGS);
+
+const rateTitleSchema = z.object({
+  rating: ratingEnum,
+});
+
+const rateEpisodeSchema = z.object({
+  rating: ratingEnum,
+  review: z
+    .string()
+    .max(500)
+    .optional()
+    .transform((v) => {
+      if (!v) return undefined;
+      const trimmed = v.trim();
+      return trimmed.length > 0 ? trimmed.slice(0, 500) : undefined;
+    }),
+});
+
+const episodeIdParamSchema = z.object({
+  episodeId: z.coerce.number().int(),
+});
+
+const seasonParamSchema = z.object({
+  titleId: z.string().min(1),
+  season: z.coerce.number().int(),
+});
 
 const app = new Hono<AppEnv>();
 
 // POST /:titleId — Rate a title
-app.post("/:titleId", async (c) => {
+app.post("/:titleId", zValidator("json", rateTitleSchema), async (c) => {
   const user = c.get("user");
   if (!user) {
     return err(c, "Authentication required", 401);
   }
 
   const titleId = c.req.param("titleId");
-  const body = await c.req.json<{ rating: string }>();
+  const { rating } = c.req.valid("json");
 
-  if (!body.rating || !VALID_RATINGS.includes(body.rating as RatingValue)) {
-    return err(c, "Invalid rating value. Must be one of: HATE, DISLIKE, LIKE, LOVE", 400);
-  }
-
-  const rating = body.rating as RatingValue;
-  await rateTitle(user.id, titleId, rating);
+  await rateTitle(user.id, titleId, rating as RatingValue);
   log.info("Title rated", { userId: user.id, titleId, rating });
   return ok(c, { success: true, rating });
 });
@@ -85,76 +109,80 @@ app.get("/:titleId", async (c) => {
 // ─── Episode Rating Endpoints ────────────────────────────────────────────────
 
 // POST /episode/:episodeId — Rate an episode
-app.post("/episode/:episodeId", async (c) => {
-  const user = c.get("user");
-  if (!user) return err(c, "Authentication required", 401);
+app.post(
+  "/episode/:episodeId",
+  zValidator("param", episodeIdParamSchema),
+  zValidator("json", rateEpisodeSchema),
+  async (c) => {
+    const user = c.get("user");
+    if (!user) return err(c, "Authentication required", 401);
 
-  const episodeId = Number(c.req.param("episodeId"));
-  if (isNaN(episodeId)) return err(c, "Invalid episode ID", 400);
+    const { episodeId } = c.req.valid("param");
+    const { rating, review } = c.req.valid("json");
 
-  const body = await c.req.json<{ rating: string; review?: string }>();
-  if (!body.rating || !VALID_RATINGS.includes(body.rating as RatingValue)) {
-    return err(c, "Invalid rating value. Must be one of: HATE, DISLIKE, LIKE, LOVE", 400);
-  }
-
-  const review = body.review && body.review.trim().length > 0
-    ? body.review.trim().slice(0, 500)
-    : undefined;
-
-  await rateEpisode(user.id, episodeId, body.rating as RatingValue, review);
-  log.info("Episode rated", { userId: user.id, episodeId, rating: body.rating });
-  return ok(c, { success: true, rating: body.rating });
-});
+    await rateEpisode(user.id, episodeId, rating as RatingValue, review);
+    log.info("Episode rated", { userId: user.id, episodeId, rating });
+    return ok(c, { success: true, rating });
+  },
+);
 
 // DELETE /episode/:episodeId — Remove episode rating
-app.delete("/episode/:episodeId", async (c) => {
-  const user = c.get("user");
-  if (!user) return err(c, "Authentication required", 401);
+app.delete(
+  "/episode/:episodeId",
+  zValidator("param", episodeIdParamSchema),
+  async (c) => {
+    const user = c.get("user");
+    if (!user) return err(c, "Authentication required", 401);
 
-  const episodeId = Number(c.req.param("episodeId"));
-  if (isNaN(episodeId)) return err(c, "Invalid episode ID", 400);
+    const { episodeId } = c.req.valid("param");
 
-  await unrateEpisode(user.id, episodeId);
-  log.info("Episode unrated", { userId: user.id, episodeId });
-  return ok(c, { success: true });
-});
+    await unrateEpisode(user.id, episodeId);
+    log.info("Episode unrated", { userId: user.id, episodeId });
+    return ok(c, { success: true });
+  },
+);
 
 // GET /episode/:episodeId — Get episode rating info
-app.get("/episode/:episodeId", async (c) => {
-  const user = c.get("user");
-  const episodeId = Number(c.req.param("episodeId"));
-  if (isNaN(episodeId)) return err(c, "Invalid episode ID", 400);
+app.get(
+  "/episode/:episodeId",
+  zValidator("param", episodeIdParamSchema),
+  async (c) => {
+    const user = c.get("user");
+    const { episodeId } = c.req.valid("param");
 
-  const userRatingData = user ? await getUserEpisodeRating(user.id, episodeId) : null;
-  const aggregated = await getEpisodeRatings(episodeId);
-  const friendsRaw = user ? await getFriendsEpisodeRatings(user.id, episodeId) : [];
+    const userRatingData = user ? await getUserEpisodeRating(user.id, episodeId) : null;
+    const aggregated = await getEpisodeRatings(episodeId);
+    const friendsRaw = user ? await getFriendsEpisodeRatings(user.id, episodeId) : [];
 
-  const friendsRatings = friendsRaw.map((f) => ({
-    user: {
-      id: f.userId,
-      username: f.username,
-      display_name: f.displayName,
-      image: f.image,
-    },
-    rating: f.rating,
-  }));
+    const friendsRatings = friendsRaw.map((f) => ({
+      user: {
+        id: f.userId,
+        username: f.username,
+        display_name: f.displayName,
+        image: f.image,
+      },
+      rating: f.rating,
+    }));
 
-  return ok(c, {
-    user_rating: userRatingData?.rating ?? null,
-    user_review: userRatingData?.review ?? null,
-    aggregated,
-    friends_ratings: friendsRatings,
-  });
-});
+    return ok(c, {
+      user_rating: userRatingData?.rating ?? null,
+      user_review: userRatingData?.review ?? null,
+      aggregated,
+      friends_ratings: friendsRatings,
+    });
+  },
+);
 
 // GET /season/:titleId/:season — Get aggregate episode ratings for a season
-app.get("/season/:titleId/:season", async (c) => {
-  const titleId = c.req.param("titleId");
-  const season = Number(c.req.param("season"));
-  if (isNaN(season)) return err(c, "Invalid season number", 400);
+app.get(
+  "/season/:titleId/:season",
+  zValidator("param", seasonParamSchema),
+  async (c) => {
+    const { titleId, season } = c.req.valid("param");
 
-  const ratings = await getSeasonEpisodeRatings(titleId, season);
-  return ok(c, { ratings });
-});
+    const ratings = await getSeasonEpisodeRatings(titleId, season);
+    return ok(c, { ratings });
+  },
+);
 
 export default app;

--- a/server/routes/recommendations.test.ts
+++ b/server/routes/recommendations.test.ts
@@ -142,7 +142,8 @@ describe("POST /recommendations", () => {
     });
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toContain("titleId is required");
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
   });
 
   it("returns 401 without auth", async () => {
@@ -401,6 +402,53 @@ describe("DELETE /recommendations/:id", () => {
       method: "DELETE",
     });
     expect(res.status).toBe(401);
+  });
+});
+
+describe("validation", () => {
+  it("rejects POST / with empty titleId via zod", async () => {
+    const res = await app.request("/recommendations", {
+      method: "POST",
+      headers: { ...authHeaders(userAToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ titleId: "" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+    expect(body.issues.length).toBeGreaterThan(0);
+  });
+
+  it("rejects POST / when message exceeds 500 chars", async () => {
+    const res = await app.request("/recommendations", {
+      method: "POST",
+      headers: { ...authHeaders(userAToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ titleId: "movie-123", message: "x".repeat(501) }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects GET / with invalid limit", async () => {
+    const res = await app.request("/recommendations?limit=9999", {
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects GET / with negative offset", async () => {
+    const res = await app.request("/recommendations?offset=-1", {
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
   });
 });
 

--- a/server/routes/recommendations.ts
+++ b/server/routes/recommendations.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { z } from "zod";
 import {
   createRecommendation,
   getUserRecommendation,
@@ -12,23 +13,30 @@ import {
 import type { AppEnv } from "../types";
 import { logger } from "../logger";
 import { ok, err } from "./response";
+import { zValidator } from "../lib/validator";
 
 const log = logger.child({ module: "recommendations" });
+
+const createRecommendationSchema = z.object({
+  titleId: z.string().min(1),
+  message: z.string().max(500).optional(),
+});
+
+const discoveryFeedQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
 
 const app = new Hono<AppEnv>();
 
 // POST / — Broadcast a recommendation (no toUserId needed)
-app.post("/", async (c) => {
+app.post("/", zValidator("json", createRecommendationSchema), async (c) => {
   const user = c.get("user");
   if (!user) {
     return err(c, "Authentication required", 401);
   }
 
-  const body = await c.req.json<{ titleId?: string; message?: string }>();
-
-  if (!body.titleId) {
-    return err(c, "titleId is required", 400);
-  }
+  const body = c.req.valid("json");
 
   // Check for duplicate recommendation
   const existing = await getUserRecommendation(user.id, body.titleId);
@@ -88,14 +96,13 @@ app.get("/check/:titleId", async (c) => {
 });
 
 // GET / — Discovery feed (recommendations from followed users)
-app.get("/", async (c) => {
+app.get("/", zValidator("query", discoveryFeedQuerySchema), async (c) => {
   const user = c.get("user");
   if (!user) {
     return err(c, "Authentication required", 401);
   }
 
-  const limit = Math.min(Math.max(parseInt(c.req.query("limit") || "20", 10), 1), 100);
-  const offset = Math.max(parseInt(c.req.query("offset") || "0", 10), 0);
+  const { limit, offset } = c.req.valid("query");
 
   const [rows, count] = await Promise.all([
     getDiscoveryFeed(user.id, limit, offset),


### PR DESCRIPTION
## Summary
- Adds `server/lib/validator.ts` — a shared `zValidator` wrapper around `@hono/zod-validator` that returns a uniform `{ error: "Validation failed", issues: ZodIssue[] }` on any validation error (400).
- Migrates 5 high-risk routes from manual request parsing to declarative zod schemas: `import.ts`, `recommendations.ts`, `ratings.ts`, `notifiers.ts`, `admin.ts`.
- Documents the pattern in `CLAUDE.md` under a new "Route validation" subsection.
- Each migrated route's test file gains a `describe("validation", ...)` block covering at least one invalid-payload case per schema and asserting the 400 / `issues` contract.
- Drive-by: removes a now-unused `eslint-disable` comment in `frontend/src/pages/CalendarPage.tsx` that was causing `bun run lint --max-warnings 0` to fail on master (unrelated to the zod migration but required for `bun run check` to go green).

## Design notes
- Provider/business-level validation stays AFTER zod in the handler. Zod only validates shape. Examples: `notifiers.ts` still calls `providerImpl.validateConfig(config)` after the zod schema parses the request body; `notifiers.ts` still refines timezone strings via `Intl.DateTimeFormat`.
- For `import.ts`, `@hono/zod-validator` cannot cleanly validate multipart `File` fields, so `FormData` is parsed manually and fed into `schema.safeParse(...)`. `instanceof File` is unreliable in the Bun test environment (happy-dom can replace the global `File`), so the upload schema duck-types the `Blob`/`File` shape instead.
- `notifiers.ts` uses a zod `.refine()` to encode the "digest_day is required when digest_mode is 'weekly'" constraint as a schema-level rule (the refine message and path show up in `issues`).
- `admin.ts` settings schema is `.passthrough()` to preserve the existing "unknown keys are ignored" behavior.

## Test plan
- [x] `bunx tsc --noEmit` (server) clean
- [x] `cd frontend && bunx tsc -b --noEmit` clean
- [x] `bun run lint` clean (no warnings, no errors)
- [x] `bun test server/` — 1215 pass, 0 fail
- [x] Migrated route tests updated to assert the new 400 shape (error: "Validation failed", issues: ZodIssue[])
- [ ] Note: the 4 `HomeRoute.test.tsx` failures observed in `bun run check` are pre-existing flakiness caused by cross-file mock module leaks in Bun on this codebase (see `MEMORY.md` → `feedback_mock_module_leak`). They reproduce on `master` at the same branch point and they all pass when the test file is run in isolation.

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)