### PR TITLE
Add backdate watched episodes to air date feature

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -312,6 +312,15 @@ export async function watchEpisodesBulk(
   });
 }
 
+export async function backdateWatchedToAirDate(
+  titleId?: string,
+): Promise<{ updated: number }> {
+  return fetchJson<{ updated: number }>("/watched/backdate", {
+    method: "POST",
+    body: JSON.stringify(titleId ? { titleId } : {}),
+  });
+}
+
 // ─── Watched Movies ──────────────────────────────────────────────────────────
 
 export async function watchMovie(titleId: string): Promise<void> {

--- a/frontend/src/components/BackdateWatchedButton.tsx
+++ b/frontend/src/components/BackdateWatchedButton.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+import { CalendarDays } from "lucide-react";
+import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
+import * as api from "../api";
+import { useAuth } from "../context/AuthContext";
+import {
+  AlertDialog,
+  AlertDialogPopup,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogClose,
+} from "./ui/alert-dialog";
+
+interface Props {
+  titleId?: string;
+  scope: "title" | "all";
+  variant?: "default" | "ghost";
+  onComplete?: (updated: number) => void;
+}
+
+export default function BackdateWatchedButton({ titleId, scope, variant = "default", onComplete }: Props) {
+  const { user } = useAuth();
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  if (!user) return null;
+
+  async function handleConfirm() {
+    setLoading(true);
+    try {
+      const { updated } = await api.backdateWatchedToAirDate(titleId);
+      setOpen(false);
+      if (updated === 0) {
+        toast(t("episodes.backdateNoChanges", "No watched episodes to backdate"));
+      } else {
+        toast.success(
+          t("episodes.backdateSuccess", "Backdated {{count}} episode to air date", { count: updated }),
+        );
+      }
+      onComplete?.(updated);
+    } catch {
+      toast.error(t("episodes.backdateError", "Failed to backdate watched episodes"));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const buttonClass = variant === "ghost"
+    ? "min-h-8 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium text-zinc-400 hover:text-white hover:bg-white/[0.06] cursor-pointer transition-colors"
+    : "min-h-8 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-white cursor-pointer transition-colors";
+
+  const label = scope === "all"
+    ? t("episodes.backdateAllAction", "Backdate to air dates")
+    : t("episodes.backdateAction", "Backdate to air dates");
+
+  const titleKey = scope === "all" ? "episodes.backdateAllConfirmTitle" : "episodes.backdateConfirmTitle";
+  const descriptionKey = scope === "all"
+    ? "episodes.backdateAllConfirmDescription"
+    : "episodes.backdateConfirmDescription";
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        disabled={loading}
+        className={`${buttonClass} disabled:opacity-50`}
+        title={label}
+      >
+        <CalendarDays size={13} aria-hidden="true" />
+        <span>{label}</span>
+      </button>
+
+      <AlertDialog open={open} onOpenChange={setOpen}>
+        <AlertDialogPopup>
+          <AlertDialogTitle>
+            {t(titleKey, scope === "all" ? "Backdate all watched episodes?" : "Backdate watched episodes?")}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {t(
+              descriptionKey,
+              scope === "all"
+                ? "Set the watched timestamp of every watched episode across your tracked shows to that episode's air date. This affects monthly stats."
+                : "Set the watched timestamp of every watched episode for this show to its air date. This affects monthly stats.",
+            )}
+          </AlertDialogDescription>
+          <div className="mt-4 flex justify-end gap-2">
+            <AlertDialogClose
+              className="inline-flex items-center justify-center rounded-md px-3 py-1.5 text-xs font-medium bg-zinc-800 text-zinc-400 hover:bg-zinc-700 cursor-pointer transition-colors"
+            >
+              {t("common.cancel")}
+            </AlertDialogClose>
+            <button
+              type="button"
+              onClick={handleConfirm}
+              disabled={loading}
+              className="inline-flex items-center justify-center rounded-md px-3 py-1.5 text-xs font-medium bg-amber-500 text-zinc-950 hover:bg-amber-400 cursor-pointer transition-colors disabled:opacity-50"
+            >
+              {loading ? "..." : t("episodes.backdateConfirm", "Backdate")}
+            </button>
+          </div>
+        </AlertDialogPopup>
+      </AlertDialog>
+    </>
+  );
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -269,7 +269,19 @@
     "markAllWatchedOptions": "Mark all watched options",
     "watchedError": "Failed to update watched status",
     "moreActions": "More actions",
-    "viewDetails": "View details"
+    "viewDetails": "View details",
+    "markWatchedOnAirDate": "Mark watched on air date",
+    "backdateAction": "Backdate to air dates",
+    "backdateAllAction": "Backdate to air dates",
+    "backdateConfirmTitle": "Backdate watched episodes?",
+    "backdateConfirmDescription": "Set the watched timestamp of every watched episode for this show to its air date. This affects monthly stats.",
+    "backdateAllConfirmTitle": "Backdate all watched episodes?",
+    "backdateAllConfirmDescription": "Set the watched timestamp of every watched episode across your tracked shows to that episode's air date. This affects monthly stats.",
+    "backdateConfirm": "Backdate",
+    "backdateSuccess_one": "Backdated {{count}} episode to air date",
+    "backdateSuccess_other": "Backdated {{count}} episodes to air dates",
+    "backdateNoChanges": "No watched episodes to backdate",
+    "backdateError": "Failed to backdate watched episodes"
   },
   "calendar": {
     "all": "All",

--- a/frontend/src/pages/SeasonDetailPage.tsx
+++ b/frontend/src/pages/SeasonDetailPage.tsx
@@ -103,6 +103,28 @@ export default function SeasonDetailPage() {
     }
   };
 
+  const markEpisodeOnAirDate = async (episodeNumber: number) => {
+    const status = statusMap.get(episodeNumber);
+    if (!status) return;
+
+    setStatusMap((prev) => {
+      const next = new Map(prev);
+      next.set(episodeNumber, { ...status, is_watched: true });
+      return next;
+    });
+
+    try {
+      await api.watchEpisodesBulk([status.id], true, { useAirDate: true });
+    } catch {
+      setStatusMap((prev) => {
+        const next = new Map(prev);
+        next.set(episodeNumber, { ...status, is_watched: status.is_watched });
+        return next;
+      });
+      toast.error(t("episodes.watchedError", "Failed to update watched status"));
+    }
+  };
+
   const toggleAllWatched = async (options?: { useAirDate?: boolean }) => {
     const episodes = data?.tmdb?.episodes || [];
     const releasedEps = episodes.filter((ep) => isReleased(ep.air_date));
@@ -379,6 +401,8 @@ export default function SeasonDetailPage() {
                         episodeNumber={ep.episode_number}
                         episodeName={ep.name}
                         showTitle={title.title}
+                        canMarkOnAirDate={released && !!status && !watched && !!ep.air_date}
+                        onMarkOnAirDate={() => markEpisodeOnAirDate(ep.episode_number)}
                       />
                     </div>
                   </div>
@@ -542,12 +566,16 @@ function EpisodeOverflowMenu({
   episodeNumber,
   episodeName,
   showTitle,
+  canMarkOnAirDate,
+  onMarkOnAirDate,
 }: {
   titleId: string;
   seasonNumber: number;
   episodeNumber: number;
   episodeName: string;
   showTitle: string;
+  canMarkOnAirDate?: boolean;
+  onMarkOnAirDate?: () => void | Promise<void>;
 }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -615,6 +643,19 @@ function EpisodeOverflowMenu({
           >
             {t("episodes.viewDetails", "View details")}
           </button>
+          {canMarkOnAirDate && onMarkOnAirDate && (
+            <button
+              role="menuitem"
+              onClick={() => {
+                setOpen(false);
+                void onMarkOnAirDate();
+              }}
+              className="w-full flex items-center gap-2 text-left px-3 py-2 text-[13px] text-zinc-200 hover:bg-white/[0.06] cursor-pointer transition-colors"
+            >
+              <CalendarDays size={13} aria-hidden="true" />
+              {t("episodes.markWatchedOnAirDate", "Mark watched on air date")}
+            </button>
+          )}
           <button
             role="menuitem"
             onClick={handleShare}

--- a/frontend/src/pages/TitleDetailPage.tsx
+++ b/frontend/src/pages/TitleDetailPage.tsx
@@ -25,6 +25,7 @@ import WatchButtonGroup from "../components/WatchButtonGroup";
 import VisibilityButton from "../components/VisibilityButton";
 import ShareButton from "../components/ShareButton";
 import RecommendButton from "../components/RecommendButton";
+import BackdateWatchedButton from "../components/BackdateWatchedButton";
 import { getProviderColor } from "../data/providerColors";
 import { Kicker, Chip } from "../components/design";
 
@@ -893,7 +894,11 @@ function ShowDetail({ data }: { data: ShowDetailsResponse }) {
 
       {/* Seasons */}
       {seasons.length > 0 && (
-        <Section title="Seasons">
+        <section className="space-y-4">
+          <div className="flex items-center justify-between gap-3 flex-wrap">
+            <h2 className="text-[18px] font-semibold text-white tracking-tight leading-tight">Seasons</h2>
+            <BackdateWatchedButton scope="title" titleId={title.id} variant="ghost" />
+          </div>
           <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
             {seasons.map((s: SeasonSummary) => {
               const airingToday = isToday(s.air_date);
@@ -937,7 +942,7 @@ function ShowDetail({ data }: { data: ShowDetailsResponse }) {
               );
             })}
           </div>
-        </Section>
+        </section>
       )}
 
       {/* Streaming Availability */}

--- a/frontend/src/pages/TrackedPage.tsx
+++ b/frontend/src/pages/TrackedPage.tsx
@@ -11,6 +11,7 @@ import { useGridNavigation } from "../hooks/useGridNavigation";
 import { useScrollRestoration } from "../hooks/useScrollRestoration";
 import { useIsMobile } from "../hooks/useIsMobile";
 import { PageHeader, Pill } from "../components/design";
+import BackdateWatchedButton from "../components/BackdateWatchedButton";
 import { StatsView } from "./StatsPage";
 
 function TrackedStatsBand({ titles }: { titles: Title[] }) {
@@ -114,7 +115,8 @@ export default function TrackedPage() {
         kicker={`Your library · ${allTitles.length} title${allTitles.length === 1 ? '' : 's'}`}
         title="Tracked"
         right={
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 flex-wrap justify-end">
+            <BackdateWatchedButton scope="all" variant="ghost" />
             <Pill active={view === 'grid'} onClick={() => setView('grid')}>Grid</Pill>
             <Pill active={view === 'list'} onClick={() => setView('list')}>List</Pill>
             <Pill active={view === 'stats'} onClick={() => setView('stats')}>Stats</Pill>

--- a/server/db/repository/episodes.ts
+++ b/server/db/repository/episodes.ts
@@ -344,6 +344,38 @@ export async function unwatchEpisodesBulk(episodeIds: number[], userId: string) 
   });
 }
 
+// Re-stamps `watched_episodes.watched_at` for already-watched episodes to the
+// episode's air date. When `titleId` is provided, scope is restricted to that
+// title; otherwise applies to every watched episode for the user.
+// Episodes without an `air_date` are skipped. Returns rows affected.
+export async function backdateWatchedEpisodesToAirDate(
+  userId: string,
+  titleId?: string,
+): Promise<number> {
+  return traceDbQuery("backdateWatchedEpisodesToAirDate", async () => {
+    const db = getDb();
+    const titleFilter = titleId ? sql`AND ${episodes.titleId} = ${titleId}` : sql``;
+    const result = await db.run(sql`
+      UPDATE watched_episodes
+      SET watched_at = (
+        SELECT ${episodes.airDate} || ' 00:00:00'
+        FROM ${episodes}
+        WHERE ${episodes.id} = watched_episodes.episode_id
+      )
+      WHERE watched_episodes.user_id = ${userId}
+        AND EXISTS (
+          SELECT 1 FROM ${episodes}
+          WHERE ${episodes.id} = watched_episodes.episode_id
+            AND ${episodes.airDate} IS NOT NULL
+            ${titleFilter}
+        )
+    `);
+    return typeof result === "object" && result !== null && "changes" in result
+      ? Number((result as { changes: number }).changes)
+      : 0;
+  });
+}
+
 export async function getSeasonEpisodeStatus(
   titleId: string,
   seasonNumber: number,

--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -38,6 +38,7 @@ export {
   unwatchEpisode,
   watchEpisodesBulk,
   unwatchEpisodesBulk,
+  backdateWatchedEpisodesToAirDate,
   getSeasonEpisodeStatus,
   getWatchedEpisodesForExport,
   getEpisodeIdsBySE,

--- a/server/routes/watched.test.ts
+++ b/server/routes/watched.test.ts
@@ -311,6 +311,182 @@ describe("POST /watched/bulk validation", () => {
   });
 });
 
+describe("POST /watched/backdate", () => {
+  it("backdates all watched episodes for a single title to their air dates", async () => {
+    const date1 = "2024-01-15";
+    const date2 = "2024-02-20";
+
+    await upsertTitles([makeParsedTitle({ id: "show-bd-1", objectType: "SHOW" })]);
+    await upsertEpisodes([
+      { title_id: "show-bd-1", season_number: 1, episode_number: 1, name: "Ep1", overview: null, air_date: date1, still_path: null },
+      { title_id: "show-bd-1", season_number: 1, episode_number: 2, name: "Ep2", overview: null, air_date: date2, still_path: null },
+    ]);
+    const ep1Id = await getEpisodeId("show-bd-1", 1, 1);
+    const ep2Id = await getEpisodeId("show-bd-1", 1, 2);
+
+    const app = makeAuthedApp();
+    // Mark watched without useAirDate (uses current timestamp).
+    await app.request("/watched/bulk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ episodeIds: [ep1Id, ep2Id], watched: true }),
+    });
+
+    const res = await app.request("/watched/backdate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ titleId: "show-bd-1" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.updated).toBe(2);
+
+    const db = getRawDb();
+    const ep1Row = db.prepare("SELECT watched_at FROM watched_episodes WHERE episode_id = ? AND user_id = ?")
+      .get(ep1Id, userId) as { watched_at: string };
+    const ep2Row = db.prepare("SELECT watched_at FROM watched_episodes WHERE episode_id = ? AND user_id = ?")
+      .get(ep2Id, userId) as { watched_at: string };
+    expect(ep1Row.watched_at).toBe(`${date1} 00:00:00`);
+    expect(ep2Row.watched_at).toBe(`${date2} 00:00:00`);
+  });
+
+  it("backdates all watched episodes across all tracked shows when titleId is omitted", async () => {
+    const dateA = "2024-03-10";
+    const dateB = "2024-04-01";
+
+    await upsertTitles([
+      makeParsedTitle({ id: "show-bd-A", objectType: "SHOW" }),
+      makeParsedTitle({ id: "show-bd-B", objectType: "SHOW" }),
+    ]);
+    await upsertEpisodes([
+      { title_id: "show-bd-A", season_number: 1, episode_number: 1, name: "A1", overview: null, air_date: dateA, still_path: null },
+      { title_id: "show-bd-B", season_number: 1, episode_number: 1, name: "B1", overview: null, air_date: dateB, still_path: null },
+    ]);
+    const epAId = await getEpisodeId("show-bd-A", 1, 1);
+    const epBId = await getEpisodeId("show-bd-B", 1, 1);
+
+    const app = makeAuthedApp();
+    await app.request("/watched/bulk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ episodeIds: [epAId, epBId], watched: true }),
+    });
+
+    const res = await app.request("/watched/backdate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.updated).toBe(2);
+
+    const db = getRawDb();
+    const rowA = db.prepare("SELECT watched_at FROM watched_episodes WHERE episode_id = ? AND user_id = ?")
+      .get(epAId, userId) as { watched_at: string };
+    const rowB = db.prepare("SELECT watched_at FROM watched_episodes WHERE episode_id = ? AND user_id = ?")
+      .get(epBId, userId) as { watched_at: string };
+    expect(rowA.watched_at).toBe(`${dateA} 00:00:00`);
+    expect(rowB.watched_at).toBe(`${dateB} 00:00:00`);
+  });
+
+  it("only touches episodes belonging to the requested title", async () => {
+    const dateA = "2024-05-01";
+    const dateB = "2024-06-01";
+
+    await upsertTitles([
+      makeParsedTitle({ id: "show-bd-only-A", objectType: "SHOW" }),
+      makeParsedTitle({ id: "show-bd-only-B", objectType: "SHOW" }),
+    ]);
+    await upsertEpisodes([
+      { title_id: "show-bd-only-A", season_number: 1, episode_number: 1, name: "A1", overview: null, air_date: dateA, still_path: null },
+      { title_id: "show-bd-only-B", season_number: 1, episode_number: 1, name: "B1", overview: null, air_date: dateB, still_path: null },
+    ]);
+    const epAId = await getEpisodeId("show-bd-only-A", 1, 1);
+    const epBId = await getEpisodeId("show-bd-only-B", 1, 1);
+
+    const app = makeAuthedApp();
+    await app.request("/watched/bulk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ episodeIds: [epAId, epBId], watched: true }),
+    });
+
+    const db = getRawDb();
+    const rowBBefore = db.prepare("SELECT watched_at FROM watched_episodes WHERE episode_id = ? AND user_id = ?")
+      .get(epBId, userId) as { watched_at: string };
+
+    const res = await app.request("/watched/backdate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ titleId: "show-bd-only-A" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.updated).toBe(1);
+
+    const rowA = db.prepare("SELECT watched_at FROM watched_episodes WHERE episode_id = ? AND user_id = ?")
+      .get(epAId, userId) as { watched_at: string };
+    const rowBAfter = db.prepare("SELECT watched_at FROM watched_episodes WHERE episode_id = ? AND user_id = ?")
+      .get(epBId, userId) as { watched_at: string };
+    expect(rowA.watched_at).toBe(`${dateA} 00:00:00`);
+    // show-bd-only-B was not touched.
+    expect(rowBAfter.watched_at).toBe(rowBBefore.watched_at);
+  });
+
+  it("skips watched episodes with no air_date", async () => {
+    await upsertTitles([makeParsedTitle({ id: "show-bd-noair", objectType: "SHOW" })]);
+    await upsertEpisodes([
+      { title_id: "show-bd-noair", season_number: 1, episode_number: 1, name: "Ep1", overview: null, air_date: null, still_path: null },
+    ]);
+    const epId = await getEpisodeId("show-bd-noair", 1, 1);
+
+    // Mark watched directly bypassing the released-only check.
+    const db = getRawDb();
+    db.prepare("INSERT INTO watched_episodes (episode_id, user_id, watched_at) VALUES (?, ?, ?)")
+      .run(epId, userId, "2024-07-15 12:00:00");
+
+    const app = makeAuthedApp();
+    const res = await app.request("/watched/backdate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ titleId: "show-bd-noair" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.updated).toBe(0);
+
+    const row = db.prepare("SELECT watched_at FROM watched_episodes WHERE episode_id = ? AND user_id = ?")
+      .get(epId, userId) as { watched_at: string };
+    expect(row.watched_at).toBe("2024-07-15 12:00:00");
+  });
+
+  it("returns 0 updated when user has no watched episodes", async () => {
+    const app = makeAuthedApp();
+    const res = await app.request("/watched/backdate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.updated).toBe(0);
+  });
+
+  it("returns 400 when titleId is not a string", async () => {
+    const app = makeAuthedApp();
+    const res = await app.request("/watched/backdate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ titleId: 123 }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+});
+
 describe("POST /watched/movies/:titleId", () => {
   it("marks a movie as watched", async () => {
     await upsertTitles([makeParsedTitle({ id: "movie-w1", objectType: "MOVIE" })]);

--- a/server/routes/watched.ts
+++ b/server/routes/watched.ts
@@ -4,6 +4,7 @@ import {
   watchEpisode, unwatchEpisode, watchEpisodesBulk, unwatchEpisodesBulk,
   getEpisodeAirDate, getReleasedEpisodeIds, getReleasedEpisodesWithAirDate,
   watchTitle, unwatchTitle, getEpisodeTitleId, getEpisodeTitleIds,
+  backdateWatchedEpisodesToAirDate,
 } from "../db/repository";
 import { logWatch, getTitlePlayCount, getTitleWatchHistory } from "../db/repository/watch-history";
 import { localDateForTimezone } from "../utils/timezone";
@@ -66,6 +67,17 @@ app.post("/bulk", zValidator("json", bulkWatchedSchema), async (c) => {
   }
 
   return ok(c, {});
+});
+
+const backdateSchema = z.object({
+  titleId: z.string().min(1).optional(),
+});
+
+app.post("/backdate", zValidator("json", backdateSchema), async (c) => {
+  const user = c.get("user")!;
+  const { titleId } = c.req.valid("json");
+  const updated = await backdateWatchedEpisodesToAirDate(user.id, titleId);
+  return ok(c, { updated });
 });
 
 app.get("/history/:titleId", async (c) => {


### PR DESCRIPTION
## Summary
This PR adds functionality to re-stamp watched episode timestamps to their original air dates, useful for correcting watch history when episodes are marked watched at the current time rather than their broadcast date.

## Key Changes

**Backend**
- Added `POST /watched/backdate` endpoint that updates `watched_at` timestamps for already-watched episodes to their `air_date`
- Supports optional `titleId` parameter to scope changes to a single show, or applies to all watched episodes when omitted
- Skips episodes without an `air_date` value
- Returns count of updated rows
- Added `backdateWatchedEpisodesToAirDate()` repository function with proper SQL query using subqueries

**Frontend**
- Created `BackdateWatchedButton` component with confirmation dialog
- Supports two scopes: single title or all tracked shows
- Integrated button into `TitleDetailPage` (show seasons section) and `TrackedPage` (stats view)
- Added "Mark watched on air date" option to episode overflow menu in `SeasonDetailPage`
- Added `markEpisodeOnAirDate()` handler to mark individual episodes with `useAirDate: true` flag
- Added `backdateWatchedToAirDate()` API client function

**Localization**
- Added 8 new translation keys for button labels, confirmation dialogs, and success/error messages
- Supports pluralization for episode count in success message

## Implementation Details
- The backdate operation uses a SQL UPDATE with a subquery to fetch the air date from the episodes table
- Episodes without air dates are filtered out via EXISTS clause to prevent NULL timestamp updates
- The feature respects user isolation (only affects current user's watched episodes)
- UI provides clear confirmation dialogs explaining the impact on monthly stats
- Individual episode marking uses the existing bulk watch API with `useAirDate` option

https://claude.ai/code/session_01G1L1rHqj1u8Sa1fZwZEeEd