### PR TITLE
feat(#524): pinned favorites on user profile

### DIFF
--- a/drizzle/0034_pinned_titles.sql
+++ b/drizzle/0034_pinned_titles.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `pinned_titles` (
+	`user_id` text NOT NULL REFERENCES `users`(`id`) ON DELETE CASCADE,
+	`title_id` text NOT NULL REFERENCES `titles`(`id`) ON DELETE CASCADE,
+	`position` integer NOT NULL DEFAULT 0,
+	`created_at` text DEFAULT (datetime('now')),
+	PRIMARY KEY(`user_id`, `title_id`)
+);
+--> statement-breakpoint
+CREATE INDEX `idx_pinned_titles_user_id` ON `pinned_titles` (`user_id`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1777939200000,
       "tag": "0033_titles_offers_checked",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "6",
+      "when": 1778025600000,
+      "tag": "0034_pinned_titles",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -254,6 +254,21 @@ export async function unhideActivityEvent(eventKind: string, eventKey: string): 
   });
 }
 
+export async function pinTitle(titleId: string): Promise<{ pinned: boolean }> {
+  return fetchJson(`/user/me/pinned/${encodeURIComponent(titleId)}`, { method: "POST" });
+}
+
+export async function unpinTitle(titleId: string): Promise<{ pinned: boolean }> {
+  return fetchJson(`/user/me/pinned/${encodeURIComponent(titleId)}`, { method: "DELETE" });
+}
+
+export async function reorderPinnedTitles(titleIds: string[]): Promise<{ ok: boolean }> {
+  return fetchJson("/user/me/pinned/order", {
+    method: "PUT",
+    body: JSON.stringify({ titleIds }),
+  });
+}
+
 export async function updateProfileVisibility(visibility: string): Promise<void> {
   await fetchJson("/track/profile-visibility", {
     method: "PATCH",

--- a/frontend/src/components/PinButton.test.tsx
+++ b/frontend/src/components/PinButton.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, mock, afterEach, beforeEach, spyOn } from "bun:test";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import type { ReactNode } from "react";
+import "../i18n";
+import PinButton from "./PinButton";
+import * as api from "../api";
+import * as sonner from "sonner";
+import { AuthContext } from "../context/AuthContext";
+
+const mockUser = {
+  id: "user-1",
+  username: "test",
+  display_name: null,
+  auth_provider: "local",
+  is_admin: false,
+};
+
+const mockAuthValue = {
+  user: mockUser,
+  providers: null,
+  loading: false,
+  login: mock(() => Promise.resolve()),
+  logout: mock(() => Promise.resolve()),
+  refresh: mock(() => Promise.resolve()),
+};
+
+function Wrapper({ children, authValue }: { children: ReactNode; authValue?: typeof mockAuthValue }) {
+  return <AuthContext value={(authValue ?? mockAuthValue) as any}>{children}</AuthContext>;
+}
+
+let spies: ReturnType<typeof spyOn>[] = [];
+
+beforeEach(() => {
+  spies = [
+    spyOn(api, "pinTitle").mockResolvedValue({ pinned: true } as any),
+    spyOn(api, "unpinTitle").mockResolvedValue({ pinned: false } as any),
+    spyOn(sonner.toast, "success").mockImplementation(() => "1" as any),
+    spyOn(sonner.toast, "error").mockImplementation(() => "1" as any),
+  ];
+});
+
+afterEach(() => {
+  cleanup();
+  for (const spy of spies) spy.mockRestore();
+  spies = [];
+});
+
+describe("PinButton", () => {
+  it("renders 'Pin' when not pinned", () => {
+    render(<PinButton titleId="movie-1" isPinned={false} />, { wrapper: Wrapper });
+    const button = screen.getByRole("button");
+    expect(button.textContent).toContain("Pin");
+  });
+
+  it("renders 'Pinned' when already pinned", () => {
+    render(<PinButton titleId="movie-1" isPinned={true} />, { wrapper: Wrapper });
+    const button = screen.getByRole("button");
+    expect(button.textContent).toContain("Pinned");
+  });
+
+  it("returns null when user is not logged in", () => {
+    const noUserAuth = { ...mockAuthValue, user: null };
+    const { container } = render(
+      <AuthContext value={noUserAuth as any}>
+        <PinButton titleId="movie-1" />
+      </AuthContext>
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("calls api.pinTitle on click when not pinned", async () => {
+    render(<PinButton titleId="movie-123" isPinned={false} />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(api.pinTitle).toHaveBeenCalledWith("movie-123");
+    });
+  });
+
+  it("calls api.unpinTitle on click when pinned", async () => {
+    render(<PinButton titleId="movie-123" isPinned={true} />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(api.unpinTitle).toHaveBeenCalledWith("movie-123");
+    });
+  });
+
+  it("shows success toast after pinning", async () => {
+    render(<PinButton titleId="movie-1" isPinned={false} />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(sonner.toast.success).toHaveBeenCalledWith("Added to pinned favorites");
+    });
+  });
+
+  it("shows success toast after unpinning", async () => {
+    render(<PinButton titleId="movie-1" isPinned={true} />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(sonner.toast.success).toHaveBeenCalledWith("Removed from pinned favorites");
+    });
+  });
+
+  it("shows error toast when pin API fails with max 8 message", async () => {
+    (api.pinTitle as any).mockRejectedValueOnce(new Error("Maximum of 8 pinned titles reached"));
+
+    render(<PinButton titleId="movie-1" isPinned={false} />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(sonner.toast.error).toHaveBeenCalledWith("Maximum of 8 pinned titles reached");
+    });
+  });
+
+  it("updates to 'Pinned' after pinning", async () => {
+    render(<PinButton titleId="movie-1" isPinned={false} />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      const button = screen.getByRole("button");
+      expect(button.textContent).toContain("Pinned");
+    });
+  });
+
+  it("updates to 'Pin' after unpinning", async () => {
+    render(<PinButton titleId="movie-1" isPinned={true} />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      const button = screen.getByRole("button");
+      expect(button.textContent).toContain("Pin");
+    });
+  });
+});

--- a/frontend/src/components/PinButton.tsx
+++ b/frontend/src/components/PinButton.tsx
@@ -1,0 +1,57 @@
+import { useState, useEffect } from "react";
+import { toast } from "sonner";
+import * as api from "../api";
+import { useAuth } from "../context/AuthContext";
+
+interface Props {
+  titleId: string;
+  isPinned?: boolean;
+}
+
+export default function PinButton({ titleId, isPinned: isPinnedProp = false }: Props) {
+  const { user } = useAuth();
+  const [pinned, setPinned] = useState(isPinnedProp);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setPinned(isPinnedProp);
+  }, [isPinnedProp]);
+
+  if (!user) return null;
+
+  async function handleClick() {
+    setLoading(true);
+    try {
+      if (pinned) {
+        await api.unpinTitle(titleId);
+        setPinned(false);
+        toast.success("Removed from pinned favorites");
+      } else {
+        await api.pinTitle(titleId);
+        setPinned(true);
+        toast.success("Added to pinned favorites");
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to update pinned favorites";
+      toast.error(msg);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={loading}
+      aria-pressed={pinned}
+      title={pinned ? "Unpin from profile" : "Pin to profile"}
+      className={`min-h-8 inline-flex items-center justify-center px-3 py-1.5 rounded-md text-xs font-medium transition-colors cursor-pointer ${
+        pinned
+          ? "bg-amber-500/20 text-amber-400 border border-amber-500/40 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/40"
+          : "bg-zinc-800 text-zinc-400 hover:bg-zinc-700 border border-transparent"
+      } disabled:opacity-50`}
+    >
+      {loading ? "..." : pinned ? "📌 Pinned" : "📌 Pin"}
+    </button>
+  );
+}

--- a/frontend/src/components/PinnedFavoritesCard.tsx
+++ b/frontend/src/components/PinnedFavoritesCard.tsx
@@ -1,0 +1,160 @@
+import { useState } from "react";
+import { Link } from "react-router";
+import { toast } from "sonner";
+import type { PinnedTitle } from "../types";
+import * as api from "../api";
+
+interface Props {
+  pinned: PinnedTitle[];
+  isOwnProfile: boolean;
+  onPinnedChanged?: () => void;
+}
+
+export default function PinnedFavoritesCard({ pinned, isOwnProfile, onPinnedChanged }: Props) {
+  const [editing, setEditing] = useState(false);
+  const [localPinned, setLocalPinned] = useState<PinnedTitle[]>(pinned);
+  const [saving, setSaving] = useState(false);
+
+  // Keep local state in sync if parent refreshes the pinned list
+  // (only when not actively editing, so we don't clobber edits)
+  const displayed = editing ? localPinned : pinned;
+  const showGrid = displayed.length > 0;
+
+  if (!showGrid && !isOwnProfile) return null;
+
+  async function handleUnpin(titleId: string) {
+    setSaving(true);
+    try {
+      await api.unpinTitle(titleId);
+      const next = localPinned.filter((t) => t.id !== titleId);
+      setLocalPinned(next);
+      onPinnedChanged?.();
+      toast.success("Removed from pinned favorites");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to unpin title";
+      toast.error(msg);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleMove(titleId: string, direction: "up" | "down") {
+    const idx = localPinned.findIndex((t) => t.id === titleId);
+    if (idx < 0) return;
+    const targetIdx = direction === "up" ? idx - 1 : idx + 1;
+    if (targetIdx < 0 || targetIdx >= localPinned.length) return;
+
+    const next = [...localPinned];
+    const tmp = next[idx];
+    next[idx] = next[targetIdx];
+    next[targetIdx] = tmp;
+    const reordered = next.map((t, i) => ({ ...t, position: i }));
+    setLocalPinned(reordered);
+
+    setSaving(true);
+    try {
+      await api.reorderPinnedTitles(reordered.map((t) => t.id));
+      onPinnedChanged?.();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to reorder";
+      toast.error(msg);
+      setLocalPinned(localPinned); // revert
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // Show up to 4 for display; all 8 when editing
+  const visibleItems = editing ? displayed : displayed.slice(0, 4);
+
+  return (
+    <div className="rounded-xl bg-zinc-900/60 border border-white/[0.06] p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-semibold text-zinc-300 tracking-wide uppercase">
+          Favorite Films
+        </h3>
+        {isOwnProfile && displayed.length > 0 && (
+          <button
+            onClick={() => {
+              setLocalPinned(pinned);
+              setEditing((e) => !e);
+            }}
+            className="text-xs text-zinc-500 hover:text-zinc-300 transition-colors cursor-pointer"
+          >
+            {editing ? "Done" : "Edit"}
+          </button>
+        )}
+      </div>
+
+      {showGrid ? (
+        <div className="grid grid-cols-4 gap-2">
+          {visibleItems.map((title, idx) => (
+            <div key={title.id} className="relative group">
+              <Link to={`/details/${title.object_type === "MOVIE" ? "movie" : "show"}/${title.id}`}>
+                {title.poster_url ? (
+                  <img
+                    src={title.poster_url}
+                    alt={title.title}
+                    className="w-full rounded-lg aspect-[2/3] object-cover border border-white/[0.06] hover:border-amber-400/40 transition-colors"
+                  />
+                ) : (
+                  <div className="w-full rounded-lg aspect-[2/3] bg-zinc-800 flex items-center justify-center border border-white/[0.06]">
+                    <span className="text-zinc-600 text-xs text-center px-1 line-clamp-2">
+                      {title.title}
+                    </span>
+                  </div>
+                )}
+              </Link>
+
+              {editing && (
+                <div className="absolute inset-0 rounded-lg bg-black/60 flex flex-col items-center justify-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <button
+                    onClick={() => handleMove(title.id, "up")}
+                    disabled={saving || idx === 0}
+                    className="text-white text-xs bg-zinc-700/80 rounded px-2 py-0.5 disabled:opacity-30 cursor-pointer hover:bg-zinc-600 transition-colors"
+                    title="Move left"
+                  >
+                    ◀
+                  </button>
+                  <button
+                    onClick={() => handleUnpin(title.id)}
+                    disabled={saving}
+                    className="text-red-400 text-xs bg-zinc-700/80 rounded px-2 py-0.5 cursor-pointer hover:bg-red-900/50 transition-colors"
+                    title="Unpin"
+                  >
+                    ✕
+                  </button>
+                  <button
+                    onClick={() => handleMove(title.id, "down")}
+                    disabled={saving || idx === visibleItems.length - 1}
+                    className="text-white text-xs bg-zinc-700/80 rounded px-2 py-0.5 disabled:opacity-30 cursor-pointer hover:bg-zinc-600 transition-colors"
+                    title="Move right"
+                  >
+                    ▶
+                  </button>
+                </div>
+              )}
+            </div>
+          ))}
+          {/* Empty slots (show 4 slots when not editing, owner only) */}
+          {isOwnProfile && !editing && displayed.length < 4 &&
+            Array.from({ length: 4 - displayed.length }).map((_, i) => (
+              <div
+                key={`empty-${i}`}
+                className="w-full rounded-lg aspect-[2/3] bg-zinc-800/40 border border-dashed border-zinc-700/50 flex items-center justify-center"
+              >
+                <span className="text-zinc-700 text-lg">+</span>
+              </div>
+            ))
+          }
+        </div>
+      ) : (
+        isOwnProfile && (
+          <p className="text-xs text-zinc-500 text-center py-4">
+            Pin your favorite titles from any title page
+          </p>
+        )
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/title-detail/MovieHero.tsx
+++ b/frontend/src/components/title-detail/MovieHero.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import type { MovieDetailsResponse, Title } from "../../types";
 import TrackButton from "../TrackButton";
+import PinButton from "../PinButton";
 import VisibilityButton from "../VisibilityButton";
 import WatchButtonGroup from "../WatchButtonGroup";
 import { Chip, Kicker } from "../design";
@@ -114,6 +115,7 @@ export default function MovieHero({ title, tmdb, watchedActions, watchHistoryPan
 
           <div className="pt-2 flex flex-wrap items-center gap-2">
             <TrackButton titleId={title.id} isTracked={title.is_tracked} titleData={title} />
+            <PinButton titleId={title.id} />
             <VisibilityButton
               titleId={title.id}
               isPublic={title.is_public ?? true}

--- a/frontend/src/components/title-detail/ShowHero.tsx
+++ b/frontend/src/components/title-detail/ShowHero.tsx
@@ -1,6 +1,7 @@
 import type { ShowDetailsResponse, Title } from "../../types";
 import { useIsMobile } from "../../hooks/useIsMobile";
 import TrackButton from "../TrackButton";
+import PinButton from "../PinButton";
 import VisibilityButton from "../VisibilityButton";
 import WatchButtonGroup from "../WatchButtonGroup";
 import { Chip, Kicker } from "../design";
@@ -100,6 +101,7 @@ export default function ShowHero({ title, tmdb, country }: ShowHeroProps) {
             </div>
           )}
           <TrackButton titleId={title.id} isTracked={title.is_tracked} titleData={title} />
+          <PinButton titleId={title.id} />
         </div>
       </>
     );
@@ -209,6 +211,7 @@ export default function ShowHero({ title, tmdb, country }: ShowHeroProps) {
 
           <div className="pt-2 flex flex-wrap items-center gap-2">
             <TrackButton titleId={title.id} isTracked={title.is_tracked} titleData={title} />
+            <PinButton titleId={title.id} />
             <VisibilityButton
               titleId={title.id}
               isPublic={title.is_public ?? true}

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import * as api from "../api";
 import ProfileHero from "../components/profile/ProfileHero";
 import BioCard from "../components/profile/BioCard";
+import PinnedFavoritesCard from "../components/PinnedFavoritesCard";
 import ProgressCard from "../components/profile/ProgressCard";
 import TopGenresCard from "../components/profile/TopGenresCard";
 import FriendsCard from "../components/profile/FriendsCard";
@@ -77,6 +78,7 @@ export default function UserProfilePage() {
     follower_count,
     following_count,
     is_following,
+    pinned,
   } = data;
 
   const bio = localBio === undefined ? user.bio : localBio;
@@ -107,6 +109,13 @@ export default function UserProfilePage() {
                 refetch();
               }}
             />
+            {(pinned.length > 0 || is_own_profile) && (
+              <PinnedFavoritesCard
+                pinned={pinned}
+                isOwnProfile={is_own_profile}
+                onPinnedChanged={refetch}
+              />
+            )}
             {show_watchlist && <ProgressCard overview={overview} />}
             {show_watchlist && genres.length > 0 && <TopGenresCard genres={genres} limit={6} />}
             {show_watchlist && friends.length > 0 && (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -545,6 +545,14 @@ export interface ProfileBackdrop {
 
 export type ProfileVisibility = "public" | "friends_only" | "private";
 
+export interface PinnedTitle {
+  id: string;
+  title: string;
+  poster_url: string | null;
+  object_type: string;
+  position: number;
+}
+
 export interface UserProfileResponse {
   user: UserProfileUser;
   stats: UserProfileStats;
@@ -563,6 +571,7 @@ export interface UserProfileResponse {
   follower_count: number;
   following_count: number;
   is_following: boolean;
+  pinned: PinnedTitle[];
 }
 
 // ─── Activity Feed ───────────────────────────────────────────────────────────

--- a/migrations/0003_pinned_titles.sql
+++ b/migrations/0003_pinned_titles.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS pinned_titles (
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  title_id TEXT NOT NULL REFERENCES titles(id) ON DELETE CASCADE,
+  position INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT DEFAULT (datetime('now')),
+  PRIMARY KEY (user_id, title_id)
+);
+CREATE INDEX IF NOT EXISTS idx_pinned_titles_user_id ON pinned_titles (user_id);

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -133,6 +133,6 @@ describe("fixSkippedMigrations", () => {
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(34);
+    expect(migrations.cnt).toBe(35);
   });
 });

--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -229,3 +229,12 @@ export {
   getUnalertedProviders,
   markAlerted,
 } from "./streaming-alerts";
+
+export {
+  getPinnedTitles,
+  pinTitle,
+  unpinTitle,
+  reorderPinnedTitles,
+  isPinnedTitle,
+} from "./pinned";
+export type { PinnedTitle } from "./pinned";

--- a/server/db/repository/pinned.ts
+++ b/server/db/repository/pinned.ts
@@ -1,0 +1,169 @@
+import { eq, and, asc, sql, max } from "drizzle-orm";
+import { getDb, pinnedTitles, titles } from "../schema";
+import { traceDbQuery } from "../../tracing";
+
+const MAX_PINNED = 8;
+
+export interface PinnedTitle {
+  id: string;
+  title: string;
+  poster_url: string | null;
+  object_type: string;
+  position: number;
+}
+
+/**
+ * Returns all pinned titles for a user, ordered by position ascending.
+ * Joins with titles to get enough data for card rendering.
+ */
+export async function getPinnedTitles(userId: string): Promise<PinnedTitle[]> {
+  return traceDbQuery("getPinnedTitles", async () => {
+    const db = getDb();
+    const rows = await db
+      .select({
+        id: titles.id,
+        title: titles.title,
+        poster_url: titles.posterUrl,
+        object_type: titles.objectType,
+        position: pinnedTitles.position,
+      })
+      .from(pinnedTitles)
+      .innerJoin(titles, eq(titles.id, pinnedTitles.titleId))
+      .where(eq(pinnedTitles.userId, userId))
+      .orderBy(asc(pinnedTitles.position))
+      .limit(MAX_PINNED)
+      .all();
+
+    return rows;
+  });
+}
+
+/**
+ * Pins a title for a user at the next available position.
+ * Returns { ok: true } on success, or { ok: false, error: string } when the limit is reached
+ * or the title is already pinned.
+ */
+export async function pinTitle(
+  userId: string,
+  titleId: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  return traceDbQuery("pinTitle", async () => {
+    const db = getDb();
+
+    // Check existing count
+    const existing = await db
+      .select({ count: sql<number>`COUNT(*)` })
+      .from(pinnedTitles)
+      .where(eq(pinnedTitles.userId, userId))
+      .get();
+
+    if ((existing?.count ?? 0) >= MAX_PINNED) {
+      return { ok: false, error: `Maximum of ${MAX_PINNED} pinned titles reached` };
+    }
+
+    // Get next position
+    const maxRow = await db
+      .select({ maxPos: max(pinnedTitles.position) })
+      .from(pinnedTitles)
+      .where(eq(pinnedTitles.userId, userId))
+      .get();
+
+    const nextPosition = (maxRow?.maxPos ?? -1) + 1;
+
+    await db
+      .insert(pinnedTitles)
+      .values({ userId, titleId, position: nextPosition })
+      .onConflictDoNothing()
+      .run();
+
+    return { ok: true };
+  });
+}
+
+/**
+ * Unpins a title for a user and renumbers remaining positions 0, 1, 2, …
+ */
+export async function unpinTitle(userId: string, titleId: string): Promise<void> {
+  return traceDbQuery("unpinTitle", async () => {
+    const db = getDb();
+
+    await db
+      .delete(pinnedTitles)
+      .where(and(eq(pinnedTitles.userId, userId), eq(pinnedTitles.titleId, titleId)))
+      .run();
+
+    // Renumber remaining rows
+    const remaining = await db
+      .select({ titleId: pinnedTitles.titleId })
+      .from(pinnedTitles)
+      .where(eq(pinnedTitles.userId, userId))
+      .orderBy(asc(pinnedTitles.position))
+      .all();
+
+    for (let i = 0; i < remaining.length; i++) {
+      await db
+        .update(pinnedTitles)
+        .set({ position: i })
+        .where(and(eq(pinnedTitles.userId, userId), eq(pinnedTitles.titleId, remaining[i].titleId)))
+        .run();
+    }
+  });
+}
+
+/**
+ * Reorders pinned titles for a user.
+ * Accepts an ordered array of titleIds; updates position for each.
+ * Titles not present in the array are removed from pinned.
+ */
+export async function reorderPinnedTitles(userId: string, titleIds: string[]): Promise<void> {
+  return traceDbQuery("reorderPinnedTitles", async () => {
+    const db = getDb();
+
+    // Clamp to MAX_PINNED
+    const ordered = titleIds.slice(0, MAX_PINNED);
+
+    // Delete any existing pinned rows not in the new ordered list
+    const existing = await db
+      .select({ titleId: pinnedTitles.titleId })
+      .from(pinnedTitles)
+      .where(eq(pinnedTitles.userId, userId))
+      .all();
+
+    const orderedSet = new Set(ordered);
+    for (const row of existing) {
+      if (!orderedSet.has(row.titleId)) {
+        await db
+          .delete(pinnedTitles)
+          .where(and(eq(pinnedTitles.userId, userId), eq(pinnedTitles.titleId, row.titleId)))
+          .run();
+      }
+    }
+
+    // Upsert each title with its new position
+    for (let i = 0; i < ordered.length; i++) {
+      await db
+        .insert(pinnedTitles)
+        .values({ userId, titleId: ordered[i], position: i })
+        .onConflictDoUpdate({
+          target: [pinnedTitles.userId, pinnedTitles.titleId],
+          set: { position: i },
+        })
+        .run();
+    }
+  });
+}
+
+/**
+ * Returns whether a specific title is pinned by the user.
+ */
+export async function isPinnedTitle(userId: string, titleId: string): Promise<boolean> {
+  return traceDbQuery("isPinnedTitle", async () => {
+    const db = getDb();
+    const row = await db
+      .select({ titleId: pinnedTitles.titleId })
+      .from(pinnedTitles)
+      .where(and(eq(pinnedTitles.userId, userId), eq(pinnedTitles.titleId, titleId)))
+      .get();
+    return row !== undefined;
+  });
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -493,6 +493,20 @@ export const titleTags = sqliteTable(
   ]
 );
 
+export const pinnedTitles = sqliteTable(
+  "pinned_titles",
+  {
+    userId: text("user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
+    titleId: text("title_id").notNull().references(() => titles.id, { onDelete: "cascade" }),
+    position: integer("position").notNull().default(0),
+    createdAt: text("created_at").default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.titleId] }),
+    index("idx_pinned_titles_user_id").on(table.userId),
+  ]
+);
+
 export const watchHistory = sqliteTable(
   "watch_history",
   {

--- a/server/routes/profile.test.ts
+++ b/server/routes/profile.test.ts
@@ -12,6 +12,8 @@ import { eq } from "drizzle-orm";
 import profileApp from "./profile";
 import type { AppEnv } from "../types";
 
+type AnyRecord = Record<string, any>;
+
 function createMockAuth() {
   return {
     api: {
@@ -655,5 +657,153 @@ describe("GET /user/:username — extended dossier fields", () => {
     expect(body.monthly).toEqual([]);
     expect(body.friends).toEqual([]);
     expect(body.shows_by_status.watching).toBe(0);
+  });
+});
+
+// ─── Pinned favorites ─────────────────────────────────────────────────────────
+
+describe("POST /user/me/pinned/:titleId", () => {
+  it("pins a title for authenticated user (happy path)", async () => {
+    await upsertTitles([makeParsedTitle()]);
+
+    const res = await app.request("/user/me/pinned/movie-123", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.pinned).toBe(true);
+  });
+
+  it("returns 401 without authentication", async () => {
+    await upsertTitles([makeParsedTitle()]);
+
+    const res = await app.request("/user/me/pinned/movie-123", { method: "POST" });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a 9th pin (max 8 enforced)", async () => {
+    const titleIds = Array.from({ length: 8 }, (_, i) => `movie-${i + 1}`);
+    await upsertTitles(titleIds.map((id) => makeParsedTitle({ id, title: `Movie ${id}` })));
+
+    // Pin 8 titles
+    for (const id of titleIds) {
+      const res = await app.request(`/user/me/pinned/${id}`, {
+        method: "POST",
+        headers: authHeaders(),
+      });
+      expect(res.status).toBe(200);
+    }
+
+    // 9th title
+    await upsertTitles([makeParsedTitle({ id: "movie-9", title: "Movie 9" })]);
+    const res = await app.request("/user/me/pinned/movie-9", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/maximum/i);
+  });
+
+  it("pinned titles appear in GET profile response", async () => {
+    await upsertTitles([makeParsedTitle()]);
+    await app.request("/user/me/pinned/movie-123", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+
+    const res = await app.request("/user/testuser", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.pinned).toHaveLength(1);
+    expect(body.pinned[0].id).toBe("movie-123");
+  });
+});
+
+describe("DELETE /user/me/pinned/:titleId", () => {
+  it("unpins a title", async () => {
+    await upsertTitles([makeParsedTitle()]);
+
+    // Pin first
+    await app.request("/user/me/pinned/movie-123", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+
+    // Then unpin
+    const res = await app.request("/user/me/pinned/movie-123", {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.pinned).toBe(false);
+
+    // Profile should have no pinned
+    const profileRes = await app.request("/user/testuser", { headers: authHeaders() });
+    const profile = await profileRes.json();
+    expect(profile.pinned).toHaveLength(0);
+  });
+
+  it("returns 401 without authentication", async () => {
+    const res = await app.request("/user/me/pinned/movie-123", { method: "DELETE" });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("PUT /user/me/pinned/order", () => {
+  it("reorders pinned titles (happy path)", async () => {
+    const titleIds = ["movie-1", "movie-2", "movie-3"];
+    await upsertTitles(titleIds.map((id) => makeParsedTitle({ id, title: `Movie ${id}` })));
+
+    for (const id of titleIds) {
+      await app.request(`/user/me/pinned/${id}`, { method: "POST", headers: authHeaders() });
+    }
+
+    // Reverse order
+    const res = await app.request("/user/me/pinned/order", {
+      method: "PUT",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ titleIds: ["movie-3", "movie-2", "movie-1"] }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    // Verify order in profile
+    const profileRes = await app.request("/user/testuser", { headers: authHeaders() });
+    const profile = await profileRes.json();
+    expect(profile.pinned[0].id).toBe("movie-3");
+    expect(profile.pinned[2].id).toBe("movie-1");
+  });
+
+  it("returns 400 when body is missing titleIds", async () => {
+    const res = await app.request("/user/me/pinned/order", {
+      method: "PUT",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json() as AnyRecord;
+    expect(body.issues).toBeInstanceOf(Array);
+  });
+
+  it("returns 401 without authentication", async () => {
+    const res = await app.request("/user/me/pinned/order", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ titleIds: [] }),
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /user/:username — pinned field", () => {
+  it("includes empty pinned array when no titles are pinned", async () => {
+    const res = await app.request("/user/testuser");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.pinned).toEqual([]);
   });
 });

--- a/server/routes/profile.ts
+++ b/server/routes/profile.ts
@@ -14,11 +14,19 @@ import {
   hideActivityEvent,
   unhideActivityEvent,
   getHiddenActivityEventKeys,
+  getPinnedTitles,
+  pinTitle,
+  unpinTitle,
+  reorderPinnedTitles,
 } from "../db/repository";
 import type { AppEnv } from "../types";
 import type { ActivityType, ActivityKindVisibilityMap } from "../db/repository";
 import { ok, err } from "./response";
 import { zValidator } from "../lib/validator";
+import { requireAuth } from "../middleware/auth";
+import { logger } from "../logger";
+
+const log = logger.child({ module: "profile" });
 
 const ACTIVITY_KINDS: ActivityType[] = [
   "rating_title",
@@ -129,9 +137,12 @@ app.get("/:username", async (c) => {
     return err(c, "User not found", 404);
   }
 
+  const pinned = await getPinnedTitles(profile.user.id);
+
   return ok(c, {
     ...profile,
     is_own_profile: isOwnProfile,
+    pinned,
   });
 });
 
@@ -193,6 +204,54 @@ app.get("/:username/activity", zValidator("query", activityQuerySchema), async (
     hiddenKeys,
   });
   return ok(c, result);
+});
+
+const reorderSchema = z.object({
+  titleIds: z.array(z.string().min(1)).min(0).max(8),
+});
+
+/** Helper: resolve a username to its user id via the profile, checking ownership. */
+async function resolveProfileOwner(username: string, viewerUserId: string) {
+  const profile = await getUserPublicProfile(username, false, null);
+  if (!profile) return { profile: null, owned: false };
+  const owned = profile.user.id === viewerUserId;
+  return { profile, owned };
+}
+
+// POST /me/pinned/:titleId — pin a title (auth required)
+app.post("/me/pinned/:titleId", requireAuth, async (c) => {
+  const user = c.get("user")!;
+  const titleId = c.req.param("titleId");
+
+  const result = await pinTitle(user.id, titleId);
+  if (!result.ok) {
+    return err(c, result.error, 400);
+  }
+
+  log.info("Title pinned", { userId: user.id, titleId });
+  return ok(c, { pinned: true });
+});
+
+// DELETE /me/pinned/:titleId — unpin a title (auth required)
+app.delete("/me/pinned/:titleId", requireAuth, async (c) => {
+  const user = c.get("user")!;
+  const titleId = c.req.param("titleId");
+
+  await unpinTitle(user.id, titleId);
+
+  log.info("Title unpinned", { userId: user.id, titleId });
+  return ok(c, { pinned: false });
+});
+
+// PUT /me/pinned/order — reorder pinned titles (auth required)
+app.put("/me/pinned/order", requireAuth, zValidator("json", reorderSchema), async (c) => {
+  const user = c.get("user")!;
+  const { titleIds } = c.req.valid("json");
+
+  await reorderPinnedTitles(user.id, titleIds);
+
+  log.info("Pinned titles reordered", { userId: user.id, count: titleIds.length });
+  return ok(c, { ok: true });
 });
 
 export { ACTIVITY_KINDS };


### PR DESCRIPTION
## Summary
- New `pinned_titles` table (max 8 per user, ordered by position) with Drizzle migration (`0034_pinned_titles`) and CF D1 companion SQL (`migrations/0003_pinned_titles.sql`)
- `POST/DELETE /api/user/me/pinned/:titleId` and `PUT /api/user/me/pinned/order` routes (auth-required) added to `server/routes/profile.ts`
- `GET /api/user/:username` now includes `pinned: PinnedTitle[]` in the response
- Pin button on movie/show detail page hero (authenticated users only)
- `PinnedFavoritesCard` on public user profile: 2×4 poster grid rendered in the sidebar above stats, with owner-only edit mode (unpin + left/right reorder arrows)
- `UserProfileResponse` in `frontend/src/types.ts` extended with `pinned` field

## Test plan
- [x] `bun run check` passes (server tsc ✓, e2e tsc ✓, frontend tsc pre-existing errors, eslint ✓, all tests pass except pre-existing flaky timing test in `sync-utils.test.ts`)
- [ ] Pin a title from its detail page → appears on profile grid
- [ ] Unpin via profile edit mode → disappears
- [ ] 9th pin attempt → 400 error toast ("Maximum of 8 pinned titles reached")
- [ ] Reorder via ◀/▶ buttons in edit mode → persists after page reload
- [ ] Public profile shows pinned grid for visitors (no edit controls)

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)