### PR TITLE
feat: read-only kiosk mode (token-gated dashboard)

### DIFF
--- a/drizzle/0031_users_kiosk_token.sql
+++ b/drizzle/0031_users_kiosk_token.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users ADD COLUMN kiosk_token text;
+CREATE UNIQUE INDEX IF NOT EXISTS users_kiosk_token_idx ON users(kiosk_token);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1777680000000,
       "tag": "0030_users_bio",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "6",
+      "when": 1777766400000,
+      "tag": "0031_users_kiosk_token",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -56,6 +56,7 @@ const InvitePage = lazyWithRetry(() => import("./pages/InvitePage"));
 const AdminUsersPage = lazyWithRetry(() => import("./pages/AdminUsersPage"));
 const NotFoundPage = lazyWithRetry(() => import("./pages/NotFoundPage"));
 const MorePage = lazyWithRetry(() => import("./pages/MorePage"));
+const KioskPage = lazyWithRetry(() => import("./pages/KioskPage"));
 
 // Wraps a route element in an inline ErrorBoundary so a single page crash
 // shows a contained fallback instead of taking down the whole shell.
@@ -78,6 +79,7 @@ export default function App() {
   const navigate = useNavigate();
   const { t } = useTranslation();
   const isReelsPage = location.pathname === "/reels";
+  const isKioskPage = location.pathname.startsWith("/kiosk/");
   usePushSubscriptionSync();
 
   const { theme } = useTheme();
@@ -87,7 +89,7 @@ export default function App() {
 
   return (
     <div
-      className={`bg-zinc-950 text-zinc-100 ${isReelsPage ? "h-[100dvh] overflow-hidden" : "min-h-screen"}`}
+      className={`bg-zinc-950 text-zinc-100 ${isReelsPage || isKioskPage ? "h-[100dvh] overflow-hidden" : "min-h-screen"}`}
       style={{ background: "var(--bg-app)", color: "var(--text-app)" }}
     >
       {/* Skip to main content link */}
@@ -97,8 +99,8 @@ export default function App() {
       >
         {t("nav.skipToMain")}
       </a>
-      {/* Hide top nav on reels page for mobile */}
-      <nav aria-label="Main navigation" className={`bg-zinc-950/80 backdrop-blur-xl border-b border-white/[0.06] sticky top-0 z-50 safe-top ${isReelsPage ? "hidden sm:block" : ""}`}>
+      {/* Hide top nav on reels page (mobile) and kiosk page (all sizes) */}
+      <nav aria-label="Main navigation" className={`bg-zinc-950/80 backdrop-blur-xl border-b border-white/[0.06] sticky top-0 z-50 safe-top ${isKioskPage ? "hidden" : isReelsPage ? "hidden sm:block" : ""}`}>
         <div className="max-w-[1440px] mx-auto px-4 flex items-center gap-8 h-14">
           {/* Logo */}
           <Link to="/" className="flex items-center gap-2 shrink-0 hover:opacity-90 transition-opacity">
@@ -196,9 +198,9 @@ export default function App() {
         </div>
       </nav>
       <ScrollToTop />
-      <InstallPrompt />
-      <main id="main-content" className={isReelsPage ? "" : "max-w-[1440px] mx-auto px-4 py-6 pb-20 sm:pb-6"}>
-        {user && <NotificationPrompt />}
+      {!isKioskPage && <InstallPrompt />}
+      <main id="main-content" className={isReelsPage || isKioskPage ? "" : "max-w-[1440px] mx-auto px-4 py-6 pb-20 sm:pb-6"}>
+        {user && !isKioskPage && <NotificationPrompt />}
         <Suspense fallback={<div className="text-center py-12 text-zinc-500">Loading...</div>}>
           <Routes>
             <Route path="/" element={<HomeRoute />} />
@@ -221,11 +223,12 @@ export default function App() {
             <Route path="/title/:id/season/:season" element={<Page><SeasonDetailPage /></Page>} />
             <Route path="/title/:id/season/:season/episode/:episode" element={<Page><EpisodeDetailPage /></Page>} />
             <Route path="/person/:personId" element={<Page><PersonPage /></Page>} />
+            <Route path="/kiosk/:token" element={<Page><KioskPage /></Page>} />
             <Route path="*" element={<Page><NotFoundPage /></Page>} />
           </Routes>
         </Suspense>
       </main>
-      <footer className={`border-t border-white/[0.06] py-6 mt-8 ${isReelsPage ? "hidden" : "hidden sm:block"}`}>
+      <footer className={`border-t border-white/[0.06] py-6 mt-8 ${isReelsPage || isKioskPage ? "hidden" : "hidden sm:block"}`}>
         <div className="max-w-[1440px] mx-auto px-4 flex items-center justify-between text-sm text-zinc-500">
           <span>&copy; {new Date().getFullYear()} Remindarr</span>
           <a
@@ -239,7 +242,7 @@ export default function App() {
           </a>
         </div>
       </footer>
-      <BottomTabBar />
+      {!isKioskPage && <BottomTabBar />}
       <OfflineIndicator />
       <Toaster theme={theme === "light" ? "light" : "dark"} position="bottom-center" richColors />
       <KeyboardShortcutsModal open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -779,6 +779,38 @@ export async function regenerateFeedToken(): Promise<{ token: string }> {
   return fetchJson("/feed/token/regenerate", { method: "POST" });
 }
 
+// ─── Kiosk ────────────────────────────────────────────────────────────────────
+
+export interface WatchingTitle extends Title {
+  watched_episodes_count?: number;
+  released_episodes_count?: number;
+  total_episodes?: number;
+  next_episode_air_date?: string | null;
+}
+
+export interface KioskData {
+  tonight: Episode[];
+  week: Episode[];
+  recent: Title[];
+  watching: WatchingTitle[];
+}
+
+export async function getKioskData(token: string): Promise<KioskData> {
+  return fetchJson(`/kiosk/${encodeURIComponent(token)}`);
+}
+
+export async function getKioskToken(): Promise<{ token: string | null }> {
+  return fetchJson("/kiosk/token");
+}
+
+export async function regenerateKioskToken(): Promise<{ token: string }> {
+  return fetchJson("/kiosk/token/regenerate", { method: "POST" });
+}
+
+export async function revokeKioskToken(): Promise<void> {
+  await doFetch("/kiosk/token", { method: "DELETE" });
+}
+
 // ─── Title Notes & Tags ───────────────────────────────────────────────────────
 
 export async function updateTrackedNotes(titleId: string, notes: string | null): Promise<void> {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -471,6 +471,19 @@
     "copied": "Copied!",
     "warning": "Keep this URL private — anyone with it can see your upcoming releases."
   },
+  "kiosk": {
+    "title": "Kiosk Display",
+    "description": "A read-only dashboard for a TV or shared screen. Anyone with the URL can view tonight's airings, this week's calendar, and what you're watching — no login required.",
+    "generate": "Generate Kiosk URL",
+    "generating": "Generating...",
+    "regenerate": "Regenerate",
+    "regenerating": "Regenerating...",
+    "revoke": "Revoke",
+    "revoking": "Revoking...",
+    "copyUrl": "Copy URL",
+    "copied": "Copied!",
+    "warning": "Anyone with this URL can view your kiosk dashboard. Keep it private."
+  },
   "tags": {
     "placeholder": "Add tag...",
     "tooMany": "Max 10 tags",

--- a/frontend/src/pages/KioskPage.test.tsx
+++ b/frontend/src/pages/KioskPage.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, mock, afterEach } from "bun:test";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+
+import "../i18n";
+
+const mockGetKioskData = mock(() =>
+  Promise.resolve({
+    tonight: [],
+    week: [],
+    recent: [],
+    watching: [],
+  })
+);
+
+mock.module("../api", () => ({
+  getKioskData: mockGetKioskData,
+}));
+
+const { default: KioskPage } = await import("./KioskPage");
+
+function Wrapper({ token = "abc123" }: { token?: string }) {
+  return (
+    <MemoryRouter initialEntries={[`/kiosk/${token}`]}>
+      <Routes>
+        <Route path="/kiosk/:token" element={<KioskPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  mockGetKioskData.mockReset();
+  mockGetKioskData.mockImplementation(() =>
+    Promise.resolve({ tonight: [], week: [], recent: [], watching: [] })
+  );
+});
+
+function makeEpisode(id: number, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    title_id: "show-1",
+    season_number: 1,
+    episode_number: id,
+    name: `Episode ${id}`,
+    overview: null,
+    air_date: "2099-01-01",
+    still_path: null,
+    show_title: "Test Show",
+    poster_url: null,
+    is_watched: false,
+    offers: [],
+    ...overrides,
+  };
+}
+
+describe("KioskPage", () => {
+  it("renders section headings", async () => {
+    render(<Wrapper />);
+    await waitFor(() => {
+      expect(screen.getByText("Tonight")).toBeTruthy();
+      expect(screen.getByText("This Week")).toBeTruthy();
+      expect(screen.getByText("Latest Releases")).toBeTruthy();
+      expect(screen.getByText("Currently Watching")).toBeTruthy();
+    });
+  });
+
+  it("renders the Remindarr branding header", async () => {
+    render(<Wrapper />);
+    await waitFor(() => {
+      expect(screen.getByText("Remindarr")).toBeTruthy();
+    });
+  });
+
+  it("shows empty state for tonight when no episodes", async () => {
+    render(<Wrapper />);
+    await waitFor(() => {
+      expect(screen.getByText("Nothing airing tonight.")).toBeTruthy();
+    });
+  });
+
+  it("shows empty state for currently watching when none", async () => {
+    render(<Wrapper />);
+    await waitFor(() => {
+      expect(screen.getByText("Nothing in progress.")).toBeTruthy();
+    });
+  });
+
+  it("renders tonight episodes when present", async () => {
+    mockGetKioskData.mockImplementation(() =>
+      Promise.resolve({
+        tonight: [makeEpisode(1)],
+        week: [],
+        recent: [],
+        watching: [],
+      })
+    );
+    render(<Wrapper />);
+    await waitFor(() => {
+      expect(screen.getByText("Test Show")).toBeTruthy();
+    });
+  });
+
+  it("renders recent titles when present", async () => {
+    mockGetKioskData.mockImplementation(() =>
+      Promise.resolve({
+        tonight: [],
+        week: [],
+        recent: [{ id: "m1", title: "New Movie", release_year: 2024, poster_url: null, object_type: "MOVIE", original_title: null, release_date: "2024-01-01", runtime_minutes: null, short_description: null, imdb_id: null, tmdb_id: null, tmdb_url: null, imdb_score: null, imdb_votes: null, tmdb_score: null, is_tracked: false, is_watched: false, genres: [], offers: [], age_certification: null, original_language: null, updated_at: null }],
+        watching: [],
+      })
+    );
+    render(<Wrapper />);
+    await waitFor(() => {
+      expect(screen.getAllByText("New Movie").length).toBeGreaterThan(0);
+    });
+  });
+
+  it("shows error state for invalid token (rejected promise)", async () => {
+    mockGetKioskData.mockImplementation(() =>
+      Promise.reject(new Error("Invalid kiosk token"))
+    );
+    render(<Wrapper token="bad-token" />);
+    await waitFor(() => {
+      expect(screen.getByText("Kiosk unavailable")).toBeTruthy();
+      expect(screen.getByText(/no longer valid/i)).toBeTruthy();
+    });
+  });
+
+  it("calls getKioskData with the token from the URL", async () => {
+    render(<Wrapper token="mytoken123" />);
+    await waitFor(() => {
+      expect(mockGetKioskData).toHaveBeenCalledWith("mytoken123");
+    });
+  });
+});

--- a/frontend/src/pages/KioskPage.tsx
+++ b/frontend/src/pages/KioskPage.tsx
@@ -1,0 +1,241 @@
+import { useEffect, useState, useCallback } from "react";
+import { useParams } from "react-router";
+import * as api from "../api";
+import type { KioskData, WatchingTitle } from "../api";
+import type { Episode, Title } from "../types";
+import { useApiCall } from "../hooks/useApiCall";
+import { EpisodeShowCard, DeckCardWrapper } from "../components/EpisodeShowCard";
+import { groupByShow, formatUpcomingDate, formatEpisodeCode } from "../components/EpisodeComponents";
+
+const REFRESH_INTERVAL_MS = 15 * 60 * 1000;
+
+function useLiveClock() {
+  const [now, setNow] = useState(() => new Date());
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(id);
+  }, []);
+  return now;
+}
+
+function formatDate(d: Date): string {
+  return d.toLocaleDateString(undefined, { weekday: "long", year: "numeric", month: "long", day: "numeric" });
+}
+
+function formatTime(d: Date): string {
+  return d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+}
+
+function groupByDate(episodes: Episode[]): Map<string, Episode[]> {
+  const map = new Map<string, Episode[]>();
+  for (const ep of episodes) {
+    const key = ep.air_date ?? "unknown";
+    if (!map.has(key)) map.set(key, []);
+    map.get(key)!.push(ep);
+  }
+  return map;
+}
+
+function PosterCard({ title }: { title: Title }) {
+  const posterUrl = title.poster_url
+    ? `https://image.tmdb.org/t/p/w342${title.poster_url.startsWith("/") ? title.poster_url : `/${title.poster_url}`}`
+    : null;
+  const raw = title.poster_url ?? "";
+  const finalUrl = raw.startsWith("http") ? raw : posterUrl;
+
+  return (
+    <div className="flex-none w-28 sm:w-36">
+      <div className="rounded-lg overflow-hidden bg-zinc-800 aspect-[2/3]">
+        {finalUrl ? (
+          <img src={finalUrl} alt={title.title} className="w-full h-full object-cover" loading="lazy" />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-zinc-600 text-xs text-center px-2">{title.title}</div>
+        )}
+      </div>
+      <p className="text-xs text-zinc-300 mt-1.5 line-clamp-2 leading-tight">{title.title}</p>
+      {title.release_year && <p className="text-[11px] text-zinc-500">{title.release_year}</p>}
+    </div>
+  );
+}
+
+function WatchingCard({ title }: { title: WatchingTitle }) {
+  const posterUrl = title.poster_url
+    ? `https://image.tmdb.org/t/p/w185${title.poster_url.startsWith("/") ? title.poster_url : `/${title.poster_url}`}`
+    : null;
+  const raw = title.poster_url ?? "";
+  const finalUrl = raw.startsWith("http") ? raw : posterUrl;
+  const watched = title.watched_episodes_count ?? 0;
+  const released = title.released_episodes_count ?? 0;
+  const pct = released > 0 ? Math.round((watched / released) * 100) : 0;
+
+  return (
+    <div className="flex items-start gap-3 bg-zinc-900 rounded-xl p-3">
+      <div className="flex-none w-14 rounded-lg overflow-hidden bg-zinc-800 aspect-[2/3]">
+        {finalUrl ? (
+          <img src={finalUrl} alt={title.title} className="w-full h-full object-cover" loading="lazy" />
+        ) : (
+          <div className="w-full h-full bg-zinc-800" />
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="font-semibold text-white text-sm truncate">{title.title}</p>
+        <p className="text-xs text-zinc-400 mt-0.5">{watched} / {released} eps watched</p>
+        <div className="mt-2 h-1.5 bg-zinc-700 rounded-full overflow-hidden">
+          <div className="h-full bg-amber-400 rounded-full transition-all" style={{ width: `${pct}%` }} />
+        </div>
+        {title.next_episode_air_date && (
+          <p className="text-[11px] text-zinc-500 mt-1.5">Next: {formatUpcomingDate(title.next_episode_air_date).replace("__TOMORROW__", "Tomorrow")}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TonightSection({ episodes }: { episodes: Episode[] }) {
+  const byShow = groupByShow(episodes);
+  if (byShow.size === 0) {
+    return <p className="text-zinc-500 text-sm">Nothing airing tonight.</p>;
+  }
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+      {Array.from(byShow.entries()).map(([titleId, eps]) => (
+        <DeckCardWrapper key={titleId} episodeCount={eps.length}>
+          <EpisodeShowCard episode={eps[0]} episodeCount={eps.length} showActions={false} />
+        </DeckCardWrapper>
+      ))}
+    </div>
+  );
+}
+
+function WeekSection({ episodes }: { episodes: Episode[] }) {
+  const byDate = groupByDate(episodes);
+  if (byDate.size === 0) {
+    return <p className="text-zinc-500 text-sm">No episodes this week.</p>;
+  }
+  return (
+    <div className="space-y-4">
+      {Array.from(byDate.entries()).map(([date, eps]) => {
+        const byShow = groupByShow(eps);
+        const label = formatUpcomingDate(date).replace("__TOMORROW__", "Tomorrow");
+        return (
+          <div key={date}>
+            <p className="text-xs font-semibold text-amber-400 uppercase tracking-wider mb-2">{label}</p>
+            <div className="flex flex-wrap gap-2">
+              {Array.from(byShow.entries()).map(([titleId, showEps]) => (
+                <div key={titleId} className="bg-zinc-900 rounded-lg px-3 py-2 text-sm">
+                  <span className="text-white font-medium">{showEps[0].show_title}</span>
+                  <span className="text-zinc-400 ml-2 text-xs">
+                    {showEps.map(ep => formatEpisodeCode(ep)).join(", ")}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function RecentSection({ titles }: { titles: Title[] }) {
+  if (titles.length === 0) {
+    return <p className="text-zinc-500 text-sm">No recent releases.</p>;
+  }
+  return (
+    <div className="flex gap-3 overflow-x-auto pb-2 scrollbar-hide">
+      {titles.map((t) => <PosterCard key={t.id} title={t} />)}
+    </div>
+  );
+}
+
+function WatchingSection({ titles }: { titles: WatchingTitle[] }) {
+  if (titles.length === 0) {
+    return <p className="text-zinc-500 text-sm">Nothing in progress.</p>;
+  }
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+      {titles.map((t) => <WatchingCard key={t.id} title={t} />)}
+    </div>
+  );
+}
+
+function SectionHeader({ title }: { title: string }) {
+  return (
+    <h2 className="text-lg font-bold text-white mb-3 flex items-center gap-2">
+      <span className="w-1 h-5 bg-amber-400 rounded-full inline-block" />
+      {title}
+    </h2>
+  );
+}
+
+export default function KioskPage() {
+  const { token } = useParams<{ token: string }>();
+  const now = useLiveClock();
+
+  const fetcher = useCallback(() => api.getKioskData(token!), [token]);
+  const { data, error, refetch } = useApiCall(fetcher, [token]);
+
+  useEffect(() => {
+    const id = setInterval(refetch, REFRESH_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [refetch]);
+
+  if (error) {
+    return (
+      <div className="h-[100dvh] bg-zinc-950 flex items-center justify-center">
+        <div className="text-center max-w-sm px-4">
+          <div className="w-12 h-12 rounded-full bg-red-500/20 flex items-center justify-center mx-auto mb-4">
+            <span className="text-red-400 text-2xl">!</span>
+          </div>
+          <h1 className="text-white text-xl font-bold mb-2">Kiosk unavailable</h1>
+          <p className="text-zinc-400 text-sm">This kiosk link is no longer valid. Ask the owner to share a new one.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const d: KioskData = data ?? { tonight: [], week: [], recent: [], watching: [] };
+
+  return (
+    <div className="h-[100dvh] bg-zinc-950 text-zinc-100 flex flex-col overflow-hidden">
+      {/* Header */}
+      <div className="flex-none px-5 py-3 border-b border-white/[0.06] flex items-center justify-between bg-zinc-900/50">
+        <div className="flex items-center gap-3">
+          <div className="w-7 h-7 rounded-md bg-amber-400 flex items-center justify-center font-extrabold text-sm text-black leading-none select-none">R</div>
+          <span className="text-base font-bold text-white tracking-tight hidden sm:inline">Remindarr</span>
+        </div>
+        <div className="text-right">
+          <p className="text-sm font-semibold text-white tabular-nums">{formatTime(now)}</p>
+          <p className="text-xs text-zinc-400">{formatDate(now)}</p>
+        </div>
+      </div>
+
+      {/* Scrollable content */}
+      <div className="flex-1 overflow-y-auto px-5 py-5 space-y-8">
+        {/* Tonight */}
+        <section>
+          <SectionHeader title="Tonight" />
+          <TonightSection episodes={d.tonight} />
+        </section>
+
+        {/* This week */}
+        <section>
+          <SectionHeader title="This Week" />
+          <WeekSection episodes={d.week} />
+        </section>
+
+        {/* Latest releases */}
+        <section>
+          <SectionHeader title="Latest Releases" />
+          <RecentSection titles={d.recent} />
+        </section>
+
+        {/* Currently watching */}
+        <section>
+          <SectionHeader title="Currently Watching" />
+          <WatchingSection titles={d.watching} />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -112,6 +112,9 @@ mock.module("../api", () => ({
   triggerPlexSync: mock(() => Promise.resolve({ success: true })),
   getFeedToken: mock(() => Promise.resolve({ token: "test-token" })),
   regenerateFeedToken: mock(() => Promise.resolve({ token: "new-token" })),
+  getKioskToken: mock(() => Promise.resolve({ token: null })),
+  regenerateKioskToken: mock(() => Promise.resolve({ token: "kiosk-token-123" })),
+  revokeKioskToken: mock(() => Promise.resolve()),
 }));
 
 // Import after mocks
@@ -246,5 +249,35 @@ describe("Settings tabs", () => {
 
     // Account-tab content should not be rendered
     expect(screen.queryByText("Profile Visibility")).toBeNull();
+  });
+});
+
+describe("KioskSection", () => {
+  it("renders the Kiosk Display section in the integrations tab", async () => {
+    render(<SettingsPage />, { wrapper: WrapperWithPath("/settings?tab=integrations") });
+    await waitFor(() => {
+      expect(screen.getByText("Kiosk Display")).toBeDefined();
+    });
+  });
+
+  it("shows generate button when no token exists", async () => {
+    render(<SettingsPage />, { wrapper: WrapperWithPath("/settings?tab=integrations") });
+    await waitFor(() => {
+      expect(screen.getByText("Generate Kiosk URL")).toBeDefined();
+    });
+  });
+
+  it("shows kiosk URL and action buttons when token exists", async () => {
+    const { getKioskToken } = await import("../api") as any;
+    getKioskToken.mockImplementation(() => Promise.resolve({ token: "existingtoken123" }));
+
+    render(<SettingsPage />, { wrapper: WrapperWithPath("/settings?tab=integrations") });
+    await waitFor(() => {
+      expect(screen.getByText("Copy URL")).toBeDefined();
+      expect(screen.getByText("Regenerate")).toBeDefined();
+      expect(screen.getByText("Revoke")).toBeDefined();
+    });
+
+    getKioskToken.mockImplementation(() => Promise.resolve({ token: null }));
   });
 });

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -151,6 +151,7 @@ function IntegrationsTab() {
     <>
       <PlexSection />
       <CalendarFeedSection />
+      <KioskSection />
       <WatchlistSection />
       <CsvImportSection />
     </>
@@ -1985,6 +1986,95 @@ function CalendarFeedSection() {
       ) : (
         <SButton onClick={handleRegenerate} disabled={regenerating}>
           {regenerating ? t("feed.generating") : t("feed.generate")}
+        </SButton>
+      )}
+    </SCard>
+  );
+}
+
+function KioskSection() {
+  const { t } = useTranslation();
+  const [token, setToken] = useState<string | null>(null);
+  const [loadingToken, setLoadingToken] = useState(true);
+  const [regenerating, setRegenerating] = useState(false);
+  const [revoking, setRevoking] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    api.getKioskToken()
+      .then(({ token: tok }) => { setToken(tok); setLoadingToken(false); })
+      .catch(() => setLoadingToken(false));
+  }, []);
+
+  const kioskUrl = token ? `${window.location.origin}/kiosk/${token}` : null;
+
+  async function handleRegenerate() {
+    setRegenerating(true);
+    try {
+      const { token: newToken } = await api.regenerateKioskToken();
+      setToken(newToken);
+    } finally {
+      setRegenerating(false);
+    }
+  }
+
+  async function handleRevoke() {
+    setRevoking(true);
+    try {
+      await api.revokeKioskToken();
+      setToken(null);
+    } finally {
+      setRevoking(false);
+    }
+  }
+
+  async function handleCopy() {
+    if (!kioskUrl) return;
+    await navigator.clipboard.writeText(kioskUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <SCard title={t("kiosk.title")} subtitle={t("kiosk.description")}>
+      {loadingToken ? (
+        <p className="text-sm text-zinc-500">{t("common.loading")}</p>
+      ) : token ? (
+        <div className="space-y-3">
+          <div className="flex flex-col sm:flex-row gap-2">
+            <SInput
+              value={kioskUrl!}
+              mono
+              readOnly
+              aria-label={t("kiosk.title")}
+            />
+            <div className="flex gap-2 shrink-0">
+              <SButton variant="ghost" small onClick={handleCopy}>
+                {copied ? t("kiosk.copied") : t("kiosk.copyUrl")}
+              </SButton>
+              <SButton
+                variant="ghost"
+                small
+                onClick={handleRegenerate}
+                disabled={regenerating}
+              >
+                {regenerating ? t("kiosk.regenerating") : t("kiosk.regenerate")}
+              </SButton>
+              <SButton
+                variant="ghost"
+                small
+                onClick={handleRevoke}
+                disabled={revoking}
+              >
+                {revoking ? t("kiosk.revoking") : t("kiosk.revoke")}
+              </SButton>
+            </div>
+          </div>
+          <SHint kind="info">{t("kiosk.warning")}</SHint>
+        </div>
+      ) : (
+        <SButton onClick={handleRegenerate} disabled={regenerating}>
+          {regenerating ? t("kiosk.generating") : t("kiosk.generate")}
         </SButton>
       )}
     </SCard>

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -133,6 +133,6 @@ describe("fixSkippedMigrations", () => {
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(31);
+    expect(migrations.cnt).toBe(32);
   });
 });

--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -99,6 +99,9 @@ export {
   getFeedToken,
   setFeedToken,
   getUserByFeedToken,
+  getKioskToken,
+  setKioskToken,
+  getUserByKioskToken,
 } from "./users";
 
 export {

--- a/server/db/repository/users.ts
+++ b/server/db/repository/users.ts
@@ -391,3 +391,28 @@ export async function getUserByFeedToken(token: string): Promise<{ id: string } 
     return row ?? null;
   });
 }
+
+// ─── Kiosk share token ────────────────────────────────────────────────────────
+
+export async function getKioskToken(userId: string): Promise<string | null> {
+  return traceDbQuery("getKioskToken", async () => {
+    const db = getDb();
+    const row = await db.select({ kioskToken: users.kioskToken }).from(users).where(eq(users.id, userId)).get();
+    return row?.kioskToken ?? null;
+  });
+}
+
+export async function setKioskToken(userId: string, token: string | null): Promise<void> {
+  return traceDbQuery("setKioskToken", async () => {
+    const db = getDb();
+    await db.update(users).set({ kioskToken: token }).where(eq(users.id, userId)).run();
+  });
+}
+
+export async function getUserByKioskToken(token: string): Promise<{ id: string } | null> {
+  return traceDbQuery("getUserByKioskToken", async () => {
+    const db = getDb();
+    const row = await db.select({ id: users.id }).from(users).where(eq(users.kioskToken, token)).get();
+    return row ?? null;
+  });
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -161,6 +161,7 @@ export const users = sqliteTable(
     profileVisibility: text("profile_visibility").notNull().default("private"),
     homepageLayout: text("homepage_layout"),
     feedToken: text("feed_token"),
+    kioskToken: text("kiosk_token"),
     bio: text("bio"),
   },
   (table) => [
@@ -169,6 +170,7 @@ export const users = sqliteTable(
       table.providerSubject
     ),
     uniqueIndex("users_feed_token_idx").on(table.feedToken),
+    uniqueIndex("users_kiosk_token_idx").on(table.kioskToken),
   ]
 );
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -34,6 +34,7 @@ import metricsRoutes from "./routes/metrics";
 import statsRoutes from "./routes/stats";
 import userSettingsRoutes from "./routes/user-settings";
 import feedRoutes from "./routes/feed";
+import kioskRoutes from "./routes/kiosk";
 import type { AppEnv } from "./types";
 import Sentry from "./sentry";
 import { logger, requestLogger } from "./logger";
@@ -266,6 +267,10 @@ app.route("/api/user/settings", userSettingsRoutes);
 // Calendar feed — /calendar.ics is public (token-authenticated); /token endpoints require session
 app.use("/api/feed/token*", requireAuth);
 app.route("/api/feed", feedRoutes);
+
+// Kiosk — /:token is public (token-authenticated); /token endpoints require session
+app.use("/api/kiosk/token*", requireAuth);
+app.route("/api/kiosk", kioskRoutes);
 
 // Admin routes
 app.use("/api/admin/*", requireAuth, requireAdmin);

--- a/server/routes/kiosk.test.ts
+++ b/server/routes/kiosk.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { createUser, createSession, getSessionWithUser } from "../db/repository";
+import { requireAuth } from "../middleware/auth";
+import kioskApp from "./kiosk";
+import type { AppEnv } from "../types";
+
+function createMockAuth() {
+  return {
+    api: {
+      getSession: async ({ headers }: { headers: Headers }) => {
+        const cookieHeader = headers.get("cookie") || "";
+        const match = cookieHeader.match(/better-auth\.session_token=([^;]+)/);
+        const token = match?.[1];
+        if (!token) return null;
+        const user = await getSessionWithUser(token);
+        if (!user) return null;
+        return {
+          session: { id: "session-id", userId: user.id },
+          user: {
+            id: user.id,
+            name: user.display_name,
+            username: user.username,
+            role: user.role || (user.is_admin ? "admin" : "user"),
+          },
+        };
+      },
+    },
+  };
+}
+
+let app: Hono<AppEnv>;
+let userToken: string;
+let userId: string;
+
+beforeEach(async () => {
+  setupTestDb();
+
+  userId = await createUser("kioskuser", "hash");
+  userToken = await createSession(userId);
+
+  app = new Hono<AppEnv>();
+  app.use("*", async (c, next) => {
+    c.set("auth", createMockAuth() as any);
+    await next();
+  });
+  app.use("/kiosk/token*", requireAuth);
+  app.route("/kiosk", kioskApp);
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+function authHeaders() {
+  return { Cookie: `better-auth.session_token=${userToken}` };
+}
+
+describe("GET /kiosk/:token (public dashboard)", () => {
+  it("returns 401 for unknown token", async () => {
+    const res = await app.request("/kiosk/not-a-real-token");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns dashboard data for valid token", async () => {
+    const regenRes = await app.request("/kiosk/token/regenerate", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    const { token } = await regenRes.json() as { token: string };
+
+    const res = await app.request(`/kiosk/${token}`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(Array.isArray(body.tonight)).toBe(true);
+    expect(Array.isArray(body.week)).toBe(true);
+    expect(Array.isArray(body.recent)).toBe(true);
+    expect(Array.isArray(body.watching)).toBe(true);
+  });
+
+  it("sets Cache-Control: no-cache on dashboard response", async () => {
+    const regenRes = await app.request("/kiosk/token/regenerate", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    const { token } = await regenRes.json() as { token: string };
+
+    const res = await app.request(`/kiosk/${token}`);
+    expect(res.headers.get("Cache-Control")).toContain("no-cache");
+  });
+
+  it("returns 401 after token is revoked", async () => {
+    const regenRes = await app.request("/kiosk/token/regenerate", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    const { token } = await regenRes.json() as { token: string };
+
+    await app.request("/kiosk/token", { method: "DELETE", headers: authHeaders() });
+
+    const res = await app.request(`/kiosk/${token}`);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 after token is regenerated (old token invalid)", async () => {
+    const res1 = await app.request("/kiosk/token/regenerate", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    const { token: oldToken } = await res1.json() as { token: string };
+
+    await app.request("/kiosk/token/regenerate", { method: "POST", headers: authHeaders() });
+
+    const res = await app.request(`/kiosk/${oldToken}`);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("validation", () => {
+  it("returns 400 for token that exceeds max length", async () => {
+    const longToken = "a".repeat(65);
+    const res = await app.request(`/kiosk/${longToken}`);
+    expect(res.status).toBe(400);
+    const body = await res.json() as any;
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+});
+
+describe("GET /kiosk/token", () => {
+  it("returns 401 without auth", async () => {
+    const res = await app.request("/kiosk/token");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns null token before any generation", async () => {
+    const res = await app.request("/kiosk/token", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { token: string | null };
+    expect(body.token).toBeNull();
+  });
+
+  it("returns token after regeneration", async () => {
+    await app.request("/kiosk/token/regenerate", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    const res = await app.request("/kiosk/token", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { token: string };
+    expect(typeof body.token).toBe("string");
+    expect(body.token.length).toBeGreaterThan(0);
+  });
+});
+
+describe("POST /kiosk/token/regenerate", () => {
+  it("returns 401 without auth", async () => {
+    const res = await app.request("/kiosk/token/regenerate", { method: "POST" });
+    expect(res.status).toBe(401);
+  });
+
+  it("generates a 32-char hex token", async () => {
+    const res = await app.request("/kiosk/token/regenerate", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { token: string };
+    expect(typeof body.token).toBe("string");
+    expect(body.token).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("new token replaces the old one", async () => {
+    const res1 = await app.request("/kiosk/token/regenerate", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    const { token: token1 } = await res1.json() as { token: string };
+
+    const res2 = await app.request("/kiosk/token/regenerate", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    const { token: token2 } = await res2.json() as { token: string };
+
+    expect(token1).not.toBe(token2);
+
+    const getRes = await app.request("/kiosk/token", { headers: authHeaders() });
+    const { token: storedToken } = await getRes.json() as { token: string };
+    expect(storedToken).toBe(token2);
+  });
+});
+
+describe("DELETE /kiosk/token", () => {
+  it("returns 401 without auth", async () => {
+    const res = await app.request("/kiosk/token", { method: "DELETE" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 204 and clears the token", async () => {
+    await app.request("/kiosk/token/regenerate", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+
+    const deleteRes = await app.request("/kiosk/token", {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+    expect(deleteRes.status).toBe(204);
+
+    const getRes = await app.request("/kiosk/token", { headers: authHeaders() });
+    const body = await getRes.json() as { token: string | null };
+    expect(body.token).toBeNull();
+  });
+});

--- a/server/routes/kiosk.ts
+++ b/server/routes/kiosk.ts
@@ -1,0 +1,75 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import {
+  getUserByKioskToken,
+  getKioskToken,
+  setKioskToken,
+  getEpisodesByDateRange,
+  getRecentTitles,
+  getTrackedTitles,
+} from "../db/repository";
+import { requireAuth } from "../middleware/auth";
+import { zValidator } from "../lib/validator";
+import { localDateForTimezone, addDays } from "../utils/timezone";
+import { ok, err } from "./response";
+import type { AppEnv } from "../types";
+
+const app = new Hono<AppEnv>();
+
+// ─── Auth-gated token management (registered before /:token to avoid shadowing) ──
+
+// GET /api/kiosk/token  (requireAuth)
+app.get("/token", requireAuth, async (c) => {
+  const user = c.get("user")!;
+  const token = await getKioskToken(user.id);
+  return c.json({ token });
+});
+
+// POST /api/kiosk/token/regenerate  (requireAuth)
+app.post("/token/regenerate", requireAuth, async (c) => {
+  const user = c.get("user")!;
+  const token = crypto.randomUUID().replace(/-/g, "");
+  await setKioskToken(user.id, token);
+  return c.json({ token });
+});
+
+// DELETE /api/kiosk/token  (requireAuth)
+app.delete("/token", requireAuth, async (c) => {
+  const user = c.get("user")!;
+  await setKioskToken(user.id, null);
+  return new Response(null, { status: 204 });
+});
+
+// ─── Public dashboard ─────────────────────────────────────────────────────────
+
+// GET /api/kiosk/:token  (public, token-authenticated)
+app.get("/:token", zValidator("param", z.object({ token: z.string().min(1).max(64) })), async (c) => {
+  const { token } = c.req.valid("param");
+
+  const user = await getUserByKioskToken(token);
+  if (!user) return err(c, "Invalid kiosk token", 401);
+
+  const timezone = c.req.header("X-Timezone") || "UTC";
+  const today = localDateForTimezone(timezone);
+  const tomorrow = addDays(today, 1);
+  const weekEnd = addDays(today, 8);
+
+  const [tonight, week, recentArr, tracked] = await Promise.all([
+    getEpisodesByDateRange(today, tomorrow, user.id),
+    getEpisodesByDateRange(tomorrow, weekEnd, user.id),
+    getRecentTitles({ daysBack: 14, limit: 24 }, user.id),
+    getTrackedTitles(user.id),
+  ]);
+
+  const watching = tracked
+    .filter((t) => t.show_status === "watching")
+    .slice(0, 12)
+    .map(({ id, object_type, title, original_title, release_year, release_date, poster_url, tmdb_id, imdb_id, tmdb_url, tmdb_score, imdb_score, genres, offers, next_episode_air_date, total_episodes, watched_episodes_count, released_episodes_count, show_status }) => ({
+      id, object_type, title, original_title, release_year, release_date, poster_url, tmdb_id, imdb_id, tmdb_url, tmdb_score, imdb_score, genres, offers, next_episode_air_date, total_episodes, watched_episodes_count, released_episodes_count, show_status,
+    }));
+
+  c.header("Cache-Control", "no-cache, no-store");
+  return ok(c, { tonight, week, recent: recentArr, watching });
+});
+
+export default app;

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -68,6 +68,7 @@ import healthRoutes from "./routes/health";
 import statsRoutes from "./routes/stats";
 import userSettingsRoutes from "./routes/user-settings";
 import feedRoutes from "./routes/feed";
+import kioskRoutes from "./routes/kiosk";
 import importRoutes from "./routes/import";
 import type { AppEnv } from "./types";
 import { logger, requestLogger, resetLogLevel } from "./logger";
@@ -348,6 +349,10 @@ function createApp(env: Env) {
   // Calendar feed
   app.use("/api/feed/token*", requireAuth);
   app.route("/api/feed", feedRoutes);
+
+  // Kiosk — /:token is public (token-authenticated); /token endpoints require session
+  app.use("/api/kiosk/token*", requireAuth);
+  app.route("/api/kiosk", kioskRoutes);
 
   // Admin routes
   app.use("/api/admin/*", requireAuth, requireAdmin);


### PR DESCRIPTION
Closes #548

## Summary

- Adds `kiosk_token` column to `users` with a unique index (migration `0031`)
- New public endpoint `GET /api/kiosk/:token` builds a dashboard payload (`tonight`, `week`, `recent`, `watching`) without exposing personal/social fields
- Session-gated token management: `GET/POST /api/kiosk/token` and `DELETE /api/kiosk/token`
- New `/kiosk/:token` frontend route renders a chrome-less full-bleed dashboard (no nav, footer, bottom tab bar, install/notification prompts)
- KioskSection in Settings (generate, regenerate, revoke) mirrors the existing CalendarFeedSection pattern
- Auto-refreshes every 15 minutes via `setInterval`

## Test plan

- [ ] `bun run check` passes (1948 pass; 4 pre-existing `HomeRoute` mock-leak failures unrelated to this PR — they pass when run in isolation)
- [ ] DB migration: `bun run db:push` applies `0031_users_kiosk_token.sql`
- [ ] Sign in → Settings → find "Kiosk display" section → Generate URL
- [ ] Open kiosk URL in a private window — dashboard renders with no nav/footer/tabs
- [ ] Tonight / This week / Recent / Currently watching sections render (track a few titles first)
- [ ] Network tab: `/api/kiosk/:token` payload contains only `{ tonight, week, recent, watching }`
- [ ] Regenerate → old URL returns 401 in private window; new URL works
- [ ] Revoke → both URLs return 401; Settings shows empty "Generate" state

🤖 Generated with [Claude Code](https://claude.com/claude-code)