### PR TITLE
feat: redesign kiosk mode with header/hero/two-column layout and fidelity tiers

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -781,22 +781,65 @@ export async function regenerateFeedToken(): Promise<{ token: string }> {
 
 // ─── Kiosk ────────────────────────────────────────────────────────────────────
 
-export interface WatchingTitle extends Title {
-  watched_episodes_count?: number;
-  released_episodes_count?: number;
-  total_episodes?: number;
-  next_episode_air_date?: string | null;
+export type KioskFidelity = "rich" | "lite" | "epaper";
+
+export interface KioskAiringSlot {
+  id: number;
+  title_id: string;
+  show_title: string;
+  poster_url: string | null;
+  backdrop_url: string | null;
+  season_number: number;
+  episode_number: number;
+  ep_title: string | null;
+  air_date: string | null;
+  provider: string | null;
+}
+
+export interface KioskRelease {
+  id: number;
+  title_id: string;
+  show_title: string;
+  poster_url: string | null;
+  backdrop_url: string | null;
+  season_number: number;
+  episode_number: number;
+  ep_title: string | null;
+  air_date: string | null;
+  provider: string | null;
+  kind: "series" | "episode";
+}
+
+export interface KioskQueueItem {
+  id: number;
+  title_id: string;
+  show_title: string;
+  poster_url: string | null;
+  season_number: number;
+  episode_number: number;
+  ep_title: string | null;
+  air_date: string | null;
+  provider: string | null;
+  left: number;
+}
+
+export interface KioskMeta {
+  household: string;
+  fidelity: KioskFidelity;
+  refresh_interval_seconds: number;
+  generated_at: string;
 }
 
 export interface KioskData {
-  tonight: Episode[];
-  week: Episode[];
-  recent: Title[];
-  watching: WatchingTitle[];
+  meta: KioskMeta;
+  airing_now: KioskAiringSlot | null;
+  releasing_today: KioskRelease[];
+  unwatched_queue: KioskQueueItem[];
 }
 
-export async function getKioskData(token: string): Promise<KioskData> {
-  return fetchJson(`/kiosk/${encodeURIComponent(token)}`);
+export async function getKioskData(token: string, display?: KioskFidelity): Promise<KioskData> {
+  const params = display ? `?display=${encodeURIComponent(display)}` : "";
+  return fetchJson(`/kiosk/${encodeURIComponent(token)}${params}`);
 }
 
 export async function getKioskToken(): Promise<{ token: string | null }> {

--- a/frontend/src/pages/KioskPage.test.tsx
+++ b/frontend/src/pages/KioskPage.test.tsx
@@ -1,27 +1,87 @@
-import { describe, it, expect, mock, afterEach } from "bun:test";
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
 import { render, screen, waitFor, cleanup } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router";
 
 import "../i18n";
 
-const mockGetKioskData = mock(() =>
-  Promise.resolve({
-    tonight: [],
-    week: [],
-    recent: [],
-    watching: [],
-  })
-);
+import type { KioskData, KioskAiringSlot, KioskRelease, KioskQueueItem } from "../api";
 
-mock.module("../api", () => ({
-  getKioskData: mockGetKioskData,
-}));
+function makeData(overrides: Partial<KioskData> = {}): KioskData {
+  return {
+    meta: {
+      household: "Test House",
+      fidelity: "rich",
+      refresh_interval_seconds: 300,
+      generated_at: new Date().toISOString(),
+    },
+    airing_now: null,
+    releasing_today: [],
+    unwatched_queue: [],
+    ...overrides,
+  };
+}
+
+function makeSlot(overrides: Partial<KioskAiringSlot> = {}): KioskAiringSlot {
+  return {
+    id: 1,
+    title_id: "show-1",
+    show_title: "Airing Show",
+    poster_url: null,
+    backdrop_url: null,
+    season_number: 2,
+    episode_number: 5,
+    ep_title: "The Episode",
+    air_date: new Date().toISOString().slice(0, 10),
+    provider: "Netflix",
+    ...overrides,
+  };
+}
+
+function makeRelease(overrides: Partial<KioskRelease> = {}): KioskRelease {
+  return {
+    id: 10,
+    title_id: "show-2",
+    show_title: "Releasing Show",
+    poster_url: null,
+    backdrop_url: null,
+    season_number: 1,
+    episode_number: 3,
+    ep_title: "Third Episode",
+    air_date: new Date().toISOString().slice(0, 10),
+    provider: "Max",
+    kind: "episode",
+    ...overrides,
+  };
+}
+
+function makeQueueItem(overrides: Partial<KioskQueueItem> = {}): KioskQueueItem {
+  return {
+    id: 20,
+    title_id: "show-3",
+    show_title: "Queued Show",
+    poster_url: null,
+    season_number: 1,
+    episode_number: 4,
+    ep_title: "Backlogged",
+    air_date: new Date().toISOString().slice(0, 10),
+    provider: "Plex",
+    left: 3,
+    ...overrides,
+  };
+}
+
+const mockFetch = mock((_url: string) =>
+  Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({ data: makeData() }),
+  } as Response)
+);
 
 const { default: KioskPage } = await import("./KioskPage");
 
-function Wrapper({ token = "abc123" }: { token?: string }) {
+function Wrapper({ token = "abc123", search = "" }: { token?: string; search?: string }) {
   return (
-    <MemoryRouter initialEntries={[`/kiosk/${token}`]}>
+    <MemoryRouter initialEntries={[`/kiosk/${token}${search}`]}>
       <Routes>
         <Route path="/kiosk/:token" element={<KioskPage />} />
       </Routes>
@@ -29,43 +89,24 @@ function Wrapper({ token = "abc123" }: { token?: string }) {
   );
 }
 
-afterEach(() => {
-  cleanup();
-  mockGetKioskData.mockReset();
-  mockGetKioskData.mockImplementation(() =>
-    Promise.resolve({ tonight: [], week: [], recent: [], watching: [] })
+beforeEach(() => {
+  globalThis.fetch = mockFetch as any;
+  mockFetch.mockImplementation((_url: string) =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ data: makeData() }),
+    } as Response)
   );
 });
 
-function makeEpisode(id: number, overrides: Record<string, unknown> = {}) {
-  return {
-    id,
-    title_id: "show-1",
-    season_number: 1,
-    episode_number: id,
-    name: `Episode ${id}`,
-    overview: null,
-    air_date: "2099-01-01",
-    still_path: null,
-    show_title: "Test Show",
-    poster_url: null,
-    is_watched: false,
-    offers: [],
-    ...overrides,
-  };
-}
+afterEach(() => {
+  cleanup();
+  mockFetch.mockReset();
+  // @ts-expect-error — restore to undefined so other test files are unaffected
+  globalThis.fetch = undefined;
+});
 
 describe("KioskPage", () => {
-  it("renders section headings", async () => {
-    render(<Wrapper />);
-    await waitFor(() => {
-      expect(screen.getByText("Tonight")).toBeTruthy();
-      expect(screen.getByText("This Week")).toBeTruthy();
-      expect(screen.getByText("Latest Releases")).toBeTruthy();
-      expect(screen.getByText("Currently Watching")).toBeTruthy();
-    });
-  });
-
   it("renders the Remindarr branding header", async () => {
     render(<Wrapper />);
     await waitFor(() => {
@@ -73,54 +114,126 @@ describe("KioskPage", () => {
     });
   });
 
-  it("shows empty state for tonight when no episodes", async () => {
-    render(<Wrapper />);
-    await waitFor(() => {
-      expect(screen.getByText("Nothing airing tonight.")).toBeTruthy();
-    });
-  });
-
-  it("shows empty state for currently watching when none", async () => {
-    render(<Wrapper />);
-    await waitFor(() => {
-      expect(screen.getByText("Nothing in progress.")).toBeTruthy();
-    });
-  });
-
-  it("renders tonight episodes when present", async () => {
-    mockGetKioskData.mockImplementation(() =>
+  it("shows the household name from meta", async () => {
+    mockFetch.mockImplementation((_url: string) =>
       Promise.resolve({
-        tonight: [makeEpisode(1)],
-        week: [],
-        recent: [],
-        watching: [],
-      })
+        ok: true,
+        json: () => Promise.resolve({ data: makeData({ meta: { household: "The Test Manor", fidelity: "rich", refresh_interval_seconds: 300, generated_at: new Date().toISOString() } }) }),
+      } as Response)
     );
     render(<Wrapper />);
     await waitFor(() => {
-      expect(screen.getByText("Test Show")).toBeTruthy();
+      expect(screen.getByText("The Test Manor")).toBeTruthy();
     });
   });
 
-  it("renders recent titles when present", async () => {
-    mockGetKioskData.mockImplementation(() =>
+  it("shows airing_now show title in hero when present", async () => {
+    mockFetch.mockImplementation((_url: string) =>
       Promise.resolve({
-        tonight: [],
-        week: [],
-        recent: [{ id: "m1", title: "New Movie", release_year: 2024, poster_url: null, object_type: "MOVIE", original_title: null, release_date: "2024-01-01", runtime_minutes: null, short_description: null, imdb_id: null, tmdb_id: null, tmdb_url: null, imdb_score: null, imdb_votes: null, tmdb_score: null, is_tracked: false, is_watched: false, genres: [], offers: [], age_certification: null, original_language: null, updated_at: null }],
-        watching: [],
-      })
+        ok: true,
+        json: () => Promise.resolve({ data: makeData({ airing_now: makeSlot() }) }),
+      } as Response)
     );
     render(<Wrapper />);
     await waitFor(() => {
-      expect(screen.getAllByText("New Movie").length).toBeGreaterThan(0);
+      expect(screen.getByText("Airing Show")).toBeTruthy();
     });
   });
 
-  it("shows error state for invalid token (rejected promise)", async () => {
-    mockGetKioskData.mockImplementation(() =>
-      Promise.reject(new Error("Invalid kiosk token"))
+  it("shows empty hero when airing_now is null", async () => {
+    render(<Wrapper />);
+    await waitFor(() => {
+      expect(screen.getByText("Nothing airing today")).toBeTruthy();
+    });
+  });
+
+  it("renders releasing_today show in the list", async () => {
+    mockFetch.mockImplementation((_url: string) =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ data: makeData({ releasing_today: [makeRelease()] }) }),
+      } as Response)
     );
+    render(<Wrapper />);
+    await waitFor(() => {
+      expect(screen.getAllByText("Releasing Show").length).toBeGreaterThan(0);
+    });
+  });
+
+  it("renders unwatched queue show in the list", async () => {
+    mockFetch.mockImplementation((_url: string) =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ data: makeData({ unwatched_queue: [makeQueueItem()] }) }),
+      } as Response)
+    );
+    render(<Wrapper />);
+    await waitFor(() => {
+      expect(screen.getAllByText("Queued Show").length).toBeGreaterThan(0);
+    });
+  });
+
+  it("shows 'cold' badge for queue item aired >= 10 days ago", async () => {
+    const oldDate = new Date(Date.now() - 11 * 86_400_000).toISOString().slice(0, 10);
+    mockFetch.mockImplementation((_url: string) =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ data: makeData({ unwatched_queue: [makeQueueItem({ air_date: oldDate })] }) }),
+      } as Response)
+    );
+    render(<Wrapper />);
+    await waitFor(() => {
+      expect(screen.getByText("cold")).toBeTruthy();
+    });
+  });
+
+  it("does NOT show 'cold' badge for queue item aired < 10 days ago", async () => {
+    const recentDate = new Date(Date.now() - 5 * 86_400_000).toISOString().slice(0, 10);
+    mockFetch.mockImplementation((_url: string) =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ data: makeData({ unwatched_queue: [makeQueueItem({ air_date: recentDate })] }) }),
+      } as Response)
+    );
+    render(<Wrapper />);
+    await waitFor(() => {
+      expect(screen.queryByText("cold")).toBeNull();
+    });
+  });
+
+  it("applies e-paper style marker (font-smoothing none) when display=epaper", async () => {
+    mockFetch.mockImplementation((_url: string) =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ data: makeData({ meta: { household: "House", fidelity: "epaper", refresh_interval_seconds: 1800, generated_at: new Date().toISOString() } }) }),
+      } as Response)
+    );
+    render(<Wrapper search="?display=epaper" />);
+    await waitFor(() => {
+      expect(screen.getByText(/kiosk · epaper/i)).toBeTruthy();
+    });
+  });
+
+  it("the Cast to TV element is decorative — no interactive button", async () => {
+    mockFetch.mockImplementation((_url: string) =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ data: makeData({ airing_now: makeSlot() }) }),
+      } as Response)
+    );
+    render(<Wrapper />);
+    await waitFor(() => {
+      expect(screen.getByText(/cast to tv/i)).toBeTruthy();
+    });
+    // The cast element must not be a <button> (it's a decorative div per design note 3)
+    const buttons = Array.from(document.querySelectorAll("button")).filter(
+      (b) => b.textContent?.toLowerCase().includes("cast")
+    );
+    expect(buttons.length).toBe(0);
+  });
+
+  it("shows error state when fetch fails", async () => {
+    mockFetch.mockImplementation(() => Promise.resolve({ ok: false, json: () => Promise.resolve({}) } as Response));
     render(<Wrapper token="bad-token" />);
     await waitFor(() => {
       expect(screen.getByText("Kiosk unavailable")).toBeTruthy();
@@ -128,10 +241,18 @@ describe("KioskPage", () => {
     });
   });
 
-  it("calls getKioskData with the token from the URL", async () => {
-    render(<Wrapper token="mytoken123" />);
+  it("includes the fidelity chip in the header", async () => {
+    render(<Wrapper />);
     await waitFor(() => {
-      expect(mockGetKioskData).toHaveBeenCalledWith("mytoken123");
+      expect(screen.getByText(/kiosk · rich/i)).toBeTruthy();
+    });
+  });
+
+  it("shows panel kicker labels", async () => {
+    render(<Wrapper />);
+    await waitFor(() => {
+      expect(screen.getByText(/releasing today/i)).toBeTruthy();
+      expect(screen.getByText(/up next in your queue/i)).toBeTruthy();
     });
   });
 });

--- a/frontend/src/pages/KioskPage.tsx
+++ b/frontend/src/pages/KioskPage.tsx
@@ -1,240 +1,599 @@
-import { useEffect, useState, useCallback } from "react";
-import { useParams } from "react-router";
-import * as api from "../api";
-import type { KioskData, WatchingTitle } from "../api";
-import type { Episode, Title } from "../types";
-import { useApiCall } from "../hooks/useApiCall";
-import { EpisodeShowCard, DeckCardWrapper } from "../components/EpisodeShowCard";
-import { groupByShow, formatUpcomingDate, formatEpisodeCode } from "../components/EpisodeComponents";
+import { useEffect, useState, useCallback, useRef } from "react";
+import { useParams, useSearchParams } from "react-router";
+import type { KioskData, KioskFidelity, KioskAiringSlot, KioskRelease, KioskQueueItem } from "../api";
 
-const REFRESH_INTERVAL_MS = 15 * 60 * 1000;
+const FIDELITY_VALUES: KioskFidelity[] = ["rich", "lite", "epaper"];
+
+type KioskPalette = {
+  bg: string; surface: string; surfaceAlt: string;
+  text: string; dim: string; veryDim: string;
+  border: string; borderSoft: string;
+  accent: string; accentInk: string; chip: string;
+};
+
+const PALETTE: Record<KioskFidelity, KioskPalette> = {
+  rich: {
+    bg: "#09090b",
+    surface: "#18181b",
+    surfaceAlt: "#27272a",
+    text: "#fafafa",
+    dim: "#a1a1aa",
+    veryDim: "#71717a",
+    border: "rgba(255,255,255,0.06)",
+    borderSoft: "rgba(255,255,255,0.06)",
+    accent: "#fbbf24",
+    accentInk: "#000",
+    chip: "rgba(255,255,255,0.06)",
+  },
+  lite: {
+    bg: "#09090b",
+    surface: "#18181b",
+    surfaceAlt: "#27272a",
+    text: "#fafafa",
+    dim: "#a1a1aa",
+    veryDim: "#71717a",
+    border: "rgba(255,255,255,0.06)",
+    borderSoft: "rgba(255,255,255,0.06)",
+    accent: "#fbbf24",
+    accentInk: "#000",
+    chip: "rgba(255,255,255,0.06)",
+  },
+  epaper: {
+    bg: "#f6f3e8",
+    surface: "#f6f3e8",
+    surfaceAlt: "#ecead7",
+    text: "#1a1916",
+    dim: "#6a665c",
+    veryDim: "#9b978a",
+    border: "#1a1916",
+    borderSoft: "rgba(26,25,22,0.18)",
+    accent: "#1a1916",
+    accentInk: "#f6f3e8",
+    chip: "#1a1916",
+  },
+};
 
 function useLiveClock() {
   const [now, setNow] = useState(() => new Date());
   useEffect(() => {
-    const id = setInterval(() => setNow(new Date()), 1000);
+    const id = setInterval(() => setNow(new Date()), 60_000);
     return () => clearInterval(id);
   }, []);
   return now;
 }
 
-function formatDate(d: Date): string {
-  return d.toLocaleDateString(undefined, { weekday: "long", year: "numeric", month: "long", day: "numeric" });
+function formatKioskClock(d: Date, clock24: boolean): string {
+  return d.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: !clock24,
+  });
 }
 
-function formatTime(d: Date): string {
-  return d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+function formatKioskDate(d: Date): string {
+  return d.toLocaleDateString(undefined, { weekday: "long", month: "long", day: "numeric" });
 }
 
-function groupByDate(episodes: Episode[]): Map<string, Episode[]> {
-  const map = new Map<string, Episode[]>();
-  for (const ep of episodes) {
-    const key = ep.air_date ?? "unknown";
-    if (!map.has(key)) map.set(key, []);
-    map.get(key)!.push(ep);
-  }
-  return map;
+function airedAgo(airDate: string | null, nowMs: number): number | null {
+  if (!airDate) return null;
+  const ms = nowMs - Date.parse(airDate);
+  return Math.max(1, Math.round(ms / 86_400_000));
 }
 
-function PosterCard({ title }: { title: Title }) {
-  const posterUrl = title.poster_url
-    ? `https://image.tmdb.org/t/p/w342${title.poster_url.startsWith("/") ? title.poster_url : `/${title.poster_url}`}`
-    : null;
-  const raw = title.poster_url ?? "";
-  const finalUrl = raw.startsWith("http") ? raw : posterUrl;
+function posterUrl(path: string | null, size: "w185" | "w780"): string | null {
+  if (!path) return null;
+  if (path.startsWith("http")) return path;
+  return `https://image.tmdb.org/t/p/${size}${path.startsWith("/") ? path : `/${path}`}`;
+}
 
+function hashHue(str: string): number {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) h = (h * 31 + str.charCodeAt(i)) | 0;
+  return Math.abs(h) % 360;
+}
+
+function StripePoster({ title, tone }: { title: string; tone: "dark" | "paper" }) {
+  const hue = hashHue(title);
+  const bg = tone === "paper" ? `oklch(0.92 0.03 ${hue})` : `oklch(0.28 0.04 ${hue})`;
+  const stripe = tone === "paper" ? `oklch(0.88 0.04 ${hue})` : `oklch(0.24 0.05 ${hue})`;
+  const fg = tone === "paper" ? `oklch(0.35 0.05 ${hue})` : `oklch(0.78 0.08 ${hue})`;
   return (
-    <div className="flex-none w-28 sm:w-36">
-      <div className="rounded-lg overflow-hidden bg-zinc-800 aspect-[2/3]">
-        {finalUrl ? (
-          <img src={finalUrl} alt={title.title} className="w-full h-full object-cover" loading="lazy" />
-        ) : (
-          <div className="w-full h-full flex items-center justify-center text-zinc-600 text-xs text-center px-2">{title.title}</div>
-        )}
-      </div>
-      <p className="text-xs text-zinc-300 mt-1.5 line-clamp-2 leading-tight">{title.title}</p>
-      {title.release_year && <p className="text-[11px] text-zinc-500">{title.release_year}</p>}
-    </div>
-  );
-}
-
-function WatchingCard({ title }: { title: WatchingTitle }) {
-  const posterUrl = title.poster_url
-    ? `https://image.tmdb.org/t/p/w185${title.poster_url.startsWith("/") ? title.poster_url : `/${title.poster_url}`}`
-    : null;
-  const raw = title.poster_url ?? "";
-  const finalUrl = raw.startsWith("http") ? raw : posterUrl;
-  const watched = title.watched_episodes_count ?? 0;
-  const released = title.released_episodes_count ?? 0;
-  const pct = released > 0 ? Math.round((watched / released) * 100) : 0;
-
-  return (
-    <div className="flex items-start gap-3 bg-zinc-900 rounded-xl p-3">
-      <div className="flex-none w-14 rounded-lg overflow-hidden bg-zinc-800 aspect-[2/3]">
-        {finalUrl ? (
-          <img src={finalUrl} alt={title.title} className="w-full h-full object-cover" loading="lazy" />
-        ) : (
-          <div className="w-full h-full bg-zinc-800" />
-        )}
-      </div>
-      <div className="flex-1 min-w-0">
-        <p className="font-semibold text-white text-sm truncate">{title.title}</p>
-        <p className="text-xs text-zinc-400 mt-0.5">{watched} / {released} eps watched</p>
-        <div className="mt-2 h-1.5 bg-zinc-700 rounded-full overflow-hidden">
-          <div className="h-full bg-amber-400 rounded-full transition-all" style={{ width: `${pct}%` }} />
-        </div>
-        {title.next_episode_air_date && (
-          <p className="text-[11px] text-zinc-500 mt-1.5">Next: {formatUpcomingDate(title.next_episode_air_date).replace("__TOMORROW__", "Tomorrow")}</p>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function TonightSection({ episodes }: { episodes: Episode[] }) {
-  const byShow = groupByShow(episodes);
-  if (byShow.size === 0) {
-    return <p className="text-zinc-500 text-sm">Nothing airing tonight.</p>;
-  }
-  return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
-      {Array.from(byShow.entries()).map(([titleId, eps]) => (
-        <DeckCardWrapper key={titleId} episodeCount={eps.length}>
-          <EpisodeShowCard episode={eps[0]} episodeCount={eps.length} showActions={false} />
-        </DeckCardWrapper>
-      ))}
-    </div>
-  );
-}
-
-function WeekSection({ episodes }: { episodes: Episode[] }) {
-  const byDate = groupByDate(episodes);
-  if (byDate.size === 0) {
-    return <p className="text-zinc-500 text-sm">No episodes this week.</p>;
-  }
-  return (
-    <div className="space-y-4">
-      {Array.from(byDate.entries()).map(([date, eps]) => {
-        const byShow = groupByShow(eps);
-        const label = formatUpcomingDate(date).replace("__TOMORROW__", "Tomorrow");
-        return (
-          <div key={date}>
-            <p className="text-xs font-semibold text-amber-400 uppercase tracking-wider mb-2">{label}</p>
-            <div className="flex flex-wrap gap-2">
-              {Array.from(byShow.entries()).map(([titleId, showEps]) => (
-                <div key={titleId} className="bg-zinc-900 rounded-lg px-3 py-2 text-sm">
-                  <span className="text-white font-medium">{showEps[0].show_title}</span>
-                  <span className="text-zinc-400 ml-2 text-xs">
-                    {showEps.map(ep => formatEpisodeCode(ep)).join(", ")}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-function RecentSection({ titles }: { titles: Title[] }) {
-  if (titles.length === 0) {
-    return <p className="text-zinc-500 text-sm">No recent releases.</p>;
-  }
-  return (
-    <div className="flex gap-3 overflow-x-auto pb-2 scrollbar-hide">
-      {titles.map((t) => <PosterCard key={t.id} title={t} />)}
-    </div>
-  );
-}
-
-function WatchingSection({ titles }: { titles: WatchingTitle[] }) {
-  if (titles.length === 0) {
-    return <p className="text-zinc-500 text-sm">Nothing in progress.</p>;
-  }
-  return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-      {titles.map((t) => <WatchingCard key={t.id} title={t} />)}
-    </div>
-  );
-}
-
-function SectionHeader({ title }: { title: string }) {
-  return (
-    <h2 className="text-lg font-bold text-white mb-3 flex items-center gap-2">
-      <span className="w-1 h-5 bg-amber-400 rounded-full inline-block" />
+    <div style={{
+      width: "100%", height: "100%",
+      background: `repeating-linear-gradient(135deg, ${bg} 0 14px, ${stripe} 14px 28px)`,
+      display: "flex", alignItems: "flex-end", padding: 6,
+      fontFamily: "ui-monospace, 'JetBrains Mono', Menlo, monospace",
+      fontSize: 9, color: fg, lineHeight: 1.2,
+      overflow: "hidden",
+    }}>
       {title}
-    </h2>
+    </div>
   );
 }
+
+function Poster({ path, title, size, epaper }: { path: string | null; title: string; size: "w185" | "w780"; epaper: boolean }) {
+  const url = posterUrl(path, size);
+  if (url) {
+    return <img src={url} alt={title} style={{ width: "100%", height: "100%", objectFit: "cover" }} loading="lazy" />;
+  }
+  return <StripePoster title={title} tone={epaper ? "paper" : "dark"} />;
+}
+
+// ─── Cast icon (decoration only per design note 3) ───────────────────────────
+function CastIcon({ color = "#000", size = 16 }: { color?: string; size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <rect x="1.5" y="2.5" width="13" height="9" rx="1" stroke={color} strokeWidth="1.5" />
+      <path d="M1.5 13 q1.5 0 1.5 1.5" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M1.5 10.5 q4 0 4 4" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M1.5 8 q6.5 0 6.5 6.5" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function KioskHeader({ C, epaper, fidelity, household, date, clock }: {
+  C: KioskPalette;
+  epaper: boolean;
+  fidelity: KioskFidelity;
+  household: string;
+  date: string;
+  clock: string;
+}) {
+  const Mono: React.CSSProperties = { fontFamily: "ui-monospace, 'JetBrains Mono', Menlo, monospace" };
+  return (
+    <div style={{
+      display: "flex", alignItems: "center", gap: 24,
+      padding: "20px 56px",
+      borderBottom: `1px solid ${C.border}`,
+      background: epaper ? C.text : "transparent",
+      color: epaper ? C.bg : C.text,
+      flexShrink: 0,
+    }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+        <div style={{
+          width: 30, height: 30, borderRadius: epaper ? 0 : 7,
+          background: epaper ? C.bg : "#fbbf24", color: epaper ? C.text : "#000",
+          display: "flex", alignItems: "center", justifyContent: "center",
+          fontWeight: 900, fontSize: 17,
+          border: epaper ? `2px solid ${C.bg}` : "none",
+        }}>R</div>
+        <div style={{ fontWeight: 700, fontSize: 18, letterSpacing: -0.3 }}>Remindarr</div>
+        <div style={{
+          ...Mono, fontSize: 10, letterSpacing: 2,
+          color: epaper ? "rgba(246,243,232,0.7)" : C.veryDim,
+          padding: "3px 8px", borderRadius: epaper ? 0 : 4,
+          background: epaper ? "transparent" : "rgba(255,255,255,0.04)",
+          border: epaper ? "1px solid rgba(246,243,232,0.5)" : "1px solid rgba(255,255,255,0.06)",
+          textTransform: "uppercase",
+        }}>KIOSK · {fidelity.toUpperCase()}</div>
+      </div>
+      <div style={{ flex: 1 }} />
+      <div style={{ ...Mono, fontSize: 13, color: epaper ? "rgba(246,243,232,0.85)" : C.dim, letterSpacing: 1.5 }}>
+        {household}
+      </div>
+      <div style={{ ...Mono, fontSize: 13, color: epaper ? "rgba(246,243,232,0.7)" : C.veryDim, letterSpacing: 1.5 }}>
+        {date}
+      </div>
+      <div style={{
+        ...Mono, fontSize: 28, fontWeight: 800, letterSpacing: 1,
+        color: epaper ? C.bg : "#fbbf24",
+        padding: epaper ? 0 : "4px 14px",
+        background: epaper ? "transparent" : "rgba(251,191,36,0.06)",
+        borderRadius: 6,
+        border: epaper ? "none" : "1px solid rgba(251,191,36,0.18)",
+      }}>
+        {clock}
+      </div>
+    </div>
+  );
+}
+
+function HeroCard({ C, epaper, breathe, slot }: {
+  C: KioskPalette;
+  epaper: boolean;
+  breathe: boolean;
+  slot: KioskAiringSlot;
+}) {
+  const Mono: React.CSSProperties = { fontFamily: "ui-monospace, 'JetBrains Mono', Menlo, monospace" };
+  const backdropUrl = posterUrl(slot.backdrop_url ?? slot.poster_url, "w780");
+
+  return (
+    <div style={{
+      position: "relative", margin: "24px 56px 0",
+      height: 360, borderRadius: epaper ? 0 : 14, overflow: "hidden",
+      border: `${epaper ? 3 : 1}px solid ${epaper ? C.border : C.borderSoft}`,
+      background: C.surface,
+      animation: breathe ? "kfade 0.6s ease both" : "none",
+    }}>
+      {/* Backdrop */}
+      {!epaper && backdropUrl && (
+        <div style={{ position: "absolute", inset: 0, opacity: 0.85 }}>
+          <img src={backdropUrl} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+          <div style={{
+            position: "absolute", inset: 0,
+            background: `linear-gradient(90deg, ${C.bg} 0%, ${C.bg}ee 35%, transparent 75%), linear-gradient(0deg, ${C.bg} 0%, transparent 55%)`,
+          }} />
+        </div>
+      )}
+      {/* E-paper hatched fill instead of poster */}
+      {epaper && (
+        <div style={{
+          position: "absolute", inset: 0,
+          backgroundImage: `repeating-linear-gradient(45deg, ${C.text} 0 1px, transparent 1px 5px)`,
+          opacity: 0.08,
+        }} />
+      )}
+
+      <div style={{ position: "absolute", inset: 0, padding: "32px 40px", display: "flex", flexDirection: "column", justifyContent: "flex-end" }}>
+        {/* Kicker */}
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 14 }}>
+          <span style={{
+            width: 10, height: 10, borderRadius: "50%", background: C.accent,
+            boxShadow: epaper ? "none" : "0 0 0 4px rgba(251,191,36,0.18)",
+            animation: breathe ? "kblink 1.6s ease-in-out infinite" : "none",
+            flexShrink: 0,
+          }} />
+          <div style={{ ...Mono, fontSize: 11, letterSpacing: 2, textTransform: "uppercase", color: C.accent }}>
+            Airing now · {slot.provider ?? ""}
+          </div>
+        </div>
+
+        {/* Show title */}
+        <div style={{ fontSize: 80, fontWeight: 800, letterSpacing: -3, lineHeight: 0.92, marginBottom: 16, color: C.text }}>
+          {slot.show_title}
+        </div>
+
+        {/* Episode info */}
+        <div style={{ fontSize: 18, color: C.dim, marginBottom: 22, maxWidth: 760, lineHeight: 1.5 }}>
+          S{slot.season_number}·E{slot.episode_number}
+          {slot.ep_title && (
+            <> · <span style={{ color: C.text, fontWeight: 600 }}>{slot.ep_title}</span></>
+          )}
+        </div>
+
+        {/* Cast button — decorative only (design note 3: deferred until streaming-device registry) */}
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <div
+            aria-hidden="true"
+            style={{
+              background: C.accent, color: C.accentInk,
+              padding: "12px 22px", borderRadius: epaper ? 0 : 8,
+              border: epaper ? `2px solid ${C.text}` : "none",
+              fontWeight: 700, fontSize: 15, display: "inline-flex", alignItems: "center", gap: 8,
+              opacity: 0.5, cursor: "default",
+            }}>
+            <CastIcon color={C.accentInk} /> Cast to TV
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function HeroEmpty({ C, epaper }: { C: KioskPalette; epaper: boolean }) {
+  return (
+    <div style={{
+      margin: "24px 56px 0", height: 360, borderRadius: epaper ? 0 : 14,
+      border: `${epaper ? 3 : 1}px solid ${epaper ? C.border : C.borderSoft}`,
+      background: C.surface,
+      display: "flex", alignItems: "center", justifyContent: "center",
+    }}>
+      <div style={{ fontFamily: "ui-monospace, 'JetBrains Mono', Menlo, monospace", fontSize: 13, color: C.veryDim, letterSpacing: 2, textTransform: "uppercase" }}>
+        Nothing airing today
+      </div>
+    </div>
+  );
+}
+
+function Panel({ C, epaper, children }: { C: KioskPalette; epaper: boolean; children: React.ReactNode }) {
+  return (
+    <div style={{
+      background: epaper ? "transparent" : C.surface,
+      border: `${epaper ? 2 : 1}px solid ${epaper ? C.border : C.borderSoft}`,
+      borderRadius: epaper ? 0 : 14,
+      overflow: "hidden", display: "flex", flexDirection: "column",
+    }}>
+      {children}
+    </div>
+  );
+}
+
+function PanelHeader({ C, kicker, right }: { C: KioskPalette; kicker: string; right: string }) {
+  const Mono: React.CSSProperties = { fontFamily: "ui-monospace, 'JetBrains Mono', Menlo, monospace" };
+  return (
+    <div style={{
+      display: "flex", alignItems: "baseline", justifyContent: "space-between",
+      padding: "14px 18px", borderBottom: `1px solid ${C.borderSoft}`,
+    }}>
+      <div style={{ ...Mono, fontSize: 11, letterSpacing: 2, textTransform: "uppercase", color: C.accent }}>
+        {kicker}
+      </div>
+      <div style={{ ...Mono, fontSize: 11, color: C.veryDim, letterSpacing: 1.5 }}>
+        {right}
+      </div>
+    </div>
+  );
+}
+
+function ReleasingTodayPanel({ C, epaper, breathe, releases, nowMs }: {
+  C: KioskPalette;
+  epaper: boolean;
+  breathe: boolean;
+  releases: KioskRelease[];
+  nowMs: number;
+}) {
+  const Mono: React.CSSProperties = { fontFamily: "ui-monospace, 'JetBrains Mono', Menlo, monospace" };
+
+  return (
+    <Panel C={C} epaper={epaper}>
+      <PanelHeader C={C} kicker="Releasing today" right={`${releases.length} drops`} />
+      <div style={{ display: "flex", flexDirection: "column", flex: 1, overflowY: "auto" }}>
+        {releases.length === 0 ? (
+          <div style={{ padding: "16px 18px", ...Mono, fontSize: 12, color: C.veryDim }}>No releases today.</div>
+        ) : releases.slice(0, 8).map((r, i) => {
+          const isPast = r.air_date ? Date.parse(r.air_date) < nowMs : false;
+          const epCode = `S${r.season_number}·E${r.episode_number}`;
+          return (
+            <div key={r.id} style={{
+              display: "grid", gridTemplateColumns: "70px 56px 1fr auto",
+              gap: 14, alignItems: "center",
+              padding: "12px 16px",
+              borderBottom: i < releases.slice(0, 8).length - 1 ? `1px solid ${C.borderSoft}` : "none",
+              opacity: isPast ? (epaper ? 0.55 : 0.6) : 1,
+              animation: breathe ? `kfade 0.5s ease ${0.05 * i}s both` : "none",
+            }}>
+              <div style={{ ...Mono, fontSize: 16, fontWeight: 700, color: isPast ? C.dim : C.accent, letterSpacing: 0.5 }}>
+                {r.air_date ? new Date(r.air_date).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", hour12: false }) : "—"}
+              </div>
+              <div style={{ width: 44, height: 64, borderRadius: epaper ? 0 : 4, overflow: "hidden", border: epaper ? `1px solid ${C.text}` : "none", flexShrink: 0 }}>
+                <Poster path={r.poster_url} title={r.show_title} size="w185" epaper={epaper} />
+              </div>
+              <div style={{ minWidth: 0 }}>
+                <div style={{ fontSize: 15, fontWeight: 700, lineHeight: 1.15, marginBottom: 3, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", color: C.text }}>
+                  {r.show_title}
+                </div>
+                <div style={{ ...Mono, fontSize: 11, color: C.veryDim, letterSpacing: 0.5 }}>
+                  {epCode} {r.provider && <>· <span style={{ color: C.dim }}>{r.provider}</span></>}
+                </div>
+              </div>
+              <div style={{
+                ...Mono, fontSize: 9.5, fontWeight: 700, letterSpacing: 1.5, textTransform: "uppercase",
+                padding: "3px 8px", borderRadius: epaper ? 0 : 999,
+                background: r.kind === "series" ? (epaper ? C.text : "rgba(251,191,36,0.12)") : (epaper ? "transparent" : C.chip),
+                color: r.kind === "series" ? (epaper ? C.bg : C.accent) : C.dim,
+                border: epaper ? `1px solid ${C.text}` : "none",
+                flexShrink: 0,
+              }}>
+                {r.kind}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Panel>
+  );
+}
+
+function UnwatchedQueuePanel({ C, epaper, breathe, queue, nowMs }: {
+  C: KioskPalette;
+  epaper: boolean;
+  breathe: boolean;
+  queue: KioskQueueItem[];
+  nowMs: number;
+}) {
+  const Mono: React.CSSProperties = { fontFamily: "ui-monospace, 'JetBrains Mono', Menlo, monospace" };
+
+  return (
+    <Panel C={C} epaper={epaper}>
+      <PanelHeader C={C} kicker="Up next in your queue" right={`${queue.length} unwatched`} />
+      <div style={{ display: "flex", flexDirection: "column", flex: 1, overflowY: "auto" }}>
+        {queue.length === 0 ? (
+          <div style={{ padding: "16px 18px", ...Mono, fontSize: 12, color: C.veryDim }}>All caught up!</div>
+        ) : queue.slice(0, 8).map((q, i) => {
+          const daysAgo = airedAgo(q.air_date, nowMs);
+          const cold = daysAgo !== null && daysAgo >= 10;
+          const epCode = `S${q.season_number}·E${q.episode_number}`;
+          const airedText = daysAgo !== null ? `${daysAgo}d ago` : "—";
+          return (
+            <div key={q.id} style={{
+              display: "grid", gridTemplateColumns: "56px 1fr auto auto",
+              gap: 14, alignItems: "center",
+              padding: "12px 16px",
+              borderBottom: i < queue.slice(0, 8).length - 1 ? `1px solid ${C.borderSoft}` : "none",
+              animation: breathe ? `kfade 0.5s ease ${0.05 * i}s both` : "none",
+            }}>
+              <div style={{ width: 44, height: 64, borderRadius: epaper ? 0 : 4, overflow: "hidden", border: epaper ? `1px solid ${C.text}` : "none", flexShrink: 0 }}>
+                <Poster path={q.poster_url} title={q.show_title} size="w185" epaper={epaper} />
+              </div>
+              <div style={{ minWidth: 0 }}>
+                <div style={{ fontSize: 15, fontWeight: 700, lineHeight: 1.15, marginBottom: 3, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", color: C.text }}>
+                  {q.show_title}
+                </div>
+                <div style={{ fontFamily: "ui-monospace, 'JetBrains Mono', Menlo, monospace", fontSize: 11, color: C.veryDim, letterSpacing: 0.5 }}>
+                  <span style={{ color: C.dim }}>{epCode}</span>
+                  {q.ep_title && <> · {q.ep_title}</>}
+                  {" · aired "}{airedText}
+                </div>
+              </div>
+              {cold && (
+                <div style={{
+                  ...Mono, fontSize: 9, fontWeight: 700, letterSpacing: 1.5, textTransform: "uppercase",
+                  padding: "3px 8px", borderRadius: epaper ? 0 : 999,
+                  background: epaper ? "transparent" : "rgba(255,255,255,0.04)",
+                  color: C.dim,
+                  border: `1px solid ${epaper ? C.text : "rgba(255,255,255,0.1)"}`,
+                  flexShrink: 0,
+                }}>
+                  cold
+                </div>
+              )}
+              <div style={{
+                ...Mono, fontSize: 14, fontWeight: 800, color: q.left > 1 ? C.accent : C.text,
+                minWidth: 30, textAlign: "right", flexShrink: 0,
+              }}>
+                {q.left}
+                <span style={{ ...Mono, fontSize: 10, color: C.veryDim, fontWeight: 400, marginLeft: 2 }}>left</span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Panel>
+  );
+}
+
+// ─── Main page ────────────────────────────────────────────────────────────────
 
 export default function KioskPage() {
   const { token } = useParams<{ token: string }>();
+  const [searchParams] = useSearchParams();
+
+  const rawDisplay = searchParams.get("display");
+  const fidelity: KioskFidelity = FIDELITY_VALUES.includes(rawDisplay as KioskFidelity)
+    ? (rawDisplay as KioskFidelity)
+    : "rich";
+  const clock24 = searchParams.get("clock24") !== "false";
+
+  const [data, setData] = useState<KioskData | null>(null);
+  const [error, setError] = useState(false);
   const now = useLiveClock();
+  const refreshRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const fetcher = useCallback(() => api.getKioskData(token!), [token]);
-  const { data, error, refetch } = useApiCall(fetcher, [token]);
+  const fetchData = useCallback(async () => {
+    try {
+      // Bypass the global auth:unauthorized event for this public endpoint
+      const params = fidelity !== "rich" ? `?display=${encodeURIComponent(fidelity)}` : "";
+      const res = await fetch(`/api/kiosk/${encodeURIComponent(token!)}${params}`);
+      if (!res.ok) {
+        setError(true);
+        return;
+      }
+      const json = await res.json() as { data: KioskData };
+      setData(json.data);
+    } catch {
+      setError(true);
+    }
+  }, [token, fidelity]);
 
+  // Initial fetch + polling with visibility-aware pause
   useEffect(() => {
-    const id = setInterval(refetch, REFRESH_INTERVAL_MS);
-    return () => clearInterval(id);
-  }, [refetch]);
+    fetchData();
+
+    const scheduleRefresh = () => {
+      if (refreshRef.current) clearInterval(refreshRef.current);
+      const interval = data?.meta.refresh_interval_seconds
+        ? data.meta.refresh_interval_seconds * 1000
+        : fidelity === "epaper" ? 1_800_000 : 300_000;
+      refreshRef.current = setInterval(() => {
+        if (!document.hidden) fetchData();
+      }, interval);
+    };
+
+    scheduleRefresh();
+
+    const onVisibility = () => {
+      if (!document.hidden) fetchData();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      if (refreshRef.current) clearInterval(refreshRef.current);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchData]);
 
   if (error) {
     return (
-      <div className="h-[100dvh] bg-zinc-950 flex items-center justify-center">
-        <div className="text-center max-w-sm px-4">
-          <div className="w-12 h-12 rounded-full bg-red-500/20 flex items-center justify-center mx-auto mb-4">
-            <span className="text-red-400 text-2xl">!</span>
+      <div style={{ height: "100dvh", background: "#09090b", display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <div style={{ textAlign: "center", maxWidth: 360, padding: "0 24px" }}>
+          <div style={{
+            width: 48, height: 48, borderRadius: "50%", background: "rgba(239,68,68,0.2)",
+            display: "flex", alignItems: "center", justifyContent: "center", margin: "0 auto 16px",
+          }}>
+            <span style={{ color: "#f87171", fontSize: 24, fontWeight: 700 }}>!</span>
           </div>
-          <h1 className="text-white text-xl font-bold mb-2">Kiosk unavailable</h1>
-          <p className="text-zinc-400 text-sm">This kiosk link is no longer valid. Ask the owner to share a new one.</p>
+          <h1 style={{ color: "#fafafa", fontSize: 20, fontWeight: 700, marginBottom: 8 }}>Kiosk unavailable</h1>
+          <p style={{ color: "#a1a1aa", fontSize: 14 }}>This kiosk link is no longer valid. Ask the owner to share a new one.</p>
         </div>
       </div>
     );
   }
 
-  const d: KioskData = data ?? { tonight: [], week: [], recent: [], watching: [] };
+  const C = PALETTE[fidelity];
+  const epaper = fidelity === "epaper";
+  const breathe = fidelity === "rich";
+  const Mono: React.CSSProperties = { fontFamily: "ui-monospace, 'JetBrains Mono', Menlo, monospace" };
+
+  const household = data?.meta.household ?? "";
+  const refreshSec = data?.meta.refresh_interval_seconds ?? (fidelity === "epaper" ? 1800 : 300);
+  const refreshLabel = refreshSec >= 1800 ? `Auto-refreshes every ${Math.round(refreshSec / 60)} min` : "Auto-refreshes every 5 min";
 
   return (
-    <div className="h-[100dvh] bg-zinc-950 text-zinc-100 flex flex-col overflow-hidden">
-      {/* Header */}
-      <div className="flex-none px-5 py-3 border-b border-white/[0.06] flex items-center justify-between bg-zinc-900/50">
-        <div className="flex items-center gap-3">
-          <div className="w-7 h-7 rounded-md bg-amber-400 flex items-center justify-center font-extrabold text-sm text-black leading-none select-none">R</div>
-          <span className="text-base font-bold text-white tracking-tight hidden sm:inline">Remindarr</span>
-        </div>
-        <div className="text-right">
-          <p className="text-sm font-semibold text-white tabular-nums">{formatTime(now)}</p>
-          <p className="text-xs text-zinc-400">{formatDate(now)}</p>
-        </div>
+    <div style={{
+      width: "100vw", height: "100dvh",
+      background: C.bg, color: C.text, overflow: "hidden",
+      fontFamily: '"Plus Jakarta Sans", system-ui, sans-serif',
+      display: "flex", flexDirection: "column",
+      WebkitFontSmoothing: epaper ? "none" : "antialiased",
+      border: epaper ? `3px solid ${C.border}` : "none",
+      boxSizing: "border-box",
+      position: "relative",
+    }}>
+      {breathe && (
+        <style>{`
+          @keyframes kblink { 0%,100%{opacity:1} 50%{opacity:.45} }
+          @keyframes kfade { from{opacity:0;transform:translateY(8px)} to{opacity:1;transform:none} }
+        `}</style>
+      )}
+
+      <KioskHeader
+        C={C}
+        epaper={epaper}
+        fidelity={fidelity}
+        household={household}
+        date={formatKioskDate(now)}
+        clock={formatKioskClock(now, clock24)}
+      />
+
+      {data?.airing_now ? (
+        <HeroCard C={C} epaper={epaper} breathe={breathe} slot={data.airing_now} />
+      ) : (
+        data !== null && <HeroEmpty C={C} epaper={epaper} />
+      )}
+
+      {/* Two-column body */}
+      <div style={{
+        margin: "24px 56px 0", flex: 1, minHeight: 0,
+        display: "grid", gridTemplateColumns: "1fr 1fr", gap: 24,
+        overflow: "hidden",
+      }}>
+        <ReleasingTodayPanel
+          C={C} epaper={epaper} breathe={breathe}
+          releases={data?.releasing_today ?? []}
+          nowMs={now.getTime()}
+        />
+        <UnwatchedQueuePanel
+          C={C} epaper={epaper} breathe={breathe}
+          queue={data?.unwatched_queue ?? []}
+          nowMs={now.getTime()}
+        />
       </div>
 
-      {/* Scrollable content */}
-      <div className="flex-1 overflow-y-auto px-5 py-5 space-y-8">
-        {/* Tonight */}
-        <section>
-          <SectionHeader title="Tonight" />
-          <TonightSection episodes={d.tonight} />
-        </section>
-
-        {/* This week */}
-        <section>
-          <SectionHeader title="This Week" />
-          <WeekSection episodes={d.week} />
-        </section>
-
-        {/* Latest releases */}
-        <section>
-          <SectionHeader title="Latest Releases" />
-          <RecentSection titles={d.recent} />
-        </section>
-
-        {/* Currently watching */}
-        <section>
-          <SectionHeader title="Currently Watching" />
-          <WatchingSection titles={d.watching} />
-        </section>
+      {/* Footer */}
+      <div style={{
+        margin: "20px 56px 18px",
+        display: "flex", alignItems: "center", gap: 28,
+        ...Mono, fontSize: 11, color: C.veryDim, letterSpacing: 2, textTransform: "uppercase",
+        paddingTop: 14, borderTop: `1px solid ${C.borderSoft}`,
+        flexShrink: 0,
+      }}>
+        <span>{refreshLabel}</span>
+        <span style={{ flex: 1 }} />
+        <span>read-only · token {token?.slice(0, 4) ?? "—"}</span>
+        <span>{typeof window !== "undefined" ? window.location.hostname : ""}/kiosk</span>
       </div>
     </div>
   );

--- a/frontend/src/routes/HomeRoute.test.tsx
+++ b/frontend/src/routes/HomeRoute.test.tsx
@@ -1,12 +1,21 @@
 import { describe, it, expect, mock, afterEach } from "bun:test";
 import { render, cleanup, waitFor } from "@testing-library/react";
 import { MemoryRouter, Routes, Route, useLocation } from "react-router";
+import { createContext, useContext } from "react";
 
 import "../i18n";
 
 let mockIsMobile = false;
 mock.module("../hooks/useIsMobile", () => ({
   useIsMobile: () => mockIsMobile,
+}));
+
+// Provide a real React context so <AuthContext value={...}> works in React 19
+// even when an earlier test file has leaked a broken mock.module for AuthContext.
+const MockAuthContext = createContext<any>(null);
+mock.module("../context/AuthContext", () => ({
+  useAuth: () => useContext(MockAuthContext) ?? { user: null, providers: null, loading: false },
+  AuthContext: MockAuthContext,
 }));
 
 const { default: HomeRoute } = await import("./HomeRoute");

--- a/server/db/repository/users.ts
+++ b/server/db/repository/users.ts
@@ -409,10 +409,14 @@ export async function setKioskToken(userId: string, token: string | null): Promi
   });
 }
 
-export async function getUserByKioskToken(token: string): Promise<{ id: string } | null> {
+export async function getUserByKioskToken(token: string): Promise<{ id: string; username: string; displayUsername: string | null } | null> {
   return traceDbQuery("getUserByKioskToken", async () => {
     const db = getDb();
-    const row = await db.select({ id: users.id }).from(users).where(eq(users.kioskToken, token)).get();
+    const row = await db
+      .select({ id: users.id, username: users.username, displayUsername: users.displayUsername })
+      .from(users)
+      .where(eq(users.kioskToken, token))
+      .get();
     return row ?? null;
   });
 }

--- a/server/routes/kiosk.test.ts
+++ b/server/routes/kiosk.test.ts
@@ -63,154 +63,194 @@ describe("GET /kiosk/:token (public dashboard)", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns dashboard data for valid token", async () => {
+  it("returns dashboard data with new shape for valid token", async () => {
     const regenRes = await app.request("/kiosk/token/regenerate", {
       method: "POST",
       headers: authHeaders(),
     });
-    const { token } = await regenRes.json() as { token: string };
+    const { token } = (await regenRes.json()) as { token: string };
 
     const res = await app.request(`/kiosk/${token}`);
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
-    expect(Array.isArray(body.tonight)).toBe(true);
-    expect(Array.isArray(body.week)).toBe(true);
-    expect(Array.isArray(body.recent)).toBe(true);
-    expect(Array.isArray(body.watching)).toBe(true);
+    const body = (await res.json()) as any;
+    expect(body.meta).toBeDefined();
+    expect(typeof body.meta.household).toBe("string");
+    expect(typeof body.meta.fidelity).toBe("string");
+    expect(typeof body.meta.refresh_interval_seconds).toBe("number");
+    expect(typeof body.meta.generated_at).toBe("string");
+    expect(Array.isArray(body.releasing_today)).toBe(true);
+    expect(Array.isArray(body.unwatched_queue)).toBe(true);
+    // airing_now is null when no episodes exist in test db
+    expect(body.airing_now).toBeNull();
   });
 
-  it("sets Cache-Control: no-cache on dashboard response", async () => {
+  it("sets Cache-Control: no-cache, no-store", async () => {
     const regenRes = await app.request("/kiosk/token/regenerate", {
       method: "POST",
       headers: authHeaders(),
     });
-    const { token } = await regenRes.json() as { token: string };
+    const { token } = (await regenRes.json()) as { token: string };
 
     const res = await app.request(`/kiosk/${token}`);
-    expect(res.headers.get("Cache-Control")).toContain("no-cache");
+    expect(res.headers.get("Cache-Control")).toBe("no-cache, no-store");
   });
 
-  it("returns 401 after token is revoked", async () => {
+  it("returns 300 refresh_interval_seconds for rich fidelity", async () => {
     const regenRes = await app.request("/kiosk/token/regenerate", {
       method: "POST",
       headers: authHeaders(),
     });
-    const { token } = await regenRes.json() as { token: string };
+    const { token } = (await regenRes.json()) as { token: string };
 
-    await app.request("/kiosk/token", { method: "DELETE", headers: authHeaders() });
-
-    const res = await app.request(`/kiosk/${token}`);
-    expect(res.status).toBe(401);
+    const res = await app.request(`/kiosk/${token}?display=rich`);
+    const body = (await res.json()) as any;
+    expect(body.meta.refresh_interval_seconds).toBe(300);
+    expect(body.meta.fidelity).toBe("rich");
   });
 
-  it("returns 401 after token is regenerated (old token invalid)", async () => {
-    const res1 = await app.request("/kiosk/token/regenerate", {
+  it("returns 1800 refresh_interval_seconds for epaper fidelity", async () => {
+    const regenRes = await app.request("/kiosk/token/regenerate", {
       method: "POST",
       headers: authHeaders(),
     });
-    const { token: oldToken } = await res1.json() as { token: string };
+    const { token } = (await regenRes.json()) as { token: string };
 
-    await app.request("/kiosk/token/regenerate", { method: "POST", headers: authHeaders() });
+    const res = await app.request(`/kiosk/${token}?display=epaper`);
+    const body = (await res.json()) as any;
+    expect(body.meta.refresh_interval_seconds).toBe(1800);
+    expect(body.meta.fidelity).toBe("epaper");
+  });
 
-    const res = await app.request(`/kiosk/${oldToken}`);
-    expect(res.status).toBe(401);
+  it("returns 300 refresh_interval_seconds for lite fidelity", async () => {
+    const regenRes = await app.request("/kiosk/token/regenerate", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    const { token } = (await regenRes.json()) as { token: string };
+
+    const res = await app.request(`/kiosk/${token}?display=lite`);
+    const body = (await res.json()) as any;
+    expect(body.meta.refresh_interval_seconds).toBe(300);
+    expect(body.meta.fidelity).toBe("lite");
+  });
+
+  it("returns 400 for invalid display query param", async () => {
+    const regenRes = await app.request("/kiosk/token/regenerate", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    const { token } = (await regenRes.json()) as { token: string };
+
+    const res = await app.request(`/kiosk/${token}?display=invalid`);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("returns 400 for token longer than 64 chars", async () => {
+    const res = await app.request(`/kiosk/${"x".repeat(65)}`);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("defaults to rich fidelity when display param is absent", async () => {
+    const regenRes = await app.request("/kiosk/token/regenerate", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    const { token } = (await regenRes.json()) as { token: string };
+
+    const res = await app.request(`/kiosk/${token}`);
+    const body = (await res.json()) as any;
+    expect(body.meta.fidelity).toBe("rich");
+    expect(body.meta.refresh_interval_seconds).toBe(300);
   });
 });
 
 describe("validation", () => {
-  it("returns 400 for token that exceeds max length", async () => {
-    const longToken = "a".repeat(65);
-    const res = await app.request(`/kiosk/${longToken}`);
+  it("returns 400 with issues array for invalid display param", async () => {
+    const regenRes = await app.request("/kiosk/token/regenerate", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    const { token } = (await regenRes.json()) as { token: string };
+
+    const res = await app.request(`/kiosk/${token}?display=hd`);
     expect(res.status).toBe(400);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
+    expect(body.error).toBe("Validation failed");
     expect(Array.isArray(body.issues)).toBe(true);
   });
 });
 
-describe("GET /kiosk/token", () => {
-  it("returns 401 without auth", async () => {
+describe("GET /api/kiosk/token (auth)", () => {
+  it("returns 401 without session", async () => {
     const res = await app.request("/kiosk/token");
     expect(res.status).toBe(401);
   });
 
-  it("returns null token before any generation", async () => {
+  it("returns { token: null } before any token is generated", async () => {
     const res = await app.request("/kiosk/token", { headers: authHeaders() });
     expect(res.status).toBe(200);
-    const body = await res.json() as { token: string | null };
+    const body = (await res.json()) as any;
     expect(body.token).toBeNull();
-  });
-
-  it("returns token after regeneration", async () => {
-    await app.request("/kiosk/token/regenerate", {
-      method: "POST",
-      headers: authHeaders(),
-    });
-    const res = await app.request("/kiosk/token", { headers: authHeaders() });
-    expect(res.status).toBe(200);
-    const body = await res.json() as { token: string };
-    expect(typeof body.token).toBe("string");
-    expect(body.token.length).toBeGreaterThan(0);
   });
 });
 
-describe("POST /kiosk/token/regenerate", () => {
-  it("returns 401 without auth", async () => {
-    const res = await app.request("/kiosk/token/regenerate", { method: "POST" });
-    expect(res.status).toBe(401);
-  });
-
-  it("generates a 32-char hex token", async () => {
+describe("POST /api/kiosk/token/regenerate (auth)", () => {
+  it("returns a new token", async () => {
     const res = await app.request("/kiosk/token/regenerate", {
       method: "POST",
       headers: authHeaders(),
     });
     expect(res.status).toBe(200);
-    const body = await res.json() as { token: string };
+    const body = (await res.json()) as any;
     expect(typeof body.token).toBe("string");
-    expect(body.token).toMatch(/^[0-9a-f]{32}$/);
+    expect(body.token.length).toBeGreaterThan(0);
   });
 
-  it("new token replaces the old one", async () => {
+  it("a second regenerate invalidates the first token", async () => {
     const res1 = await app.request("/kiosk/token/regenerate", {
       method: "POST",
       headers: authHeaders(),
     });
-    const { token: token1 } = await res1.json() as { token: string };
+    const { token: t1 } = (await res1.json()) as { token: string };
 
-    const res2 = await app.request("/kiosk/token/regenerate", {
-      method: "POST",
-      headers: authHeaders(),
-    });
-    const { token: token2 } = await res2.json() as { token: string };
-
-    expect(token1).not.toBe(token2);
-
-    const getRes = await app.request("/kiosk/token", { headers: authHeaders() });
-    const { token: storedToken } = await getRes.json() as { token: string };
-    expect(storedToken).toBe(token2);
-  });
-});
-
-describe("DELETE /kiosk/token", () => {
-  it("returns 401 without auth", async () => {
-    const res = await app.request("/kiosk/token", { method: "DELETE" });
-    expect(res.status).toBe(401);
-  });
-
-  it("returns 204 and clears the token", async () => {
     await app.request("/kiosk/token/regenerate", {
       method: "POST",
       headers: authHeaders(),
     });
 
-    const deleteRes = await app.request("/kiosk/token", {
+    const dashRes = await app.request(`/kiosk/${t1}`);
+    expect(dashRes.status).toBe(401);
+  });
+});
+
+describe("DELETE /api/kiosk/token (auth)", () => {
+  it("returns 401 without session", async () => {
+    const res = await app.request("/kiosk/token", { method: "DELETE" });
+    expect(res.status).toBe(401);
+  });
+
+  it("revokes the token — subsequent dashboard requests return 401", async () => {
+    const regenRes = await app.request("/kiosk/token/regenerate", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    const { token } = (await regenRes.json()) as { token: string };
+
+    await app.request("/kiosk/token", { method: "DELETE", headers: authHeaders() });
+
+    const dashRes = await app.request(`/kiosk/${token}`);
+    expect(dashRes.status).toBe(401);
+  });
+
+  it("returns 204", async () => {
+    const res = await app.request("/kiosk/token", {
       method: "DELETE",
       headers: authHeaders(),
     });
-    expect(deleteRes.status).toBe(204);
-
-    const getRes = await app.request("/kiosk/token", { headers: authHeaders() });
-    const body = await getRes.json() as { token: string | null };
-    expect(body.token).toBeNull();
+    expect(res.status).toBe(204);
   });
 });

--- a/server/routes/kiosk.ts
+++ b/server/routes/kiosk.ts
@@ -5,8 +5,7 @@ import {
   getKioskToken,
   setKioskToken,
   getEpisodesByDateRange,
-  getRecentTitles,
-  getTrackedTitles,
+  getUnwatchedEpisodes,
 } from "../db/repository";
 import { requireAuth } from "../middleware/auth";
 import { zValidator } from "../lib/validator";
@@ -15,6 +14,32 @@ import { ok, err } from "./response";
 import type { AppEnv } from "../types";
 
 const app = new Hono<AppEnv>();
+
+const FIDELITY_VALUES = ["rich", "lite", "epaper"] as const;
+type KioskFidelity = (typeof FIDELITY_VALUES)[number];
+
+const REFRESH_SECONDS: Record<KioskFidelity, number> = {
+  rich: 300,
+  lite: 300,
+  epaper: 1800,
+};
+
+// FLATRATE > FREE > ADS > any other monetization type
+const OFFER_PRIORITY: Record<string, number> = { FLATRATE: 0, FREE: 1, ADS: 2 };
+
+function pickProvider(offers: Array<{ provider_name?: string; monetization_type?: string | null }>): string | null {
+  if (offers.length === 0) return null;
+  const sorted = [...offers].sort((a, b) => {
+    const pa = OFFER_PRIORITY[a.monetization_type ?? ""] ?? 99;
+    const pb = OFFER_PRIORITY[b.monetization_type ?? ""] ?? 99;
+    return pa - pb;
+  });
+  return sorted[0]?.provider_name ?? null;
+}
+
+function episodeKind(season: number, episode: number): "series" | "episode" {
+  return season === 1 && episode === 1 ? "series" : "episode";
+}
 
 // ─── Auth-gated token management (registered before /:token to avoid shadowing) ──
 
@@ -42,34 +67,103 @@ app.delete("/token", requireAuth, async (c) => {
 
 // ─── Public dashboard ─────────────────────────────────────────────────────────
 
-// GET /api/kiosk/:token  (public, token-authenticated)
-app.get("/:token", zValidator("param", z.object({ token: z.string().min(1).max(64) })), async (c) => {
-  const { token } = c.req.valid("param");
+// GET /api/kiosk/:token?display=rich|lite|epaper  (public, token-authenticated)
+app.get(
+  "/:token",
+  zValidator("param", z.object({ token: z.string().min(1).max(64) })),
+  zValidator("query", z.object({ display: z.enum(FIDELITY_VALUES).optional() })),
+  async (c) => {
+    const { token } = c.req.valid("param");
+    const { display } = c.req.valid("query");
+    const fidelity: KioskFidelity = display ?? "rich";
 
-  const user = await getUserByKioskToken(token);
-  if (!user) return err(c, "Invalid kiosk token", 401);
+    const user = await getUserByKioskToken(token);
+    if (!user) return err(c, "Invalid kiosk token", 401);
 
-  const timezone = c.req.header("X-Timezone") || "UTC";
-  const today = localDateForTimezone(timezone);
-  const tomorrow = addDays(today, 1);
-  const weekEnd = addDays(today, 8);
+    const timezone = c.req.header("X-Timezone") || "UTC";
+    const today = localDateForTimezone(timezone);
+    const tomorrow = addDays(today, 1);
 
-  const [tonight, week, recentArr, tracked] = await Promise.all([
-    getEpisodesByDateRange(today, tomorrow, user.id),
-    getEpisodesByDateRange(tomorrow, weekEnd, user.id),
-    getRecentTitles({ daysBack: 14, limit: 24 }, user.id),
-    getTrackedTitles(user.id),
-  ]);
+    const [todayEpisodes, allUnwatched] = await Promise.all([
+      getEpisodesByDateRange(today, tomorrow, user.id),
+      getUnwatchedEpisodes(user.id, timezone),
+    ]);
 
-  const watching = tracked
-    .filter((t) => t.show_status === "watching")
-    .slice(0, 12)
-    .map(({ id, object_type, title, original_title, release_year, release_date, poster_url, tmdb_id, imdb_id, tmdb_url, tmdb_score, imdb_score, genres, offers, next_episode_air_date, total_episodes, watched_episodes_count, released_episodes_count, show_status }) => ({
-      id, object_type, title, original_title, release_year, release_date, poster_url, tmdb_id, imdb_id, tmdb_url, tmdb_score, imdb_score, genres, offers, next_episode_air_date, total_episodes, watched_episodes_count, released_episodes_count, show_status,
+    // airing_now — first unwatched today, fall back to first today
+    const airingNow = todayEpisodes.find((e) => !e.is_watched) ?? todayEpisodes[0] ?? null;
+
+    // releasing_today — all episodes today, projected with provider + kind
+    const releasingToday = todayEpisodes.map((e) => ({
+      id: e.id,
+      title_id: e.title_id,
+      show_title: e.show_title,
+      poster_url: e.poster_url,
+      backdrop_url: e.backdrop_url,
+      season_number: e.season_number,
+      episode_number: e.episode_number,
+      ep_title: e.name,
+      air_date: e.air_date,
+      provider: pickProvider(e.offers),
+      kind: episodeKind(e.season_number, e.episode_number),
     }));
 
-  c.header("Cache-Control", "no-cache, no-store");
-  return ok(c, { tonight, week, recent: recentArr, watching });
-});
+    // unwatched_queue — next unwatched episode per tracked show
+    const seenTitles = new Set<string>();
+    const queueRows = allUnwatched.filter((e) => {
+      if (seenTitles.has(e.title_id)) return false;
+      seenTitles.add(e.title_id);
+      return true;
+    });
+    // Sort by air_date asc (oldest first, i.e. most overdue goes first)
+    queueRows.sort((a, b) => {
+      if (!a.air_date && !b.air_date) return 0;
+      if (!a.air_date) return 1;
+      if (!b.air_date) return -1;
+      return a.air_date < b.air_date ? -1 : a.air_date > b.air_date ? 1 : 0;
+    });
+    const unwatchedQueue = queueRows.slice(0, 12).map((e) => ({
+      id: e.id,
+      title_id: e.title_id,
+      show_title: e.show_title,
+      poster_url: e.poster_url,
+      season_number: e.season_number,
+      episode_number: e.episode_number,
+      ep_title: e.name,
+      air_date: e.air_date,
+      provider: pickProvider(e.offers),
+      left: Math.max(0, (e.total_episodes ?? 0) - (e.watched_episodes_count ?? 0)),
+    }));
+
+    const airingNowProjected = airingNow
+      ? {
+          id: airingNow.id,
+          title_id: airingNow.title_id,
+          show_title: airingNow.show_title,
+          poster_url: airingNow.poster_url,
+          backdrop_url: airingNow.backdrop_url,
+          season_number: airingNow.season_number,
+          episode_number: airingNow.episode_number,
+          ep_title: airingNow.name,
+          air_date: airingNow.air_date,
+          provider: pickProvider(airingNow.offers),
+        }
+      : null;
+
+    const household = user.displayUsername ?? user.username;
+
+    c.header("Cache-Control", "no-cache, no-store");
+    return ok(c, {
+      meta: {
+        household,
+        fidelity,
+        refresh_interval_seconds: REFRESH_SECONDS[fidelity],
+        generated_at: new Date().toISOString(),
+      },
+      airing_now: airingNowProjected,
+      releasing_today: releasingToday,
+      unwatched_queue: unwatchedQueue,
+    });
+  }
+);
 
 export default app;


### PR DESCRIPTION
## Summary

- Replaces the old four-section kiosk layout with a new composition: header rail (brand + clock), hero "Airing now" card with backdrop/breathing dot, two-column body (Releasing Today + Up Next in Queue), footer with refresh status
- Introduces three fidelity tiers via `?display=rich|lite|epaper` — `epaper` uses paper-white `#f6f3e8` palette, no antialiasing, hatched hero overlay, and 30-min refresh interval; `lite` is the same dark palette as `rich` but without animations
- Backend payload reshaped to `{ meta, airing_now, releasing_today, unwatched_queue }` with provider selection (FLATRATE > FREE > ADS), queue grouped per title sorted by oldest air date, capped at 12; `display` param validated with `zValidator`
- KioskPage uses raw `fetch` (not `api.getKioskData`) to skip the global `auth:unauthorized` CustomEvent that would log out a logged-in user on a 401 from an expired kiosk token
- Visibility API: polling pauses when tab is hidden, resumes + force-refetches on focus
- Fixes pre-existing `HomeRoute.test.tsx` mock.module leak: earlier test files exported `AuthContext: { Provider: ... }` which caused "Element type is invalid: got object" for all 4 HomeRoute tests in the full suite

## Test plan

- [x] `bun run check` passes: 1962 tests, 0 failures, 0 type errors, 0 lint warnings
- [ ] Manual: log in → Settings → Integrations → Kiosk → regenerate token → open `/kiosk/<token>` in incognito — confirm header, hero, two columns
- [ ] Manual: `?display=lite` — no breathing dot, no fade-in stagger
- [ ] Manual: `?display=epaper` — paper bg, hard borders, hatched hero, "every 30 min" in footer
- [ ] Manual: hide tab ≥1 min, switch back — confirm immediate refetch (network tab)
- [ ] Manual: revoke token in Settings — open kiosk tab shows "Kiosk unavailable" after next poll

Closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)