### PR TITLE
Fix Reels progress bar not updating after marking episode watched

### DIFF
--- a/frontend/src/pages/ReelsPage.test.tsx
+++ b/frontend/src/pages/ReelsPage.test.tsx
@@ -216,6 +216,83 @@ describe("ReelsPage swipe to open season panel", () => {
   });
 });
 
+describe("ReelsPage progress bar updates after marking watched", () => {
+  const baseEpisode = {
+    ...sampleEpisode,
+    title_id: "show-progress",
+    show_title: "Progress Show",
+    total_episodes: 10,
+    watched_episodes_count: 5,
+  };
+  const ep1 = { ...baseEpisode, id: 501, season_number: 1, episode_number: 1 };
+  const ep2 = { ...baseEpisode, id: 502, season_number: 1, episode_number: 2 };
+
+  it("advances progress bar when episode is marked watched", async () => {
+    mockGetUpcomingEpisodes.mockImplementation(() =>
+      Promise.resolve({ today: [], upcoming: [], unwatched: [ep1, ep2] })
+    );
+    mockWatchEpisode.mockImplementation(() => Promise.resolve());
+
+    render(<ReelsPage />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByText("Progress Show")).toBeDefined());
+    expect(screen.getByText("50% CAUGHT UP")).toBeDefined();
+    expect(screen.getByText("5 OF 10")).toBeDefined();
+
+    await act(async () => {
+      screen.getByText("Mark as Watched").click();
+    });
+
+    await waitFor(() => expect(screen.getByText("60% CAUGHT UP")).toBeDefined());
+    expect(screen.getByText("6 OF 10")).toBeDefined();
+  });
+
+  it("rewinds progress bar when undo is clicked", async () => {
+    mockGetUpcomingEpisodes.mockImplementation(() =>
+      Promise.resolve({ today: [], upcoming: [], unwatched: [ep1, ep2] })
+    );
+    mockWatchEpisode.mockImplementation(() => Promise.resolve());
+    mockUnwatchEpisode.mockImplementation(() => Promise.resolve());
+
+    render(<ReelsPage />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByText("Progress Show")).toBeDefined());
+
+    await act(async () => {
+      screen.getByText("Mark as Watched").click();
+    });
+    await waitFor(() => expect(screen.getByText("60% CAUGHT UP")).toBeDefined());
+
+    await act(async () => {
+      screen.getByLabelText("Undo").click();
+    });
+
+    await waitFor(() => expect(screen.getByText("50% CAUGHT UP")).toBeDefined());
+    expect(screen.getByText("5 OF 10")).toBeDefined();
+  });
+
+  it("rewinds progress bar when watchEpisode API fails", async () => {
+    mockGetUpcomingEpisodes.mockImplementation(() =>
+      Promise.resolve({ today: [], upcoming: [], unwatched: [ep1, ep2] })
+    );
+    mockWatchEpisode.mockImplementation(() =>
+      Promise.reject(new Error("Network error"))
+    );
+
+    render(<ReelsPage />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByText("Progress Show")).toBeDefined());
+
+    await act(async () => {
+      screen.getByText("Mark as Watched").click();
+    });
+
+    await waitFor(() => expect(screen.getByText("Network error")).toBeDefined());
+    expect(screen.getByText("50% CAUGHT UP")).toBeDefined();
+    expect(screen.getByText("5 OF 10")).toBeDefined();
+  });
+});
+
 describe("getFirstUnwatchedPerShow", () => {
   it("groups episodes by show and returns first unwatched per show", () => {
     const episodes = [

--- a/frontend/src/pages/ReelsPage.tsx
+++ b/frontend/src/pages/ReelsPage.tsx
@@ -23,6 +23,15 @@ interface UndoAction {
   wasCaughtUp: boolean;
 }
 
+function adjustWatchedCount(episodes: Episode[], delta: number): Episode[] {
+  return episodes.map((ep) => {
+    if (ep.watched_episodes_count == null) return ep;
+    const max = ep.total_episodes ?? Number.POSITIVE_INFINITY;
+    const next = Math.max(0, Math.min(max, ep.watched_episodes_count + delta));
+    return { ...ep, watched_episodes_count: next };
+  });
+}
+
 export function getFirstUnwatchedPerShow(episodes: Episode[]): ShowCard[] {
   const grouped = new Map<string, Episode[]>();
   for (const ep of episodes) {
@@ -213,11 +222,12 @@ export default function ReelsPage() {
         const ep = c.episodes[c.currentIndex];
         if (!ep) return c;
 
+        const bumpedEpisodes = adjustWatchedCount(c.episodes, 1);
         const nextIndex = c.currentIndex + 1;
         if (nextIndex >= c.episodes.length) {
-          return { ...c, caughtUp: true };
+          return { ...c, episodes: bumpedEpisodes, caughtUp: true };
         }
-        return { ...c, currentIndex: nextIndex };
+        return { ...c, episodes: bumpedEpisodes, currentIndex: nextIndex };
       });
     });
 
@@ -234,10 +244,11 @@ export default function ReelsPage() {
       setCards((prev) =>
         prev.map((c) => {
           if (c.titleId !== titleId) return c;
+          const restoredEpisodes = adjustWatchedCount(c.episodes, -1);
           if (c.caughtUp) {
-            return { ...c, caughtUp: false, currentIndex: c.episodes.length - 1 };
+            return { ...c, episodes: restoredEpisodes, caughtUp: false, currentIndex: c.episodes.length - 1 };
           }
-          return { ...c, currentIndex: Math.max(0, c.currentIndex - 1) };
+          return { ...c, episodes: restoredEpisodes, currentIndex: Math.max(0, c.currentIndex - 1) };
         })
       );
       setUndoAction(null);
@@ -274,6 +285,7 @@ export default function ReelsPage() {
         if (c.titleId !== undoAction.titleId) return c;
         return {
           ...c,
+          episodes: adjustWatchedCount(c.episodes, -1),
           currentIndex: undoAction.previousIndex,
           caughtUp: false,
         };


### PR DESCRIPTION
Each unwatched episode returned by getUpcomingEpisodes carries its own
snapshot of the show's watched_episodes_count. After advancing
currentIndex, the next episode object still held the original count, so
the progress bar appeared frozen.

Optimistically adjust watched_episodes_count on every episode in the
affected card whenever markWatched advances, the API call fails, or
Undo rewinds.

https://claude.ai/code/session_019Ha8KUno5VfwVuDvLwJJbX