### PR TITLE
feat(#483): add retry + exponential backoff for outbound HTTP calls

### DIFF
--- a/server/lib/http.test.ts
+++ b/server/lib/http.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, spyOn } from "bun:test";
+import { resetMetrics } from "../metrics";
+
+// Reset metrics before each test so counters start from zero
+beforeEach(() => {
+  resetMetrics();
+});
+
+function makeResponse(status: number, headers: Record<string, string> = {}): Response {
+  return new Response(null, { status, headers });
+}
+
+describe("httpFetch", () => {
+  it("returns immediately on 200 without retrying", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(makeResponse(200));
+    try {
+      const { httpFetch } = await import("./http");
+      const { httpRetryTotal } = await import("../metrics");
+
+      const res = await httpFetch("https://example.com", undefined, { baseDelayMs: 0 });
+      expect(res.status).toBe(200);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      // No retries should have been counted
+      const rendered = httpRetryTotal.render();
+      expect(rendered).toContain("http_retry_total 0");
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("retries on 500 and resolves when 200 is returned", async () => {
+    let callCount = 0;
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((() => {
+      callCount++;
+      if (callCount <= 2) return Promise.resolve(makeResponse(500));
+      return Promise.resolve(makeResponse(200));
+    }) as any);
+    try {
+      const { httpFetch } = await import("./http");
+      const { httpRetryTotal } = await import("../metrics");
+
+      const res = await httpFetch("https://example.com", undefined, { baseDelayMs: 0 });
+      expect(res.status).toBe(200);
+      expect(callCount).toBe(3);
+
+      // Two retries were incremented (status 500 twice)
+      const rendered = httpRetryTotal.render();
+      expect(rendered).toContain('status="500"');
+      expect(rendered).toMatch(/status="500"\} 2/);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("returns 400 immediately without retrying (non-retryable 4xx)", async () => {
+    let callCount = 0;
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((() => {
+      callCount++;
+      return Promise.resolve(makeResponse(400));
+    }) as any);
+    try {
+      const { httpFetch } = await import("./http");
+
+      const res = await httpFetch("https://example.com", undefined, { baseDelayMs: 0 });
+      expect(res.status).toBe(400);
+      expect(callCount).toBe(1);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("retries on 429 and uses Retry-After header", async () => {
+    let callCount = 0;
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((() => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve(makeResponse(429, { "Retry-After": "0" }));
+      return Promise.resolve(makeResponse(200));
+    }) as any);
+    try {
+      const { httpFetch } = await import("./http");
+      const { httpRetryTotal } = await import("../metrics");
+
+      const res = await httpFetch("https://example.com", undefined, { baseDelayMs: 0 });
+      expect(res.status).toBe(200);
+      expect(callCount).toBe(2);
+
+      const rendered = httpRetryTotal.render();
+      expect(rendered).toContain('status="429"');
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("throws after exhausting maxRetries on repeated network errors", async () => {
+    let callCount = 0;
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((() => {
+      callCount++;
+      return Promise.reject(new Error("ECONNREFUSED"));
+    }) as any);
+    try {
+      const { httpFetch } = await import("./http");
+      const { httpRetryTotal } = await import("../metrics");
+
+      await expect(
+        httpFetch("https://example.com", undefined, { maxRetries: 3, baseDelayMs: 0 })
+      ).rejects.toThrow("ECONNREFUSED");
+
+      // Called maxRetries+1 times total (attempts 0,1,2,3)
+      expect(callCount).toBe(4);
+
+      // 3 retries were counted (the last attempt's error is re-thrown, not counted)
+      const rendered = httpRetryTotal.render();
+      expect(rendered).toContain('status="network_error"');
+      expect(rendered).toMatch(/status="network_error"\} 3/);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("returns the last retryable response on final attempt instead of throwing", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(makeResponse(503));
+    try {
+      const { httpFetch } = await import("./http");
+
+      const res = await httpFetch("https://example.com", undefined, {
+        maxRetries: 2,
+        baseDelayMs: 0,
+      });
+      // After exhausting retries on a retryable status, returns the response as-is
+      expect(res.status).toBe(503);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});

--- a/server/lib/http.ts
+++ b/server/lib/http.ts
@@ -1,0 +1,74 @@
+import { logger } from "../logger";
+import { httpRetryTotal } from "../metrics";
+
+const log = logger.child({ module: "http" });
+
+export interface RetryOptions {
+  maxRetries?: number; // default 3
+  baseDelayMs?: number; // default 250
+  maxDelayMs?: number; // default 30_000
+}
+
+const RETRYABLE_STATUS = new Set([408, 429, 500, 502, 503, 504]);
+
+export async function httpFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  opts: RetryOptions = {}
+): Promise<Response> {
+  const { maxRetries = 3, baseDelayMs = 250, maxDelayMs = 30_000 } = opts;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const res = await fetch(input, init);
+      if (res.ok || !RETRYABLE_STATUS.has(res.status)) {
+        return res;
+      }
+      // Retryable status
+      if (attempt === maxRetries) return res; // Last attempt — return as-is
+      const retryAfter = res.headers.get("Retry-After");
+      const delay = retryAfter
+        ? parseRetryAfter(retryAfter)
+        : jitteredDelay(baseDelayMs, attempt, maxDelayMs);
+      log.warn("Retryable HTTP error", {
+        status: res.status,
+        attempt,
+        delay,
+        url: String(input),
+      });
+      httpRetryTotal.inc({ status: String(res.status) });
+      await sleep(delay);
+    } catch (err) {
+      lastError = err;
+      if (attempt === maxRetries) break;
+      const delay = jitteredDelay(baseDelayMs, attempt, maxDelayMs);
+      log.warn("HTTP fetch error, retrying", {
+        attempt,
+        delay,
+        url: String(input),
+        err,
+      });
+      httpRetryTotal.inc({ status: "network_error" });
+      await sleep(delay);
+    }
+  }
+  throw lastError ?? new Error("httpFetch exhausted retries");
+}
+
+function jitteredDelay(base: number, attempt: number, max: number): number {
+  const exp = Math.min(base * 2 ** attempt, max);
+  return exp * (0.5 + Math.random() * 0.5);
+}
+
+function parseRetryAfter(header: string): number {
+  const sec = Number(header);
+  if (!isNaN(sec)) return sec * 1000;
+  const date = new Date(header);
+  const diff = date.getTime() - Date.now();
+  return Math.max(diff, 1000);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/server/notifications/discord.ts
+++ b/server/notifications/discord.ts
@@ -1,5 +1,6 @@
 import { CONFIG } from "../config";
 import { traceHttp } from "../tracing";
+import { httpFetch } from "../lib/http";
 import { formatProviderNames, groupEpisodesByShow } from "./format";
 import type { NotificationContent, NotificationProvider } from "./types";
 
@@ -34,7 +35,7 @@ export class DiscordProvider implements NotificationProvider {
     if (embeds.length === 0) return;
 
     await traceHttp("POST", config.webhookUrl, async () => {
-      const response = await fetch(config.webhookUrl, {
+      const response = await httpFetch(config.webhookUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/server/notifications/gotify.ts
+++ b/server/notifications/gotify.ts
@@ -1,4 +1,5 @@
 import { traceHttp } from "../tracing";
+import { httpFetch } from "../lib/http";
 import { formatProviderNames, groupEpisodesByShow } from "./format";
 import type { NotificationContent, NotificationProvider } from "./types";
 
@@ -33,7 +34,7 @@ export class GotifyProvider implements NotificationProvider {
     const url = `${base}/message`;
 
     await traceHttp("POST", url, async () => {
-      const response = await fetch(url, {
+      const response = await httpFetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json", "X-Gotify-Key": config.token },
         body: JSON.stringify({ title, message, priority: 5 }),

--- a/server/notifications/ntfy.ts
+++ b/server/notifications/ntfy.ts
@@ -1,4 +1,5 @@
 import { traceHttp } from "../tracing";
+import { httpFetch } from "../lib/http";
 import { formatProviderNames, groupEpisodesByShow } from "./format";
 import type { NotificationContent, NotificationProvider } from "./types";
 
@@ -43,7 +44,7 @@ export class NtfyProvider implements NotificationProvider {
     }
 
     await traceHttp("POST", config.url, async () => {
-      const response = await fetch(config.url, {
+      const response = await httpFetch(config.url, {
         method: "POST",
         headers,
         body: message,

--- a/server/notifications/telegram.ts
+++ b/server/notifications/telegram.ts
@@ -1,4 +1,5 @@
 import { traceHttp } from "../tracing";
+import { httpFetch } from "../lib/http";
 import { formatProviderNames, groupEpisodesByShow } from "./format";
 import type { NotificationContent, NotificationProvider } from "./types";
 
@@ -31,7 +32,7 @@ export class TelegramProvider implements NotificationProvider {
     const url = `${TELEGRAM_API}/bot${config.botToken}/sendMessage`;
 
     await traceHttp("POST", url, async () => {
-      const response = await fetch(url, {
+      const response = await httpFetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/server/notifications/webhook.ts
+++ b/server/notifications/webhook.ts
@@ -1,4 +1,5 @@
 import { traceHttp } from "../tracing";
+import { httpFetch } from "../lib/http";
 import { groupEpisodesByShow } from "./format";
 import type { NotificationContent, NotificationProvider } from "./types";
 
@@ -37,7 +38,7 @@ export class WebhookProvider implements NotificationProvider {
     }
 
     await traceHttp("POST", config.url, async () => {
-      const response = await fetch(config.url, {
+      const response = await httpFetch(config.url, {
         method: "POST",
         headers,
         body,

--- a/server/plex/client.ts
+++ b/server/plex/client.ts
@@ -1,5 +1,6 @@
 import { CONFIG } from "../config";
 import { logger } from "../logger";
+import { httpFetch } from "../lib/http";
 
 const log = logger.child({ module: "plex" });
 
@@ -35,7 +36,7 @@ export class PlexApiError extends Error {
 }
 
 async function plexFetch<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const res = await fetch(url, options);
+  const res = await httpFetch(url, options);
   if (res.status === 401) throw new PlexAuthError("Plex token is invalid or revoked");
   if (!res.ok) throw new PlexApiError(`Plex API error: ${res.status} ${res.statusText}`, res.status);
   return res.json() as Promise<T>;

--- a/server/streaming-availability/client.ts
+++ b/server/streaming-availability/client.ts
@@ -2,6 +2,7 @@ import { CONFIG } from "../config";
 import { traceHttp } from "../tracing";
 import { logger } from "../logger";
 import { getCache } from "../cache";
+import { httpFetch } from "../lib/http";
 import type { SAShow, SAStreamingOption } from "./types";
 import { RateLimitError } from "./types";
 
@@ -33,13 +34,18 @@ export async function fetchStreamingOptions(
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), CONFIG.TMDB_API_TIMEOUT_MS);
     try {
-      const res = await fetch(url.toString(), {
-        headers: {
-          "X-RapidAPI-Key": CONFIG.STREAMING_AVAILABILITY_API_KEY,
-          "X-RapidAPI-Host": "streaming-availability.p.rapidapi.com",
+      // maxRetries: 0 — SA has custom 429/403 handling; don't retry at the httpFetch layer
+      const res = await httpFetch(
+        url.toString(),
+        {
+          headers: {
+            "X-RapidAPI-Key": CONFIG.STREAMING_AVAILABILITY_API_KEY,
+            "X-RapidAPI-Host": "streaming-availability.p.rapidapi.com",
+          },
+          signal: controller.signal,
         },
-        signal: controller.signal,
-      });
+        { maxRetries: 0 }
+      );
 
       if (res.status === 404) {
         log.debug("Title not found on SA", { tmdbId, objectType });

--- a/server/tmdb/client.test.ts
+++ b/server/tmdb/client.test.ts
@@ -73,17 +73,21 @@ describe("tmdbRequest error handling", () => {
   });
 
   it("throws on 5xx response", async () => {
-    fetchSpy.mockResolvedValueOnce(textResponse("Internal Server Error", 500));
+    // httpFetch retries on 500; mock all attempts to return 500 so the TMDB
+    // client still sees a 500 error after retries are exhausted.
+    fetchSpy.mockResolvedValue(textResponse("Internal Server Error", 500));
     await expect(fetchShowDetails("123")).rejects.toThrow("TMDB API error 500: Internal Server Error");
   });
 
   it("throws on 404 response", async () => {
+    // 404 is not retried by httpFetch, so a single mock is sufficient.
     fetchSpy.mockResolvedValueOnce(textResponse("Not Found", 404));
     await expect(fetchMovieDetails(999)).rejects.toThrow("TMDB API error 404: Not Found");
   });
 
   it("throws on 429 rate limit response", async () => {
-    fetchSpy.mockResolvedValueOnce(textResponse("Rate limit exceeded", 429));
+    // httpFetch retries on 429; mock all attempts so TMDB client sees the error.
+    fetchSpy.mockResolvedValue(textResponse("Rate limit exceeded", 429));
     await expect(searchMulti("test")).rejects.toThrow("TMDB API error 429: Rate limit exceeded");
   });
 

--- a/server/tmdb/client.ts
+++ b/server/tmdb/client.ts
@@ -1,6 +1,7 @@
 import { CONFIG } from "../config";
 import { traceHttp } from "../tracing";
 import { getCache } from "../cache";
+import { httpFetch } from "../lib/http";
 import type {
   TmdbShowDetails,
   TmdbSeasonResponse,
@@ -32,7 +33,7 @@ async function tmdbRequest<T>(path: string, params?: Record<string, string>): Pr
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), CONFIG.TMDB_API_TIMEOUT_MS);
     try {
-      const res = await fetch(url.toString(), {
+      const res = await httpFetch(url.toString(), {
         headers: {
           Authorization: `Bearer ${CONFIG.TMDB_API_KEY}`,
           "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- New `server/lib/http.ts` with `httpFetch()`: 3 retries, 250ms base delay with jitter, respects `Retry-After` header
- Retries on: network errors, 408, 429, 5xx; never retries other 4xx
- Wired into TMDB, Plex, Streaming Availability, and all 5 notification providers (Discord, Telegram, Gotify, Ntfy, Webhook)
- SA client uses `maxRetries: 0` to preserve its custom 429/403 handling (avoids double-handling of rate limits)
- New `http_retry_total` Prometheus counter with `status` label

## Test plan
- [x] Unit tests cover retry/no-retry paths, Retry-After header, network error exhaustion (6 tests in `server/lib/http.test.ts`)
- [x] TMDB client tests updated to mock all retry attempts for retryable status codes (500, 429)
- [x] `bun run check` passes — 2 pre-existing `validator.test.ts` mock-contamination failures unrelated to this PR

Closes #483