### PR TITLE
fix(#603): DO job queue never ran + migrate-offers zero progress

### DIFF
--- a/server/jobs/backend.test.ts
+++ b/server/jobs/backend.test.ts
@@ -134,10 +134,27 @@ describe("recoverStale (D1 mode)", () => {
 });
 
 describe("enqueueOnce", () => {
-  it("always delegates to enqueueOneTimeMigration regardless of backend", async () => {
-    CONFIG.JOB_QUEUE_BACKEND = "durable-object";
+  it("delegates to enqueueOneTimeMigration in D1 mode", async () => {
+    CONFIG.JOB_QUEUE_BACKEND = "d1";
     await enqueueOnce("migrate-offers");
     expect(mockEnqueueOneTimeMigration).toHaveBeenCalledWith("migrate-offers");
+  });
+
+  it("enqueues directly in the named DO in DO mode", async () => {
+    const fetchCalls: { path: string; body: unknown }[] = [];
+    const doEnv = {
+      DB: {} as D1Database,
+      JOB_QUEUE_DO: makeFakeDoNamespace((_path, _method, body) => {
+        fetchCalls.push({ path: _path, body });
+        return { id: 1 };
+      }),
+    };
+    CONFIG.JOB_QUEUE_BACKEND = "durable-object";
+    await runWithEnv(doEnv as any, () => enqueueOnce("migrate-offers"));
+    expect(mockEnqueueOneTimeMigration).not.toHaveBeenCalled();
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0].path).toBe("/enqueue");
+    expect((fetchCalls[0].body as any).maxAttempts).toBe(1);
   });
 });
 

--- a/server/jobs/backend.ts
+++ b/server/jobs/backend.ts
@@ -138,12 +138,17 @@ export async function enqueueAdhoc(
 
 /**
  * Enqueue a one-time migration job (idempotent — skips if any row exists).
- * D1 mode only: called from scheduled() keep-alive block.
+ * In D1 mode the D1 jobs table row is the dedup sentinel.
+ * In DO mode we enqueue directly in the named DO (the DO's own SQLite is the sentinel).
  */
 export async function enqueueOnce(name: string): Promise<void> {
-  // One-time migrations are D1-only: the row in the D1 jobs table is the
-  // sentinel that prevents re-running. DO mode doesn't have a shared jobs
-  // table, so we fall back to D1 for migration dedup regardless of mode.
+  if (CONFIG.JOB_QUEUE_BACKEND === "durable-object") {
+    const env = getEnvOrNull();
+    if (env?.JOB_QUEUE_DO) {
+      await doFetch(env, name, "/enqueue", "POST", { name, maxAttempts: 1 });
+    }
+    return;
+  }
   await enqueueOneTimeMigration(name);
 }
 

--- a/server/jobs/durable-object.test.ts
+++ b/server/jobs/durable-object.test.ts
@@ -172,11 +172,16 @@ describe("JobQueueDO", () => {
     expect(rows[0].completed_at).not.toBeNull();
   });
 
-  it("alarm does nothing when no pending jobs exist", async () => {
+  it("alarm auto-creates and runs a job for cron DOs when no pending rows exist", async () => {
+    let called = false;
+    processorModule.handlers["sync-titles"] = async () => { called = true; };
     await do_.armCron("sync-titles", "0 3 * * *");
-    await do_.alarm(); // no rows inserted
+    await do_.alarm(); // no rows pre-inserted — auto-create kicks in
+
+    expect(called).toBe(true);
     const rows = do_.getRecentJobs();
-    expect(rows).toHaveLength(0);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("completed");
   });
 
   it("alarm skips jobs not yet ready (future run_at)", async () => {
@@ -194,12 +199,13 @@ describe("JobQueueDO", () => {
   it("two concurrent alarm() calls process a job at most once (single-writer guarantee)", async () => {
     let callCount = 0;
     processorModule.handlers["sync-titles"] = async () => { callCount++; };
-    await do_.armCron("sync-titles", "0 3 * * *");
+    // No armCron — use bare enqueue so cron is null and auto-create doesn't kick in.
+    // enqueue() sets the "name" key so alarm() still identifies the DO.
     await do_.enqueue("sync-titles", null);
 
     // In the DO model, only one alarm fires at a time — simulate two concurrent
-    // invocations; the second should find no pending work.
-    const [, ] = await Promise.all([do_.alarm(), do_.alarm()]);
+    // invocations; the second should find no pending work (job already claimed).
+    await Promise.all([do_.alarm(), do_.alarm()]);
     expect(callCount).toBe(1);
   });
 
@@ -252,6 +258,19 @@ describe("JobQueueDO", () => {
 
   // ── armCron + alarm re-arm ────────────────────────────────────────────────
 
+  it("armCron does not reset the alarm if one is already scheduled", async () => {
+    await do_.armCron("sync-titles", "0 3 * * *");
+    const firstAlarm = await state.storage.getAlarm();
+    expect(firstAlarm).not.toBeNull();
+
+    // Second armCron call (as the CF scheduled handler would do) should NOT push
+    // the alarm forward — doing so would cause the current tick's job to be skipped.
+    await do_.armCron("sync-titles", "0 3 * * *");
+    const secondAlarm = await state.storage.getAlarm();
+    expect(secondAlarm).toBe(firstAlarm); // unchanged
+    expect(state.storage.alarmHistory).toHaveLength(1); // set only once
+  });
+
   it("armCron sets the cron expression and schedules an alarm", async () => {
     await do_.armCron("sync-titles", "0 3 * * *");
     const cronInfo = await do_.getCronInfo();
@@ -271,6 +290,21 @@ describe("JobQueueDO", () => {
     expect(state.storage.alarmHistory.length).toBeGreaterThan(beforeAlarmCount);
     const newAlarm = state.storage.scheduledAlarm!;
     expect(newAlarm).toBeGreaterThan(Date.now());
+  });
+
+  it("ad-hoc DO (no cron) does NOT auto-create when no pending rows exist", async () => {
+    const { do_: adHocDo, state: adHocState } = makeDO("sync-show-episodes:99");
+    // Enqueue then manually mark it completed, so the DO has a "name" but no pending rows
+    await adHocDo.enqueue("sync-show-episodes", null);
+    adHocState.rawDb.prepare("UPDATE jobs SET status='completed', completed_at=? WHERE status='pending'")
+      .run(new Date().toISOString());
+
+    const alarmsBefore = adHocState.storage.alarmHistory.length;
+    await adHocDo.alarm();
+    // No auto-create for ad-hoc DOs — alarm just re-arms check and exits
+    expect(adHocDo.getRecentJobs().filter((r) => r.status === "pending")).toHaveLength(0);
+    expect(adHocState.storage.alarmHistory.length).toBe(alarmsBefore); // no new alarm
+    adHocState.close();
   });
 
   it("ad-hoc DO (no cron) re-arms only when pending rows remain", async () => {

--- a/server/jobs/durable-object.ts
+++ b/server/jobs/durable-object.ts
@@ -10,7 +10,8 @@
  */
 import { parseExpression } from "cron-parser";
 import { drizzle } from "drizzle-orm/d1";
-import { runWithDb, schemaExports } from "../db/schema";
+import { eq, sql } from "drizzle-orm";
+import { runWithDb, schemaExports, titles } from "../db/schema";
 import { runWithCache } from "../cache";
 import { CloudflareKvCache } from "../cache/cloudflare-kv";
 import { MemoryCache } from "../cache/memory";
@@ -184,8 +185,10 @@ export class JobQueueDO {
     const name = await this.ctx.storage.get<string>("name");
     if (!name) return;
 
+    const cron = await this.ctx.storage.get<string>("cron");
     const now = new Date().toISOString();
-    const rows = this.ctx.storage.sql
+
+    let rows = this.ctx.storage.sql
       .exec(
         "SELECT id, name, data, attempts, max_attempts FROM jobs WHERE status = 'pending' AND run_at <= ? ORDER BY run_at ASC LIMIT 1",
         now,
@@ -193,8 +196,30 @@ export class JobQueueDO {
       .toArray() as Pick<DOJobRow, "id" | "name" | "data" | "attempts" | "max_attempts">[];
 
     if (rows.length === 0) {
-      await this.scheduleNextAlarm();
-      return;
+      if (cron) {
+        // Cron singleton: alarm fires at each scheduled tick. Auto-create the job for
+        // this tick if no pending rows exist (including future-scheduled ones).
+        const anyPending = this.ctx.storage.sql
+          .exec("SELECT 1 FROM jobs WHERE status = 'pending' LIMIT 1")
+          .toArray().length > 0;
+        if (!anyPending) {
+          this.ctx.storage.sql.exec(
+            "INSERT INTO jobs (name, run_at, max_attempts) VALUES (?, ?, 3)",
+            name,
+            now,
+          );
+          rows = this.ctx.storage.sql
+            .exec(
+              "SELECT id, name, data, attempts, max_attempts FROM jobs WHERE status = 'pending' AND run_at <= ? ORDER BY run_at ASC LIMIT 1",
+              now,
+            )
+            .toArray() as Pick<DOJobRow, "id" | "name" | "data" | "attempts" | "max_attempts">[];
+        }
+      }
+      if (rows.length === 0) {
+        await this.scheduleNextAlarm();
+        return;
+      }
     }
 
     const job = rows[0];
@@ -214,22 +239,23 @@ export class JobQueueDO {
       : new MemoryCache();
 
     try {
-      if (name === "cleanup") {
+      // Use job.name (from the DB row) so any DO can run any handler type.
+      if (job.name === "cleanup") {
         await runWithCache(cache, () => runWithDb(db, () => this.runCleanup()));
       } else {
-        const handler = handlers[name];
+        const handler = handlers[job.name];
         if (!handler) {
-          log.warn("Unknown job type, marking failed", { name, jobId: job.id });
+          log.warn("Unknown job type, marking failed", { name: job.name, jobId: job.id });
           this.ctx.storage.sql.exec(
             "UPDATE jobs SET status = 'failed', error = ?, completed_at = ? WHERE id = ?",
-            `Unknown job type: ${name}`,
+            `Unknown job type: ${job.name}`,
             new Date().toISOString(),
             job.id,
           );
           await this.scheduleNextAlarm();
           return;
         }
-        log.info("Running job", { name, jobId: job.id });
+        log.info("Running job", { name: job.name, jobId: job.id });
         await runWithCache(cache, () => runWithDb(db, () => handler(job.data)));
       }
 
@@ -238,13 +264,33 @@ export class JobQueueDO {
         new Date().toISOString(),
         job.id,
       );
-      log.info("Completed job", { name, jobId: job.id });
+      log.info("Completed job", { name: job.name, jobId: job.id });
+
+      // migrate-offers: re-enqueue next batch in this DO's SQLite when more titles remain.
+      // In D1 mode this is handled by handleMigrateOffers inserting a D1 row directly;
+      // in DO mode the handler skips that and we do it here instead.
+      if (job.name === "migrate-offers") {
+        const remaining = await db
+          .select({ count: sql<number>`count(*)` })
+          .from(titles)
+          .where(eq(titles.offersChecked, 0))
+          .get();
+        if (remaining && remaining.count > 0) {
+          this.ctx.storage.sql.exec(
+            "INSERT INTO jobs (name, run_at, max_attempts) VALUES ('migrate-offers', ?, 1)",
+            new Date().toISOString(),
+          );
+          log.info("migrate-offers batch done, re-queued in DO", { remaining: remaining.count });
+        } else {
+          log.info("migrate-offers migration complete");
+        }
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       const newAttempts = job.attempts + 1;
 
       if (newAttempts < job.max_attempts) {
-        // Exponential backoff: 2^attempts × 30 s — mirrors processor.ts:264
+        // Exponential backoff: 2^attempts × 30 s — mirrors processor.ts
         const delaySec = Math.pow(2, newAttempts) * 30;
         const retryAt = new Date(Date.now() + delaySec * 1000).toISOString();
         this.ctx.storage.sql.exec(
@@ -253,7 +299,7 @@ export class JobQueueDO {
           retryAt,
           job.id,
         );
-        log.warn("Job failed, will retry", { name, jobId: job.id, attempt: newAttempts, retryAt, err });
+        log.warn("Job failed, will retry", { name: job.name, jobId: job.id, attempt: newAttempts, retryAt, err });
       } else {
         this.ctx.storage.sql.exec(
           "UPDATE jobs SET status = 'failed', error = ?, completed_at = ? WHERE id = ?",
@@ -261,7 +307,7 @@ export class JobQueueDO {
           new Date().toISOString(),
           job.id,
         );
-        log.error("Job failed permanently", { name, jobId: job.id, attempts: newAttempts, err });
+        log.error("Job failed permanently", { name: job.name, jobId: job.id, attempts: newAttempts, err });
       }
     }
 
@@ -275,7 +321,13 @@ export class JobQueueDO {
     this.initSchema();
     await this.ctx.storage.put("name", name);
     await this.ctx.storage.put("cron", cron);
-    await this.scheduleNextAlarm(cron);
+    // Only set alarm if none is already scheduled — the alarm handler manages re-arming.
+    // Calling scheduleNextAlarm() on every cron trigger would push the alarm forward and
+    // cause the job to be skipped at the current tick.
+    const existing = await this.ctx.storage.getAlarm();
+    if (existing === null) {
+      await this.scheduleNextAlarm(cron);
+    }
   }
 
   /** Insert a job row and schedule an immediate alarm. */

--- a/server/jobs/processor.ts
+++ b/server/jobs/processor.ts
@@ -143,9 +143,10 @@ async function handleBackfillTitleOffers(data: string | null): Promise<void> {
 async function handleMigrateOffers(): Promise<void> {
   const { migrateOffers } = await import("./migrate-offers");
   const result = await migrateOffers();
-  if (result.hasMore) {
+  if (result.hasMore && CONFIG.JOB_QUEUE_BACKEND !== "durable-object") {
     // Direct insert bypasses enqueueOneTimeMigration's "any row" sentinel so the
-    // backfill continues across multiple cron ticks.
+    // backfill continues across multiple cron ticks. In DO mode the alarm() handler
+    // re-enqueues the next batch in DO SQLite instead.
     const db = getDb();
     await db.insert(jobs).values({ name: "migrate-offers", runAt: new Date().toISOString(), maxAttempts: 1 });
     log.info("migrate-offers batch done, re-enqueued for next tick");


### PR DESCRIPTION
## Summary

Three root causes all fixed in one PR:

- **`armCron` pushed the alarm forward on every cron trigger** — the CF scheduled handler calls `armCron` on every tick as a keep-alive. `armCron` was calling `scheduleNextAlarm()` unconditionally, deferring the alarm by one cron interval each time, so the current tick's job was always skipped. Fix: skip `scheduleNextAlarm` in `armCron` if an alarm is already scheduled (`getAlarm() !== null`).

- **`alarm()` found no pending rows and exited** — the DO's local SQLite starts empty. When `alarm()` fired it found no pending rows and returned immediately — jobs showed "Last: Never" forever. Fix: when a cron DO alarm fires with no pending rows, auto-create a job row for the current tick before processing.

- **`migrate-offers` made zero progress in DO mode** — `enqueueOnce()` wrote a sentinel row into the D1 jobs table; in DO mode D1 rows are never processed. After each batch, `handleMigrateOffers` also re-inserted into D1. Fix: `enqueueOnce` in DO mode calls `/enqueue` on the named DO directly; `handleMigrateOffers` skips the D1 re-insert in DO mode; the DO `alarm()` handler re-queues the next batch in its own SQLite after each completed batch.

## Test plan

- [x] `bun test server/jobs/durable-object.test.ts server/jobs/backend.test.ts` — 41 pass, 0 fail
- [x] `bun run check` — 2171 pass, 2 fail (both pre-existing on master: stats.test.ts + sync-utils.test.ts timing flake)
- [x] New tests: armCron idempotency, auto-create on empty cron DO, ad-hoc DO no auto-create, enqueueOnce DO-mode routing
- [x] Updated tests: alarm auto-creates + completes (was "does nothing"), concurrent atomicity test removed armCron to avoid auto-create interference, backend enqueueOnce test split into D1 and DO cases

Closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)