### PR TITLE
fix: kiosk empty queue + HeroBanner-style fallback hero

### DIFF
--- a/frontend/src/pages/KioskPage.test.tsx
+++ b/frontend/src/pages/KioskPage.test.tsx
@@ -70,7 +70,7 @@ function makeQueueItem(overrides: Partial<KioskQueueItem> = {}): KioskQueueItem 
   };
 }
 
-const mockFetch = mock((_url: string) =>
+const mockFetch = mock((_url: string, _init?: RequestInit) =>
   Promise.resolve({
     ok: true,
     json: () => Promise.resolve({ data: makeData() }),
@@ -140,10 +140,10 @@ describe("KioskPage", () => {
     });
   });
 
-  it("shows empty hero when airing_now is null", async () => {
+  it("shows empty hero when airing_now is null and no releases or queue", async () => {
     render(<Wrapper />);
     await waitFor(() => {
-      expect(screen.getByText("Nothing airing today")).toBeTruthy();
+      expect(screen.getByText("Nothing on the slate today")).toBeTruthy();
     });
   });
 
@@ -254,5 +254,46 @@ describe("KioskPage", () => {
       expect(screen.getByText(/releasing today/i)).toBeTruthy();
       expect(screen.getByText(/up next in your queue/i)).toBeTruthy();
     });
+  });
+
+  it("sends X-Timezone header on fetch", async () => {
+    mockFetch.mockClear();
+    render(<Wrapper />);
+    await waitFor(() => {
+      expect(screen.getByText("Remindarr")).toBeTruthy();
+    });
+    const calls = mockFetch.mock.calls as [string, RequestInit?][];
+    const init = calls[0]?.[1];
+    const headers = init?.headers as Record<string, string> | undefined;
+    expect(headers?.["X-Timezone"]).toBeTruthy();
+  });
+
+  it("shows fallback hero from releasing_today when airing_now is null", async () => {
+    mockFetch.mockImplementation((_url: string, _init?: RequestInit) =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ data: makeData({ airing_now: null, releasing_today: [makeRelease()] }) }),
+      } as Response)
+    );
+    render(<Wrapper />);
+    await waitFor(() => {
+      expect(screen.getAllByText("Releasing Show").length).toBeGreaterThan(0);
+    });
+    // The hero kicker for a releasing_today fallback
+    expect(screen.getAllByText(/releasing today/i).length).toBeGreaterThan(0);
+  });
+
+  it("shows fallback hero from unwatched_queue when airing_now and releasing_today are empty", async () => {
+    mockFetch.mockImplementation((_url: string, _init?: RequestInit) =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ data: makeData({ airing_now: null, releasing_today: [], unwatched_queue: [makeQueueItem()] }) }),
+      } as Response)
+    );
+    render(<Wrapper />);
+    await waitFor(() => {
+      expect(screen.getAllByText("Queued Show").length).toBeGreaterThan(0);
+    });
+    expect(screen.getAllByText(/up next in your queue/i).length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/pages/KioskPage.tsx
+++ b/frontend/src/pages/KioskPage.tsx
@@ -272,6 +272,95 @@ function HeroCard({ C, epaper, breathe, slot }: {
   );
 }
 
+type FeaturedItem = {
+  show_title: string;
+  season_number: number;
+  episode_number: number;
+  ep_title: string | null;
+  poster_url: string | null;
+  backdrop_url?: string | null;
+  provider: string | null;
+};
+
+function HeroFeatured({ C, epaper, breathe, item, kicker }: {
+  C: KioskPalette;
+  epaper: boolean;
+  breathe: boolean;
+  item: FeaturedItem;
+  kicker: string;
+}) {
+  const Mono: React.CSSProperties = { fontFamily: "ui-monospace, 'JetBrains Mono', Menlo, monospace" };
+  const backdropSrc = posterUrl(item.backdrop_url ?? item.poster_url, "w780");
+
+  return (
+    <div style={{
+      position: "relative", margin: "24px 56px 0",
+      height: 360, borderRadius: epaper ? 0 : 14, overflow: "hidden",
+      border: `${epaper ? 3 : 1}px solid ${epaper ? C.border : C.borderSoft}`,
+      background: C.surface,
+      animation: breathe ? "kfade 0.6s ease both" : "none",
+    }}>
+      {/* Backdrop */}
+      {!epaper && backdropSrc && (
+        <div style={{ position: "absolute", inset: 0, opacity: 0.85 }}>
+          <img src={backdropSrc} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+          <div style={{
+            position: "absolute", inset: 0,
+            background: `linear-gradient(90deg, ${C.bg} 0%, ${C.bg}ee 35%, transparent 75%), linear-gradient(0deg, ${C.bg} 0%, transparent 55%)`,
+          }} />
+        </div>
+      )}
+      {/* E-paper hatched fill */}
+      {epaper && (
+        <div style={{
+          position: "absolute", inset: 0,
+          backgroundImage: `repeating-linear-gradient(45deg, ${C.text} 0 1px, transparent 1px 5px)`,
+          opacity: 0.08,
+        }} />
+      )}
+
+      <div style={{ position: "absolute", inset: 0, padding: "32px 40px", display: "flex", flexDirection: "column", justifyContent: "flex-end" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 14 }}>
+          <span style={{
+            width: 10, height: 10, borderRadius: "50%", background: C.accent,
+            boxShadow: epaper ? "none" : "0 0 0 4px rgba(251,191,36,0.18)",
+            flexShrink: 0,
+          }} />
+          <div style={{ ...Mono, fontSize: 11, letterSpacing: 2, textTransform: "uppercase", color: C.accent }}>
+            {kicker}{item.provider ? ` · ${item.provider}` : ""}
+          </div>
+        </div>
+
+        <div style={{ fontSize: 80, fontWeight: 800, letterSpacing: -3, lineHeight: 0.92, marginBottom: 16, color: C.text }}>
+          {item.show_title}
+        </div>
+
+        <div style={{ fontSize: 18, color: C.dim, marginBottom: 22, maxWidth: 760, lineHeight: 1.5 }}>
+          S{item.season_number}·E{item.episode_number}
+          {item.ep_title && (
+            <> · <span style={{ color: C.text, fontWeight: 600 }}>{item.ep_title}</span></>
+          )}
+        </div>
+
+        {/* Cast button — decorative only (design note 3: deferred until streaming-device registry) */}
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <div
+            aria-hidden="true"
+            style={{
+              background: C.accent, color: C.accentInk,
+              padding: "12px 22px", borderRadius: epaper ? 0 : 8,
+              border: epaper ? `2px solid ${C.text}` : "none",
+              fontWeight: 700, fontSize: 15, display: "inline-flex", alignItems: "center", gap: 8,
+              opacity: 0.5, cursor: "default",
+            }}>
+            <CastIcon color={C.accentInk} /> Cast to TV
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function HeroEmpty({ C, epaper }: { C: KioskPalette; epaper: boolean }) {
   return (
     <div style={{
@@ -281,7 +370,7 @@ function HeroEmpty({ C, epaper }: { C: KioskPalette; epaper: boolean }) {
       display: "flex", alignItems: "center", justifyContent: "center",
     }}>
       <div style={{ fontFamily: "ui-monospace, 'JetBrains Mono', Menlo, monospace", fontSize: 13, color: C.veryDim, letterSpacing: 2, textTransform: "uppercase" }}>
-        Nothing airing today
+        Nothing on the slate today
       </div>
     </div>
   );
@@ -465,7 +554,10 @@ export default function KioskPage() {
     try {
       // Bypass the global auth:unauthorized event for this public endpoint
       const params = fidelity !== "rich" ? `?display=${encodeURIComponent(fidelity)}` : "";
-      const res = await fetch(`/api/kiosk/${encodeURIComponent(token!)}${params}`);
+      const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+      const res = await fetch(`/api/kiosk/${encodeURIComponent(token!)}${params}`, {
+        headers: { "X-Timezone": tz },
+      });
       if (!res.ok) {
         setError(true);
         return;
@@ -531,6 +623,18 @@ export default function KioskPage() {
   const refreshSec = data?.meta.refresh_interval_seconds ?? (fidelity === "epaper" ? 1800 : 300);
   const refreshLabel = refreshSec >= 1800 ? `Auto-refreshes every ${Math.round(refreshSec / 60)} min` : "Auto-refreshes every 5 min";
 
+  let heroFallbackItem: FeaturedItem | null = null;
+  let heroFallbackKicker = "";
+  if (data && !data.airing_now) {
+    if (data.releasing_today.length > 0) {
+      heroFallbackItem = data.releasing_today[0];
+      heroFallbackKicker = "Releasing today";
+    } else if (data.unwatched_queue.length > 0) {
+      heroFallbackItem = data.unwatched_queue[0];
+      heroFallbackKicker = "Up next in your queue";
+    }
+  }
+
   return (
     <div style={{
       width: "100vw", height: "100dvh",
@@ -560,6 +664,8 @@ export default function KioskPage() {
 
       {data?.airing_now ? (
         <HeroCard C={C} epaper={epaper} breathe={breathe} slot={data.airing_now} />
+      ) : heroFallbackItem ? (
+        <HeroFeatured C={C} epaper={epaper} breathe={breathe} item={heroFallbackItem} kicker={heroFallbackKicker} />
       ) : (
         data !== null && <HeroEmpty C={C} epaper={epaper} />
       )}

--- a/server/routes/kiosk.ts
+++ b/server/routes/kiosk.ts
@@ -11,7 +11,10 @@ import { requireAuth } from "../middleware/auth";
 import { zValidator } from "../lib/validator";
 import { localDateForTimezone, addDays } from "../utils/timezone";
 import { ok, err } from "./response";
+import { logger } from "../logger";
 import type { AppEnv } from "../types";
+
+const log = logger.child({ module: "kiosk" });
 
 const app = new Hono<AppEnv>();
 
@@ -88,6 +91,14 @@ app.get(
       getEpisodesByDateRange(today, tomorrow, user.id),
       getUnwatchedEpisodes(user.id, timezone),
     ]);
+
+    log.debug("kiosk dashboard query", {
+      userId: user.id,
+      timezone,
+      today,
+      todayCount: todayEpisodes.length,
+      unwatchedCount: allUnwatched.length,
+    });
 
     // airing_now — first unwatched today, fall back to first today
     const airingNow = todayEpisodes.find((e) => !e.is_watched) ?? todayEpisodes[0] ?? null;


### PR DESCRIPTION
## Summary

- **Empty unwatched queue fix**: Kiosk page now sends `X-Timezone` header on every fetch, so the server uses the browser's local date when filtering unwatched episodes. Without this the server always used UTC, causing episodes already aired in the user's timezone (but still "tomorrow" in UTC) to be excluded — making the queue appear empty while the home page showed the same shows correctly.
- **Diagnostic logging**: Added `log.debug("kiosk dashboard query", { userId, timezone, today, todayCount, unwatchedCount })` in `server/routes/kiosk.ts` so any remaining mismatch after the timezone fix is observable from Cloudflare logs without a new deploy.
- **HeroBanner-style fallback hero**: When `airing_now` is `null`, instead of the flat "nothing airing today" plate the hero now shows the first item from `releasing_today` (kicker: `RELEASING TODAY`) or falls back to `unwatched_queue[0]` (kicker: `UP NEXT IN YOUR QUEUE`), with a full-bleed backdrop image, dual gradient scrim, amber kicker, 80 px show title, S·E line, and decorative Cast button — matching the `HeroBanner` visual language from the home page. The truly-empty plate only appears when both lists are empty.

## Test plan

- [x] `bun test server/routes/kiosk.test.ts frontend/src/pages/KioskPage.test.tsx` → 33 pass, 0 fail
- [x] `bun run check` passes (only pre-existing flaky timing tests in `sync-utils.test.ts` fail intermittently)
- [ ] Open `/kiosk/<token>` in incognito; confirm queue populates with shows visible on home page
- [ ] Confirm hero shows backdrop + kicker + title from `releasing_today` or `unwatched_queue` when nothing airs today
- [ ] `?display=epaper` → ink + hatched overlay (no gradient) in fallback hero
- [ ] Token revoked in Settings → "Kiosk unavailable" after next poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)