### PR TITLE
refactor: integrate @cloudflare/actors/alarms into JobQueueDO

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,14 +6,17 @@
       "name": "remindarr",
       "dependencies": {
         "@better-auth/passkey": "^1.5.6",
+        "@cloudflare/actors": "^0.0.1-beta.6",
         "@hono/zod-validator": "^0.7.6",
         "@sentry/bun": "^10.43.0",
         "@sentry/cloudflare": "^10.46.0",
         "@simplewebauthn/server": "^13.3.0",
         "better-auth": "^1.5.5",
         "cron-parser": "^4.9.0",
+        "cron-schedule": "^6.0.0",
         "drizzle-orm": "^0.45.1",
         "hono": "^4.4.0",
+        "nanoid": "^5.1.9",
         "web-push": "^3.6.7",
         "zod": "^4.3.6",
       },
@@ -306,6 +309,8 @@
     "@better-auth/utils": ["@better-auth/utils@0.3.1", "", {}, "sha512-+CGp4UmZSUrHHnpHhLPYu6cV+wSUSvVbZbNykxhUDocpVNTo9uFFxw/NqJlh1iC4wQ9HKKWGCKuZ5wUgS0v6Kg=="],
 
     "@better-fetch/fetch": ["@better-fetch/fetch@1.1.21", "", {}, "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="],
+
+    "@cloudflare/actors": ["@cloudflare/actors@0.0.1-beta.6", "", { "optionalDependencies": { "cron-schedule": "^5.0.4", "nanoid": "^5.1.5" } }, "sha512-8SuwZww14K5YHdF6HdkWCthWZCvuIKk7E0xARI/7vWYtd+OymA2Y3JBhPd+hnuA2R9sr57cZHKhKOcfNbf9xOQ=="],
 
     "@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
 
@@ -979,6 +984,8 @@
 
     "cron-parser": ["cron-parser@4.9.0", "", { "dependencies": { "luxon": "^3.2.1" } }, "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q=="],
 
+    "cron-schedule": ["cron-schedule@6.0.0", "", {}, "sha512-BoZaseYGXOo5j5HUwTaegIog3JJbuH4BbrY9A1ArLjXpy+RWb3mV28F/9Gv1dDA7E2L8kngWva4NWisnLTyfgQ=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "crypto-random-string": ["crypto-random-string@2.0.0", "", {}, "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="],
@@ -1493,7 +1500,7 @@
 
     "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
 
-    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+    "nanoid": ["nanoid@5.1.9", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw=="],
 
     "nanostores": ["nanostores@1.2.0", "", {}, "sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg=="],
 
@@ -1999,6 +2006,8 @@
 
     "@babel/preset-env/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@cloudflare/actors/cron-schedule": ["cron-schedule@5.0.4", "", {}, "sha512-nH0a49E/kSVk6BeFgKZy4uUsy6D2A16p120h5bYD9ILBhQu7o2sJFH+WI4R731TSBQ0dB1Ik7inB/dRAB4C8QQ=="],
+
     "@dotenvx/dotenvx/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
     "@dotenvx/dotenvx/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
@@ -2106,6 +2115,8 @@
     "path-scurry/lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 

--- a/package.json
+++ b/package.json
@@ -28,14 +28,17 @@
   },
   "dependencies": {
     "@better-auth/passkey": "^1.5.6",
+    "@cloudflare/actors": "^0.0.1-beta.6",
     "@hono/zod-validator": "^0.7.6",
     "@sentry/bun": "^10.43.0",
     "@sentry/cloudflare": "^10.46.0",
     "@simplewebauthn/server": "^13.3.0",
     "better-auth": "^1.5.5",
     "cron-parser": "^4.9.0",
+    "cron-schedule": "^6.0.0",
     "drizzle-orm": "^0.45.1",
     "hono": "^4.4.0",
+    "nanoid": "^5.1.9",
     "web-push": "^3.6.7",
     "zod": "^4.3.6"
   },

--- a/server/jobs/durable-object.test.ts
+++ b/server/jobs/durable-object.test.ts
@@ -3,6 +3,12 @@
  *
  * Uses a fake DurableObjectState whose storage.sql is backed by bun:sqlite
  * in-memory so tests run under the standard bun:test runner without Miniflare.
+ *
+ * Tests that exercise job-processing logic (retry, backoff, single-writer) call
+ * runJob() directly — bypassing the Alarms timestamp dispatch so tests don't
+ * depend on wall-clock timing. Tests that exercise alarm scheduling (armCron
+ * idempotency, re-arm after processing) call alarm() and manipulate the
+ * _actor_alarms table directly.
  */
 import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { Database } from "bun:sqlite";
@@ -12,6 +18,31 @@ import { setupTestDb, teardownTestDb } from "../test-utils/setup";
 
 // ─── Fake CF storage ──────────────────────────────────────────────────────────
 
+class FakeSqlCursor {
+  private rows: Record<string, unknown>[];
+
+  constructor(rows: Record<string, unknown>[]) {
+    this.rows = rows;
+  }
+
+  toArray(): Record<string, unknown>[] {
+    return this.rows;
+  }
+
+  one(): Record<string, unknown> {
+    return this.rows[0];
+  }
+
+  // Iterable so spread ([...cursor]) works — required by @cloudflare/actors/alarms internals
+  [Symbol.iterator](): IterableIterator<Record<string, unknown>> {
+    return this.rows[Symbol.iterator]();
+  }
+
+  // Stub row-count properties used by SQLSchemaMigrations (unused here but satisfies types)
+  rowsRead = 0;
+  rowsWritten = 0;
+}
+
 class FakeSqlStorage {
   private db: Database;
 
@@ -19,10 +50,10 @@ class FakeSqlStorage {
     this.db = db;
   }
 
-  exec(sql: string, ...params: (string | number | boolean | null)[]): { toArray(): Record<string, unknown>[] } {
+  exec(sql: string, ...params: (string | number | boolean | null)[]): FakeSqlCursor {
     const stmt = this.db.prepare(sql);
     const rows = stmt.all(...params) as Record<string, unknown>[];
-    return { toArray: () => rows };
+    return new FakeSqlCursor(rows);
   }
 }
 
@@ -146,6 +177,7 @@ describe("JobQueueDO", () => {
     expect(rows[0].status).toBe("pending");
     expect(rows[0].name).toBe("sync-titles");
 
+    // Alarms.schedule() calls _scheduleNextAlarm() → setAlarm()
     const alarm = await state.storage.getAlarm();
     expect(alarm).not.toBeNull();
   });
@@ -157,14 +189,15 @@ describe("JobQueueDO", () => {
     expect(rows[0].data).toBe(data);
   });
 
-  // ── alarm: basic execution ────────────────────────────────────────────────
+  // ── runJob: basic execution ───────────────────────────────────────────────
+  // Tests below call runJob() directly to exercise processing logic without
+  // depending on Alarms dispatch timing (which uses integer-second precision).
 
-  it("alarm processes a pending job and marks it completed", async () => {
+  it("runJob processes a pending job and marks it completed", async () => {
     let called = false;
     processorModule.handlers["sync-titles"] = async () => { called = true; };
-    await do_.armCron("sync-titles", "0 3 * * *");
     await do_.enqueue("sync-titles", null);
-    await do_.alarm();
+    await do_.runJob(null);
 
     expect(called).toBe(true);
     const rows = do_.getRecentJobs();
@@ -172,11 +205,11 @@ describe("JobQueueDO", () => {
     expect(rows[0].completed_at).not.toBeNull();
   });
 
-  it("alarm auto-creates and runs a job for cron DOs when no pending rows exist", async () => {
+  it("runJob auto-creates and runs a job for cron DOs when no pending rows exist", async () => {
     let called = false;
     processorModule.handlers["sync-titles"] = async () => { called = true; };
     await do_.armCron("sync-titles", "0 3 * * *");
-    await do_.alarm(); // no rows pre-inserted — auto-create kicks in
+    await do_.runJob(null); // no rows pre-inserted — auto-create kicks in
 
     expect(called).toBe(true);
     const rows = do_.getRecentJobs();
@@ -184,41 +217,40 @@ describe("JobQueueDO", () => {
     expect(rows[0].status).toBe("completed");
   });
 
-  it("alarm skips jobs not yet ready (future run_at)", async () => {
+  it("runJob skips jobs not yet ready (future run_at)", async () => {
     let called = false;
-    processorModule.handlers["sync-titles"] = async () => { called = true; };
-    await do_.armCron("sync-titles", "0 3 * * *");
-    const future = new Date(Date.now() + 60_000).toISOString();
-    await do_.enqueue("sync-titles", null, future);
-    await do_.alarm();
+    processorModule.handlers["sync-show-episodes"] = async () => { called = true; };
+    // Ad-hoc DO (no armCron) — no auto-create when nothing is pending
+    await do_.enqueue("sync-show-episodes", null, new Date(Date.now() + 60_000).toISOString());
+    await do_.runJob(null);
     expect(called).toBe(false);
   });
 
-  // ── alarm: single-writer atomicity ────────────────────────────────────────
+  // ── single-writer atomicity ───────────────────────────────────────────────
 
-  it("two concurrent alarm() calls process a job at most once (single-writer guarantee)", async () => {
+  it("two concurrent runJob() calls process a job at most once (single-writer guarantee)", async () => {
     let callCount = 0;
     processorModule.handlers["sync-titles"] = async () => { callCount++; };
-    // No armCron — use bare enqueue so cron is null and auto-create doesn't kick in.
-    // enqueue() sets the "name" key so alarm() still identifies the DO.
+    // No armCron — bare enqueue so cron is null and auto-create doesn't kick in.
+    // enqueue() sets the "name" key so runJob() still identifies the DO.
     await do_.enqueue("sync-titles", null);
 
-    // In the DO model, only one alarm fires at a time — simulate two concurrent
-    // invocations; the second should find no pending work (job already claimed).
-    await Promise.all([do_.alarm(), do_.alarm()]);
+    // In the DO model, single-writer guarantees exclusion. In tests, runJob() claims
+    // via UPDATE before any await on the handler, so the second concurrent call finds
+    // no pending work after the first claims the row.
+    await Promise.all([do_.runJob(null), do_.runJob(null)]);
     expect(callCount).toBe(1);
   });
 
-  // ── alarm: exponential backoff ────────────────────────────────────────────
+  // ── exponential backoff ───────────────────────────────────────────────────
 
   it("retries a failed job with exponential backoff", async () => {
     processorModule.handlers["sync-titles"] = async () => {
       throw new Error("transient error");
     };
-    await do_.armCron("sync-titles", "0 3 * * *");
     await do_.enqueue("sync-titles", null, undefined, 3);
     const before = Date.now();
-    await do_.alarm();
+    await do_.runJob(null);
 
     const rows = do_.getRecentJobs();
     expect(rows[0].status).toBe("pending");
@@ -233,10 +265,9 @@ describe("JobQueueDO", () => {
     processorModule.handlers["sync-titles"] = async () => {
       throw new Error("fatal error");
     };
-    await do_.armCron("sync-titles", "0 3 * * *");
     // Insert with maxAttempts=1 so first failure is permanent
     await do_.enqueue("sync-titles", null, undefined, 1);
-    await do_.alarm();
+    await do_.runJob(null);
 
     const rows = do_.getRecentJobs();
     expect(rows[0].status).toBe("failed");
@@ -244,49 +275,53 @@ describe("JobQueueDO", () => {
     expect(rows[0].completed_at).not.toBeNull();
   });
 
-  // ── alarm: unknown handler ────────────────────────────────────────────────
+  // ── unknown handler ───────────────────────────────────────────────────────
 
   it("marks unknown job types as failed without running a handler", async () => {
-    await do_.armCron("nonexistent-job", "0 3 * * *");
     await do_.enqueue("nonexistent-job", null);
-    await do_.alarm();
+    await do_.runJob(null);
 
     const rows = do_.getRecentJobs();
     expect(rows[0].status).toBe("failed");
     expect(rows[0].error).toContain("Unknown job type");
   });
 
-  // ── armCron + alarm re-arm ────────────────────────────────────────────────
+  // ── armCron ───────────────────────────────────────────────────────────────
 
   it("armCron does not reset the alarm if one is already scheduled", async () => {
     await do_.armCron("sync-titles", "0 3 * * *");
     const firstAlarm = await state.storage.getAlarm();
     expect(firstAlarm).not.toBeNull();
 
-    // Second armCron call (as the CF scheduled handler would do) should NOT push
-    // the alarm forward — doing so would cause the current tick's job to be skipped.
+    // Second armCron call (as the CF scheduled handler does each cron tick) must NOT
+    // push the alarm forward — doing so would cause the current tick's job to be skipped.
     await do_.armCron("sync-titles", "0 3 * * *");
     const secondAlarm = await state.storage.getAlarm();
     expect(secondAlarm).toBe(firstAlarm); // unchanged
-    expect(state.storage.alarmHistory).toHaveLength(1); // set only once
+    // Only one alarm was set (by the first armCron call)
+    expect(state.storage.alarmHistory).toHaveLength(1);
   });
 
   it("armCron sets the cron expression and schedules an alarm", async () => {
     await do_.armCron("sync-titles", "0 3 * * *");
     const cronInfo = await do_.getCronInfo();
     expect(cronInfo.cron).toBe("0 3 * * *");
+    expect(cronInfo.nextRun).not.toBeNull();
     const alarm = await state.storage.getAlarm();
     expect(alarm).not.toBeNull();
     expect(alarm!).toBeGreaterThan(Date.now());
   });
 
-  it("alarm re-arms to the next cron tick after processing", async () => {
+  it("alarm() re-arms to the next cron tick after processing", async () => {
     processorModule.handlers["sync-titles"] = async () => {};
     await do_.armCron("sync-titles", "0 3 * * *");
-    await do_.enqueue("sync-titles", null);
+    // Force the cron schedule to be due (past time) so alarm() actually dispatches it
+    state.rawDb.prepare("UPDATE _actor_alarms SET time = 0 WHERE callback = 'runJob'").run();
+
     const beforeAlarmCount = state.storage.alarmHistory.length;
     await do_.alarm();
-    // A new alarm should have been scheduled after the job ran
+
+    // After processing, Alarms framework updates the cron row and calls _scheduleNextAlarm
     expect(state.storage.alarmHistory.length).toBeGreaterThan(beforeAlarmCount);
     const newAlarm = state.storage.scheduledAlarm!;
     expect(newAlarm).toBeGreaterThan(Date.now());
@@ -300,29 +335,36 @@ describe("JobQueueDO", () => {
       .run(new Date().toISOString());
 
     const alarmsBefore = adHocState.storage.alarmHistory.length;
-    await adHocDo.alarm();
-    // No auto-create for ad-hoc DOs — alarm just re-arms check and exits
+    await adHocDo.runJob(null);
+    // No auto-create for ad-hoc DOs — runJob exits without creating a new job row
     expect(adHocDo.getRecentJobs().filter((r) => r.status === "pending")).toHaveLength(0);
-    expect(adHocState.storage.alarmHistory.length).toBe(alarmsBefore); // no new alarm
+    // rearmIfPending finds no pending work → no new alarm scheduled
+    expect(adHocState.storage.alarmHistory.length).toBe(alarmsBefore);
     adHocState.close();
   });
 
   it("ad-hoc DO (no cron) re-arms only when pending rows remain", async () => {
-    // No armCron call — pure ad-hoc DO
     processorModule.handlers["sync-show-episodes"] = async () => {};
     const { do_: adHocDo, state: adHocState } = makeDO("sync-show-episodes:42");
     await adHocDo.enqueue("sync-show-episodes", null);
     await adHocDo.enqueue("sync-show-episodes", null); // second job
 
-    await adHocDo.alarm(); // processes first
-    // Still pending job → alarm should be re-set
-    expect(adHocState.storage.scheduledAlarm).not.toBeNull();
+    const alarmsAfterEnqueue = adHocState.storage.alarmHistory.length;
 
-    await adHocDo.alarm(); // processes second
-    // Now both processed → no more pending → alarm stays at last set (no new re-arm)
-    const lastAlarmCount = adHocState.storage.alarmHistory.length;
-    await adHocDo.alarm(); // no-op
-    expect(adHocState.storage.alarmHistory.length).toBe(lastAlarmCount); // no new alarm after empty
+    await adHocDo.runJob(null); // processes first
+    // Second job still pending → re-arm check: a delayed schedule should exist
+    const hasDelayedSchedule = adHocDo.alarms.getSchedules({ type: "delayed" }).some(
+      (s) => s.callback === "runJob",
+    );
+    expect(hasDelayedSchedule).toBe(true);
+
+    await adHocDo.runJob(null); // processes second
+
+    // After all jobs done, another runJob call should not schedule a new alarm
+    const alarmsBeforeFinal = adHocState.storage.alarmHistory.length;
+    await adHocDo.runJob(null); // no-op
+    expect(adHocState.storage.alarmHistory.length).toBe(alarmsBeforeFinal);
+
     adHocState.close();
   });
 
@@ -341,8 +383,8 @@ describe("JobQueueDO", () => {
     await do1.enqueue("sync-show-episodes", JSON.stringify({ titleId: 1 }));
     await do2.enqueue("sync-show-episodes", JSON.stringify({ titleId: 2 }));
 
-    await do1.alarm();
-    await do2.alarm();
+    await do1.runJob(null);
+    await do2.runJob(null);
 
     expect(calls).toContain(1);
     expect(calls).toContain(2);
@@ -491,3 +533,6 @@ describe("JobQueueDO", () => {
     expect(resp.status).toBe(404);
   });
 });
+
+// Suppress unused-variable warning for the spy (it suppresses console output in tests)
+void mockSyncTitles;

--- a/server/jobs/durable-object.ts
+++ b/server/jobs/durable-object.ts
@@ -1,14 +1,12 @@
 /**
  * Durable Object job queue for Cloudflare Workers.
  *
+ * Powered by @cloudflare/actors/alarms for cron scheduling and alarm dispatch.
  * One DO instance per job name (e.g. "sync-titles") for cron singletons,
  * or per "name:partitionKey" (e.g. "sync-show-episodes:42") for ad-hoc work.
- * DO Alarms drive execution; wrangler.toml cron triggers call armCron() as
- * a keep-alive in case DO storage is wiped.
- *
  * The Bun runtime never imports this file.
  */
-import { parseExpression } from "cron-parser";
+import { Alarms } from "@cloudflare/actors/alarms";
 import { drizzle } from "drizzle-orm/d1";
 import { eq, sql } from "drizzle-orm";
 import { runWithDb, schemaExports, titles } from "../db/schema";
@@ -97,11 +95,19 @@ export class JobQueueDO {
   private ctx: DurableObjectState;
   private env: DOEnv;
   private initialized = false;
+  // Cast to any: Alarms<P> requires P extends DurableObject, but P only needs
+  // callable methods by name at runtime. The constraint is TS-only.
+  alarms: Alarms<JobQueueDO>;
 
   constructor(ctx: DurableObjectState, env: DOEnv) {
     this.ctx = ctx;
     this.env = env;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    this.alarms = new Alarms(ctx, this as any);
   }
+
+  /** Required stub — Alarms calls setName() on the parent before each callback. */
+  setName(_name: string): void {}
 
   // ─── Schema bootstrap ────────────────────────────────────────────────────
 
@@ -178,14 +184,19 @@ export class JobQueueDO {
     }
   }
 
-  // ─── Alarm: claim + run one job, then re-arm ─────────────────────────────
+  // ─── CF alarm handler — delegates to Alarms dispatcher ───────────────────
 
   async alarm(): Promise<void> {
     this.initSchema();
+    await this.alarms.alarm();
+  }
+
+  // ─── Job execution: invoked by Alarms when a cron or delayed schedule fires
+
+  async runJob(_payload: unknown = null): Promise<void> {
     const name = await this.ctx.storage.get<string>("name");
     if (!name) return;
-
-    const cron = await this.ctx.storage.get<string>("cron");
+    const cron = (await this.ctx.storage.get<string>("cron")) ?? null;
     const now = new Date().toISOString();
 
     let rows = this.ctx.storage.sql
@@ -217,7 +228,7 @@ export class JobQueueDO {
         }
       }
       if (rows.length === 0) {
-        await this.scheduleNextAlarm();
+        await this.rearmIfPending(cron);
         return;
       }
     }
@@ -239,7 +250,6 @@ export class JobQueueDO {
       : new MemoryCache();
 
     try {
-      // Use job.name (from the DB row) so any DO can run any handler type.
       if (job.name === "cleanup") {
         await runWithCache(cache, () => runWithDb(db, () => this.runCleanup()));
       } else {
@@ -252,7 +262,7 @@ export class JobQueueDO {
             new Date().toISOString(),
             job.id,
           );
-          await this.scheduleNextAlarm();
+          await this.rearmIfPending(cron);
           return;
         }
         log.info("Running job", { name: job.name, jobId: job.id });
@@ -311,26 +321,23 @@ export class JobQueueDO {
       }
     }
 
-    await this.scheduleNextAlarm();
+    await this.rearmIfPending(cron);
   }
 
   // ─── Internal methods (also used by tests via subclass) ──────────────────
 
-  /** Arm this DO as a cron singleton. Stores name + cron, sets first alarm. */
+  /** Arm this DO as a cron singleton. Idempotent — only schedules if no cron alarm exists. */
   async armCron(name: string, cron: string): Promise<void> {
     this.initSchema();
     await this.ctx.storage.put("name", name);
     await this.ctx.storage.put("cron", cron);
-    // Only set alarm if none is already scheduled — the alarm handler manages re-arming.
-    // Calling scheduleNextAlarm() on every cron trigger would push the alarm forward and
-    // cause the job to be skipped at the current tick.
-    const existing = await this.ctx.storage.getAlarm();
-    if (existing === null) {
-      await this.scheduleNextAlarm(cron);
+    const existing = this.alarms.getSchedules({ type: "cron" });
+    if (!existing.some((s) => s.callback === "runJob")) {
+      await this.alarms.schedule(cron, "runJob" as keyof JobQueueDO, null);
     }
   }
 
-  /** Insert a job row and schedule an immediate alarm. */
+  /** Insert a job row and schedule an alarm to fire within 1 second. */
   async enqueue(
     name: string,
     data: string | null,
@@ -350,10 +357,10 @@ export class JobQueueDO {
       )
       .toArray() as Array<{ id: number }>;
 
-    // Schedule alarm as soon as possible (CF dedupes alarms within a DO)
-    const currentAlarm = await this.ctx.storage.getAlarm();
-    if (currentAlarm === null || currentAlarm > Date.now() + 1000) {
-      await this.ctx.storage.setAlarm(Date.now());
+    // Only schedule if no delayed runJob alarm is already pending
+    const existing = this.alarms.getSchedules({ type: "delayed" });
+    if (!existing.some((s) => s.callback === "runJob")) {
+      await this.alarms.schedule(1, "runJob" as keyof JobQueueDO, null);
     }
     return rows[0].id;
   }
@@ -422,13 +429,12 @@ export class JobQueueDO {
   async getCronInfo(): Promise<{ cron: string | null; nextRun: string | null; lastRun: string | null }> {
     this.initSchema();
     const cron = (await this.ctx.storage.get<string>("cron")) ?? null;
+    // nextRun is read from the Alarms table (authoritative next execution time)
     let nextRun: string | null = null;
-    if (cron) {
-      try {
-        nextRun = parseExpression(cron).next().toDate().toISOString();
-      } catch {
-        // invalid expression
-      }
+    const cronSchedules = this.alarms.getSchedules({ type: "cron" });
+    if (cronSchedules.length > 0) {
+      const schedule = cronSchedules[0] as { time: number };
+      nextRun = new Date(schedule.time * 1000).toISOString();
     }
     const lastRows = this.ctx.storage.sql
       .exec(
@@ -440,19 +446,21 @@ export class JobQueueDO {
 
   // ─── Private helpers ─────────────────────────────────────────────────────
 
-  private async scheduleNextAlarm(cron?: string): Promise<void> {
-    const cronExpr = cron ?? (await this.ctx.storage.get<string>("cron")) ?? null;
-    if (cronExpr) {
-      const next = parseExpression(cronExpr).next().toDate().getTime();
-      await this.ctx.storage.setAlarm(next);
-      return;
-    }
-    // Ad-hoc DO: re-arm only if there are still pending jobs
+  /**
+   * For ad-hoc DOs: re-arm with a 1-second delayed alarm if pending jobs remain.
+   * Cron DOs are re-armed automatically by the Alarms framework (cron type schedules
+   * update their own next-execution time after each run).
+   */
+  private async rearmIfPending(cron: string | null): Promise<void> {
+    if (cron) return;
     const rows = this.ctx.storage.sql
       .exec("SELECT COUNT(*) as count FROM jobs WHERE status = 'pending'")
       .toArray() as Array<{ count: number }>;
     if ((rows[0]?.count ?? 0) > 0) {
-      await this.ctx.storage.setAlarm(Date.now());
+      const existing = this.alarms.getSchedules({ type: "delayed" });
+      if (!existing.some((s) => s.callback === "runJob")) {
+        await this.alarms.schedule(1, "runJob" as keyof JobQueueDO, null);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Replaces the hand-rolled alarm scheduling in `JobQueueDO` with `Alarms` from `@cloudflare/actors@0.0.1-beta.6`
- Removes `scheduleNextAlarm()`, the `cron-parser` import, and ~80 lines of manual plumbing
- `alarm()` now delegates to `this.alarms.alarm()` which dispatches to `runJob()`; `armCron()` guards idempotency via `alarms.getSchedules({ type: "cron" })`; `enqueue()` schedules a 1s delayed alarm so `_scheduleNextAlarm`'s `time > now` predicate holds
- Only the `@cloudflare/actors/alarms` subpackage is imported — the `Actor` base class transitively imports `cloudflare:workers` at the JS level and would break Bun tests; `JobQueueDO` stays a plain class with a `this as any` cast to satisfy the TS generic constraint
- `FakeSqlStorage.exec()` updated to return an iterable `FakeSqlCursor` (required by `Alarms.sql()` spread); job-processing tests call `runJob()` directly to avoid alarm dispatch timing issues

## Test plan

- [x] `bun test server/jobs/durable-object.test.ts` — 26/26 pass
- [x] `bun run check` — 2174/2174 tests pass, 0 TypeScript errors, 0 ESLint warnings
- [ ] Manual: `wrangler dev --local` with `JOB_QUEUE_BACKEND=durable-object` — verify `armCron`, `runJob` claim/complete in logs
- [ ] Manual: second `armCron()` call is idempotent (no duplicate cron alarm in `getSchedules`)
- [ ] Rollback: flip `JOB_QUEUE_BACKEND=d1` — D1 polling path unaffected

Closes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)