### PR TITLE
fix(watched): chunk bulk insert to stay under D1's 100-param limit

### DIFF
--- a/server/db/repository/episodes.ts
+++ b/server/db/repository/episodes.ts
@@ -314,6 +314,11 @@ export async function unwatchEpisode(episodeId: number, userId: string) {
   });
 }
 
+// Cloudflare D1 caps bound parameters per statement at 100. With 3 columns
+// per row (episode_id, user_id, watched_at) a chunk of 30 rows uses 90 params,
+// leaving headroom for future columns.
+const BULK_WATCHED_CHUNK_SIZE = 30;
+
 export async function watchEpisodesBulk(
   episodeIds: number[],
   userId: string,
@@ -322,15 +327,18 @@ export async function watchEpisodesBulk(
   return traceDbQuery("watchEpisodesBulk", async () => {
     if (episodeIds.length === 0) return;
     const db = getDb();
-    await db.insert(watchedEpisodes)
-      .values(
-        episodeIds.map((episodeId) => {
-          const watchedAt = watchedAtByEpisodeId?.get(episodeId);
-          return watchedAt ? { episodeId, userId, watchedAt } : { episodeId, userId };
-        })
-      )
-      .onConflictDoNothing()
-      .run();
+    for (let i = 0; i < episodeIds.length; i += BULK_WATCHED_CHUNK_SIZE) {
+      const chunk = episodeIds.slice(i, i + BULK_WATCHED_CHUNK_SIZE);
+      await db.insert(watchedEpisodes)
+        .values(
+          chunk.map((episodeId) => {
+            const watchedAt = watchedAtByEpisodeId?.get(episodeId);
+            return watchedAt ? { episodeId, userId, watchedAt } : { episodeId, userId };
+          })
+        )
+        .onConflictDoNothing()
+        .run();
+    }
   });
 }
 
@@ -338,9 +346,12 @@ export async function unwatchEpisodesBulk(episodeIds: number[], userId: string) 
   return traceDbQuery("unwatchEpisodesBulk", async () => {
     if (episodeIds.length === 0) return;
     const db = getDb();
-    await db.delete(watchedEpisodes)
-      .where(and(eq(watchedEpisodes.userId, userId), inArray(watchedEpisodes.episodeId, episodeIds)))
-      .run();
+    for (let i = 0; i < episodeIds.length; i += BULK_WATCHED_CHUNK_SIZE) {
+      const chunk = episodeIds.slice(i, i + BULK_WATCHED_CHUNK_SIZE);
+      await db.delete(watchedEpisodes)
+        .where(and(eq(watchedEpisodes.userId, userId), inArray(watchedEpisodes.episodeId, chunk)))
+        .run();
+    }
   });
 }
 

--- a/server/routes/watched.test.ts
+++ b/server/routes/watched.test.ts
@@ -228,6 +228,89 @@ describe("POST /watched/bulk", () => {
     expect(body.error).toContain("unreleased");
   });
 
+  it("handles bulk insert larger than D1's 100-param limit (38 episodes × 3 cols = 114 binds)", async () => {
+    // Regression: pre-fix this triggered "Failed query" on D1 because the
+    // single INSERT exceeded SQLITE_LIMIT_VARIABLE_NUMBER. The repo function
+    // now chunks the insert; this test seeds a season with 38 aired episodes
+    // and asserts every row is written.
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const yesterdayStr = yesterday.toISOString().slice(0, 10);
+
+    await upsertTitles([makeParsedTitle({ id: "show-bulk-large", objectType: "SHOW" })]);
+    const eps = Array.from({ length: 38 }, (_, i) => ({
+      title_id: "show-bulk-large",
+      season_number: 1,
+      episode_number: i + 1,
+      name: `Ep${i + 1}`,
+      overview: null,
+      air_date: yesterdayStr,
+      still_path: null,
+    }));
+    await upsertEpisodes(eps);
+    const ids: number[] = [];
+    for (let i = 1; i <= 38; i++) {
+      ids.push(await getEpisodeId("show-bulk-large", 1, i));
+    }
+
+    const app = makeAuthedApp();
+    const res = await app.request("/watched/bulk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ episodeIds: ids, watched: true, useAirDate: true }),
+    });
+    expect(res.status).toBe(200);
+
+    const db = getRawDb();
+    const row = db.prepare("SELECT COUNT(*) as cnt FROM watched_episodes WHERE user_id = ?")
+      .get(userId) as { cnt: number };
+    expect(row.cnt).toBe(38);
+
+    const histRow = db.prepare("SELECT COUNT(*) as cnt FROM watch_history WHERE user_id = ? AND title_id = ?")
+      .get(userId, "show-bulk-large") as { cnt: number };
+    expect(histRow.cnt).toBe(38);
+  });
+
+  it("bulk unwatch handles >30 episodes (chunked)", async () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const yesterdayStr = yesterday.toISOString().slice(0, 10);
+
+    await upsertTitles([makeParsedTitle({ id: "show-bulk-unwatch", objectType: "SHOW" })]);
+    const eps = Array.from({ length: 35 }, (_, i) => ({
+      title_id: "show-bulk-unwatch",
+      season_number: 1,
+      episode_number: i + 1,
+      name: `Ep${i + 1}`,
+      overview: null,
+      air_date: yesterdayStr,
+      still_path: null,
+    }));
+    await upsertEpisodes(eps);
+    const ids: number[] = [];
+    for (let i = 1; i <= 35; i++) {
+      ids.push(await getEpisodeId("show-bulk-unwatch", 1, i));
+    }
+
+    const app = makeAuthedApp();
+    await app.request("/watched/bulk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ episodeIds: ids, watched: true }),
+    });
+    const res = await app.request("/watched/bulk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ episodeIds: ids, watched: false }),
+    });
+    expect(res.status).toBe(200);
+
+    const db = getRawDb();
+    const row = db.prepare("SELECT COUNT(*) as cnt FROM watched_episodes WHERE user_id = ?")
+      .get(userId) as { cnt: number };
+    expect(row.cnt).toBe(0);
+  });
+
   it("bulk unwatch succeeds for released and unreleased episodes", async () => {
     const yesterday = new Date();
     yesterday.setDate(yesterday.getDate() - 1);


### PR DESCRIPTION
## Summary

- `POST /api/watched/bulk` returns 500 when marking ≥34 released episodes watched with `useAirDate: true`. Cloudflare D1 caps bound parameters at 100, but the recent air-date commit pushed the single INSERT to 3 cols × 38 rows = 114 params, so D1 rejected the query.
- `watchEpisodesBulk` / `unwatchEpisodesBulk` in `server/db/repository/episodes.ts` now chunk inserts/deletes at 30 rows per statement (≤90 params even at 3 cols, leaving headroom).

## Root cause (from production logs)

```
Error: Failed query: insert into "watched_episodes" ("episode_id", "user_id", "watched_at")
  values (?, ?, ?), (?, ?, ?), ... [38 rows] ...
  on conflict do nothing
    at D1PreparedQuery.queryWithCache (worker.js:7408:19)
    at async D1PreparedQuery.run (worker.js:132290:12)
```

Sentry showed nothing; the actual error was only in Cloudflare Worker observability logs.

## Test plan

- [x] `bun test server/routes/watched.test.ts` — 32 pass, includes new regression test for 38-episode `useAirDate` bulk and 35-episode bulk unwatch
- [x] `bun run check` — 1839 pass (4 pre-existing `HomeRoute.test.tsx` flakes also fail on master, unrelated)
- [ ] Manual: deploy and re-mark a ≥34-episode season as watched on https://remindarr.app — confirm no 500 in Cloudflare logs for the new script version

🤖 Generated with [Claude Code](https://claude.com/claude-code)