### PR TITLE
refactor: collapse Worker cron triggers to single daily bootstrap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,7 @@ Inventory is large (~45 components). Broad groups:
 - Rate limiting uses a token bucket algorithm keyed by `x-forwarded-for` — deployments MUST terminate at a proxy that sets this header
 - Auth middleware is composable: `optionalAuth` → `requireAuth` → `requireAdmin`
 - OIDC settings have env-var precedence over DB (admin UI editable)
-- Jobs use an in-memory queue with cron scheduling on Bun; Cloudflare uses scheduled triggers
+- Jobs use an in-memory queue with cron scheduling on Bun. Cloudflare uses Durable Object alarms (`@cloudflare/actors/alarms`) for per-job scheduling; a single daily Worker cron acts as the bootstrap/recovery tick that arms DOs and runs stale-job recovery
 - Notification jobs dynamically reschedule based on user timezone preferences
 - Recommendations are 1-to-N broadcast (to followers), not 1-to-1
 - New notification providers must guard on `streamingAlerts.length` before rendering streaming-alert content

--- a/server/jobs/backend.test.ts
+++ b/server/jobs/backend.test.ts
@@ -252,6 +252,50 @@ describe("enqueueAdhoc (DO mode)", () => {
   });
 });
 
+// ─── scheduled() bootstrap pattern — arm all CRON_JOBS ───────────────────────
+//
+// Verifies the pattern used by server/worker.ts scheduled() handler:
+// iterate CRON_JOBS and call armCron for each one, regardless of which Worker
+// cron expression fired. This ensures any daily bootstrap tick arms every
+// cron-singleton DO, not just the one whose expression matches event.cron.
+
+describe("scheduled() bootstrap pattern (DO mode)", () => {
+  it("arms every CRON_JOBS entry with one /arm request each", async () => {
+    CONFIG.JOB_QUEUE_BACKEND = "durable-object";
+    const fetchCalls: FetchCall[] = [];
+    const ns = makeFakeDoNamespace((path, method, body) => {
+      fetchCalls.push({ path, method, body });
+      return { ok: true };
+    });
+    const env = { ...d1Env, JOB_QUEUE_DO: ns as unknown as DurableObjectNamespace };
+
+    // Mirror what worker.ts scheduled() now does
+    for (const { name, cron } of CRON_JOBS) {
+      await armCron(env, name, cron);
+    }
+
+    const armCalls = fetchCalls.filter((c) => c.path === "/arm");
+    expect(armCalls).toHaveLength(CRON_JOBS.length);
+    for (const { name, cron } of CRON_JOBS) {
+      expect(armCalls).toContainEqual(
+        expect.objectContaining({ path: "/arm", body: expect.objectContaining({ name, cron }) }),
+      );
+    }
+  });
+
+  it("does not call enqueueCronJob (D1 path) in DO mode", async () => {
+    CONFIG.JOB_QUEUE_BACKEND = "durable-object";
+    const ns = makeFakeDoNamespace(() => ({ ok: true }));
+    const env = { ...d1Env, JOB_QUEUE_DO: ns as unknown as DurableObjectNamespace };
+
+    for (const { name, cron } of CRON_JOBS) {
+      await armCron(env, name, cron);
+    }
+
+    expect(mockEnqueueCronJob).not.toHaveBeenCalled();
+  });
+});
+
 // ─── runWithEnv ───────────────────────────────────────────────────────────────
 
 describe("runWithEnv", () => {

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -77,8 +77,7 @@ import { patchConfig, CONFIG } from "./config";
 import Sentry from "./sentry";
 import { withSentry } from "@sentry/cloudflare";
 import { CloudflarePlatform } from "./platform/cloudflare";
-import { enqueueOnce } from "./jobs/backend";
-import { armCron, processPending, recoverStale, runWithEnv, CRON_BY_EXPRESSION } from "./jobs/backend";
+import { armCron, enqueueOnce, processPending, recoverStale, runWithEnv, CRON_JOBS } from "./jobs/backend";
 export { JobQueueDO } from "./jobs/durable-object";
 import { createAuth } from "./auth/better-auth";
 import { migrateAuthData } from "./db/migrate-auth";
@@ -488,23 +487,23 @@ const handler = {
 
       const cfEnv = env as unknown as import("./jobs/backend").CFEnv;
       await runWithEnv(cfEnv, () => runWithCache(cache, () => runWithDb(db, async () => {
-        const cron = event.cron;
-        logger.info("Scheduled event", { cron });
+        logger.info("Scheduled bootstrap tick", { cron: event.cron });
 
-        // Arm the DO (DO mode) or enqueue job (D1 mode) for the firing cron
-        const jobName = CRON_BY_EXPRESSION[cron];
-        if (jobName) {
-          await armCron(cfEnv, jobName, cron);
+        // Arm every cron-singleton DO. Idempotent — the DO only schedules its
+        // alarm if no `runJob` cron schedule exists. DOs drive their own
+        // sub-daily execution via @cloudflare/actors/alarms.
+        for (const { name, cron } of CRON_JOBS) {
+          await armCron(cfEnv, name, cron);
         }
 
-        // One-time migrations always run through D1 regardless of backend
+        // One-time migrations (idempotent — no-ops once done)
         await enqueueOnce("migrate-offers");
 
         // Recover stuck jobs and drain D1 pending jobs (no-ops in DO mode)
         await recoverStale(cfEnv, 15);
         const processed = await processPending();
         if (processed > 0) {
-          logger.info("Processed jobs", { count: processed, cron });
+          logger.info("Processed jobs", { count: processed });
         }
       })));
     } catch (err) {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -65,12 +65,10 @@ head_sampling_rate = 1
 persist = true
 invocation_logs = true
 
-# Cron triggers for background jobs
+# Cron triggers — bootstrap window only. Per-job sub-daily schedules
+# (e.g. send-notifications every 5 min) live in CRON_JOBS in
+# server/jobs/backend.ts and are driven by Durable Object alarms via
+# @cloudflare/actors/alarms. This single daily tick arms every cron DO
+# (idempotent), runs stale-job recovery, and enqueues one-time migrations.
 [triggers]
-crons = [
-  "0 3 * * *",      # sync-titles
-  "30 3 * * *",     # sync-episodes
-  "0 4 * * *",      # sync-deep-links (Streaming Availability API)
-  "*/5 * * * *",    # send-notifications (check every 5 min)
-  "0 0 * * *",      # cleanup (expired sessions, old jobs)
-]
+crons = ["0 0 * * *"]


### PR DESCRIPTION
## Summary

- Now that `JobQueueDO` uses `@cloudflare/actors/alarms`, every cron-singleton DO self-reschedules its own alarm after each run — the five Worker cron triggers in `wrangler.toml` were no longer driving execution, only serving as bootstrap/recovery paths
- Collapse `wrangler.toml` from five cron triggers to a single daily tick (`0 0 * * *`)
- Update `scheduled()` to arm **all** `CRON_JOBS` on every tick (idempotent — DO skips if alarm already exists), instead of matching only the firing expression via `CRON_BY_EXPRESSION`
- Per-job sub-daily schedules (e.g. `send-notifications` every 5 min) remain unchanged in `CRON_JOBS` and live inside the DO alarm framework

## Test plan

- [x] `bun run check` — 2179 tests pass, zero failures
- [x] New tests in `server/jobs/backend.test.ts`: "scheduled() bootstrap pattern (DO mode)" — asserts arm-all produces one `/arm` POST per `CRON_JOBS` entry with correct `name`/`cron`, and `enqueueCronJob` is never called
- [ ] Post-deploy: `GET /api/jobs` (admin) — every cron DO should report `next_run` matching its expected per-job schedule; re-check 5 min later to confirm `lastRun` for `send-notifications` advances without a Worker `scheduled()` invocation driving it

🤖 Generated with [Claude Code](https://claude.com/claude-code)