### PR TITLE
fix(#592,#593): atomic job claim + rate-limit public endpoints

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -207,8 +207,9 @@ app.use("/api/search/*", optionalAuth);
 app.use("/api/search", optionalAuth);
 app.route("/api/search", searchRoutes);
 
-app.use("/api/browse/*", optionalAuth);
-app.use("/api/browse", optionalAuth);
+const browseRateLimiter = rateLimiter({ limit: 30, windowMs: 60_000 });
+app.use("/api/browse/*", browseRateLimiter, optionalAuth);
+app.use("/api/browse", browseRateLimiter, optionalAuth);
 app.route("/api/browse", browseRoutes);
 
 app.use("/api/calendar/*", optionalAuth);
@@ -300,8 +301,9 @@ app.use("/api/jobs", requireAuth, requireAdmin);
 app.route("/api/jobs", jobsRoutes);
 
 // Detail pages (optionalAuth for is_tracked)
-app.use("/api/details/*", optionalAuth);
-app.use("/api/details", optionalAuth);
+const detailsRateLimiter = rateLimiter({ limit: 60, windowMs: 60_000 });
+app.use("/api/details/*", detailsRateLimiter, optionalAuth);
+app.use("/api/details", detailsRateLimiter, optionalAuth);
 app.route("/api/details", detailsRoutes);
 
 // Sync (admin only — rate limited + require admin)

--- a/server/jobs/processor.test.ts
+++ b/server/jobs/processor.test.ts
@@ -211,6 +211,22 @@ describe("processPendingJobs", () => {
     expect(count).toBe(1); // Still completes, just skips the actual sync
     expect(mockSyncEpisodes).not.toHaveBeenCalled();
   });
+
+  it("claims jobs atomically — handler runs at most once if two invocations race on the same pending job", async () => {
+    let callCount = 0;
+    mockFetchNewReleases.mockImplementation(async () => {
+      callCount++;
+      return [];
+    });
+    mockUpsertTitles.mockResolvedValue(0);
+
+    await insertJob("sync-titles");
+
+    const [c1, c2] = await Promise.all([processPendingJobs(), processPendingJobs()]);
+
+    expect(callCount).toBe(1);
+    expect(c1 + c2).toBe(1);
+  });
 });
 
 // ─── enqueueCronJob ──────────────────────────────────────────────────────────

--- a/server/jobs/processor.ts
+++ b/server/jobs/processor.ts
@@ -232,11 +232,21 @@ export async function processPendingJobs(): Promise<number> {
       continue;
     }
 
-    // Claim the job
-    await db
+    // Claim the job atomically — the status check in WHERE prevents a second
+    // concurrent CF scheduled invocation from executing the same job if both
+    // selected it as "pending" before either claimed it. .returning() is used
+    // instead of rowsAffected because the bun:sqlite Drizzle driver doesn't
+    // populate rowsAffected reliably; an empty result means 0 rows matched.
+    const [claimed] = await db
       .update(jobs)
       .set({ status: "running", startedAt: now, attempts: job.attempts + 1 })
-      .where(eq(jobs.id, job.id));
+      .where(and(eq(jobs.id, job.id), eq(jobs.status, "pending")))
+      .returning({ id: jobs.id });
+
+    if (!claimed) {
+      log.info("Job already claimed by concurrent invocation, skipping", { name: job.name, jobId: job.id });
+      continue;
+    }
 
     try {
       await handler(job.data);
@@ -303,7 +313,7 @@ export async function enqueueJobReturningId(name: string): Promise<number | null
     .get();
 
   if (existing) {
-    log.debug("Cron job already pending/running, skipping", { name });
+    log.info("Cron job already pending/running, skipping", { name });
     return null;
   }
 

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -278,8 +278,9 @@ function createApp(env: Env) {
   app.use("/api/search", optionalAuth);
   app.route("/api/search", searchRoutes);
 
-  app.use("/api/browse/*", optionalAuth);
-  app.use("/api/browse", optionalAuth);
+  const browseRateLimiter = rateLimiter({ limit: 30, windowMs: 60_000 });
+  app.use("/api/browse/*", browseRateLimiter, optionalAuth);
+  app.use("/api/browse", browseRateLimiter, optionalAuth);
   app.route("/api/browse", browseRoutes);
 
   app.use("/api/calendar/*", optionalAuth);
@@ -300,8 +301,9 @@ function createApp(env: Env) {
   app.route("/api/social", socialRoutes);
 
   // Ratings routes — optionalAuth base, POST/DELETE check auth internally
-  app.use("/api/ratings/*", optionalAuth);
-  app.use("/api/ratings", optionalAuth);
+  const ratingsRateLimiter = rateLimiter({ limit: 60, windowMs: 60_000 });
+  app.use("/api/ratings/*", ratingsRateLimiter, optionalAuth);
+  app.use("/api/ratings", ratingsRateLimiter, optionalAuth);
   app.route("/api/ratings", ratingsRoutes);
 
   // Recommendations routes
@@ -365,8 +367,9 @@ function createApp(env: Env) {
   app.route("/api/jobs", jobsCfRoutes);
 
   // Detail pages
-  app.use("/api/details/*", optionalAuth);
-  app.use("/api/details", optionalAuth);
+  const detailsRateLimiter = rateLimiter({ limit: 60, windowMs: 60_000 });
+  app.use("/api/details/*", detailsRateLimiter, optionalAuth);
+  app.use("/api/details", detailsRateLimiter, optionalAuth);
   app.route("/api/details", detailsRoutes);
 
   // Sync (admin only — rate limited + require admin)


### PR DESCRIPTION
## Summary

- **#592** — Makes `processPendingJobs` claim each job atomically by adding `eq(jobs.status, "pending")` to the UPDATE's WHERE clause and using `.returning()` to detect whether the claim succeeded. Previously, two concurrent CF scheduled invocations could both SELECT the same pending job before either claimed it (TOCTOU), causing the handler to execute twice. `.returning()` is used instead of `rowsAffected` because the bun:sqlite Drizzle driver doesn't populate `rowsAffected` reliably.
- **#593** — Adds rate limiters to `/api/browse` (30 req/min), `/api/details` (60 req/min), and `/api/ratings` (60 req/min on CF) in both `server/index.ts` (Bun) and `server/worker.ts` (CF Workers). These endpoints were unprotected and showed up as the main traffic vectors in Workers Observability.

## Test plan

- [x] New concurrent-claim test in `processor.test.ts`: two `Promise.all`'d `processPendingJobs()` calls on the same pending job — asserts the handler fires exactly once and combined processed count is 1
- [x] `bun run check` passes — 2130 tests, 0 failures

Closes #592
Closes #593