### PR TITLE
Extract shared notification content builder

### DIFF
--- a/server/notifications/discord.ts
+++ b/server/notifications/discord.ts
@@ -1,5 +1,6 @@
 import { CONFIG } from "../config";
 import { traceHttp } from "../tracing";
+import { formatProviderNames, groupEpisodesByShow } from "./format";
 import type { NotificationContent, NotificationProvider } from "./types";
 
 const DISCORD_WEBHOOK_PATTERN =
@@ -80,15 +81,7 @@ export class DiscordProvider implements NotificationProvider {
     }
 
     // Episode embeds (grouped by show)
-    const showMap = new Map<
-      string,
-      typeof episodes
-    >();
-    for (const ep of episodes) {
-      const existing = showMap.get(ep.showTitle) || [];
-      existing.push(ep);
-      showMap.set(ep.showTitle, existing);
-    }
+    const showMap = groupEpisodesByShow(episodes);
 
     for (const [showTitle, eps] of showMap) {
       const episodeLines = eps.map((ep) => {
@@ -98,7 +91,7 @@ export class DiscordProvider implements NotificationProvider {
           : `**${code}**`;
       });
 
-      const providers = this.formatProviders(eps[0].offers);
+      const providers = formatProviderNames(eps[0].offers);
 
       const embed: any = {
         title: showTitle,
@@ -121,7 +114,7 @@ export class DiscordProvider implements NotificationProvider {
 
     // Movie embeds
     for (const movie of movies) {
-      const providers = this.formatProviders(movie.offers);
+      const providers = formatProviderNames(movie.offers);
       const embed: any = {
         title: movie.title,
         description: movie.releaseYear
@@ -160,12 +153,5 @@ export class DiscordProvider implements NotificationProvider {
 
     // Discord has a limit of 10 embeds per message
     return embeds.slice(0, 10);
-  }
-
-  private formatProviders(
-    offers: Array<{ providerName: string; providerIconUrl: string | null }>
-  ): string {
-    const unique = [...new Set(offers.map((o) => o.providerName))];
-    return unique.join(", ");
   }
 }

--- a/server/notifications/format.test.ts
+++ b/server/notifications/format.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "bun:test";
+import { formatProviderNames, groupEpisodesByShow } from "./format";
+import type { NotificationEpisode } from "./types";
+
+function makeEpisode(
+  showTitle: string,
+  seasonNumber: number,
+  episodeNumber: number,
+  offers: Array<{ providerName: string; providerIconUrl: string | null }> = []
+): NotificationEpisode {
+  return {
+    showTitle,
+    seasonNumber,
+    episodeNumber,
+    episodeName: null,
+    posterUrl: null,
+    offers,
+  };
+}
+
+describe("groupEpisodesByShow", () => {
+  it("returns an empty map when given no episodes", () => {
+    const result = groupEpisodesByShow([]);
+    expect(result.size).toBe(0);
+  });
+
+  it("groups episodes from the same show together", () => {
+    const episodes = [
+      makeEpisode("Show A", 1, 1),
+      makeEpisode("Show A", 1, 2),
+      makeEpisode("Show A", 2, 1),
+    ];
+    const result = groupEpisodesByShow(episodes);
+    expect(result.size).toBe(1);
+    expect(result.get("Show A")?.length).toBe(3);
+  });
+
+  it("preserves insertion order across distinct shows", () => {
+    const episodes = [
+      makeEpisode("Beta", 1, 1),
+      makeEpisode("Alpha", 1, 1),
+      makeEpisode("Beta", 1, 2),
+      makeEpisode("Gamma", 1, 1),
+    ];
+    const result = groupEpisodesByShow(episodes);
+    expect([...result.keys()]).toEqual(["Beta", "Alpha", "Gamma"]);
+    expect(result.get("Beta")?.map((ep) => ep.episodeNumber)).toEqual([1, 2]);
+  });
+
+  it("preserves the original episode references", () => {
+    const ep = makeEpisode("Show", 3, 4, [
+      { providerName: "Netflix", providerIconUrl: null },
+    ]);
+    const result = groupEpisodesByShow([ep]);
+    expect(result.get("Show")?.[0]).toBe(ep);
+  });
+});
+
+describe("formatProviderNames", () => {
+  it("returns an empty string for an empty list", () => {
+    expect(formatProviderNames([])).toBe("");
+  });
+
+  it("joins unique provider names with a comma and space", () => {
+    expect(
+      formatProviderNames([
+        { providerName: "Netflix", providerIconUrl: null },
+        { providerName: "Hulu", providerIconUrl: null },
+      ])
+    ).toBe("Netflix, Hulu");
+  });
+
+  it("deduplicates repeated provider names while preserving first occurrence order", () => {
+    expect(
+      formatProviderNames([
+        { providerName: "Netflix", providerIconUrl: null },
+        { providerName: "Hulu", providerIconUrl: null },
+        { providerName: "Netflix", providerIconUrl: "/icon.png" },
+        { providerName: "Disney+", providerIconUrl: null },
+        { providerName: "Hulu", providerIconUrl: null },
+      ])
+    ).toBe("Netflix, Hulu, Disney+");
+  });
+
+  it("returns a single name when only one provider is present", () => {
+    expect(
+      formatProviderNames([{ providerName: "Apple TV+", providerIconUrl: null }])
+    ).toBe("Apple TV+");
+  });
+});

--- a/server/notifications/format.ts
+++ b/server/notifications/format.ts
@@ -1,0 +1,30 @@
+import type { NotificationEpisode } from "./types";
+
+/**
+ * Groups episodes by their show title, preserving insertion order.
+ * Used by every notification provider to render one entry per show
+ * (e.g. "Show Title — S01E01, S01E02") instead of duplicating the show name
+ * for each episode.
+ */
+export function groupEpisodesByShow(
+  episodes: NotificationEpisode[]
+): Map<string, NotificationEpisode[]> {
+  const showMap = new Map<string, NotificationEpisode[]>();
+  for (const ep of episodes) {
+    const existing = showMap.get(ep.showTitle) ?? [];
+    existing.push(ep);
+    showMap.set(ep.showTitle, existing);
+  }
+  return showMap;
+}
+
+/**
+ * Deduplicates and joins provider names from an offers list. Returns an
+ * empty string when there are no offers, which lets callers concatenate
+ * without producing trailing separators.
+ */
+export function formatProviderNames(
+  offers: ReadonlyArray<{ providerName: string; providerIconUrl: string | null }>
+): string {
+  return [...new Set(offers.map((o) => o.providerName))].join(", ");
+}

--- a/server/notifications/gotify.ts
+++ b/server/notifications/gotify.ts
@@ -1,4 +1,5 @@
 import { traceHttp } from "../tracing";
+import { formatProviderNames, groupEpisodesByShow } from "./format";
 import type { NotificationContent, NotificationProvider } from "./types";
 
 export class GotifyProvider implements NotificationProvider {
@@ -58,23 +59,18 @@ export class GotifyProvider implements NotificationProvider {
     const { streamingAlerts = [] } = content;
     const lines: string[] = [];
 
-    const showMap = new Map<string, typeof content.episodes>();
-    for (const ep of content.episodes) {
-      const existing = showMap.get(ep.showTitle) ?? [];
-      existing.push(ep);
-      showMap.set(ep.showTitle, existing);
-    }
+    const showMap = groupEpisodesByShow(content.episodes);
 
     for (const [showTitle, eps] of showMap) {
       const codes = eps.map(
         (ep) => `S${String(ep.seasonNumber).padStart(2, "0")}E${String(ep.episodeNumber).padStart(2, "0")}`
       );
-      const providers = [...new Set(eps[0].offers.map((o) => o.providerName))].join(", ");
+      const providers = formatProviderNames(eps[0].offers);
       lines.push(`${showTitle} ${codes.join(", ")}${providers ? ` (${providers})` : ""}`);
     }
 
     for (const movie of content.movies) {
-      const providers = [...new Set(movie.offers.map((o) => o.providerName))].join(", ");
+      const providers = formatProviderNames(movie.offers);
       const label = movie.releaseYear ? `${movie.title} (${movie.releaseYear})` : movie.title;
       lines.push(`${label}${providers ? ` (${providers})` : ""}`);
     }

--- a/server/notifications/ntfy.ts
+++ b/server/notifications/ntfy.ts
@@ -1,4 +1,5 @@
 import { traceHttp } from "../tracing";
+import { formatProviderNames, groupEpisodesByShow } from "./format";
 import type { NotificationContent, NotificationProvider } from "./types";
 
 export class NtfyProvider implements NotificationProvider {
@@ -68,23 +69,18 @@ export class NtfyProvider implements NotificationProvider {
     const { streamingAlerts = [] } = content;
     const lines: string[] = [];
 
-    const showMap = new Map<string, typeof content.episodes>();
-    for (const ep of content.episodes) {
-      const existing = showMap.get(ep.showTitle) ?? [];
-      existing.push(ep);
-      showMap.set(ep.showTitle, existing);
-    }
+    const showMap = groupEpisodesByShow(content.episodes);
 
     for (const [showTitle, eps] of showMap) {
       const codes = eps.map(
         (ep) => `S${String(ep.seasonNumber).padStart(2, "0")}E${String(ep.episodeNumber).padStart(2, "0")}`
       );
-      const providers = [...new Set(eps[0].offers.map((o) => o.providerName))].join(", ");
+      const providers = formatProviderNames(eps[0].offers);
       lines.push(`${showTitle} ${codes.join(", ")}${providers ? ` · ${providers}` : ""}`);
     }
 
     for (const movie of content.movies) {
-      const providers = [...new Set(movie.offers.map((o) => o.providerName))].join(", ");
+      const providers = formatProviderNames(movie.offers);
       const label = movie.releaseYear ? `${movie.title} (${movie.releaseYear})` : movie.title;
       lines.push(`${label}${providers ? ` · ${providers}` : ""}`);
     }

--- a/server/notifications/telegram.ts
+++ b/server/notifications/telegram.ts
@@ -1,4 +1,5 @@
 import { traceHttp } from "../tracing";
+import { formatProviderNames, groupEpisodesByShow } from "./format";
 import type { NotificationContent, NotificationProvider } from "./types";
 
 const TELEGRAM_API = "https://api.telegram.org";
@@ -57,24 +58,19 @@ export class TelegramProvider implements NotificationProvider {
 
     const lines: string[] = [`<b>📺 Remindarr — ${parts.join(" and ")} today (${date})</b>`, ""];
 
-    const showMap = new Map<string, typeof episodes>();
-    for (const ep of episodes) {
-      const existing = showMap.get(ep.showTitle) ?? [];
-      existing.push(ep);
-      showMap.set(ep.showTitle, existing);
-    }
+    const showMap = groupEpisodesByShow(episodes);
 
     for (const [showTitle, eps] of showMap) {
       const codes = eps.map(
         (ep) => `S${String(ep.seasonNumber).padStart(2, "0")}E${String(ep.episodeNumber).padStart(2, "0")}`
       );
-      const providers = [...new Set(eps[0].offers.map((o) => o.providerName))].join(", ");
+      const providers = formatProviderNames(eps[0].offers);
       const providerStr = providers ? ` <i>(${providers})</i>` : "";
       lines.push(`🎬 <b>${escapeHtml(showTitle)}</b> — ${codes.join(", ")}${providerStr}`);
     }
 
     for (const movie of movies) {
-      const providers = [...new Set(movie.offers.map((o) => o.providerName))].join(", ");
+      const providers = formatProviderNames(movie.offers);
       const providerStr = providers ? ` <i>(${providers})</i>` : "";
       const label = movie.releaseYear ? `${movie.title} (${movie.releaseYear})` : movie.title;
       lines.push(`🎥 <b>${escapeHtml(label)}</b>${providerStr}`);

--- a/server/notifications/webhook.ts
+++ b/server/notifications/webhook.ts
@@ -1,4 +1,5 @@
 import { traceHttp } from "../tracing";
+import { groupEpisodesByShow } from "./format";
 import type { NotificationContent, NotificationProvider } from "./types";
 
 export class WebhookProvider implements NotificationProvider {
@@ -53,12 +54,7 @@ export class WebhookProvider implements NotificationProvider {
     const { episodes, movies, date, streamingAlerts = [] } = content;
 
     const summaryLines: string[] = [];
-    const showMap = new Map<string, typeof episodes>();
-    for (const ep of episodes) {
-      const existing = showMap.get(ep.showTitle) ?? [];
-      existing.push(ep);
-      showMap.set(ep.showTitle, existing);
-    }
+    const showMap = groupEpisodesByShow(episodes);
     for (const [showTitle, eps] of showMap) {
       const codes = eps.map(
         (ep) => `S${String(ep.seasonNumber).padStart(2, "0")}E${String(ep.episodeNumber).padStart(2, "0")}`

--- a/server/notifications/webpush.ts
+++ b/server/notifications/webpush.ts
@@ -1,5 +1,6 @@
 import webpush from "web-push";
 import { logger } from "../logger";
+import { groupEpisodesByShow } from "./format";
 import { getVapidKeys } from "./vapid";
 import type { NotificationContent, NotificationProvider } from "./types";
 
@@ -76,12 +77,7 @@ export class WebPushProvider implements NotificationProvider {
 
     const lines: string[] = [];
     // Group episodes by show
-    const showMap = new Map<string, typeof episodes>();
-    for (const ep of episodes) {
-      const existing = showMap.get(ep.showTitle) || [];
-      existing.push(ep);
-      showMap.set(ep.showTitle, existing);
-    }
+    const showMap = groupEpisodesByShow(episodes);
 
     for (const [showTitle, eps] of showMap) {
       const codes = eps.map(


### PR DESCRIPTION
## Summary
- New `server/notifications/format.ts` exposing `groupEpisodesByShow(episodes)` and `formatProviderNames(offers)`. Placed in a separate file rather than `content.ts` because `content.ts` is concerned with building notification content from the database, while these helpers are about formatting that content for delivery.
- All six notification providers (Discord, Telegram, Gotify, Ntfy, Webhook, Web Push) now consume the shared helpers instead of re-implementing the show-grouping `Map` and the `[...new Set(...)].join(", ")` provider dedup.
- New `server/notifications/format.test.ts` unit-tests both helpers (empty input, dedup, insertion order preservation, reference identity).
- No behavior change in produced messages — the helpers are byte-equivalent replacements for the inlined patterns.

Closes #479

## Test plan
- [x] `bun test server/notifications/` passes (94/94)
- [x] `bun run check` introduces no new failures (the 4 pre-existing `HomeRoute` failures reproduce on master without these changes)
- [ ] Manually fire a Discord/Telegram/Gotify/Ntfy/Webhook/Web Push test notification and confirm the rendered output is identical to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)