### PR TITLE
fix(#599): batch migrateOffers to 20 titles/run to avoid CF CPU timeout

### DIFF
--- a/server/jobs/migrate-offers.test.ts
+++ b/server/jobs/migrate-offers.test.ts
@@ -82,7 +82,7 @@ describe("migrateOffers", () => {
 
     const result = await migrateOffers();
 
-    expect(result).toEqual({ updated: 0, skipped: 0, failed: 0 });
+    expect(result).toEqual({ updated: 0, skipped: 0, failed: 0, hasMore: false });
     expect(mockFetchMovieDetails).not.toHaveBeenCalled();
     expect(mockFetchTvDetails).not.toHaveBeenCalled();
   });
@@ -90,7 +90,7 @@ describe("migrateOffers", () => {
   it("returns zeros when no titles exist", async () => {
     const result = await migrateOffers();
 
-    expect(result).toEqual({ updated: 0, skipped: 0, failed: 0 });
+    expect(result).toEqual({ updated: 0, skipped: 0, failed: 0, hasMore: false });
   });
 
   it("skips titles that already have offers", async () => {
@@ -99,7 +99,7 @@ describe("migrateOffers", () => {
 
     const result = await migrateOffers();
 
-    expect(result).toEqual({ updated: 0, skipped: 0, failed: 0 });
+    expect(result).toEqual({ updated: 0, skipped: 0, failed: 0, hasMore: false });
     expect(mockFetchMovieDetails).not.toHaveBeenCalled();
   });
 
@@ -116,7 +116,7 @@ describe("migrateOffers", () => {
 
     const result = await migrateOffers();
 
-    expect(result).toEqual({ updated: 1, skipped: 0, failed: 0 });
+    expect(result).toEqual({ updated: 1, skipped: 0, failed: 0, hasMore: false });
     expect(mockFetchMovieDetails).toHaveBeenCalledWith(200);
     expect(countOffers("movie-200")).toBe(1);
   });
@@ -135,7 +135,7 @@ describe("migrateOffers", () => {
 
     const result = await migrateOffers();
 
-    expect(result).toEqual({ updated: 1, skipped: 0, failed: 0 });
+    expect(result).toEqual({ updated: 1, skipped: 0, failed: 0, hasMore: false });
     expect(mockFetchTvDetails).toHaveBeenCalledWith(300);
     expect(countOffers("tv-300")).toBe(1);
   });
@@ -148,7 +148,7 @@ describe("migrateOffers", () => {
 
     const result = await migrateOffers();
 
-    expect(result).toEqual({ updated: 0, skipped: 1, failed: 0 });
+    expect(result).toEqual({ updated: 0, skipped: 1, failed: 0, hasMore: false });
     expect(countOffers("movie-400")).toBe(0);
   });
 
@@ -159,7 +159,7 @@ describe("migrateOffers", () => {
 
     const result = await migrateOffers();
 
-    expect(result).toEqual({ updated: 0, skipped: 0, failed: 1 });
+    expect(result).toEqual({ updated: 0, skipped: 0, failed: 1, hasMore: false });
   });
 
   it("continues after a failure and processes remaining titles", async () => {
@@ -177,6 +177,19 @@ describe("migrateOffers", () => {
 
     const result = await migrateOffers();
 
-    expect(result).toEqual({ updated: 1, skipped: 0, failed: 1 });
+    expect(result).toEqual({ updated: 1, skipped: 0, failed: 1, hasMore: false });
+  });
+
+  it("returns hasMore: true when the batch is full and more titles remain", async () => {
+    insertTitle("movie-701", "MOVIE", "701");
+    insertTitle("movie-702", "MOVIE", "702");
+
+    mockFetchMovieDetails.mockRejectedValue(new Error("API error"));
+
+    // batchSize=1 so only movie-701 is processed; movie-702 remains
+    const result = await migrateOffers(1);
+
+    expect(result).toMatchObject({ hasMore: true });
+    expect(mockFetchMovieDetails).toHaveBeenCalledTimes(1);
   });
 });

--- a/server/jobs/migrate-offers.ts
+++ b/server/jobs/migrate-offers.ts
@@ -10,6 +10,7 @@ import { CONFIG } from "../config";
 const log = logger.child({ module: "migrate-offers" });
 
 const DELAY_MS = 500;
+const DEFAULT_BATCH_SIZE = 20;
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -18,11 +19,14 @@ function delay(ms: number): Promise<void> {
 /**
  * One-time migration: fetches watch provider offers from TMDB
  * for all existing titles that have no offers in the database.
+ *
+ * Processes at most `batchSize` titles per call to stay within CF CPU limits.
+ * Returns `hasMore: true` when the batch was full — callers should re-enqueue.
  */
-export async function migrateOffers(): Promise<{ updated: number; skipped: number; failed: number }> {
+export async function migrateOffers(batchSize = DEFAULT_BATCH_SIZE): Promise<{ updated: number; skipped: number; failed: number; hasMore: boolean }> {
   if (!CONFIG.TMDB_API_KEY) {
     log.info("Skipping offers migration", { reason: "TMDB_API_KEY not configured" });
-    return { updated: 0, skipped: 0, failed: 0 };
+    return { updated: 0, skipped: 0, failed: 0, hasMore: false };
   }
 
   const db = getDb();
@@ -32,14 +36,17 @@ export async function migrateOffers(): Promise<{ updated: number; skipped: numbe
     .where(
       sql`${titles.tmdbId} IS NOT NULL AND NOT EXISTS (SELECT 1 FROM ${offers} WHERE ${offers.titleId} = ${titles.id})`
     )
+    .limit(batchSize)
     .all();
 
   if (rows.length === 0) {
     log.info("No titles need offers migration");
-    return { updated: 0, skipped: 0, failed: 0 };
+    return { updated: 0, skipped: 0, failed: 0, hasMore: false };
   }
 
-  log.info("Migrating offers", { count: rows.length });
+  // A full batch means there are likely more rows beyond this page.
+  const hasMore = rows.length === batchSize;
+  log.info("Migrating offers batch", { count: rows.length, hasMore });
   let updated = 0;
   let skipped = 0;
   let failed = 0;
@@ -67,6 +74,6 @@ export async function migrateOffers(): Promise<{ updated: number; skipped: numbe
     await delay(DELAY_MS);
   }
 
-  log.info("Offers migration complete", { updated, skipped, failed });
-  return { updated, skipped, failed };
+  log.info("Offers migration batch complete", { updated, skipped, failed, hasMore });
+  return { updated, skipped, failed, hasMore };
 }

--- a/server/jobs/processor.ts
+++ b/server/jobs/processor.ts
@@ -142,7 +142,14 @@ async function handleBackfillTitleOffers(data: string | null): Promise<void> {
 
 async function handleMigrateOffers(): Promise<void> {
   const { migrateOffers } = await import("./migrate-offers");
-  await migrateOffers();
+  const result = await migrateOffers();
+  if (result.hasMore) {
+    // Direct insert bypasses enqueueOneTimeMigration's "any row" sentinel so the
+    // backfill continues across multiple cron ticks.
+    const db = getDb();
+    await db.insert(jobs).values({ name: "migrate-offers", runAt: new Date().toISOString(), maxAttempts: 1 });
+    log.info("migrate-offers batch done, re-enqueued for next tick");
+  }
 }
 
 async function handleSyncDeepLinks(): Promise<void> {

--- a/server/jobs/sync.test.ts
+++ b/server/jobs/sync.test.ts
@@ -45,7 +45,7 @@ const mockMigrateTitles = spyOn(migrateTitlesModule, "migrateTitles").mockResolv
 
 // Mock migrate-offers — use spyOn
 import * as migrateOffersModule from "./migrate-offers";
-const mockMigrateOffers = spyOn(migrateOffersModule, "migrateOffers").mockResolvedValue({ updated: 0, skipped: 0, failed: 0 });
+const mockMigrateOffers = spyOn(migrateOffersModule, "migrateOffers").mockResolvedValue({ updated: 0, skipped: 0, failed: 0, hasMore: false });
 
 // Mock Plex sync modules
 import * as plexSync from "../plex/sync";


### PR DESCRIPTION
## Summary

- `migrateOffers()` iterated over **all** titles with no offers in a single invocation, making one TMDB API call + 500 ms delay per title
- On CF Workers, this always blew the CPU/wall-clock limit — the job was killed before completing, left in `running` state, then reset to `pending` every 15 min by `recoverStaleJobs`, looping forever
- Adds a **batch cap of 20 titles per run** and returns `hasMore: true` when the batch was full
- `handleMigrateOffers` re-enqueues a fresh `pending` row so the backfill continues on the next cron tick without touching the `enqueueOneTimeMigration` sentinel (which only deduplicates, not blocks continuation)

## Test plan

- [ ] `bun test server/jobs/migrate-offers.test.ts` — all 9 tests pass, including new `hasMore: true` case
- [ ] `bun run check` — 2169 tests, 0 failures
- [ ] Deploy and verify `*/5 * * * *` cron no longer shows `exceededCpu` in CF Observability

Closes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)