### PR TITLE
Refactor PageHeader padding to use default values

### DIFF
--- a/frontend/src/components/design/PageHeader.tsx
+++ b/frontend/src/components/design/PageHeader.tsx
@@ -12,7 +12,7 @@ export function PageHeader({ kicker, title, right, className }: PageHeaderProps)
   return (
     <div
       className={cn(
-        "px-6 md:px-16 pt-10 pb-6 flex items-end justify-between gap-4",
+        "pt-4 pb-4 flex items-end justify-between gap-4",
         className
       )}
     >

--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -276,7 +276,6 @@ export default function BrowsePage() {
               : "Catalog · discover titles"
         }
         title="Browse"
-        className="px-0 pt-4 pb-4"
       />
       <SearchBar onSearch={handleSearch} onImdb={handleImdb} loading={searchLoading} />
 

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -747,7 +747,6 @@ function GridCalendar({
         kicker={`Month view · ${Intl.DateTimeFormat().resolvedOptions().timeZone}`}
         title={monthTitle}
         right={headerRight}
-        className="px-0 pt-4 pb-4"
       />
 
       {/* Stats bar */}

--- a/frontend/src/pages/DiscoveryPage.tsx
+++ b/frontend/src/pages/DiscoveryPage.tsx
@@ -368,7 +368,7 @@ export default function DiscoveryPage() {
 
   return (
     <div className="space-y-0">
-      <PageHeader kicker="Based on what you watch" title="For you" className="px-0 pt-4 pb-4" />
+      <PageHeader kicker="Based on what you watch" title="For you" />
 
       {/* Tab toggle */}
       <div className="flex gap-2 mb-6">

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -67,7 +67,7 @@ export default function SettingsPage() {
 
   return (
     <div className="max-w-7xl mx-auto">
-      <PageHeader kicker="Your preferences" title="Settings" className="px-0 pt-4 pb-4" />
+      <PageHeader kicker="Your preferences" title="Settings" />
 
       <div className="grid grid-cols-1 sm:grid-cols-[240px_1fr] gap-6 sm:gap-8">
         {/* Sidebar — pill row on mobile, vertical list on desktop */}

--- a/frontend/src/pages/TrackedPage.tsx
+++ b/frontend/src/pages/TrackedPage.tsx
@@ -113,7 +113,6 @@ export default function TrackedPage() {
       <PageHeader
         kicker={`Your library · ${allTitles.length} title${allTitles.length === 1 ? '' : 's'}`}
         title="Tracked"
-        className="px-0 pt-4 pb-4"
         right={
           <div className="flex items-center gap-2">
             <Pill active={view === 'grid'} onClick={() => setView('grid')}>Grid</Pill>


### PR DESCRIPTION
## Summary
Consolidated PageHeader padding styles by moving default padding values into the component itself, eliminating the need to repeatedly pass `className="px-0 pt-4 pb-4"` across multiple pages.

## Key Changes
- Updated `PageHeader` component to include default padding classes (`pt-4 pb-4`) instead of relying on page-level overrides
- Removed hardcoded `px-6 md:px-16` responsive padding from PageHeader, replacing with consistent horizontal padding handling
- Removed redundant `className="px-0 pt-4 pb-4"` prop from PageHeader usage in:
  - DiscoveryPage
  - SettingsPage
  - BrowsePage
  - CalendarPage
  - TrackedPage

## Implementation Details
The PageHeader component now applies `pt-4 pb-4 flex items-end justify-between gap-4` as its base styling, with the `className` prop still available for additional customizations. This reduces boilerplate across pages while maintaining consistent spacing and layout behavior.

https://claude.ai/code/session_01VhzZFTbGjcLe9QX7vpabFV