### PR TITLE
fix: unwrap kiosk JSON response

### DIFF
--- a/frontend/src/pages/KioskPage.test.tsx
+++ b/frontend/src/pages/KioskPage.test.tsx
@@ -73,7 +73,7 @@ function makeQueueItem(overrides: Partial<KioskQueueItem> = {}): KioskQueueItem 
 const mockFetch = mock((_url: string, _init?: RequestInit) =>
   Promise.resolve({
     ok: true,
-    json: () => Promise.resolve({ data: makeData() }),
+    json: () => Promise.resolve(makeData()),
   } as Response)
 );
 
@@ -94,7 +94,7 @@ beforeEach(() => {
   mockFetch.mockImplementation((_url: string) =>
     Promise.resolve({
       ok: true,
-      json: () => Promise.resolve({ data: makeData() }),
+      json: () => Promise.resolve(makeData()),
     } as Response)
   );
 });
@@ -118,7 +118,7 @@ describe("KioskPage", () => {
     mockFetch.mockImplementation((_url: string) =>
       Promise.resolve({
         ok: true,
-        json: () => Promise.resolve({ data: makeData({ meta: { household: "The Test Manor", fidelity: "rich", refresh_interval_seconds: 300, generated_at: new Date().toISOString() } }) }),
+        json: () => Promise.resolve(makeData({ meta: { household: "The Test Manor", fidelity: "rich", refresh_interval_seconds: 300, generated_at: new Date().toISOString() } })),
       } as Response)
     );
     render(<Wrapper />);
@@ -131,7 +131,7 @@ describe("KioskPage", () => {
     mockFetch.mockImplementation((_url: string) =>
       Promise.resolve({
         ok: true,
-        json: () => Promise.resolve({ data: makeData({ airing_now: makeSlot() }) }),
+        json: () => Promise.resolve(makeData({ airing_now: makeSlot() })),
       } as Response)
     );
     render(<Wrapper />);
@@ -151,7 +151,7 @@ describe("KioskPage", () => {
     mockFetch.mockImplementation((_url: string) =>
       Promise.resolve({
         ok: true,
-        json: () => Promise.resolve({ data: makeData({ releasing_today: [makeRelease()] }) }),
+        json: () => Promise.resolve(makeData({ releasing_today: [makeRelease()] })),
       } as Response)
     );
     render(<Wrapper />);
@@ -164,7 +164,7 @@ describe("KioskPage", () => {
     mockFetch.mockImplementation((_url: string) =>
       Promise.resolve({
         ok: true,
-        json: () => Promise.resolve({ data: makeData({ unwatched_queue: [makeQueueItem()] }) }),
+        json: () => Promise.resolve(makeData({ unwatched_queue: [makeQueueItem()] })),
       } as Response)
     );
     render(<Wrapper />);
@@ -178,7 +178,7 @@ describe("KioskPage", () => {
     mockFetch.mockImplementation((_url: string) =>
       Promise.resolve({
         ok: true,
-        json: () => Promise.resolve({ data: makeData({ unwatched_queue: [makeQueueItem({ air_date: oldDate })] }) }),
+        json: () => Promise.resolve(makeData({ unwatched_queue: [makeQueueItem({ air_date: oldDate })] })),
       } as Response)
     );
     render(<Wrapper />);
@@ -192,7 +192,7 @@ describe("KioskPage", () => {
     mockFetch.mockImplementation((_url: string) =>
       Promise.resolve({
         ok: true,
-        json: () => Promise.resolve({ data: makeData({ unwatched_queue: [makeQueueItem({ air_date: recentDate })] }) }),
+        json: () => Promise.resolve(makeData({ unwatched_queue: [makeQueueItem({ air_date: recentDate })] })),
       } as Response)
     );
     render(<Wrapper />);
@@ -205,7 +205,7 @@ describe("KioskPage", () => {
     mockFetch.mockImplementation((_url: string) =>
       Promise.resolve({
         ok: true,
-        json: () => Promise.resolve({ data: makeData({ meta: { household: "House", fidelity: "epaper", refresh_interval_seconds: 1800, generated_at: new Date().toISOString() } }) }),
+        json: () => Promise.resolve(makeData({ meta: { household: "House", fidelity: "epaper", refresh_interval_seconds: 1800, generated_at: new Date().toISOString() } })),
       } as Response)
     );
     render(<Wrapper search="?display=epaper" />);
@@ -218,7 +218,7 @@ describe("KioskPage", () => {
     mockFetch.mockImplementation((_url: string) =>
       Promise.resolve({
         ok: true,
-        json: () => Promise.resolve({ data: makeData({ airing_now: makeSlot() }) }),
+        json: () => Promise.resolve(makeData({ airing_now: makeSlot() })),
       } as Response)
     );
     render(<Wrapper />);
@@ -272,7 +272,7 @@ describe("KioskPage", () => {
     mockFetch.mockImplementation((_url: string, _init?: RequestInit) =>
       Promise.resolve({
         ok: true,
-        json: () => Promise.resolve({ data: makeData({ airing_now: null, releasing_today: [makeRelease()] }) }),
+        json: () => Promise.resolve(makeData({ airing_now: null, releasing_today: [makeRelease()] })),
       } as Response)
     );
     render(<Wrapper />);
@@ -287,7 +287,7 @@ describe("KioskPage", () => {
     mockFetch.mockImplementation((_url: string, _init?: RequestInit) =>
       Promise.resolve({
         ok: true,
-        json: () => Promise.resolve({ data: makeData({ airing_now: null, releasing_today: [], unwatched_queue: [makeQueueItem()] }) }),
+        json: () => Promise.resolve(makeData({ airing_now: null, releasing_today: [], unwatched_queue: [makeQueueItem()] })),
       } as Response)
     );
     render(<Wrapper />);

--- a/frontend/src/pages/KioskPage.tsx
+++ b/frontend/src/pages/KioskPage.tsx
@@ -562,8 +562,8 @@ export default function KioskPage() {
         setError(true);
         return;
       }
-      const json = await res.json() as { data: KioskData };
-      setData(json.data);
+      const json = await res.json() as KioskData;
+      setData(json);
     } catch {
       setError(true);
     }


### PR DESCRIPTION
## Summary

- The kiosk page was reading `json.data` from the API response, but the server's `ok()` helper sends data **unwrapped** (`c.json(data)` with no `{ data: ... }` envelope) — so `setData` was always called with `undefined`, leaving the queue and hero blank even when the API returned a full payload
- Updated `KioskPage.tsx` to read `json` directly instead of `json.data`
- Updated all 12 mock fixtures in `KioskPage.test.tsx` to match the real server shape (they had been wrapping in `{ data: ... }` which masked the bug)

This is the root-cause fix behind the "still nothing and requests are being made that return stuff in the response" report after PR #566 merged.

Closes #548

## Test plan

- [ ] `bun run check` passes clean (tsc + lint + all tests)
- [ ] Hard-refresh live kiosk URL — "Up Next In Your Queue" now populates with tracked shows
- [ ] `?display=epaper` and `?display=lite` still render correctly
- [ ] Cloudflare log line `kiosk dashboard query` shows `unwatchedCount > 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)