### PR TITLE
Add option to mark episodes watched on their air date

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -301,10 +301,14 @@ export async function unwatchEpisode(episodeId: number): Promise<void> {
   await fetchJson(`/watched/${episodeId}`, { method: "DELETE" });
 }
 
-export async function watchEpisodesBulk(episodeIds: number[], watched: boolean): Promise<void> {
+export async function watchEpisodesBulk(
+  episodeIds: number[],
+  watched: boolean,
+  options?: { useAirDate?: boolean },
+): Promise<void> {
   await fetchJson("/watched/bulk", {
     method: "POST",
-    body: JSON.stringify({ episodeIds, watched }),
+    body: JSON.stringify({ episodeIds, watched, useAirDate: options?.useAirDate }),
   });
 }
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -260,7 +260,16 @@
     "markAsUnwatched": "Mark as unwatched",
     "watched": "Watched",
     "watch": "Watch",
-    "markWatchedShort": "Mark watched"
+    "markWatchedShort": "Mark watched",
+    "markAllWatched": "Mark all watched",
+    "markAllUnwatched": "Mark all unwatched",
+    "markAllWatchedToday": "Mark all watched today",
+    "markAllWatchedOnAirDate": "Mark watched on air date",
+    "markAllWatchedOnAirDateHint": "Backdate to keep stats accurate",
+    "markAllWatchedOptions": "Mark all watched options",
+    "watchedError": "Failed to update watched status",
+    "moreActions": "More actions",
+    "viewDetails": "View details"
   },
   "calendar": {
     "all": "All",

--- a/frontend/src/pages/SeasonDetailPage.test.tsx
+++ b/frontend/src/pages/SeasonDetailPage.test.tsx
@@ -225,7 +225,7 @@ describe("SeasonDetailPage", () => {
     await waitFor(() => expect(screen.getByText("Pilot")).toBeDefined());
 
     // Should show "Mark all watched" since not all released are watched
-    const markAllBtn = screen.getByText(/mark all watched/i);
+    const markAllBtn = screen.getByRole("button", { name: "Mark all watched" });
     expect(markAllBtn).toBeDefined();
 
     await act(async () => {
@@ -233,7 +233,27 @@ describe("SeasonDetailPage", () => {
     });
 
     await waitFor(() => {
-      expect(mockWatchEpisodesBulk).toHaveBeenCalledWith([10, 11], true);
+      expect(mockWatchEpisodesBulk).toHaveBeenCalledWith([10, 11], true, undefined);
+    });
+  });
+
+  it("offers an option to mark all watched on air date", async () => {
+    render(<SeasonDetailPage />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByText("Pilot")).toBeDefined());
+
+    const optionsBtn = screen.getByRole("button", { name: /mark all watched options/i });
+    await act(async () => {
+      fireEvent.click(optionsBtn);
+    });
+
+    const airDateOption = screen.getByRole("menuitem", { name: /mark watched on air date/i });
+    await act(async () => {
+      fireEvent.click(airDateOption);
+    });
+
+    await waitFor(() => {
+      expect(mockWatchEpisodesBulk).toHaveBeenCalledWith([10, 11], true, { useAirDate: true });
     });
   });
 

--- a/frontend/src/pages/SeasonDetailPage.tsx
+++ b/frontend/src/pages/SeasonDetailPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useParams, Link, useNavigate } from "react-router";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
-import { CheckCircle, Circle, MoreHorizontal, Share2 } from "lucide-react";
+import { CalendarDays, CheckCircle, ChevronDown, Circle, MoreHorizontal, Share2 } from "lucide-react";
 import ScrollableRow from "../components/ScrollableRow";
 import * as api from "../api";
 import type { SeasonDetailsResponse, RatingValue } from "../types";
@@ -103,7 +103,7 @@ export default function SeasonDetailPage() {
     }
   };
 
-  const toggleAllWatched = async () => {
+  const toggleAllWatched = async (options?: { useAirDate?: boolean }) => {
     const episodes = data?.tmdb?.episodes || [];
     const releasedEps = episodes.filter((ep) => isReleased(ep.air_date));
     const releasedStatuses = releasedEps
@@ -127,7 +127,7 @@ export default function SeasonDetailPage() {
     });
 
     try {
-      await api.watchEpisodesBulk(ids, newWatched);
+      await api.watchEpisodesBulk(ids, newWatched, newWatched ? options : undefined);
     } catch {
       setStatusMap(prevMap);
       toast.error(t("episodes.watchedError", "Failed to update watched status"));
@@ -238,14 +238,16 @@ export default function SeasonDetailPage() {
                 </span>
               )}
               {hasStatus && releasedWithStatus.length > 0 && (
-                <button
-                  onClick={toggleAllWatched}
-                  className="text-sm text-zinc-400 hover:text-white transition-colors cursor-pointer"
-                >
-                  {allReleasedWatched
-                    ? t("episodes.markAllUnwatched", "Mark all unwatched")
-                    : t("episodes.markAllWatched", "Mark all watched")}
-                </button>
+                allReleasedWatched ? (
+                  <button
+                    onClick={() => toggleAllWatched()}
+                    className="text-sm text-zinc-400 hover:text-white transition-colors cursor-pointer"
+                  >
+                    {t("episodes.markAllUnwatched", "Mark all unwatched")}
+                  </button>
+                ) : (
+                  <MarkAllWatchedMenu onMarkAll={toggleAllWatched} />
+                )
               )}
             </div>
           </div>
@@ -452,6 +454,85 @@ function EpisodeWatchedPill({
         {watched ? t("episodes.watched", "Watched") : t("episodes.markWatchedShort", "Mark")}
       </span>
     </button>
+  );
+}
+
+function MarkAllWatchedMenu({
+  onMarkAll,
+}: {
+  onMarkAll: (options?: { useAirDate?: boolean }) => void | Promise<void>;
+}) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative inline-flex items-stretch">
+      <button
+        onClick={() => onMarkAll()}
+        className="text-sm text-zinc-400 hover:text-white transition-colors cursor-pointer pr-1"
+      >
+        {t("episodes.markAllWatched", "Mark all watched")}
+      </button>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={t("episodes.markAllWatchedOptions", "Mark all watched options")}
+        className="inline-flex items-center justify-center w-6 text-zinc-400 hover:text-white transition-colors cursor-pointer"
+      >
+        <ChevronDown size={14} aria-hidden="true" />
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-full mt-1 z-20 min-w-[240px] rounded-lg border border-white/[0.08] bg-zinc-900 shadow-xl py-1"
+        >
+          <button
+            role="menuitem"
+            onClick={() => {
+              setOpen(false);
+              onMarkAll();
+            }}
+            className="w-full text-left px-3 py-2 text-[13px] text-zinc-200 hover:bg-white/[0.06] cursor-pointer transition-colors"
+          >
+            {t("episodes.markAllWatchedToday", "Mark all watched today")}
+          </button>
+          <button
+            role="menuitem"
+            onClick={() => {
+              setOpen(false);
+              onMarkAll({ useAirDate: true });
+            }}
+            className="w-full flex items-start gap-2 text-left px-3 py-2 text-[13px] text-zinc-200 hover:bg-white/[0.06] cursor-pointer transition-colors"
+          >
+            <CalendarDays size={13} aria-hidden="true" className="mt-0.5 shrink-0" />
+            <span className="flex flex-col">
+              <span>{t("episodes.markAllWatchedOnAirDate", "Mark watched on air date")}</span>
+              <span className="text-[11px] text-zinc-500">
+                {t("episodes.markAllWatchedOnAirDateHint", "Backdate to keep stats accurate")}
+              </span>
+            </span>
+          </button>
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/server/db/repository/episodes.ts
+++ b/server/db/repository/episodes.ts
@@ -271,6 +271,30 @@ export async function getReleasedEpisodeIds(episodeIds: number[], timezone = "UT
   });
 }
 
+export async function getReleasedEpisodesWithAirDate(
+  episodeIds: number[],
+  timezone = "UTC"
+): Promise<Array<{ id: number; airDate: string }>> {
+  return traceDbQuery("getReleasedEpisodesWithAirDate", async () => {
+    if (episodeIds.length === 0) return [];
+    const today = localDateForTimezone(timezone);
+    const db = getDb();
+    const rows = await db
+      .select({ id: episodes.id, airDate: episodes.airDate })
+      .from(episodes)
+      .where(
+        and(
+          inArray(episodes.id, episodeIds),
+          sql`${episodes.airDate} IS NOT NULL`,
+          sql`${episodes.airDate} <= ${today}`
+        )
+      )
+      .all();
+    return rows
+      .filter((r): r is { id: number; airDate: string } => r.airDate !== null);
+  });
+}
+
 export async function watchEpisode(episodeId: number, userId: string) {
   return traceDbQuery("watchEpisode", async () => {
     const db = getDb();
@@ -290,12 +314,21 @@ export async function unwatchEpisode(episodeId: number, userId: string) {
   });
 }
 
-export async function watchEpisodesBulk(episodeIds: number[], userId: string) {
+export async function watchEpisodesBulk(
+  episodeIds: number[],
+  userId: string,
+  watchedAtByEpisodeId?: Map<number, string>
+) {
   return traceDbQuery("watchEpisodesBulk", async () => {
     if (episodeIds.length === 0) return;
     const db = getDb();
     await db.insert(watchedEpisodes)
-      .values(episodeIds.map((episodeId) => ({ episodeId, userId })))
+      .values(
+        episodeIds.map((episodeId) => {
+          const watchedAt = watchedAtByEpisodeId?.get(episodeId);
+          return watchedAt ? { episodeId, userId, watchedAt } : { episodeId, userId };
+        })
+      )
       .onConflictDoNothing()
       .run();
   });

--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -33,6 +33,7 @@ export {
   getEpisodeTitleId,
   getEpisodeTitleIds,
   getReleasedEpisodeIds,
+  getReleasedEpisodesWithAirDate,
   watchEpisode,
   unwatchEpisode,
   watchEpisodesBulk,

--- a/server/db/repository/watch-history.ts
+++ b/server/db/repository/watch-history.ts
@@ -4,7 +4,12 @@ import { watchHistory } from "../schema";
 import { traceDbQuery } from "../../tracing";
 import { randomUUID } from "node:crypto";
 
-export async function logWatch(userId: string, titleId: string, episodeId?: number): Promise<void> {
+export async function logWatch(
+  userId: string,
+  titleId: string,
+  episodeId?: number,
+  watchedAt?: string,
+): Promise<void> {
   return traceDbQuery("logWatch", async () => {
     const db = getDb();
     await db.insert(watchHistory)
@@ -13,6 +18,7 @@ export async function logWatch(userId: string, titleId: string, episodeId?: numb
         userId,
         titleId,
         episodeId: episodeId ?? null,
+        ...(watchedAt ? { watchedAt } : {}),
       })
       .run();
   });

--- a/server/routes/watched.test.ts
+++ b/server/routes/watched.test.ts
@@ -256,7 +256,10 @@ describe("POST /watched/bulk", () => {
     expect(res.status).toBe(200);
   });
 
-  it("returns 400 for empty episodeIds", async () => {
+});
+
+describe("POST /watched/bulk validation", () => {
+  it("returns 400 with issues array for empty episodeIds", async () => {
     const app = makeAuthedApp();
     const res = await app.request("/watched/bulk", {
       method: "POST",
@@ -265,10 +268,12 @@ describe("POST /watched/bulk", () => {
     });
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toContain("episodeIds");
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+    expect(body.issues.length).toBeGreaterThan(0);
   });
 
-  it("returns 400 when episodeIds is missing", async () => {
+  it("returns 400 with issues array when episodeIds is missing", async () => {
     const app = makeAuthedApp();
     const res = await app.request("/watched/bulk", {
       method: "POST",
@@ -277,7 +282,32 @@ describe("POST /watched/bulk", () => {
     });
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toContain("episodeIds");
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("returns 400 when watched is not a boolean", async () => {
+    const app = makeAuthedApp();
+    const res = await app.request("/watched/bulk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ episodeIds: [1], watched: "yes" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+  });
+
+  it("returns 400 when useAirDate is not a boolean", async () => {
+    const app = makeAuthedApp();
+    const res = await app.request("/watched/bulk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ episodeIds: [1], watched: true, useAirDate: "yes" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
   });
 });
 
@@ -371,6 +401,72 @@ describe("Watch history logging", () => {
     const row = db.prepare("SELECT COUNT(*) as cnt FROM watch_history WHERE user_id = ? AND title_id = ?")
       .get(userId, "movie-hist-1") as { cnt: number };
     expect(row.cnt).toBe(1);
+  });
+
+  it("bulk watch with useAirDate sets watched_at to each episode's air date", async () => {
+    const date1 = "2024-01-15";
+    const date2 = "2024-02-20";
+
+    await upsertTitles([makeParsedTitle({ id: "show-air-1", objectType: "SHOW" })]);
+    await upsertEpisodes([
+      { title_id: "show-air-1", season_number: 1, episode_number: 1, name: "Ep1", overview: null, air_date: date1, still_path: null },
+      { title_id: "show-air-1", season_number: 1, episode_number: 2, name: "Ep2", overview: null, air_date: date2, still_path: null },
+    ]);
+    const ep1Id = await getEpisodeId("show-air-1", 1, 1);
+    const ep2Id = await getEpisodeId("show-air-1", 1, 2);
+
+    const app = makeAuthedApp();
+    const res = await app.request("/watched/bulk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ episodeIds: [ep1Id, ep2Id], watched: true, useAirDate: true }),
+    });
+    expect(res.status).toBe(200);
+
+    const db = getRawDb();
+    const ep1Row = db.prepare("SELECT watched_at FROM watched_episodes WHERE episode_id = ? AND user_id = ?")
+      .get(ep1Id, userId) as { watched_at: string };
+    const ep2Row = db.prepare("SELECT watched_at FROM watched_episodes WHERE episode_id = ? AND user_id = ?")
+      .get(ep2Id, userId) as { watched_at: string };
+    expect(ep1Row.watched_at).toBe(`${date1} 00:00:00`);
+    expect(ep2Row.watched_at).toBe(`${date2} 00:00:00`);
+
+    // Watch history should also use the air date
+    const histRow1 = db.prepare("SELECT watched_at FROM watch_history WHERE user_id = ? AND episode_id = ?")
+      .get(userId, ep1Id) as { watched_at: string };
+    const histRow2 = db.prepare("SELECT watched_at FROM watch_history WHERE user_id = ? AND episode_id = ?")
+      .get(userId, ep2Id) as { watched_at: string };
+    expect(histRow1.watched_at).toBe(`${date1} 00:00:00`);
+    expect(histRow2.watched_at).toBe(`${date2} 00:00:00`);
+  });
+
+  it("bulk watch without useAirDate uses current timestamp", async () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const yesterdayStr = yesterday.toISOString().slice(0, 10);
+
+    await upsertTitles([makeParsedTitle({ id: "show-air-2", objectType: "SHOW" })]);
+    await upsertEpisodes([
+      { title_id: "show-air-2", season_number: 1, episode_number: 1, name: "Ep1", overview: null, air_date: yesterdayStr, still_path: null },
+    ]);
+    const ep1Id = await getEpisodeId("show-air-2", 1, 1);
+
+    const app = makeAuthedApp();
+    const res = await app.request("/watched/bulk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ episodeIds: [ep1Id], watched: true }),
+    });
+    expect(res.status).toBe(200);
+
+    const db = getRawDb();
+    const row = db.prepare("SELECT watched_at FROM watched_episodes WHERE episode_id = ? AND user_id = ?")
+      .get(ep1Id, userId) as { watched_at: string };
+    // Default is datetime('now') — should not equal the air date
+    expect(row.watched_at).not.toBe(`${yesterdayStr} 00:00:00`);
+    // Should be today's UTC date
+    const todayUtc = new Date().toISOString().slice(0, 10);
+    expect(row.watched_at.startsWith(todayUtc)).toBe(true);
   });
 
   it("bulk watch logs history for each released episode", async () => {

--- a/server/routes/watched.ts
+++ b/server/routes/watched.ts
@@ -1,13 +1,15 @@
 import { Hono } from "hono";
+import { z } from "zod";
 import {
   watchEpisode, unwatchEpisode, watchEpisodesBulk, unwatchEpisodesBulk,
-  getEpisodeAirDate, getReleasedEpisodeIds, watchTitle, unwatchTitle,
-  getEpisodeTitleId, getEpisodeTitleIds,
+  getEpisodeAirDate, getReleasedEpisodeIds, getReleasedEpisodesWithAirDate,
+  watchTitle, unwatchTitle, getEpisodeTitleId, getEpisodeTitleIds,
 } from "../db/repository";
 import { logWatch, getTitlePlayCount, getTitleWatchHistory } from "../db/repository/watch-history";
 import { localDateForTimezone } from "../utils/timezone";
 import type { AppEnv } from "../types";
 import { ok, err } from "./response";
+import { zValidator } from "../lib/validator";
 
 const app = new Hono<AppEnv>();
 
@@ -17,29 +19,46 @@ function isReleased(airDate: string | null, timezone: string): boolean {
   return airDate <= today;
 }
 
-app.post("/bulk", async (c) => {
+// SQLite stores `watched_at` as text via `datetime('now')`, format `YYYY-MM-DD HH:MM:SS`.
+// Match that shape so monthly stats grouping (`strftime('%Y-%m', watched_at)`) works.
+function airDateToWatchedAt(airDate: string): string {
+  return `${airDate} 00:00:00`;
+}
+
+const bulkWatchedSchema = z.object({
+  episodeIds: z.array(z.number().int()).min(1, "episodeIds must be a non-empty array"),
+  watched: z.boolean(),
+  useAirDate: z.boolean().optional(),
+});
+
+app.post("/bulk", zValidator("json", bulkWatchedSchema), async (c) => {
   const user = c.get("user")!;
   const timezone = c.req.header("X-Timezone") || "UTC";
-  const body = await c.req.json();
-  const { episodeIds, watched } = body as { episodeIds: number[]; watched: boolean };
-
-  if (!Array.isArray(episodeIds) || episodeIds.length === 0) {
-    return err(c, "episodeIds must be a non-empty array");
-  }
+  const { episodeIds, watched, useAirDate } = c.req.valid("json");
 
   if (watched) {
-    const releasedIds = await getReleasedEpisodeIds(episodeIds, timezone);
+    let releasedIds: number[];
+    let watchedAtByEpisodeId: Map<number, string> | undefined;
+
+    if (useAirDate) {
+      const released = await getReleasedEpisodesWithAirDate(episodeIds, timezone);
+      releasedIds = released.map((r) => r.id);
+      watchedAtByEpisodeId = new Map(released.map((r) => [r.id, airDateToWatchedAt(r.airDate)]));
+    } else {
+      releasedIds = await getReleasedEpisodeIds(episodeIds, timezone);
+    }
+
     if (releasedIds.length === 0) {
       return err(c, "Cannot mark unreleased episodes as watched");
     }
-    await watchEpisodesBulk(releasedIds, user.id);
+    await watchEpisodesBulk(releasedIds, user.id, watchedAtByEpisodeId);
 
     // Log watch history for each released episode
     const titleIdMap = await getEpisodeTitleIds(releasedIds);
     for (const episodeId of releasedIds) {
       const titleId = titleIdMap.get(episodeId);
       if (titleId) {
-        await logWatch(user.id, titleId, episodeId);
+        await logWatch(user.id, titleId, episodeId, watchedAtByEpisodeId?.get(episodeId));
       }
     }
   } else {


### PR DESCRIPTION
## Summary
This PR adds the ability to mark episodes as watched using their air date instead of the current timestamp. This allows users to backdate watch history to keep viewing statistics accurate when bulk-marking episodes as watched.

## Key Changes

**Backend (Server)**
- Added `useAirDate` optional parameter to the bulk watch endpoint (`POST /watched/bulk`)
- Implemented input validation using Zod schema for the bulk watch request
- Added `getReleasedEpisodesWithAirDate()` function to fetch released episodes with their air dates
- Modified `watchEpisodesBulk()` to accept optional `watchedAtByEpisodeId` map for custom timestamps
- Updated `logWatch()` to accept optional `watchedAt` parameter for watch history logging
- Added helper function `airDateToWatchedAt()` to format air dates as SQLite datetime strings

**Frontend (UI)**
- Created new `MarkAllWatchedMenu` component with dropdown menu offering two options:
  - "Mark all watched today" (default behavior)
  - "Mark watched on air date" (new feature with visual hint)
- Updated `toggleAllWatched()` to accept options parameter and pass `useAirDate` flag to API
- Modified UI to show dropdown menu only when episodes are not all watched
- Added new translation keys for the menu options and descriptions

**Testing**
- Added validation tests for empty/missing `episodeIds` and invalid boolean fields
- Added tests verifying `watched_at` is set to air date when `useAirDate: true`
- Added test verifying current timestamp is used when `useAirDate` is not provided
- Updated existing test to verify correct API call parameters

**Localization**
- Added English translations for new UI strings including menu options and helpful hints

## Implementation Details
- The `useAirDate` parameter is only applied when marking episodes as watched (not when unwatching)
- Air dates are formatted as `YYYY-MM-DD 00:00:00` to match SQLite's datetime format for proper stats grouping
- Only released episodes (with non-null air dates) are included when using air date mode
- The watch history log also respects the custom `watched_at` timestamp for consistency

https://claude.ai/code/session_01PBDzL7GJU4yQHThTdJr1ss