### PR TITLE
perf(#490): cap concurrent TMDB detail fetches in browse/search

### DIFF
--- a/server/lib/p-limit.test.ts
+++ b/server/lib/p-limit.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "bun:test";
+import { pLimit } from "./p-limit";
+
+describe("pLimit", () => {
+  it("resolves all tasks and returns correct values", async () => {
+    const limit = pLimit(3);
+    const results = await Promise.all(
+      [1, 2, 3, 4, 5].map((n) => limit(async () => n * 2))
+    );
+    expect(results).toEqual([2, 4, 6, 8, 10]);
+  });
+
+  it("never exceeds concurrency limit", async () => {
+    const concurrency = 3;
+    const limit = pLimit(concurrency);
+    let active = 0;
+    let maxActive = 0;
+
+    const tasks = Array.from({ length: 50 }, (_, i) => i);
+    await Promise.all(
+      tasks.map(() =>
+        limit(async () => {
+          active++;
+          maxActive = Math.max(maxActive, active);
+          await new Promise<void>((r) => setTimeout(r, 1));
+          active--;
+        })
+      )
+    );
+
+    expect(maxActive).toBeLessThanOrEqual(concurrency);
+  });
+
+  it("propagates errors without blocking remaining tasks", async () => {
+    const limit = pLimit(2);
+    const results = await Promise.allSettled([
+      limit(async () => { throw new Error("fail"); }),
+      limit(async () => 42),
+      limit(async () => 99),
+    ]);
+    expect(results[0].status).toBe("rejected");
+    expect(results[1].status).toBe("fulfilled");
+    expect(results[2].status).toBe("fulfilled");
+  });
+});

--- a/server/lib/p-limit.ts
+++ b/server/lib/p-limit.ts
@@ -1,0 +1,30 @@
+/**
+ * Minimal concurrency limiter. Returns a scheduler function that ensures at
+ * most `concurrency` promises are running at the same time.
+ *
+ *   const limit = pLimit(5);
+ *   const results = await Promise.all(items.map((item) => limit(() => fetch(item))));
+ */
+export function pLimit(concurrency: number) {
+  let active = 0;
+  const queue: (() => void)[] = [];
+
+  function next() {
+    if (queue.length > 0 && active < concurrency) {
+      active++;
+      queue.shift()!();
+    }
+  }
+
+  return function limit<T>(fn: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      queue.push(() => {
+        fn().then(resolve, reject).finally(() => {
+          active--;
+          next();
+        });
+      });
+      next();
+    });
+  };
+}

--- a/server/routes/browse.ts
+++ b/server/routes/browse.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { pLimit } from "../lib/p-limit";
 import {
   discoverMovies,
   discoverTv,
@@ -163,20 +164,24 @@ app.get("/", async (c) => {
       totalResults = movieRes.total_results + tvRes.total_results;
     }
 
-    // Fetch full details with watch providers for each result
+    // Fetch full details with watch providers for each result — capped at 5
+    // concurrent requests to avoid bursting TMDB's rate limit.
+    const limit = pLimit(5);
     const titles = await Promise.all(
-      basicTitles.map(async (t) => {
-        try {
-          const tmdbId = parseInt(t.tmdbId || "0", 10);
-          if (t.objectType === "MOVIE") {
-            return parseMovieDetails(await fetchMovieDetails(tmdbId));
-          } else {
-            return parseTvDetails(await fetchTvDetails(tmdbId));
+      basicTitles.map((t) =>
+        limit(async () => {
+          try {
+            const tmdbId = parseInt(t.tmdbId || "0", 10);
+            if (t.objectType === "MOVIE") {
+              return parseMovieDetails(await fetchMovieDetails(tmdbId));
+            } else {
+              return parseTvDetails(await fetchTvDetails(tmdbId));
+            }
+          } catch {
+            return t;
           }
-        } catch {
-          return t;
-        }
-      })
+        })
+      )
     );
 
     // Persist titles with offers to DB so stream buttons appear on subsequent views

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { pLimit } from "../lib/p-limit";
 import { searchMulti, fetchMovieDetails, fetchTvDetails, getMovieGenres, getTvGenres } from "../tmdb/client";
 import { parseSearchResult, parseMovieDetails, parseTvDetails, type ParsedTitle } from "../tmdb/parser";
 import { getTrackedTitleIds, upsertTitles } from "../db/repository";
@@ -61,20 +62,23 @@ app.get("/", async (c) => {
       basicTitles = basicTitles.filter((t) => t.originalLanguage === languageParam);
     }
 
-    // Fetch watch providers for each result
+    // Fetch watch providers for each result — capped at 5 concurrent requests.
+    const limit = pLimit(5);
     const titles = await Promise.all(
-      basicTitles.slice(0, 20).map(async (t) => {
-        try {
-          const tmdbId = parseInt(t.tmdbId || "0", 10);
-          if (t.objectType === "MOVIE") {
-            return parseMovieDetails(await fetchMovieDetails(tmdbId));
-          } else {
-            return parseTvDetails(await fetchTvDetails(tmdbId));
+      basicTitles.slice(0, 20).map((t) =>
+        limit(async () => {
+          try {
+            const tmdbId = parseInt(t.tmdbId || "0", 10);
+            if (t.objectType === "MOVIE") {
+              return parseMovieDetails(await fetchMovieDetails(tmdbId));
+            } else {
+              return parseTvDetails(await fetchTvDetails(tmdbId));
+            }
+          } catch {
+            return t; // Fallback to basic data without watch providers
           }
-        } catch {
-          return t; // Fallback to basic data without watch providers
-        }
-      })
+        })
+      )
     );
 
     // Apply rating filter only after fetching details (TMDB search results lack ratings;


### PR DESCRIPTION
## Summary

- `GET /api/browse` fired an unbounded `Promise.all` over up to 500 items against TMDB's detail API, spiking memory and easily triggering the 50 req/s rate limit under load
- `GET /api/search` had the same pattern over up to 20 items (defensive: the `.slice(0,20)` cap could be relaxed in future)
- Introduce a tiny `server/lib/p-limit.ts` concurrency scheduler (no new npm dep, ~25 LOC) and wrap both fanouts with `pLimit(5)` — at most 5 in-flight TMDB calls at a time

## Test plan

- [x] `bun test server/lib/p-limit.test.ts` — 3 tests (all tasks complete, max concurrency invariant, error propagation)
- [x] `bun test server/routes/browse.test.ts server/routes/search.test.ts` — existing route tests still pass

Closes #490