### PR TITLE
fix: replace catch(e: any) with catch(e: unknown) across server

### DIFF
--- a/server/notifications/webpush.ts
+++ b/server/notifications/webpush.ts
@@ -51,12 +51,21 @@ export class WebPushProvider implements NotificationProvider {
 
     try {
       await webpush.sendNotification(subscription, JSON.stringify(payload));
-    } catch (err: any) {
-      if (err.statusCode === 410 || err.statusCode === 404) {
+    } catch (err: unknown) {
+      const statusCode =
+        typeof err === "object" && err !== null && "statusCode" in err
+          ? (err as { statusCode?: number }).statusCode
+          : undefined;
+      if (statusCode === 410 || statusCode === 404) {
         throw new SubscriptionExpiredError(config.endpoint);
       }
+      const body =
+        typeof err === "object" && err !== null && "body" in err
+          ? (err as { body?: string }).body
+          : undefined;
+      const message = err instanceof Error ? err.message : String(err);
       throw new Error(
-        `Web push failed (${err.statusCode || "unknown"}): ${err.body || err.message}`
+        `Web push failed (${statusCode ?? "unknown"}): ${body || message}`
       );
     }
   }

--- a/server/routes/browse.ts
+++ b/server/routes/browse.ts
@@ -219,9 +219,11 @@ app.get("/", async (c) => {
       .map((l) => l.code);
 
     return ok(c, { titles: titlesWithTracked, page, totalPages, totalResults, availableGenres, availableProviders, availableLanguages, regionProviderIds, priorityLanguageCodes });
-  } catch (e: any) {
-    log.error("Browse error", { error: e.message, stack: e.stack });
-    return err(c, e.message, 500);
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    const stack = e instanceof Error ? e.stack : undefined;
+    log.error("Browse error", { error: message, stack });
+    return err(c, message, 500);
   }
 });
 

--- a/server/routes/notifiers.ts
+++ b/server/routes/notifiers.ts
@@ -270,12 +270,13 @@ app.post("/:id/test", async (c) => {
   try {
     await providerImpl.send(notifier.config, content);
     return c.json({ success: true, message: "Test notification sent" });
-  } catch (err: any) {
+  } catch (err: unknown) {
     if (!(err instanceof SubscriptionExpiredError)) {
       Sentry.captureException(err);
     }
+    const message = err instanceof Error ? err.message : String(err);
     return c.json(
-      { success: false, message: err.message || "Failed to send" },
+      { success: false, message: message || "Failed to send" },
     );
   }
 });

--- a/server/routes/sync.ts
+++ b/server/routes/sync.ts
@@ -20,8 +20,9 @@ app.post("/", async (c) => {
     const titles = await syncTitles.fetchNewReleases({ daysBack, objectType, maxPages });
     const count = await upsertTitles(titles);
     return ok(c, { count, message: `Synced ${count} titles` });
-  } catch (e: any) {
-    return err(c, e.message, 500);
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    return err(c, message, 500);
   }
 });
 


### PR DESCRIPTION
## Summary

Closes #471

Replaces the four remaining `catch(e: any)` / `catch(err: any)` sites in the server with `catch(e: unknown)`, narrowing with `instanceof Error` (and property checks for the web-push shape) before reading any properties. Aligns with the project's `no-explicit-any` rule.

### Files changed
- `server/routes/sync.ts` — narrow `e` before reading `.message`
- `server/routes/browse.ts` — narrow `e` before reading `.message` / `.stack`
- `server/routes/notifiers.ts` — narrow `err` before reading `.message`; preserve `SubscriptionExpiredError` instance check (which already works on `unknown`)
- `server/notifications/webpush.ts` — guard for `statusCode` and `body` properties on the unknown error, fall back to `instanceof Error` for `message`

### Notes
- A grep across `server/` confirmed these were the only four remaining `catch(... : any)` sites in non-test files.

## Test plan
- [x] `bunx tsc --noEmit` (server) passes
- [x] `bunx tsc --noEmit -p e2e/tsconfig.json` passes
- [x] `cd frontend && bunx tsc -b --noEmit` passes
- [x] `cd frontend && bun run lint` passes (zero errors / warnings)
- [x] `bun test server/` — 1243 pass, 0 fail
- [x] Local tests for `sync.test.ts`, `browse.test.ts`, `notifiers.test.ts`, `webpush.test.ts` all pass
- Note: 4 frontend `HomeRoute.test.tsx` failures appear in the full `bun test` run only when other test files are loaded first (mock.module leakage); they pass in isolation and reproduce identically on master without these changes — pre-existing flakiness, unrelated to this PR.

Co-Authored-By: Claude Opus 4.7 (1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)