### PR TITLE
fix: replace console.log in worker.ts admin password bootstrap with structured logger

### DIFF
--- a/server/worker.ts
+++ b/server/worker.ts
@@ -204,8 +204,14 @@ function createApp(env: Env) {
         const password = crypto.randomUUID().slice(0, 16);
         const hash = await platform.hashPassword(password);
         await createUser("admin", hash, "Admin", "local", undefined, true);
-        logger.info("Admin account created", { username: "admin" });
-        console.log(`\n  Default admin password: ${password}\n  Change it after first login.\n`);
+        // Keep the password inline in the human-readable message only —
+        // do NOT pass it as a structured field so it isn't indexed by log
+        // aggregators. The operator still sees it once in dev/server logs.
+        const bootstrapLog = logger.child({ module: "worker-bootstrap" });
+        bootstrapLog.warn(
+          `Admin account created — default password: ${password} (change it after first login)`,
+          { username: "admin" }
+        );
       }
     }
 


### PR DESCRIPTION
## Summary
- Replace `console.log` at `server/worker.ts:208` with a module-scoped child logger (`logger.child({ module: "worker-bootstrap" })`) per CLAUDE.md logging rules.
- Log at `warn` level. The plaintext default admin password remains inline in the human-readable message string only and is NOT passed as a structured field, so log aggregators do not index it while the operator still sees it once in dev/server logs.
- The pre-existing `logger.info("Admin account created", ...)` line is folded into the new single warn-level entry to avoid duplication.

Closes #472

## Test plan
- [x] `bunx tsc --noEmit` (server) passes
- [x] `bunx tsc --noEmit -p e2e/tsconfig.json` passes
- [x] `bunx tsc -b --noEmit` (frontend) passes
- [x] `bun run lint` passes
- [x] `bun test server/` passes (1243/1243)
- [ ] Manually verify on a fresh Cloudflare Workers deployment that the password message appears prominently in `wrangler tail` / dev logs on first request

Note: `bun test frontend/src/` shows 4 unrelated failures in `frontend/src/routes/HomeRoute.test.tsx` due to the known Bun `mock.module()` cross-file leak on Windows; those tests pass in isolation and are pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)