### PR TITLE
fix(#578): log zod validation failures + harden test convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,7 @@ Inventory is large (~45 components). Broad groups:
 - Supported targets: `"json"`, `"query"`, `"param"`, `"form"`, `"header"`, `"cookie"`. For multipart `File` uploads, parse `FormData` manually and feed into `schema.safeParse(...)` (see `server/routes/import.ts`) — `instanceof File` is unreliable in the Bun test env, duck-type the upload instead.
 - Provider- or business-level validation (e.g. notifier `validateConfig`, timezone semantics, uniqueness) runs AFTER zod inside the handler. Zod only validates shape/types.
 - Tests for every migrated route should include a `describe("validation", ...)` block asserting `res.status === 400` and that the response body exposes an `issues` array.
+- **Happy-path requirement**: also include at least one test that sends the smallest realistic body the frontend actually sends and asserts `res.status === 200`. This prevents schema regressions (e.g. zod 3→4 semantic changes) from slipping past a rejection-only test suite. If the frontend can omit any optional field, the happy-path test must exercise that minimal shape. (Background: #577 / #578 — a silent HTTP 400 regression ran in prod undetected because only rejection cases were tested.)
 
 ### API Routes
 Grouped by middleware. All routes are under `/api` except `/metrics`.

--- a/server/lib/validator.test.ts
+++ b/server/lib/validator.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, spyOn } from "bun:test";
+import { Hono } from "hono";
+import { z } from "zod";
+import { zValidator } from "./validator";
+
+const schema = z.object({ name: z.string().min(1) });
+
+function makeApp() {
+  const app = new Hono();
+  app.post("/test", zValidator("json", schema), (c) => {
+    return c.json({ ok: true });
+  });
+  return app;
+}
+
+describe("zValidator", () => {
+  it("passes valid payload through", async () => {
+    const app = makeApp();
+    const res = await app.request("/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "hello" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  it("returns 400 with issues array on invalid payload", async () => {
+    const app = makeApp();
+    const res = await app.request("/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+    expect(body.issues.length).toBeGreaterThan(0);
+  });
+
+  it("emits a structured warn log on validation failure", async () => {
+    const errSpy = spyOn(console, "error");
+    const app = makeApp();
+    await app.request("/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: 42 }),
+    });
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    const rawLine = errSpy.mock.calls[0][0] as string;
+    const entry = JSON.parse(rawLine);
+    expect(entry.msg).toBe("Request validation failed");
+    expect(entry.level).toBe("warn");
+    expect(entry.path).toBe("/test");
+    expect(entry.method).toBe("POST");
+    expect(entry.target).toBe("json");
+    expect(Array.isArray(entry.issues)).toBe(true);
+    errSpy.mockRestore();
+  });
+
+  it("does NOT log on successful validation", async () => {
+    const errSpy = spyOn(console, "error");
+    const app = makeApp();
+    await app.request("/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "valid" }),
+    });
+    expect(errSpy).not.toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});

--- a/server/lib/validator.ts
+++ b/server/lib/validator.ts
@@ -1,6 +1,9 @@
 import { zValidator as baseValidator } from "@hono/zod-validator";
 import type { ValidationTargets } from "hono";
 import type { ZodType } from "zod";
+import { logger } from "../logger";
+
+const log = logger.child({ module: "validator" });
 
 /**
  * Standard route validator.
@@ -31,6 +34,12 @@ export function zValidator<
 >(target: T, schema: S) {
   return baseValidator(target, schema, (result, c) => {
     if (!result.success) {
+      log.warn("Request validation failed", {
+        target,
+        method: c.req.method,
+        path: c.req.path,
+        issues: result.error.issues,
+      });
       return c.json(
         { error: "Validation failed", issues: result.error.issues },
         400,


### PR DESCRIPTION
## Summary

- Emit a structured `level: warn` log entry on every HTTP 400 validation failure — gives instant visibility into schema regressions in production logs (Cloudflare Logs, stdout)
- Add unit tests that assert the log is emitted and that valid payloads do **not** trigger it
- Extend `CLAUDE.md` validation-test convention to require a happy-path test alongside rejection tests, so minimal-body regressions (like #577) can't slip past CI undetected
- Confirmed: no `z.record(z.enum(...))` call sites remain — the one affected site was already fixed to `z.partialRecord` in #577; happy-path test for that is already present in `profile-activity.test.ts`

## Test plan

- [x] `bun test server/lib/validator.test.ts` — 4 tests pass
- [x] `bun run check` — full CI pipeline green

Closes #578