### PR TITLE
feat(#492): add per-section error boundaries on detail pages

### DIFF
--- a/frontend/src/components/SectionErrorBoundary.test.tsx
+++ b/frontend/src/components/SectionErrorBoundary.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, mock, afterEach } from "bun:test";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import "../i18n";
+import SectionErrorBoundary from "./SectionErrorBoundary";
+
+function Bomb({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error("boom");
+  return <div>content</div>;
+}
+
+afterEach(() => cleanup());
+
+describe("SectionErrorBoundary", () => {
+  it("renders children when there is no error", () => {
+    render(
+      <SectionErrorBoundary label="Cast">
+        <Bomb shouldThrow={false} />
+      </SectionErrorBoundary>
+    );
+    expect(screen.getByText("content")).toBeDefined();
+  });
+
+  it("shows labeled fallback when a child throws", () => {
+    const consoleError = mock(() => {});
+    const original = console.error;
+    console.error = consoleError;
+
+    render(
+      <SectionErrorBoundary label="Cast">
+        <Bomb shouldThrow={true} />
+      </SectionErrorBoundary>
+    );
+    expect(screen.getByText(/Couldn't load Cast/)).toBeDefined();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeDefined();
+
+    console.error = original;
+  });
+
+  it("calls onRetry prop when Retry is clicked", () => {
+    const consoleError = mock(() => {});
+    const original = console.error;
+    console.error = consoleError;
+
+    const onRetry = mock(() => {});
+    render(
+      <SectionErrorBoundary label="Ratings" onRetry={onRetry}>
+        <Bomb shouldThrow={true} />
+      </SectionErrorBoundary>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+
+    console.error = original;
+  });
+});

--- a/frontend/src/components/SectionErrorBoundary.tsx
+++ b/frontend/src/components/SectionErrorBoundary.tsx
@@ -1,0 +1,48 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  label?: string;
+  onRetry?: () => void;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class SectionErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error(`[SectionErrorBoundary] ${this.props.label ?? "section"} failed to render`, error, info.componentStack);
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false });
+    this.props.onRetry?.();
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="py-6 flex flex-col items-center justify-center gap-3 text-center">
+          <p className="text-sm text-zinc-500">
+            Couldn&apos;t load {this.props.label ?? "this section"}
+          </p>
+          <button
+            onClick={this.handleRetry}
+            className="px-3 py-1.5 text-xs font-medium rounded-md bg-zinc-800 text-zinc-300 hover:bg-zinc-700 transition-colors cursor-pointer"
+          >
+            Retry
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/pages/EpisodeDetailPage.tsx
+++ b/frontend/src/pages/EpisodeDetailPage.tsx
@@ -13,6 +13,7 @@ import { WatchedIcon } from "../components/EpisodeComponents";
 import ShareButton from "../components/ShareButton";
 import EpisodeRatingButtons from "../components/EpisodeRatingButtons";
 import { stillUrl as mkStillUrl } from "../lib/tmdb-images";
+import SectionErrorBoundary from "../components/SectionErrorBoundary";
 
 function formatDate(dateStr: string | null | undefined): string {
   if (!dateStr) return "—";
@@ -168,10 +169,12 @@ export default function EpisodeDetailPage() {
 
       {/* Rating */}
       {released && episodeStatus && (
-        <section className="space-y-2">
-          <h2 className="text-lg font-semibold text-white">Rate this episode</h2>
-          <EpisodeRatingButtons episodeId={episodeStatus.id} />
-        </section>
+        <SectionErrorBoundary label="ratings">
+          <section className="space-y-2">
+            <h2 className="text-lg font-semibold text-white">Rate this episode</h2>
+            <EpisodeRatingButtons episodeId={episodeStatus.id} />
+          </section>
+        </SectionErrorBoundary>
       )}
 
       {/* Overview */}
@@ -184,35 +187,39 @@ export default function EpisodeDetailPage() {
 
       {/* Key Crew */}
       {(directors.length > 0 || writers.length > 0) && (
-        <section className="space-y-2">
-          <h2 className="text-lg font-semibold text-white">Crew</h2>
-          <div className="flex flex-wrap gap-x-6 gap-y-1 text-sm">
-            {directors.length > 0 && (
-              <div>
-                <span className="text-zinc-400">Directed by: </span>
-                <span className="text-white">{directors.map(d => d.name).join(", ")}</span>
-              </div>
-            )}
-            {writers.length > 0 && (
-              <div>
-                <span className="text-zinc-400">Written by: </span>
-                <span className="text-white">{writers.map(w => w.name).join(", ")}</span>
-              </div>
-            )}
-          </div>
-        </section>
+        <SectionErrorBoundary label="crew">
+          <section className="space-y-2">
+            <h2 className="text-lg font-semibold text-white">Crew</h2>
+            <div className="flex flex-wrap gap-x-6 gap-y-1 text-sm">
+              {directors.length > 0 && (
+                <div>
+                  <span className="text-zinc-400">Directed by: </span>
+                  <span className="text-white">{directors.map(d => d.name).join(", ")}</span>
+                </div>
+              )}
+              {writers.length > 0 && (
+                <div>
+                  <span className="text-zinc-400">Written by: </span>
+                  <span className="text-white">{writers.map(w => w.name).join(", ")}</span>
+                </div>
+              )}
+            </div>
+          </section>
+        </SectionErrorBoundary>
       )}
 
       {/* Guest Stars / Cast */}
       {allCast.length > 0 && (
-        <section className="space-y-3">
-          <h2 className="text-lg font-semibold text-white">Cast</h2>
-          <ScrollableRow className="gap-4 pb-2">
-            {allCast.slice(0, 20).map((c) => (
-              <PersonCard key={c.id} id={c.id} name={c.name} role={c.character} profilePath={c.profile_path} />
-            ))}
-          </ScrollableRow>
-        </section>
+        <SectionErrorBoundary label="cast">
+          <section className="space-y-3">
+            <h2 className="text-lg font-semibold text-white">Cast</h2>
+            <ScrollableRow className="gap-4 pb-2">
+              {allCast.slice(0, 20).map((c) => (
+                <PersonCard key={c.id} id={c.id} name={c.name} role={c.character} profilePath={c.profile_path} />
+              ))}
+            </ScrollableRow>
+          </section>
+        </SectionErrorBoundary>
       )}
     </div>
   );

--- a/frontend/src/pages/SeasonDetailPage.tsx
+++ b/frontend/src/pages/SeasonDetailPage.tsx
@@ -13,6 +13,7 @@ import { useApiCall } from "../hooks/useApiCall";
 import { useAuth } from "../context/AuthContext";
 import ShareButton from "../components/ShareButton";
 import { posterUrl as mkPosterUrl, stillUrl as mkStillUrl } from "../lib/tmdb-images";
+import SectionErrorBoundary from "../components/SectionErrorBoundary";
 
 function formatDate(dateStr: string | null | undefined): string {
   if (!dateStr) return "—";
@@ -424,14 +425,16 @@ export default function SeasonDetailPage() {
 
       {/* Season Cast */}
       {tmdb?.credits?.cast && tmdb.credits.cast.length > 0 && (
-        <section className="space-y-3">
-          <h2 className="text-lg font-semibold text-white">Season Cast</h2>
-          <ScrollableRow className="gap-4 pb-2">
-            {tmdb.credits.cast.slice(0, 15).map((c) => (
-              <PersonCard key={c.id} id={c.id} name={c.name} role={c.character} profilePath={c.profile_path} />
-            ))}
-          </ScrollableRow>
-        </section>
+        <SectionErrorBoundary label="cast">
+          <section className="space-y-3">
+            <h2 className="text-lg font-semibold text-white">Season Cast</h2>
+            <ScrollableRow className="gap-4 pb-2">
+              {tmdb.credits.cast.slice(0, 15).map((c) => (
+                <PersonCard key={c.id} id={c.id} name={c.name} role={c.character} profilePath={c.profile_path} />
+              ))}
+            </ScrollableRow>
+          </section>
+        </SectionErrorBoundary>
       )}
     </div>
   );

--- a/frontend/src/pages/title/MovieDetail.tsx
+++ b/frontend/src/pages/title/MovieDetail.tsx
@@ -18,6 +18,7 @@ import RatingsSection from "../../components/title-detail/RatingsSection";
 import ReleaseDates from "../../components/title-detail/ReleaseDates";
 import { Section } from "../../components/title-detail/Section";
 import { formatCurrency } from "../../components/title-detail/utils";
+import SectionErrorBoundary from "../../components/SectionErrorBoundary";
 
 export default function MovieDetail({ data }: { data: MovieDetailsResponse }) {
   const { t } = useTranslation();
@@ -162,17 +163,27 @@ export default function MovieDetail({ data }: { data: MovieDetailsResponse }) {
       )}
 
       {/* Rating & Social */}
-      <RatingsSection titleId={title.id} shareTitle={tmdb?.title || title.title} />
+      <SectionErrorBoundary label="ratings">
+        <RatingsSection titleId={title.id} shareTitle={tmdb?.title || title.title} />
+      </SectionErrorBoundary>
 
       {/* Cast & Crew */}
-      <Crew directors={directors} writers={writers} />
-      <Cast cast={cast} />
+      <SectionErrorBoundary label="crew">
+        <Crew directors={directors} writers={writers} />
+      </SectionErrorBoundary>
+      <SectionErrorBoundary label="cast">
+        <Cast cast={cast} />
+      </SectionErrorBoundary>
 
       {/* Release Dates */}
-      <ReleaseDates releaseDates={releaseDates} />
+      <SectionErrorBoundary label="release dates">
+        <ReleaseDates releaseDates={releaseDates} />
+      </SectionErrorBoundary>
 
       {/* Streaming Availability */}
-      <ProvidersSection offers={title.offers} watchProviders={watchProviders} watchLink={watchProviders?.link} />
+      <SectionErrorBoundary label="streaming providers">
+        <ProvidersSection offers={title.offers} watchProviders={watchProviders} watchLink={watchProviders?.link} />
+      </SectionErrorBoundary>
 
       {/* External Links */}
       {tmdb && (

--- a/frontend/src/pages/title/ShowDetail.tsx
+++ b/frontend/src/pages/title/ShowDetail.tsx
@@ -10,6 +10,7 @@ import ShowHero from "../../components/title-detail/ShowHero";
 import { Section } from "../../components/title-detail/Section";
 import { posterUrl as mkPosterUrl } from "../../lib/tmdb-images";
 import { formatDate, isToday } from "../../components/title-detail/utils";
+import SectionErrorBoundary from "../../components/SectionErrorBoundary";
 
 export default function ShowDetail({ data }: { data: ShowDetailsResponse }) {
   const { title, tmdb, country } = data;
@@ -61,20 +62,26 @@ export default function ShowDetail({ data }: { data: ShowDetailsResponse }) {
       )}
 
       {/* Rating & Social */}
-      <RatingsSection titleId={title.id} shareTitle={tmdb?.name || title.title} />
+      <SectionErrorBoundary label="ratings">
+        <RatingsSection titleId={title.id} shareTitle={tmdb?.name || title.title} />
+      </SectionErrorBoundary>
 
       {/* Creators & Cast */}
       {creators.length > 0 && (
-        <Section title="Created By">
-          <div className="flex gap-4">
-            {creators.map((c) => (
-              <PersonCard key={c.id} id={c.id} name={c.name} role="Creator" profilePath={c.profile_path} />
-            ))}
-          </div>
-        </Section>
+        <SectionErrorBoundary label="creators">
+          <Section title="Created By">
+            <div className="flex gap-4">
+              {creators.map((c) => (
+                <PersonCard key={c.id} id={c.id} name={c.name} role="Creator" profilePath={c.profile_path} />
+              ))}
+            </div>
+          </Section>
+        </SectionErrorBoundary>
       )}
 
-      <Cast cast={cast} />
+      <SectionErrorBoundary label="cast">
+        <Cast cast={cast} />
+      </SectionErrorBoundary>
 
       {/* Seasons */}
       {seasons.length > 0 && (
@@ -136,7 +143,9 @@ export default function ShowDetail({ data }: { data: ShowDetailsResponse }) {
       )}
 
       {/* Streaming Availability */}
-      <ProvidersSection offers={title.offers} watchProviders={watchProviders} watchLink={watchProviders?.link} />
+      <SectionErrorBoundary label="streaming providers">
+        <ProvidersSection offers={title.offers} watchProviders={watchProviders} watchLink={watchProviders?.link} />
+      </SectionErrorBoundary>
 
       {/* External Links */}
       {tmdb && (


### PR DESCRIPTION
## Summary

- A single failed render in Cast, Ratings, Providers, or Crew would crash the entire `TitleDetailPage`, `SeasonDetailPage`, or `EpisodeDetailPage`
- Add a reusable `SectionErrorBoundary` class component: compact inline fallback with a "Retry" button that resets boundary state and calls an optional `onRetry` callback
- Wrap key sections across all four detail pages:
  - **MovieDetail**: ratings, crew, cast, release dates, streaming providers
  - **ShowDetail**: ratings, creators, cast, streaming providers
  - **SeasonDetailPage**: cast block
  - **EpisodeDetailPage**: ratings, crew, cast

## Manual test plan

1. Open `/title/<movie-id>` in devtools → Network tab → block the ratings API call → ratings section shows compact fallback, rest of page renders normally
2. Click Retry on the fallback → section re-attempts
3. Open `/title/<show-id>/season/1` → block the episode status endpoint → page still loads
4. Open `/title/<show-id>/season/1/episode/1` → block ratings endpoint → rating section fallback, episode details still visible

## Test plan

- [x] `bun test frontend/src/components/SectionErrorBoundary.test.tsx` — 3 tests (no-error render, labeled fallback on throw, onRetry called)
- [x] `bun test frontend/src/pages/SeasonDetailPage.test.tsx frontend/src/pages/EpisodeDetailPage.test.tsx` — 21 tests pass
- [x] `bunx tsc -b --noEmit` clean
- [x] ESLint: zero warnings/errors

Closes #492