### PR TITLE
perf(#488): single-flight cache for getGenres / getLanguages

### DIFF
--- a/server/db/repository/titles.test.ts
+++ b/server/db/repository/titles.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { describe, it, expect, beforeEach, afterAll, spyOn, afterEach } from "bun:test";
 import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
 import { makeParsedTitle, makeParsedOffer } from "../../test-utils/fixtures";
 import {
@@ -8,10 +8,14 @@ import {
   upsertTitleGenres,
   mergeOffers,
   upsertScores,
+  getGenres,
+  getLanguages,
+  invalidateFilterCaches,
 } from "./titles";
 import { getDb } from "../schema";
 import { titles, providers, offers, scores, titleGenres } from "../schema";
 import { eq } from "drizzle-orm";
+import * as tracing from "../../tracing";
 
 beforeEach(() => {
   setupTestDb();
@@ -370,5 +374,40 @@ describe("upsertScores", () => {
     expect(row?.imdbScore).toBeNull();
     expect(row?.imdbVotes).toBeNull();
     expect(row?.tmdbScore).toBeNull();
+  });
+});
+
+describe("getGenres / getLanguages — single-flight cache stampede prevention", () => {
+  let traceSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    invalidateFilterCaches();
+    traceSpy = spyOn(tracing, "traceDbQuery").mockImplementation(
+      (_name: any, fn: any) => fn(),
+    );
+  });
+
+  afterEach(() => {
+    traceSpy.mockRestore();
+    invalidateFilterCaches();
+  });
+
+  it("getGenres: 10 concurrent callers with empty cache trigger exactly one DB query", async () => {
+    const calls = Array.from({ length: 10 }, () => getGenres());
+    await Promise.all(calls);
+    expect(traceSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("getLanguages: 10 concurrent callers with empty cache trigger exactly one DB query", async () => {
+    const calls = Array.from({ length: 10 }, () => getLanguages());
+    await Promise.all(calls);
+    expect(traceSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("getGenres: returns cached value on second call without hitting DB", async () => {
+    await getGenres(); // prime the cache
+    traceSpy.mockClear();
+    await getGenres();
+    expect(traceSpy).not.toHaveBeenCalled();
   });
 });

--- a/server/db/repository/titles.ts
+++ b/server/db/repository/titles.ts
@@ -21,6 +21,11 @@ interface FilterCache<T> {
 let genresCache: FilterCache<string[]> | null = null;
 let languagesCache: FilterCache<string[]> | null = null;
 
+// In-flight promise refs prevent thundering-herd: concurrent callers that
+// arrive while the cache is expired all await the same refresh promise.
+let genresInflight: Promise<string[]> | null = null;
+let languagesInflight: Promise<string[]> | null = null;
+
 export function invalidateFilterCaches(): void {
   genresCache = null;
   languagesCache = null;
@@ -670,13 +675,14 @@ export async function getProviders() {
   });
 }
 
-export async function getGenres(): Promise<string[]> {
+export function getGenres(): Promise<string[]> {
   const now = Date.now();
   if (genresCache && now < genresCache.expiresAt) {
-    return genresCache.value;
+    return Promise.resolve(genresCache.value);
   }
+  if (genresInflight) return genresInflight;
 
-  const result = await traceDbQuery("getGenres", async () => {
+  genresInflight = traceDbQuery("getGenres", async () => {
     const db = getDb();
     const rows = await db
       .selectDistinct({ genre: titleGenres.genre })
@@ -685,19 +691,24 @@ export async function getGenres(): Promise<string[]> {
       .all();
     const rawGenres = rows.map((r) => r.genre);
     return [...new Set(rawGenres.map(toCanonicalGenre))].sort();
+  }).then((result) => {
+    genresCache = { value: result, expiresAt: Date.now() + CACHE_TTL_MS };
+    return result;
+  }).finally(() => {
+    genresInflight = null;
   });
 
-  genresCache = { value: result, expiresAt: now + CACHE_TTL_MS };
-  return result;
+  return genresInflight;
 }
 
-export async function getLanguages(): Promise<string[]> {
+export function getLanguages(): Promise<string[]> {
   const now = Date.now();
   if (languagesCache && now < languagesCache.expiresAt) {
-    return languagesCache.value;
+    return Promise.resolve(languagesCache.value);
   }
+  if (languagesInflight) return languagesInflight;
 
-  const result = await traceDbQuery("getLanguages", async () => {
+  languagesInflight = traceDbQuery("getLanguages", async () => {
     const db = getDb();
     const rows = await db
       .selectDistinct({ original_language: titles.originalLanguage })
@@ -706,8 +717,12 @@ export async function getLanguages(): Promise<string[]> {
       .orderBy(asc(titles.originalLanguage))
       .all();
     return rows.map((r) => r.original_language!);
+  }).then((result) => {
+    languagesCache = { value: result, expiresAt: Date.now() + CACHE_TTL_MS };
+    return result;
+  }).finally(() => {
+    languagesInflight = null;
   });
 
-  languagesCache = { value: result, expiresAt: now + CACHE_TTL_MS };
-  return result;
+  return languagesInflight;
 }


### PR DESCRIPTION
## Summary

- `getGenres()` and `getLanguages()` used a 1-hour in-memory TTL cache but had no coordination between concurrent callers when the cache expired — every request that arrived during the cold refresh would independently hit the DB (thundering herd)
- Introduce an in-flight `Promise` ref per cache key: the first expired caller creates the promise; all other concurrent callers await it instead of launching a duplicate query
- Cache is still written on resolution; the inflight ref is cleared in `.finally()` so a transient DB error allows retry rather than permanently blocking

## Test plan

- [x] 10 concurrent `getGenres()` calls with empty cache → `traceDbQuery` called exactly once
- [x] 10 concurrent `getLanguages()` calls with empty cache → `traceDbQuery` called exactly once
- [x] Second serial call after cache is primed → no DB round-trip
- [x] `bunx tsc --noEmit` clean
- [x] `bun test server/db/repository/titles.test.ts` — 25 pass

Closes #488