### PR TITLE
fix: chunk plex titleIds to stay under D1's 100-param limit; remove Sync button

### DIFF
--- a/frontend/src/components/NewReleases.tsx
+++ b/frontend/src/components/NewReleases.tsx
@@ -45,12 +45,11 @@ export default function NewReleases({
   showRating,
   onResultsCount,
 }: Props) {
+  const { t } = useTranslation();
   const [titles, setTitles] = useState<Title[]>([]);
   const [loading, setLoading] = useState(false);
-  const [syncing, setSyncing] = useState(false);
   const [error, setError] = useState("");
 
-  const { t } = useTranslation();
   const [genres, setGenres] = useState<string[]>([]);
   const [providers, setProviders] = useState<Provider[]>([]);
   const [languages, setLanguages] = useState<string[]>([]);
@@ -92,52 +91,30 @@ export default function NewReleases({
     fetchTitles();
   }, [fetchTitles]);
 
-  async function handleSync() {
-    setSyncing(true);
-    setError("");
-    try {
-      await api.syncReleases(daysBack, type.length === 1 ? type[0] : undefined);
-      await fetchTitles();
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setSyncing(false);
-    }
-  }
-
   return (
     <div className="space-y-4">
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        {!hideFilterBar && (
-          <FilterBar
-            type={type}
-            onTypeChange={onTypeChange}
-            daysBack={daysBack}
-            onDaysBackChange={onDaysBackChange}
-            genre={genre}
-            onGenreChange={onGenreChange}
-            genres={genres}
-            provider={provider}
-            onProviderChange={onProviderChange}
-            providers={providers}
-            regionProviderIds={regionProviderIds}
-            language={language}
-            onLanguageChange={onLanguageChange}
-            languages={languages}
-            priorityLanguageCodes={priorityLanguageCodes}
-            onClearFilters={onClearFilters}
-            hideTracked={hideTracked}
-            onHideTrackedChange={onHideTrackedChange}
-          />
-        )}
-        <button
-          onClick={handleSync}
-          disabled={syncing}
-          className="px-4 py-2 bg-green-600 hover:bg-green-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors cursor-pointer"
-        >
-          {syncing ? t("releases.syncing") : t("releases.sync")}
-        </button>
-      </div>
+      {!hideFilterBar && (
+        <FilterBar
+          type={type}
+          onTypeChange={onTypeChange}
+          daysBack={daysBack}
+          onDaysBackChange={onDaysBackChange}
+          genre={genre}
+          onGenreChange={onGenreChange}
+          genres={genres}
+          provider={provider}
+          onProviderChange={onProviderChange}
+          providers={providers}
+          regionProviderIds={regionProviderIds}
+          language={language}
+          onLanguageChange={onLanguageChange}
+          languages={languages}
+          priorityLanguageCodes={priorityLanguageCodes}
+          onClearFilters={onClearFilters}
+          hideTracked={hideTracked}
+          onHideTrackedChange={onHideTrackedChange}
+        />
+      )}
 
       {error && (
         <div className="bg-red-900/50 border border-red-800 text-red-200 px-4 py-2 rounded-lg text-sm">

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -241,10 +241,8 @@
     "advancedFilters": "Filters"
   },
   "releases": {
-    "syncing": "Syncing...",
-    "sync": "Sync New Releases",
     "loading": "Loading...",
-    "empty": "No releases found. Click 'Sync New Releases' to fetch data from TMDB."
+    "empty": "No releases found."
   },
   "track": {
     "track": "Track",

--- a/server/db/repository/plex-library.test.ts
+++ b/server/db/repository/plex-library.test.ts
@@ -182,6 +182,22 @@ describe("getPlexOffersForUser", () => {
     expect(result.size).toBe(0);
   });
 
+  it("handles more than 99 titleIds without hitting D1 param limit", async () => {
+    insertIntegration("int-1", userId, "srv-1");
+    const titleIds: string[] = [];
+    for (let i = 1; i <= 120; i++) {
+      const id = `movie-bulk-${i}`;
+      insertTitle(id);
+      titleIds.push(id);
+      getRawDb()
+        .prepare(`INSERT INTO plex_library_items (integration_id, user_id, title_id, rating_key, media_type) VALUES (?, ?, ?, ?, ?)`)
+        .run("int-1", userId, id, `rk-${i}`, "movie");
+    }
+
+    const result = await getPlexOffersForUser(titleIds, userId);
+    expect(result.size).toBe(120);
+  });
+
   it("does not return offers for another user", async () => {
     insertTitle("movie-1");
     insertIntegration("int-1", userId, "srv-1");

--- a/server/db/repository/plex-library.ts
+++ b/server/db/repository/plex-library.ts
@@ -8,6 +8,9 @@ import type { PlexConfig } from "./integrations";
 // Reserved provider ID for Plex (out-of-range for TMDB provider IDs)
 export const PLEX_PROVIDER_ID = 9999;
 
+// D1 caps bound parameters at 100 per statement; userId takes 1 slot.
+const PLEX_TITLEIDS_CHUNK_SIZE = 99;
+
 export type PlexLibraryItem = {
   integrationId: string;
   userId: string;
@@ -104,23 +107,29 @@ export async function getPlexOffersForUser(
     if (titleIds.length === 0) return new Map();
 
     const db = getDb();
-    const rows = await db
-      .select({
-        titleId: plexLibraryItems.titleId,
-        ratingKey: plexLibraryItems.ratingKey,
-        mediaType: plexLibraryItems.mediaType,
-        plexSlug: plexLibraryItems.plexSlug,
-        config: integrations.config,
-      })
-      .from(plexLibraryItems)
-      .innerJoin(integrations, eq(plexLibraryItems.integrationId, integrations.id))
-      .where(
-        and(
-          eq(plexLibraryItems.userId, userId),
-          inArray(plexLibraryItems.titleId, titleIds)
+    const allRows: Array<{ titleId: string; ratingKey: string; mediaType: string; plexSlug: string | null; config: string }> = [];
+    for (let i = 0; i < titleIds.length; i += PLEX_TITLEIDS_CHUNK_SIZE) {
+      const chunk = titleIds.slice(i, i + PLEX_TITLEIDS_CHUNK_SIZE);
+      const rows = await db
+        .select({
+          titleId: plexLibraryItems.titleId,
+          ratingKey: plexLibraryItems.ratingKey,
+          mediaType: plexLibraryItems.mediaType,
+          plexSlug: plexLibraryItems.plexSlug,
+          config: integrations.config,
+        })
+        .from(plexLibraryItems)
+        .innerJoin(integrations, eq(plexLibraryItems.integrationId, integrations.id))
+        .where(
+          and(
+            eq(plexLibraryItems.userId, userId),
+            inArray(plexLibraryItems.titleId, chunk)
+          )
         )
-      )
-      .all();
+        .all();
+      allRows.push(...rows);
+    }
+    const rows = allRows;
 
     const result = new Map<string, SyntheticOffer[]>();
     for (const row of rows) {


### PR DESCRIPTION
## Summary

- **Root cause**: `GET /api/titles` was returning 500 for users with a Plex integration. The query in `getPlexOffersForUser` binds `userId` (1 param) + up to 100 `titleIds` = **101 bound parameters**, exceeding D1's hard cap of 100 per statement. Confirmed in Cloudflare Workers Observability logs: `Failed query: select "plex_library_items"... params: JyMfhmY1JlU9UI1oxw7ANfRYxKSGbG2a,movie-393209,...` (101 values).
- **Fix**: chunk `titleIds` into batches of 99 in `getPlexOffersForUser`, identical pattern to the prior `unwatchEpisodesBulk` fix (d24a1ec).
- **UX**: removes the manual "Sync New Releases" button — the daily `0 3 * * *` cron already populates the DB, so the button was misleading for non-admins and unnecessary after the read-path is fixed.

## Test plan

- [x] New regression test: `getPlexOffersForUser` with 120 titleIds — all 12 plex-library tests pass
- [x] Server tsc, frontend tsc, ESLint all clean
- [ ] Deploy + run `bun run db:migrate:cf` (pending migration `0031_users_kiosk_token.sql` from #548)
- [ ] Verify `GET /api/titles` returns 200 in prod for the affected user

Closes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)