### PR TITLE
fix: remove any types from cache/redis.ts and auth/better-auth.ts

### DIFF
--- a/server/auth/better-auth.ts
+++ b/server/auth/better-auth.ts
@@ -1,4 +1,4 @@
-import { betterAuth } from "better-auth";
+import { betterAuth, type BetterAuthPlugin } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { username } from "better-auth/plugins/username";
 import { admin } from "better-auth/plugins/admin";
@@ -86,7 +86,7 @@ export function createAuth(db: DrizzleDb, platform: Platform, oidcConfig?: {
   const pendingOidcAdminStatus = new Map<string, boolean>(); // nonce → isAdmin
   const pendingNoncesByAccountId = new Map<string, string[]>(); // sub → nonce queue
 
-  const plugins: any[] = [
+  const plugins: BetterAuthPlugin[] = [
     username({
       minUsernameLength: 1,
       maxUsernameLength: 100,

--- a/server/cache/redis.ts
+++ b/server/cache/redis.ts
@@ -4,11 +4,31 @@ import { logger } from "../logger";
 const log = logger.child({ module: "cache-redis" });
 
 /**
+ * Minimal structural type for the subset of the ioredis client we use.
+ * ioredis is loaded via dynamic import (optional dependency), so we describe
+ * only the methods we call rather than depending on the ioredis types.
+ */
+interface RedisClient {
+  get(key: string): Promise<string | null>;
+  setex(key: string, ttlSeconds: number, value: string): Promise<unknown>;
+  del(key: string): Promise<unknown>;
+  quit(): Promise<unknown>;
+  on(event: "error", listener: (err: Error) => void): unknown;
+}
+
+interface RedisConstructor {
+  new (
+    url: string,
+    options?: { lazyConnect?: boolean; maxRetriesPerRequest?: number },
+  ): RedisClient;
+}
+
+/**
  * Redis-backed distributed cache.
  * Requires the `ioredis` package to be installed (`bun add ioredis`).
  */
 export class RedisCache implements Cache {
-  private client: any;
+  private client: RedisClient | null = null;
   private ready: Promise<void>;
 
   constructor(redisUrl: string) {
@@ -18,12 +38,15 @@ export class RedisCache implements Cache {
   private async connect(url: string): Promise<void> {
     try {
       // Dynamic import — ioredis is an optional dependency
-      const mod = await import(/* webpackIgnore: true */ "ioredis" as string);
-      const Redis = mod.default ?? mod;
-      this.client = new Redis(url, { lazyConnect: false, maxRetriesPerRequest: 3 });
-      this.client.on("error", (err: Error) => {
+      const mod = (await import(/* webpackIgnore: true */ "ioredis" as string)) as {
+        default?: RedisConstructor;
+      } & RedisConstructor;
+      const Redis: RedisConstructor = mod.default ?? mod;
+      const client = new Redis(url, { lazyConnect: false, maxRetriesPerRequest: 3 });
+      client.on("error", (err: Error) => {
         log.error("Redis connection error", { error: err.message });
       });
+      this.client = client;
       log.info("Redis cache connected");
     } catch {
       throw new Error(
@@ -34,6 +57,7 @@ export class RedisCache implements Cache {
 
   async get<T = unknown>(key: string): Promise<T | null> {
     await this.ready;
+    if (!this.client) return null;
     const value = await this.client.get(key);
     if (value === null) return null;
     try {
@@ -45,11 +69,13 @@ export class RedisCache implements Cache {
 
   async set(key: string, value: unknown, ttlSeconds: number): Promise<void> {
     await this.ready;
+    if (!this.client) return;
     await this.client.setex(key, ttlSeconds, JSON.stringify(value));
   }
 
   async delete(key: string): Promise<void> {
     await this.ready;
+    if (!this.client) return;
     await this.client.del(key);
   }
 


### PR DESCRIPTION
## Summary
- Replaces `private client: any` in `server/cache/redis.ts` with a structural `RedisClient` interface (typed `get`/`setex`/`del`/`quit`/`on`). ioredis is loaded via dynamic optional import, so this gives us real type checking without taking a hard dependency on ioredis types. The field is now `RedisClient | null` and methods short-circuit when the dynamic import failed.
- Replaces `const plugins: any[]` in `server/auth/better-auth.ts` with `BetterAuthPlugin[]`, imported directly from `better-auth`.

Closes #477

## Test plan
- [x] `bunx tsc --noEmit` (server) passes
- [x] `bunx tsc --noEmit -p e2e/tsconfig.json` passes
- [x] `frontend` `bunx tsc -b --noEmit` passes
- [x] `bun run lint` passes with zero warnings
- [x] `bun test server/cache/ server/auth/` passes (83/83)
- [x] No new test failures introduced; the 4 pre-existing `HomeRoute` failures in the full suite are present on master and are caused by mock-module leak across files (unrelated to this PR)

Generated with Claude Code.