### PR TITLE
fix(a11y): convert browse filter chips to button elements

### DIFF
--- a/frontend/src/pages/BrowsePage.test.tsx
+++ b/frontend/src/pages/BrowsePage.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, mock, afterEach } from "bun:test";
+import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import type { ReactNode } from "react";
+import "../i18n";
+
+mock.module("../hooks/useIsMobile", () => ({ useIsMobile: () => false }));
+mock.module("../hooks/useGridNavigation", () => ({ useGridNavigation: () => undefined }));
+
+mock.module("../components/loadFilters", () => ({
+  loadFilters: () =>
+    Promise.resolve({
+      genres: [],
+      providers: [],
+      languages: [],
+      regionProviderIds: [],
+      priorityLanguageCodes: [],
+    }),
+}));
+
+// Stub out child components that make API calls or have complex browser deps.
+// We do not mock ../api here to avoid leaking into other test files — the only
+// on-mount API call (getLanguages) is silently swallowed by the component on failure.
+mock.module("../components/SearchBar", () => ({
+  default: ({ onSearch }: any) => (
+    <input data-testid="search-bar" onChange={(e) => onSearch(e.target.value)} />
+  ),
+}));
+mock.module("../components/NewReleases", () => ({ default: () => null }));
+mock.module("../components/CategoryBrowse", () => ({ default: () => null }));
+
+const { default: BrowsePage } = await import("./BrowsePage");
+
+function makeWrapper(initialPath: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <MemoryRouter initialEntries={[initialPath]}>{children}</MemoryRouter>;
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("BrowsePage active filter chips", () => {
+  it("renders type filter chip as a <button>", () => {
+    render(<BrowsePage />, { wrapper: makeWrapper("/browse?type=MOVIE") });
+
+    const chip = screen.getByRole("button", { name: /remove movies filter/i });
+    expect(chip).toBeDefined();
+    expect(chip.tagName).toBe("BUTTON");
+  });
+
+  it("renders Shows type filter chip as a <button>", () => {
+    render(<BrowsePage />, { wrapper: makeWrapper("/browse?type=SHOW") });
+
+    const chip = screen.getByRole("button", { name: /remove shows filter/i });
+    expect(chip.tagName).toBe("BUTTON");
+  });
+
+  it("renders genre filter chip as a <button>", () => {
+    render(<BrowsePage />, { wrapper: makeWrapper("/browse?genre=Action") });
+
+    const chip = screen.getByRole("button", { name: /remove action filter/i });
+    expect(chip.tagName).toBe("BUTTON");
+  });
+
+  it("renders year range filter chip as a <button>", () => {
+    render(<BrowsePage />, { wrapper: makeWrapper("/browse?yearMin=2020&yearMax=2024") });
+
+    const chip = screen.getByRole("button", { name: /remove year range filter/i });
+    expect(chip.tagName).toBe("BUTTON");
+  });
+
+  it("renders minimum rating filter chip as a <button>", () => {
+    render(<BrowsePage />, { wrapper: makeWrapper("/browse?minRating=7") });
+
+    const chip = screen.getByRole("button", { name: /remove minimum rating filter/i });
+    expect(chip.tagName).toBe("BUTTON");
+  });
+
+  it("renders multiple active filter chips all as <button> elements", () => {
+    render(<BrowsePage />, {
+      wrapper: makeWrapper("/browse?type=SHOW&genre=Drama&minRating=8"),
+    });
+
+    const chips = screen.getAllByRole("button", { name: /remove .* filter/i });
+    expect(chips.length).toBe(3);
+    for (const chip of chips) {
+      expect(chip.tagName).toBe("BUTTON");
+    }
+  });
+
+  it("clicking a type chip removes the Movies filter from the page", () => {
+    render(<BrowsePage />, { wrapper: makeWrapper("/browse?type=MOVIE&genre=Action") });
+
+    const moviesChip = screen.getByRole("button", { name: /remove movies filter/i });
+    expect(moviesChip).toBeDefined();
+
+    act(() => { fireEvent.click(moviesChip); });
+
+    // After removing the Movies filter, the Movies chip should be gone
+    expect(screen.queryByRole("button", { name: /remove movies filter/i })).toBeNull();
+    // Genre chip for Action should still be present
+    expect(screen.getByRole("button", { name: /remove action filter/i })).toBeDefined();
+  });
+});

--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -472,56 +472,68 @@ export default function BrowsePage() {
         <div className="flex flex-wrap items-center gap-2">
           <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-500 mr-1">Active</span>
           {type.map((t) => (
-            <span
+            <button
               key={t}
+              type="button"
               onClick={() => setType(type.filter((v) => v !== t))}
+              aria-label={`Remove ${t === "MOVIE" ? "Movies" : "Shows"} filter`}
               className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-semibold bg-amber-400/[0.12] text-amber-400 border border-amber-400/[0.25] cursor-pointer hover:bg-amber-400/20 transition-colors"
             >
               {t === "MOVIE" ? "Movies" : "Shows"} ×
-            </span>
+            </button>
           ))}
           {genre.map((g) => (
-            <span
+            <button
               key={g}
+              type="button"
               onClick={() => setGenre(genre.filter((v) => v !== g))}
+              aria-label={`Remove ${g} filter`}
               className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-semibold bg-amber-400/[0.12] text-amber-400 border border-amber-400/[0.25] cursor-pointer hover:bg-amber-400/20 transition-colors"
             >
               {g} ×
-            </span>
+            </button>
           ))}
           {provider.map((p) => (
-            <span
+            <button
               key={p}
+              type="button"
               onClick={() => setProvider(provider.filter((v) => v !== p))}
+              aria-label={`Remove ${filterProviders.find((fp) => String(fp.id) === p)?.name ?? p} filter`}
               className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-semibold bg-amber-400/[0.12] text-amber-400 border border-amber-400/[0.25] cursor-pointer hover:bg-amber-400/20 transition-colors"
             >
               {filterProviders.find((fp) => String(fp.id) === p)?.name ?? p} ×
-            </span>
+            </button>
           ))}
           {language.map((l) => (
-            <span
+            <button
               key={l}
+              type="button"
               onClick={() => setLanguage(language.filter((v) => v !== l))}
+              aria-label={`Remove ${l} language filter`}
               className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-semibold bg-amber-400/[0.12] text-amber-400 border border-amber-400/[0.25] cursor-pointer hover:bg-amber-400/20 transition-colors"
             >
               {l} ×
-            </span>
+            </button>
           ))}
           {(browseYearMin !== "" || browseYearMax !== "") && (
-            <span
+            <button
+              type="button"
               onClick={() => setBrowseYearRange("", "")}
+              aria-label="Remove year range filter"
               className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-semibold bg-amber-400/[0.12] text-amber-400 border border-amber-400/[0.25] cursor-pointer hover:bg-amber-400/20 transition-colors"
             >
               {browseYearMin || "…"}–{browseYearMax || "…"} ×
-            </span>
+            </button>
           )}
           {browseMinRating !== "" && (
-            <span
+            <button
+              type="button"
               onClick={() => setBrowseMinRating("")}
+              aria-label="Remove minimum rating filter"
               className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-semibold bg-amber-400/[0.12] text-amber-400 border border-amber-400/[0.25] cursor-pointer hover:bg-amber-400/20 transition-colors"
             >
               ★ {browseMinRating}+ ×
-            </span>
+            </button>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary

- Replace 6 `<span onClick>` active-filter dismisser chips in `BrowsePage.tsx` (lines 474–525) with `<button type="button">` elements
- Each button gets a descriptive `aria-label` (`"Remove X filter"`) so screen readers announce the action
- Chips are now keyboard-reachable via Enter/Space by default (no extra `onKeyDown` needed)
- Add `BrowsePage.test.tsx` with 7 component render tests verifying the buttons are semantically correct and clicking dismisses the filter

**Note:** The issue referenced `HomePage.tsx:226` as a clickable span — that line is actually a `<Link>`, not an onClick span. All real offenders were in BrowsePage at lines 474–525. The provider chips at `:402–414` and modal backdrops were already correct.

## Test plan

- [x] `bun run check` passes (2063 tests, 0 fail)
- [x] New `BrowsePage.test.tsx` verifies each chip variant is a `<button>` with correct `aria-label`
- [x] Chip click-dismissal regression test added
- [ ] Manual: navigate to `/browse?type=MOVIE&genre=Action`, keyboard-Tab into the active-chip row, confirm Enter and Space dismiss each chip

Closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)