### PR TITLE
fix: stop accumulating pending sync-deep-links rows in DO mode

### DIFF
--- a/server/jobs/backend.ts
+++ b/server/jobs/backend.ts
@@ -137,15 +137,15 @@ export async function enqueueAdhoc(
 }
 
 /**
- * Enqueue a one-time migration job (idempotent — skips if any row exists).
+ * Enqueue a one-time migration job (idempotent — skips if any pending row exists).
  * In D1 mode the D1 jobs table row is the dedup sentinel.
- * In DO mode we enqueue directly in the named DO (the DO's own SQLite is the sentinel).
+ * In DO mode the DO's own SQLite is the sentinel (enforced by the idempotent flag).
  */
 export async function enqueueOnce(name: string): Promise<void> {
   if (CONFIG.JOB_QUEUE_BACKEND === "durable-object") {
     const env = getEnvOrNull();
     if (env?.JOB_QUEUE_DO) {
-      await doFetch(env, name, "/enqueue", "POST", { name, maxAttempts: 1 });
+      await doFetch(env, name, "/enqueue", "POST", { name, maxAttempts: 1, idempotent: true });
     }
     return;
   }

--- a/server/jobs/durable-object.test.ts
+++ b/server/jobs/durable-object.test.ts
@@ -189,6 +189,22 @@ describe("JobQueueDO", () => {
     expect(rows[0].data).toBe(data);
   });
 
+  it("enqueue with idempotent=true skips insert when a pending row for that name already exists", async () => {
+    const id1 = await do_.enqueue("sync-titles", null, undefined, 1, true);
+    const id2 = await do_.enqueue("sync-titles", null, undefined, 1, true);
+    expect(id2).toBe(id1);
+    expect(do_.getRecentJobs()).toHaveLength(1);
+  });
+
+  it("enqueue with idempotent=true inserts when existing row is not pending", async () => {
+    await do_.enqueue("sync-titles", null, undefined, 1, true);
+    await do_.runJob(null); // consumes the row → status = completed
+    const id2 = await do_.enqueue("sync-titles", null, undefined, 1, true);
+    expect(id2).toBeGreaterThan(0);
+    const rows = do_.getRecentJobs();
+    expect(rows.filter((r) => r.status === "pending")).toHaveLength(1);
+  });
+
   // ── runJob: basic execution ───────────────────────────────────────────────
   // Tests below call runJob() directly to exercise processing logic without
   // depending on Alarms dispatch timing (which uses integer-second precision).
@@ -341,6 +357,22 @@ describe("JobQueueDO", () => {
     // rearmIfPending finds no pending work → no new alarm scheduled
     expect(adHocState.storage.alarmHistory.length).toBe(alarmsBefore);
     adHocState.close();
+  });
+
+  it("cron DO re-arms when extra pending rows remain after runJob", async () => {
+    processorModule.handlers["sync-titles"] = async () => {};
+    await do_.armCron("sync-titles", "0 3 * * *");
+    // Enqueue two extra rows on top of the cron singleton (mimics enqueueOnce calls)
+    await do_.enqueue("sync-titles", null);
+    await do_.enqueue("sync-titles", null);
+
+    await do_.runJob(null); // processes one
+
+    // Two rows still pending → rearmIfPending must schedule a delayed alarm
+    const hasDelayedSchedule = do_.alarms.getSchedules({ type: "delayed" }).some(
+      (s) => s.callback === "runJob",
+    );
+    expect(hasDelayedSchedule).toBe(true);
   });
 
   it("ad-hoc DO (no cron) re-arms only when pending rows remain", async () => {

--- a/server/jobs/durable-object.ts
+++ b/server/jobs/durable-object.ts
@@ -160,8 +160,9 @@ export class JobQueueDO {
           data?: string | null;
           runAt?: string;
           maxAttempts?: number;
+          idempotent?: boolean;
         };
-        const id = await this.enqueue(body.name, body.data ?? null, body.runAt, body.maxAttempts);
+        const id = await this.enqueue(body.name, body.data ?? null, body.runAt, body.maxAttempts, body.idempotent);
         return Response.json({ id });
       }
       if (request.method === "POST" && path === "/recover") {
@@ -337,16 +338,26 @@ export class JobQueueDO {
     }
   }
 
-  /** Insert a job row and schedule an alarm to fire within 1 second. */
+  /** Insert a job row and schedule an alarm to fire within 1 second.
+   *  When idempotent is true, skips insert if a pending row for this name already exists. */
   async enqueue(
     name: string,
     data: string | null,
     runAt?: string,
     maxAttempts?: number,
+    idempotent?: boolean,
   ): Promise<number> {
     this.initSchema();
     await this.ctx.storage.put("name", name);
     const now = new Date().toISOString();
+
+    if (idempotent) {
+      const existing = this.ctx.storage.sql
+        .exec("SELECT id FROM jobs WHERE name = ? AND status = 'pending' LIMIT 1", name)
+        .toArray() as Array<{ id: number }>;
+      if (existing.length > 0) return existing[0].id;
+    }
+
     const rows = this.ctx.storage.sql
       .exec(
         "INSERT INTO jobs (name, data, run_at, max_attempts) VALUES (?, ?, ?, ?) RETURNING id",
@@ -358,8 +369,8 @@ export class JobQueueDO {
       .toArray() as Array<{ id: number }>;
 
     // Only schedule if no delayed runJob alarm is already pending
-    const existing = this.alarms.getSchedules({ type: "delayed" });
-    if (!existing.some((s) => s.callback === "runJob")) {
+    const existingAlarms = this.alarms.getSchedules({ type: "delayed" });
+    if (!existingAlarms.some((s) => s.callback === "runJob")) {
       await this.alarms.schedule(1, "runJob" as keyof JobQueueDO, null);
     }
     return rows[0].id;
@@ -447,12 +458,12 @@ export class JobQueueDO {
   // ─── Private helpers ─────────────────────────────────────────────────────
 
   /**
-   * For ad-hoc DOs: re-arm with a 1-second delayed alarm if pending jobs remain.
-   * Cron DOs are re-armed automatically by the Alarms framework (cron type schedules
-   * update their own next-execution time after each run).
+   * Re-arm with a 1-second delayed alarm if pending jobs remain.
+   * Applies to both cron and ad-hoc DOs — cron alarms only fire on their schedule
+   * (e.g. once per day), so extra pending rows inserted via enqueue() must still
+   * drain promptly via a delayed alarm.
    */
-  private async rearmIfPending(cron: string | null): Promise<void> {
-    if (cron) return;
+  private async rearmIfPending(_cron: string | null): Promise<void> {
     const rows = this.ctx.storage.sql
       .exec("SELECT COUNT(*) as count FROM jobs WHERE status = 'pending'")
       .toArray() as Array<{ count: number }>;

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -499,7 +499,6 @@ const handler = {
 
         // One-time migrations always run through D1 regardless of backend
         await enqueueOnce("migrate-offers");
-        await enqueueOnce("sync-deep-links");
 
         // Recover stuck jobs and drain D1 pending jobs (no-ops in DO mode)
         await recoverStale(cfEnv, 15);


### PR DESCRIPTION
## Summary

- `worker.ts` was calling `enqueueOnce("sync-deep-links")` on every cron tick (including `*/5` send-notifications = 288×/day), when the job is already a daily cron singleton — removed the call entirely
- `enqueueOnce` in DO mode was not actually idempotent: it blindly POST `/enqueue` without checking for an existing pending row; added `idempotent: true` flag + `SELECT`-before-`INSERT` guard in `enqueue()`
- `rearmIfPending` returned early for cron DOs (`if (cron) return`), leaving extra pending rows stranded until the next daily cron tick; removed the short-circuit so pending rows always drain via a 1-second delayed alarm

## Test plan

- [x] `bun run check` — 2177 pass, 0 fail
- [x] New tests: `enqueue` with `idempotent=true` dedupes pending rows; cron DO re-arms when extra pending rows remain after `runJob`
- [ ] Deploy and verify 4 stuck pending `sync-deep-links` rows drain within seconds
- [ ] Monitor jobs UI for ~30 min — pending count should stay at 0 between daily 04:00 UTC runs

Closes #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)