### PR TITLE
fix(activity): use z.partialRecord for kind_visibility (fixes prod 400)

### DIFF
--- a/server/routes/profile-activity.test.ts
+++ b/server/routes/profile-activity.test.ts
@@ -18,6 +18,7 @@ import {
   follow,
   setActivitySettings,
   hideActivityEvent,
+  getActivityKindVisibilityMap,
 } from "../db/repository";
 import { optionalAuth } from "../middleware/auth";
 import { getDb, episodes, ratings, episodeRatings, watchedTitles, watchedEpisodes, tracked, recommendations, users } from "../db/schema";
@@ -376,5 +377,77 @@ describe("GET /user/:username/activity", () => {
     const body = await res.json();
     expect(body.activities).toHaveLength(1);
     expect(body.activities[0].title.id).toBe("m2");
+  });
+});
+
+describe("PATCH /user/me/activity-settings", () => {
+  it("accepts toggle-only body", async () => {
+    const res = await app.request("/user/me/activity-settings", {
+      method: "PATCH",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled: true }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.enabled).toBe(true);
+  });
+
+  it("accepts a partial kind_visibility map (regression: zod partialRecord)", async () => {
+    const res = await app.request("/user/me/activity-settings", {
+      method: "PATCH",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ kind_visibility: { rating_title: "private" } }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.kind_visibility.rating_title).toBe("private");
+
+    const stored = await getActivityKindVisibilityMap(userId);
+    expect(stored.rating_title).toBe("private");
+  });
+
+  it("accepts a full kind_visibility map", async () => {
+    const full = {
+      rating_title: "private",
+      rating_episode: "friends_only",
+      watched_title: "public",
+      watched_episode: "private",
+      tracked: "friends_only",
+      recommendation: "public",
+    };
+    const res = await app.request("/user/me/activity-settings", {
+      method: "PATCH",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ kind_visibility: full }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.kind_visibility).toMatchObject(full);
+  });
+
+  describe("validation", () => {
+    it("rejects an unknown activity kind", async () => {
+      const res = await app.request("/user/me/activity-settings", {
+        method: "PATCH",
+        headers: { ...authHeaders(), "Content-Type": "application/json" },
+        body: JSON.stringify({ kind_visibility: { not_a_kind: "public" } }),
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("Validation failed");
+      expect(Array.isArray(body.issues)).toBe(true);
+    });
+
+    it("rejects an invalid visibility value", async () => {
+      const res = await app.request("/user/me/activity-settings", {
+        method: "PATCH",
+        headers: { ...authHeaders(), "Content-Type": "application/json" },
+        body: JSON.stringify({ kind_visibility: { rating_title: "nope" } }),
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("Validation failed");
+      expect(Array.isArray(body.issues)).toBe(true);
+    });
   });
 });

--- a/server/routes/profile.ts
+++ b/server/routes/profile.ts
@@ -56,7 +56,7 @@ const visibilityEnum = z.enum(["public", "friends_only", "private"]);
 
 const activitySettingsSchema = z.object({
   enabled: z.boolean().optional(),
-  kind_visibility: z.record(activityKindEnum, visibilityEnum).optional(),
+  kind_visibility: z.partialRecord(activityKindEnum, visibilityEnum).optional(),
 });
 
 app.get("/me/activity-settings", async (c) => {
@@ -72,7 +72,7 @@ app.patch("/me/activity-settings", zValidator("json", activitySettingsSchema), a
   const { enabled, kind_visibility } = c.req.valid("json");
   await setActivitySettings(user.id, {
     enabled,
-    kindVisibility: kind_visibility as ActivityKindVisibilityMap | undefined,
+    kindVisibility: kind_visibility,
   });
   const updated = await getActivitySettings(user.id);
   return ok(c, updated);


### PR DESCRIPTION
## Summary

The Settings → Activity stream → "Per-kind visibility" buttons fail with **"Validation failed"** every time a user clicks Everyone / Friends only / Only me. The toggle works; only changes that include \`kind_visibility\` are rejected.

### Root cause

\`server/routes/profile.ts:59\` uses \`z.record(activityKindEnum, visibilityEnum)\`. In **zod 4** (we're on 4.3.6), a record with an enum key schema iterates *every* enum value as a key and parses the value at that key against the value schema. Missing keys come through as \`undefined\`, which the visibility enum rejects with \`{ code: "invalid_value", values: ["public","friends_only","private"] }\`.

The frontend (\`AccountTab.tsx:585-598\`) sends a *partial* map — only the changed kind (plus whatever GET previously returned). For a fresh user this is one key, so zod fails on the other five with five \`invalid_value\` issues. Symptoms in Cloudflare logs: every PATCH \`/api/user/me/activity-settings\` with a \`kind_visibility\` field returns 400; toggle-only PATCHes return 200.

### Fix

- \`z.record(activityKindEnum, visibilityEnum)\` → \`z.partialRecord(activityKindEnum, visibilityEnum)\`. Zod 4's \`partialRecord\` is exactly this case: enum-keyed map where keys are optional. Matches the partial intent already declared in \`frontend/src/types.ts\` (\`Partial<Record<ActivityType, ...>>\`).
- Drops the now-unnecessary \`as ActivityKindVisibilityMap | undefined\` cast at the handler boundary.

### Tests

Adds \`describe("PATCH /user/me/activity-settings")\` to \`profile-activity.test.ts\` covering:
- toggle-only body accepted
- partial \`kind_visibility\` accepted (regression)
- full map accepted
- unknown kind rejected (400 + \`issues\` array)
- invalid visibility value rejected (400 + \`issues\` array)

## Test plan

- [x] \`bun test server/routes/profile-activity.test.ts\` — 25/25 passing
- [ ] After deploy: confirm in Cloudflare logs that PATCH \`/api/user/me/activity-settings\` no longer returns 400 for per-kind clicks
- [ ] Manual: open Settings → Activity stream, enable, click any "Friends only" / "Only me" — selection sticks, no red banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)