### PR TITLE
fix(#474): surface OIDC reload failure instead of swallowing it

### DIFF
--- a/server/routes/admin.test.ts
+++ b/server/routes/admin.test.ts
@@ -10,7 +10,7 @@ import {
   getUserById,
 } from "../db/repository";
 import { requireAuth, requireAdmin } from "../middleware/auth";
-import adminApp from "./admin";
+import adminApp, { setOnOidcSettingsChanged } from "./admin";
 import type { AppEnv } from "../types";
 
 function createMockAuth() {
@@ -429,5 +429,42 @@ describe("DELETE /admin/users/:id", () => {
       headers: { Cookie: adminCookie },
     });
     expect(res.status).toBe(400);
+  });
+});
+
+describe("PUT /admin/settings — OIDC reload callback error handling", () => {
+  it("returns 500 with oidc_reload_failed when the callback throws", async () => {
+    setOnOidcSettingsChanged(async () => {
+      throw new Error("discovery doc unreachable");
+    });
+
+    const res = await app.request("/admin/settings", {
+      method: "PUT",
+      headers: { Cookie: adminCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ oidc_issuer_url: "https://auth.example.com" }),
+    });
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("oidc_reload_failed");
+    expect(typeof body.message).toBe("string");
+    expect(body.message).toContain("discovery doc unreachable");
+
+    // Settings must still have been persisted despite the reload failure
+    expect(await getSetting("oidc_issuer_url")).toBe("https://auth.example.com");
+  });
+
+  it("returns 200 when callback succeeds", async () => {
+    let called = false;
+    setOnOidcSettingsChanged(async () => { called = true; });
+
+    const res = await app.request("/admin/settings", {
+      method: "PUT",
+      headers: { Cookie: adminCookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ oidc_issuer_url: "https://auth.example.com" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(called).toBe(true);
   });
 });

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -118,7 +118,18 @@ app.put("/settings", zValidator("json", updateSettingsSchema), async (c) => {
 
   // On Bun, recreate auth instance to pick up new OIDC config
   if (_onOidcSettingsChanged) {
-    await _onOidcSettingsChanged();
+    try {
+      await _onOidcSettingsChanged();
+    } catch (err) {
+      log.error("OIDC settings reload failed", { error: err });
+      return c.json(
+        {
+          error: "oidc_reload_failed",
+          message: `Settings saved but OIDC reload failed: ${(err as Error).message}. Restart the server to recover.`,
+        },
+        500,
+      );
+    }
   }
 
   return ok(c, { oidc_configured: await isOidcConfigured() });


### PR DESCRIPTION
## Summary

- `PUT /api/admin/settings` previously returned 200 even when the post-save auth-instance recreation threw, leaving the server in an inconsistent auth state with no feedback to the admin
- Wrap the `_onOidcSettingsChanged()` call in try/catch: on failure return HTTP 500 with `{ error: "oidc_reload_failed", message: "…" }`
- DB write is **kept** — settings are persisted even on reload failure; message tells admin to restart to recover
- Full error logged at `error` level with stack trace for operator visibility

## Test plan

- [x] New test: callback throws → 500 + `oidc_reload_failed` body + settings persisted
- [x] New test: callback succeeds → 200 (happy path)
- [x] All existing admin tests still pass (33 total)
- [x] `bun test server/routes/admin.test.ts` — 33 pass

Closes #474