### PR TITLE
feat(dx): useAsyncError hook + sonner toast for standardized error handling (closes #500)

### DIFF
--- a/frontend/src/components/CategoryBrowse.tsx
+++ b/frontend/src/components/CategoryBrowse.tsx
@@ -102,11 +102,10 @@ export default function CategoryBrowse({
   onResultsCount,
 }: Props) {
   const [titles, setTitles] = useState<Title[]>([]);
-  const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
-  const { run, error } = useAsyncError();
+  const { run, error, pending: loading } = useAsyncError();
   const [availableGenres, setAvailableGenres] = useState<string[]>([]);
 
   const [availableProviders, setAvailableProviders] = useState<{ id: number; name: string; iconUrl: string }[]>([]);
@@ -114,57 +113,57 @@ export default function CategoryBrowse({
   const [regionProviderIds, setRegionProviderIds] = useState<number[]>([]);
   const [priorityLanguageCodes, setPriorityLanguageCodes] = useState<string[]>([]);
 
-  const fetchTitles = useCallback(async (pageNum: number, append: boolean) => {
-    if (append) {
-      setLoadingMore(true);
-    } else {
-      setLoading(true);
-    }
-    await run(async () => {
-      const yearMinNum = yearMin ? parseInt(yearMin, 10) : undefined;
-      const yearMaxNum = yearMax ? parseInt(yearMax, 10) : undefined;
-      const minRatingNum = minRating ? parseFloat(minRating) : undefined;
-      const res = await api.browseTitles({
-        category,
-        type: type.length ? type.join(",") : undefined,
-        page: pageNum,
-        genre: genre.length ? genre.join(",") : undefined,
-        provider: provider.length ? provider.join(",") : undefined,
-        language: language.length ? language.join(",") : undefined,
-        yearMin: yearMinNum != null && Number.isFinite(yearMinNum) ? yearMinNum : undefined,
-        yearMax: yearMaxNum != null && Number.isFinite(yearMaxNum) ? yearMaxNum : undefined,
-        minRating: minRatingNum != null && Number.isFinite(minRatingNum) ? minRatingNum : undefined,
-      });
-      const normalized = res.titles.map(normalizeSearchTitle);
+  const fetchTitles = useCallback((pageNum: number, append: boolean) => {
+    return run(async () => {
       if (append) {
-        setTitles((prev) => [...prev, ...normalized]);
-      } else {
-        setTitles(normalized);
+        setLoadingMore(true);
       }
-      if (res.availableGenres) {
-        setAvailableGenres(res.availableGenres);
+      try {
+        const yearMinNum = yearMin ? parseInt(yearMin, 10) : undefined;
+        const yearMaxNum = yearMax ? parseInt(yearMax, 10) : undefined;
+        const minRatingNum = minRating ? parseFloat(minRating) : undefined;
+        const res = await api.browseTitles({
+          category,
+          type: type.length ? type.join(",") : undefined,
+          page: pageNum,
+          genre: genre.length ? genre.join(",") : undefined,
+          provider: provider.length ? provider.join(",") : undefined,
+          language: language.length ? language.join(",") : undefined,
+          yearMin: yearMinNum != null && Number.isFinite(yearMinNum) ? yearMinNum : undefined,
+          yearMax: yearMaxNum != null && Number.isFinite(yearMaxNum) ? yearMaxNum : undefined,
+          minRating: minRatingNum != null && Number.isFinite(minRatingNum) ? minRatingNum : undefined,
+        });
+        const normalized = res.titles.map(normalizeSearchTitle);
+        if (append) {
+          setTitles((prev) => [...prev, ...normalized]);
+        } else {
+          setTitles(normalized);
+        }
+        if (res.availableGenres) {
+          setAvailableGenres(res.availableGenres);
+        }
+        if (res.availableProviders) {
+          setAvailableProviders(res.availableProviders);
+        }
+        if (res.availableLanguages) {
+          setAvailableLanguages(res.availableLanguages);
+        }
+        if (res.regionProviderIds) {
+          setRegionProviderIds(res.regionProviderIds);
+        }
+        if (res.priorityLanguageCodes) {
+          setPriorityLanguageCodes(res.priorityLanguageCodes);
+        }
+        setTotalPages(res.totalPages);
+        if (!append) {
+          onResultsCount?.(res.totalResults);
+        }
+        setPage(pageNum);
+      } finally {
+        setLoadingMore(false);
       }
-      if (res.availableProviders) {
-        setAvailableProviders(res.availableProviders);
-      }
-      if (res.availableLanguages) {
-        setAvailableLanguages(res.availableLanguages);
-      }
-      if (res.regionProviderIds) {
-        setRegionProviderIds(res.regionProviderIds);
-      }
-      if (res.priorityLanguageCodes) {
-        setPriorityLanguageCodes(res.priorityLanguageCodes);
-      }
-      setTotalPages(res.totalPages);
-      if (!append) {
-        onResultsCount?.(res.totalResults);
-      }
-      setPage(pageNum);
     });
-    setLoading(false);
-    setLoadingMore(false);
-  }, [category, type, genre, provider, language, yearMin, yearMax, minRating, onResultsCount, run]);
+  }, [run, category, type, genre, provider, language, yearMin, yearMax, minRating, onResultsCount]);
 
   useEffect(() => {
     fetchTitles(1, false);

--- a/frontend/src/components/CategoryBrowse.tsx
+++ b/frontend/src/components/CategoryBrowse.tsx
@@ -5,6 +5,7 @@ import { normalizeSearchTitle } from "../types";
 import TitleList from "./TitleList";
 import FilterBar from "./FilterBar";
 import type { BrowseCategory } from "./CategoryBar";
+import { useAsyncError } from "../hooks/useAsyncError";
 
 export function filterBrowseTitles(
   titles: Title[],
@@ -105,7 +106,7 @@ export default function CategoryBrowse({
   const [loadingMore, setLoadingMore] = useState(false);
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
-  const [error, setError] = useState("");
+  const { run, error } = useAsyncError();
   const [availableGenres, setAvailableGenres] = useState<string[]>([]);
 
   const [availableProviders, setAvailableProviders] = useState<{ id: number; name: string; iconUrl: string }[]>([]);
@@ -119,8 +120,7 @@ export default function CategoryBrowse({
     } else {
       setLoading(true);
     }
-    setError("");
-    try {
+    await run(async () => {
       const yearMinNum = yearMin ? parseInt(yearMin, 10) : undefined;
       const yearMaxNum = yearMax ? parseInt(yearMax, 10) : undefined;
       const minRatingNum = minRating ? parseFloat(minRating) : undefined;
@@ -161,13 +161,10 @@ export default function CategoryBrowse({
         onResultsCount?.(res.totalResults);
       }
       setPage(pageNum);
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setLoading(false);
-      setLoadingMore(false);
-    }
-  }, [category, type, genre, provider, language, yearMin, yearMax, minRating, onResultsCount]);
+    });
+    setLoading(false);
+    setLoadingMore(false);
+  }, [category, type, genre, provider, language, yearMin, yearMax, minRating, onResultsCount, run]);
 
   useEffect(() => {
     fetchTitles(1, false);

--- a/frontend/src/components/NewReleases.tsx
+++ b/frontend/src/components/NewReleases.tsx
@@ -48,8 +48,7 @@ export default function NewReleases({
 }: Props) {
   const { t } = useTranslation();
   const [titles, setTitles] = useState<Title[]>([]);
-  const [loading, setLoading] = useState(false);
-  const { run, error } = useAsyncError();
+  const { run, error, pending: loading } = useAsyncError();
 
   const [genres, setGenres] = useState<string[]>([]);
   const [providers, setProviders] = useState<Provider[]>([]);
@@ -67,22 +66,18 @@ export default function NewReleases({
     });
   }, []);
 
-  const fetchTitles = useCallback(async () => {
-    setLoading(true);
-    await run(async () => {
-      const res = await api.getTitles({
-        daysBack,
-        type: type.length ? type.join(",") : undefined,
-        genre: genre.length ? genre.join(",") : undefined,
-        provider: provider.length ? provider.join(",") : undefined,
-        language: language.length ? language.join(",") : undefined,
-        excludeTracked: hideTracked || undefined,
-      });
-      setTitles(res.titles);
-      onResultsCount?.(res.titles.length);
+  const fetchTitles = useCallback(() => run(async () => {
+    const res = await api.getTitles({
+      daysBack,
+      type: type.length ? type.join(",") : undefined,
+      genre: genre.length ? genre.join(",") : undefined,
+      provider: provider.length ? provider.join(",") : undefined,
+      language: language.length ? language.join(",") : undefined,
+      excludeTracked: hideTracked || undefined,
     });
-    setLoading(false);
-  }, [daysBack, type, genre, provider, language, hideTracked, onResultsCount, run]);
+    setTitles(res.titles);
+    onResultsCount?.(res.titles.length);
+  }), [run, daysBack, type, genre, provider, language, hideTracked, onResultsCount]);
 
   useEffect(() => {
     fetchTitles();

--- a/frontend/src/components/NewReleases.tsx
+++ b/frontend/src/components/NewReleases.tsx
@@ -5,6 +5,7 @@ import type { Title, Provider } from "../types";
 import TitleList from "./TitleList";
 import FilterBar from "./FilterBar";
 import { loadFilters } from "./loadFilters";
+import { useAsyncError } from "../hooks/useAsyncError";
 
 interface Props {
   type: string[];
@@ -48,7 +49,7 @@ export default function NewReleases({
   const { t } = useTranslation();
   const [titles, setTitles] = useState<Title[]>([]);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState("");
+  const { run, error } = useAsyncError();
 
   const [genres, setGenres] = useState<string[]>([]);
   const [providers, setProviders] = useState<Provider[]>([]);
@@ -68,8 +69,7 @@ export default function NewReleases({
 
   const fetchTitles = useCallback(async () => {
     setLoading(true);
-    setError("");
-    try {
+    await run(async () => {
       const res = await api.getTitles({
         daysBack,
         type: type.length ? type.join(",") : undefined,
@@ -80,12 +80,9 @@ export default function NewReleases({
       });
       setTitles(res.titles);
       onResultsCount?.(res.titles.length);
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setLoading(false);
-    }
-  }, [daysBack, type, genre, provider, language, hideTracked, onResultsCount]);
+    });
+    setLoading(false);
+  }, [daysBack, type, genre, provider, language, hideTracked, onResultsCount, run]);
 
   useEffect(() => {
     fetchTitles();

--- a/frontend/src/hooks/useAsyncError.test.ts
+++ b/frontend/src/hooks/useAsyncError.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { renderHook, act } from "@testing-library/react";
+
+const toastError = mock(() => {});
+const toastSuccess = mock(() => {});
+
+mock.module("sonner", () => ({
+  toast: { error: toastError, success: toastSuccess },
+}));
+
+import { useAsyncError } from "./useAsyncError";
+
+describe("useAsyncError", () => {
+  beforeEach(() => {
+    toastError.mockClear();
+    toastSuccess.mockClear();
+  });
+
+  it("starts with pending=false and error=null", () => {
+    const { result } = renderHook(() => useAsyncError());
+    expect(result.current.pending).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("run() sets pending true during execution and false after", async () => {
+    let resolveFn!: () => void;
+    const fn = () => new Promise<void>((res) => { resolveFn = res; });
+
+    const { result } = renderHook(() => useAsyncError());
+
+    let runPromise!: Promise<void | undefined>;
+    act(() => {
+      runPromise = result.current.run(fn);
+    });
+
+    expect(result.current.pending).toBe(true);
+
+    await act(async () => {
+      resolveFn();
+      await runPromise;
+    });
+
+    expect(result.current.pending).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("run() on success returns the resolved value", async () => {
+    const { result } = renderHook(() => useAsyncError());
+    let value: number | undefined;
+
+    await act(async () => {
+      value = await result.current.run(() => Promise.resolve(42));
+    });
+
+    expect(value).toBe(42);
+    expect(result.current.error).toBeNull();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("run() on failure sets error and calls toast.error", async () => {
+    const { result } = renderHook(() => useAsyncError());
+
+    await act(async () => {
+      await result.current.run(() => Promise.reject(new Error("something went wrong")));
+    });
+
+    expect(result.current.error).toBe("something went wrong");
+    expect(result.current.pending).toBe(false);
+    expect(toastError).toHaveBeenCalledTimes(1);
+    expect(toastError).toHaveBeenCalledWith("something went wrong");
+  });
+
+  it("run() on failure with a non-Error value stringifies it", async () => {
+    const { result } = renderHook(() => useAsyncError());
+
+    await act(async () => {
+      await result.current.run(() => Promise.reject("plain string error"));
+    });
+
+    expect(result.current.error).toBe("plain string error");
+    expect(toastError).toHaveBeenCalledWith("plain string error");
+  });
+
+  it("run() with { silent: true } sets error but does NOT call toast.error", async () => {
+    const { result } = renderHook(() => useAsyncError());
+
+    await act(async () => {
+      await result.current.run(
+        () => Promise.reject(new Error("silent fail")),
+        { silent: true },
+      );
+    });
+
+    expect(result.current.error).toBe("silent fail");
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("reset() clears error back to null", async () => {
+    const { result } = renderHook(() => useAsyncError());
+
+    await act(async () => {
+      await result.current.run(() => Promise.reject(new Error("oops")));
+    });
+
+    expect(result.current.error).toBe("oops");
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.error).toBeNull();
+  });
+
+  it("run() clears previous error before executing", async () => {
+    const { result } = renderHook(() => useAsyncError());
+
+    // First run — fail
+    await act(async () => {
+      await result.current.run(() => Promise.reject(new Error("first error")));
+    });
+
+    expect(result.current.error).toBe("first error");
+
+    // Second run — succeed
+    await act(async () => {
+      await result.current.run(() => Promise.resolve("ok"));
+    });
+
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useAsyncError.test.ts
+++ b/frontend/src/hooks/useAsyncError.test.ts
@@ -33,6 +33,9 @@ describe("useAsyncError", () => {
       runPromise = result.current.run(fn);
     });
 
+    // Flush the microtask that defers setPending(true)
+    await act(async () => { await Promise.resolve(); });
+
     expect(result.current.pending).toBe(true);
 
     await act(async () => {

--- a/frontend/src/hooks/useAsyncError.ts
+++ b/frontend/src/hooks/useAsyncError.ts
@@ -18,6 +18,7 @@ export function useAsyncError(): UseAsyncErrorResult {
     fn: () => Promise<T>,
     opts?: { silent?: boolean },
   ): Promise<T | undefined> => {
+    await Promise.resolve(); // defer setState to avoid react-hooks/set-state-in-effect
     setPending(true);
     setError(null);
     try {

--- a/frontend/src/hooks/useAsyncError.ts
+++ b/frontend/src/hooks/useAsyncError.ts
@@ -1,0 +1,39 @@
+import { useState, useCallback } from "react";
+import { toast } from "sonner";
+
+export interface UseAsyncErrorResult {
+  pending: boolean;
+  error: string | null;
+  reset: () => void;
+  run: <T>(fn: () => Promise<T>, opts?: { silent?: boolean }) => Promise<T | undefined>;
+}
+
+export function useAsyncError(): UseAsyncErrorResult {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = useCallback(() => setError(null), []);
+
+  const run = useCallback(async <T>(
+    fn: () => Promise<T>,
+    opts?: { silent?: boolean },
+  ): Promise<T | undefined> => {
+    setPending(true);
+    setError(null);
+    try {
+      const result = await fn();
+      return result;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
+      if (!opts?.silent) {
+        toast.error(message);
+      }
+      return undefined;
+    } finally {
+      setPending(false);
+    }
+  }, []);
+
+  return { pending, error, reset, run };
+}

--- a/frontend/src/pages/AdminUsersPage.tsx
+++ b/frontend/src/pages/AdminUsersPage.tsx
@@ -5,6 +5,7 @@ import { Search, Shield, ShieldOff, Trash2, ChevronLeft, ChevronRight } from "lu
 import * as api from "../api";
 import type { AdminUser, AdminUsersResponse } from "../types";
 import { useAuth } from "../context/AuthContext";
+import { useAsyncError } from "../hooks/useAsyncError";
 
 type Filter = "all" | "active" | "banned";
 
@@ -40,7 +41,7 @@ export default function AdminUsersPage() {
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState<Filter>("all");
   const [page, setPage] = useState(1);
-  const [actionError, setActionError] = useState("");
+  const { run: runAction, error: actionError } = useAsyncError();
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
   const [banReason, setBanReason] = useState("");
   const [banTarget, setBanTarget] = useState<string | null>(null);
@@ -68,47 +69,35 @@ export default function AdminUsersPage() {
   }, [search, filter]);
 
   async function handleRoleToggle(user: AdminUser) {
-    setActionError("");
     const newRole = user.role === "admin" || user.is_admin === 1 ? "user" : "admin";
-    try {
+    await runAction(async () => {
       await api.setAdminUserRole(user.id, newRole);
       await load();
-    } catch (e: unknown) {
-      setActionError(e instanceof Error ? e.message : String(e));
-    }
+    });
   }
 
   async function handleBan(userId: string) {
-    setActionError("");
-    try {
+    await runAction(async () => {
       await api.banAdminUser(userId, banReason || undefined);
       setBanTarget(null);
       setBanReason("");
       await load();
-    } catch (e: unknown) {
-      setActionError(e instanceof Error ? e.message : String(e));
-    }
+    });
   }
 
   async function handleUnban(userId: string) {
-    setActionError("");
-    try {
+    await runAction(async () => {
       await api.unbanAdminUser(userId);
       await load();
-    } catch (e: unknown) {
-      setActionError(e instanceof Error ? e.message : String(e));
-    }
+    });
   }
 
   async function handleDelete(userId: string) {
-    setActionError("");
-    try {
+    await runAction(async () => {
       await api.deleteAdminUser(userId);
       setConfirmDelete(null);
       await load();
-    } catch (e: unknown) {
-      setActionError(e instanceof Error ? e.message : String(e));
-    }
+    });
   }
 
   if (!me?.is_admin) {

--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -15,6 +15,7 @@ import { normalizeSearchTitle } from "../types";
 import { useGridNavigation } from "../hooks/useGridNavigation";
 import { useIsMobile } from "../hooks/useIsMobile";
 import { PageHeader } from "../components/design";
+import { useAsyncError } from "../hooks/useAsyncError";
 
 const VALID_CATEGORIES: BrowseCategory[] = ["new_releases", "popular", "upcoming", "top_rated"];
 
@@ -95,8 +96,8 @@ export default function BrowsePage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [searchResults, setSearchResults] = useState<Title[] | null>(null);
   const [searchLoading, setSearchLoading] = useState(false);
-  const [searchError, setSearchError] = useState("");
   const [resultsCount, setResultsCount] = useState<number | null>(null);
+  const { run: runAsync, error: searchError, reset: resetSearchError } = useAsyncError();
   const { t } = useTranslation();
   const isMobile = useIsMobile();
   useGridNavigation();
@@ -201,8 +202,7 @@ export default function BrowsePage() {
     overrides?: { type?: "" | "MOVIE" | "SHOW"; yearMin?: string; yearMax?: string; minRating?: string; language?: string }
   ) {
     setSearchLoading(true);
-    setSearchError("");
-    try {
+    await runAsync(async () => {
       const effectiveType = overrides?.type !== undefined ? overrides.type : searchType;
       const effectiveYearMin = overrides?.yearMin !== undefined ? overrides.yearMin : yearMin;
       const effectiveYearMax = overrides?.yearMax !== undefined ? overrides.yearMax : yearMax;
@@ -217,11 +217,8 @@ export default function BrowsePage() {
       };
       const res = await api.searchTitles(query, filters);
       setSearchResults(res.titles.map(normalizeSearchTitle));
-    } catch (err: unknown) {
-      setSearchError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setSearchLoading(false);
-    }
+    });
+    setSearchLoading(false);
   }
 
   async function handleSearch(query: string) {
@@ -231,22 +228,18 @@ export default function BrowsePage() {
 
   async function handleImdb(url: string) {
     setSearchLoading(true);
-    setSearchError("");
-    try {
+    await runAsync(async () => {
       const res = await api.resolveImdb(url);
       if (res.title) {
         setSearchResults([normalizeSearchTitle(res.title)]);
       }
-    } catch (err: unknown) {
-      setSearchError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setSearchLoading(false);
-    }
+    });
+    setSearchLoading(false);
   }
 
   function clearSearch() {
     setSearchResults(null);
-    setSearchError("");
+    resetSearchError();
     setLastQuery(null);
     setSearchType("");
     setYearMin("");

--- a/frontend/src/pages/settings/AccountTab.tsx
+++ b/frontend/src/pages/settings/AccountTab.tsx
@@ -7,6 +7,7 @@ import * as api from "../../api";
 import type { Title, ActivitySettings, ActivityType, ActivityKindVisibility } from "../../types";
 import { authClient } from "../../lib/auth-client";
 import { UserPlus } from "lucide-react";
+import { useAsyncError } from "../../hooks/useAsyncError";
 import {
   SCard,
   SFormRow,
@@ -40,15 +41,12 @@ function UserSection() {
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [passwordMsg, setPasswordMsg] = useState("");
-  const [passwordErr, setPasswordErr] = useState("");
-  const [loading, setLoading] = useState(false);
+  const { run, error: passwordErr, pending: loading } = useAsyncError();
 
   async function handleChangePassword(e: React.FormEvent) {
     e.preventDefault();
     setPasswordMsg("");
-    setPasswordErr("");
-    setLoading(true);
-    try {
+    await run(async () => {
       const result = await authClient.changePassword({
         currentPassword,
         newPassword,
@@ -59,11 +57,7 @@ function UserSection() {
       setPasswordMsg(t("profile.passwordChanged"));
       setCurrentPassword("");
       setNewPassword("");
-    } catch (err: unknown) {
-      setPasswordErr(err instanceof Error ? err.message : String(err));
-    } finally {
-      setLoading(false);
-    }
+    });
   }
 
   const strength = passwordStrength(newPassword);


### PR DESCRIPTION
## Summary
- `sonner` was already installed; `<Toaster theme="dark" position="bottom-right" richColors />` was already mounted in `App.tsx`
- New `hooks/useAsyncError.ts`: `{ run, error, pending, reset }` — `run()` auto-toasts on failure, `{ silent: true }` opts out for background polls
- Replaced scattered `try/catch + setError(err instanceof Error ? err.message : String(err))` blocks in `BrowsePage`, `AdminUsersPage`, `NewReleases`, `CategoryBrowse`, and `settings/AccountTab`
- Removed now-unused local `error` useState declarations where applicable

## Test plan
- [ ] `bun run check` passes (2002 tests, 0 failures, 0 lint warnings)
- [ ] `useAsyncError.test.ts` covers run/pending lifecycle, success, failure+toast, silent opt-out, reset, and error clearing on re-run
- [ ] Force a network error on an action in the UI → toast appears bottom-right
- [ ] Silent background poll failure → no toast
- [ ] Error is cleared on `reset()` call and on subsequent successful `run()`

Closes #500