### PR TITLE
fix: exclude future-dated titles from Now Playing view

### DIFF
--- a/server/db/repository.test.ts
+++ b/server/db/repository.test.ts
@@ -385,6 +385,20 @@ describe("getRecentTitles", () => {
     expect(results).toHaveLength(2);
   });
 
+  it("excludes titles with release dates in the future", async () => {
+    const past = new Date();
+    past.setDate(past.getDate() - 1);
+    const future = new Date();
+    future.setDate(future.getDate() + 365);
+    await upsertTitles([
+      makeParsedTitle({ id: "movie-past", title: "Past Movie", releaseDate: past.toISOString().slice(0, 10) }),
+      makeParsedTitle({ id: "movie-future", title: "Future Movie", releaseDate: future.toISOString().slice(0, 10) }),
+    ]);
+    const results = await getRecentTitles({ daysBack: 0 });
+    expect(results.some((r) => r.id === "movie-future")).toBe(false);
+    expect(results.some((r) => r.id === "movie-past")).toBe(true);
+  });
+
   it("returns is_tracked=false without userId", async () => {
     await upsertTitles([makeParsedTitle({ id: "movie-1", releaseDate: "2025-01-01" })]);
     const results = await getRecentTitles({ daysBack: 0 });

--- a/server/db/repository/titles.ts
+++ b/server/db/repository/titles.ts
@@ -1,4 +1,4 @@
-import { eq, and, or, sql, gte, lt, desc, asc, exists, notExists, inArray, like } from "drizzle-orm";
+import { eq, and, or, sql, gte, lte, lt, desc, asc, exists, notExists, inArray, like } from "drizzle-orm";
 import { getDb } from "../schema";
 import { titles, providers, offers, scores, tracked, titleGenres, watchedTitles } from "../schema";
 import type { ParsedTitle, ParsedOffer, ParsedProvider, ParsedScores } from "../../tmdb/parser";
@@ -339,6 +339,8 @@ export async function getRecentTitles(filters: TitleFilters = {}, userId?: strin
 
     const conditions: ReturnType<typeof eq>[] = [];
 
+    const todayStr = new Date().toISOString().slice(0, 10);
+    conditions.push(lte(titles.releaseDate, todayStr));
     if (daysBack) {
       const cutoff = new Date();
       cutoff.setDate(cutoff.getDate() - daysBack);


### PR DESCRIPTION
## Summary

- `getRecentTitles` only had a lower-bound date filter (`releaseDate >= today − daysBack`), so any titles whose canonical TMDB `release_date` sits in the future (e.g. Avatar 5 → 2031, Incredibles 3 → 2028) sorted to the top under `ORDER BY release_date DESC` and appeared on the Now Playing / New Releases tab
- Root cause: TMDB's discover endpoint filters on *any* `release_dates[].release_date` (premieres, festival screenings), so titles with an early-access event can enter the DB even though their canonical release date is still years away
- Fix: add `lte(releaseDate, today)` upper bound in `getRecentTitles` so future-dated rows are filtered out at query time — no re-sync required, and both call sites (`/api/titles` and the kiosk row) want past/current releases only

## Test plan

- [ ] New regression test in `server/db/repository.test.ts`: inserts a past-dated and a future-dated title; asserts only the past one is returned by `getRecentTitles`
- [ ] `bun run check` passes (1950 pass, 4 pre-existing `HomeRoute` mock-leak failures unchanged)
- [ ] Browse → Now Playing shows recently released titles, not 2027–2031 unreleased sequels

🤖 Generated with [Claude Code](https://claude.com/claude-code)