### PR TITLE
feat(#476): notifier delivery history (notification_log)

### DIFF
--- a/drizzle/0035_notification_log.sql
+++ b/drizzle/0035_notification_log.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS `notification_log` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`notifier_id` text NOT NULL,
+	`attempted_at` integer NOT NULL,
+	`status` text NOT NULL,
+	`latency_ms` integer,
+	`http_status` integer,
+	`error_message` text,
+	`event_kind` text,
+	FOREIGN KEY (`notifier_id`) REFERENCES `notifiers`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_notification_log_notifier` ON `notification_log` (`notifier_id`,`attempted_at`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1778025600000,
       "tag": "0034_pinned_titles",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "6",
+      "when": 1778112000000,
+      "tag": "0035_notification_log",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -26,6 +26,7 @@ import type {
   HomepageSection,
   WatchHistoryEntry,
   ActivitySettings,
+  NotifierHistoryResponse,
 } from "./types";
 
 const BASE = "/api";
@@ -548,6 +549,12 @@ export async function testNotifier(
   return fetchJson(`/notifiers/${encodeURIComponent(id)}/test`, {
     method: "POST",
   });
+}
+
+export async function getNotifierHistory(
+  id: string
+): Promise<NotifierHistoryResponse> {
+  return fetchJson<NotifierHistoryResponse>(`/notifiers/${encodeURIComponent(id)}/history`);
 }
 
 // ─── Social (Follow/Unfollow) ────────────────────────────────────────────────

--- a/frontend/src/pages/settings/NotificationsTab.tsx
+++ b/frontend/src/pages/settings/NotificationsTab.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import * as api from "../../api";
 import type { Notifier } from "../../api";
+import type { NotificationLogRow } from "../../types";
 import { isPushSupported, subscribeToPush, unsubscribeFromPush, getExistingSubscription } from "../../lib/push";
 import {
   SCard,
@@ -250,6 +251,93 @@ function PushNotificationsSection() {
   );
 }
 
+type NotifierHistoryState = {
+  rows: NotificationLogRow[];
+  successRate: number;
+} | null;
+
+function statusPillKind(rate: number): "ok" | "warning" | "error" {
+  if (rate >= 90) return "ok";
+  if (rate >= 60) return "warning";
+  return "error";
+}
+
+function formatAttemptedAt(ts: number): string {
+  try {
+    return new Date(ts).toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return String(ts);
+  }
+}
+
+function NotifierDeliveryHistory({ notifierId, refreshKey }: { notifierId: string; refreshKey?: number }) {
+  const [history, setHistory] = useState<NotifierHistoryState>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const data = await api.getNotifierHistory(notifierId);
+        if (!cancelled) {
+          setHistory(data);
+          setLoading(false);
+        }
+      } catch {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    load();
+    return () => { cancelled = true; };
+  }, [notifierId, refreshKey]);
+
+  if (loading) {
+    return <div className="text-zinc-500 text-xs font-mono mt-3">Loading history...</div>;
+  }
+
+  if (!history || history.rows.length === 0) {
+    return (
+      <div className="mt-3 pt-3 border-t border-white/[0.04]">
+        <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-500 mb-1.5">Delivery History</div>
+        <div className="text-zinc-500 text-xs font-mono">No deliveries recorded yet.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-3 pt-3 border-t border-white/[0.04]">
+      <div className="flex items-center gap-2 mb-2">
+        <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-500">Delivery History</div>
+        <SStatusPill kind={statusPillKind(history.successRate)}>
+          {history.successRate}% 7d
+        </SStatusPill>
+      </div>
+      <div className="space-y-1">
+        {history.rows.map((row) => (
+          <div key={row.id} className="flex items-start gap-2 text-xs font-mono py-1 border-b border-white/[0.03] last:border-b-0">
+            <span className={cn(
+              "shrink-0 w-2 h-2 rounded-full mt-0.5",
+              row.status === "success" ? "bg-emerald-400" :
+              row.status === "failure" ? "bg-red-400" : "bg-zinc-500"
+            )} />
+            <span className="text-zinc-500 shrink-0">{formatAttemptedAt(row.attemptedAt)}</span>
+            {row.eventKind && <span className="text-zinc-400 shrink-0">{row.eventKind}</span>}
+            {row.latencyMs != null && <span className="text-zinc-600 shrink-0">{row.latencyMs}ms</span>}
+            {row.status === "failure" && row.errorMessage && (
+              <span className="text-red-400 truncate" title={row.errorMessage}>{row.errorMessage}</span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function NotificationsSection() {
   const [notifiers, setNotifiers] = useState<Notifier[]>([]);
   const [providers, setProviders] = useState<string[]>([]);
@@ -260,6 +348,7 @@ function NotificationsSection() {
   const [err, setErr] = useState("");
   const [testing, setTesting] = useState<string | null>(null);
   const [toggling, setToggling] = useState<string | null>(null);
+  const [historyKeys, setHistoryKeys] = useState<Record<string, number>>({});
 
   const [formProvider, setFormProvider] = useState("discord");
   const [formWebhookUrl, setFormWebhookUrl] = useState("");
@@ -413,6 +502,7 @@ function NotificationsSection() {
       setErr(e instanceof Error ? e.message : String(e));
     } finally {
       setTesting(null);
+      setHistoryKeys((prev) => ({ ...prev, [id]: (prev[id] ?? 0) + 1 }));
     }
   }
 
@@ -522,6 +612,7 @@ function NotificationsSection() {
                   <SKeyValue k="Frequency" v={describeDigest(n)} />
                   <SKeyValue k="Last sent" v={n.last_sent_date ?? "—"} />
                 </div>
+                <NotifierDeliveryHistory notifierId={n.id} refreshKey={historyKeys[n.id] ?? 0} />
               </div>
             );
           })}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -735,3 +735,18 @@ export function normalizeSearchTitle(t: SearchTitle): Title {
     })),
   };
 }
+
+export interface NotificationLogRow {
+  id: number;
+  attemptedAt: number;
+  status: "success" | "failure" | "skipped";
+  latencyMs: number | null;
+  httpStatus: number | null;
+  errorMessage: string | null;
+  eventKind: string | null;
+}
+
+export interface NotifierHistoryResponse {
+  rows: NotificationLogRow[];
+  successRate: number;
+}

--- a/migrations/0004_notification_log.sql
+++ b/migrations/0004_notification_log.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS notification_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  notifier_id TEXT NOT NULL REFERENCES notifiers(id) ON DELETE CASCADE,
+  attempted_at INTEGER NOT NULL,
+  status TEXT NOT NULL CHECK(status IN ('success', 'failure', 'skipped')),
+  latency_ms INTEGER,
+  http_status INTEGER,
+  error_message TEXT,
+  event_kind TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_notification_log_notifier ON notification_log(notifier_id, attempted_at DESC);

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -133,6 +133,6 @@ describe("fixSkippedMigrations", () => {
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(35);
+    expect(migrations.cnt).toBe(36);
   });
 });

--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -238,3 +238,11 @@ export {
   isPinnedTitle,
 } from "./pinned";
 export type { PinnedTitle } from "./pinned";
+
+export {
+  recordDelivery,
+  getRecentForNotifier,
+  getSuccessRateForNotifier,
+  pruneOldRows,
+} from "./notification-log";
+export type { NotificationLogRow } from "./notification-log";

--- a/server/db/repository/notification-log.test.ts
+++ b/server/db/repository/notification-log.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
+import { createUser } from "./users";
+import { createNotifier } from "./notifiers";
+import {
+  recordDelivery,
+  getRecentForNotifier,
+  getSuccessRateForNotifier,
+  pruneOldRows,
+} from "./notification-log";
+
+let notifierId: string;
+
+beforeEach(async () => {
+  setupTestDb();
+
+  const userId = await createUser("testuser", "hash");
+  notifierId = await createNotifier(
+    userId,
+    "discord",
+    "Discord",
+    { webhookUrl: "https://discord.com/api/webhooks/123456789/abcdefghijklmnop" },
+    "09:00",
+    "UTC"
+  );
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+describe("recordDelivery", () => {
+  it("writes a success row", async () => {
+    await recordDelivery({ notifierId, status: "success", latencyMs: 150, eventKind: "test" });
+    const rows = await getRecentForNotifier(notifierId, 10);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("success");
+    expect(rows[0].latencyMs).toBe(150);
+    expect(rows[0].eventKind).toBe("test");
+    expect(rows[0].notifierId).toBe(notifierId);
+    expect(rows[0].errorMessage).toBeNull();
+  });
+
+  it("writes a failure row with errorMessage", async () => {
+    await recordDelivery({ notifierId, status: "failure", latencyMs: 200, errorMessage: "Connection refused", eventKind: "episode_air" });
+    const rows = await getRecentForNotifier(notifierId, 10);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("failure");
+    expect(rows[0].errorMessage).toBe("Connection refused");
+    expect(rows[0].eventKind).toBe("episode_air");
+  });
+
+  it("writes a skipped row", async () => {
+    await recordDelivery({ notifierId, status: "skipped" });
+    const rows = await getRecentForNotifier(notifierId, 10);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("skipped");
+    expect(rows[0].latencyMs).toBeNull();
+  });
+});
+
+describe("getRecentForNotifier", () => {
+  it("returns at most n rows", async () => {
+    for (let i = 0; i < 8; i++) {
+      await recordDelivery({ notifierId, status: "success", latencyMs: i * 10, eventKind: "test" });
+    }
+    const rows = await getRecentForNotifier(notifierId, 5);
+    expect(rows).toHaveLength(5);
+  });
+
+  it("returns rows ordered by most-recent first", async () => {
+    await recordDelivery({ notifierId, status: "success", latencyMs: 10, eventKind: "first" });
+    await recordDelivery({ notifierId, status: "failure", latencyMs: 20, eventKind: "second" });
+    await recordDelivery({ notifierId, status: "skipped", latencyMs: 30, eventKind: "third" });
+
+    const rows = await getRecentForNotifier(notifierId, 10);
+    expect(rows).toHaveLength(3);
+    // Most recent (highest id / most recently inserted) should come first
+    expect(rows[0].eventKind).toBe("third");
+    expect(rows[2].eventKind).toBe("first");
+  });
+
+  it("returns empty array for notifier with no logs", async () => {
+    const rows = await getRecentForNotifier(notifierId, 5);
+    expect(rows).toHaveLength(0);
+  });
+});
+
+describe("getSuccessRateForNotifier", () => {
+  it("returns 100 when no rows exist", async () => {
+    const rate = await getSuccessRateForNotifier(notifierId, 7);
+    expect(rate).toBe(100);
+  });
+
+  it("returns 100 when all rows are success", async () => {
+    await recordDelivery({ notifierId, status: "success" });
+    await recordDelivery({ notifierId, status: "success" });
+    const rate = await getSuccessRateForNotifier(notifierId, 7);
+    expect(rate).toBe(100);
+  });
+
+  it("returns 0 when all rows are failure", async () => {
+    await recordDelivery({ notifierId, status: "failure" });
+    await recordDelivery({ notifierId, status: "failure" });
+    const rate = await getSuccessRateForNotifier(notifierId, 7);
+    expect(rate).toBe(0);
+  });
+
+  it("returns 50 for equal success and failure", async () => {
+    await recordDelivery({ notifierId, status: "success" });
+    await recordDelivery({ notifierId, status: "failure" });
+    const rate = await getSuccessRateForNotifier(notifierId, 7);
+    expect(rate).toBe(50);
+  });
+
+  it("excludes skipped rows from calculation", async () => {
+    await recordDelivery({ notifierId, status: "success" });
+    await recordDelivery({ notifierId, status: "skipped" });
+    await recordDelivery({ notifierId, status: "skipped" });
+    // Only 1 row counted (success), rate = 100
+    const rate = await getSuccessRateForNotifier(notifierId, 7);
+    expect(rate).toBe(100);
+  });
+
+  it("returns 100 when only skipped rows exist", async () => {
+    await recordDelivery({ notifierId, status: "skipped" });
+    const rate = await getSuccessRateForNotifier(notifierId, 7);
+    expect(rate).toBe(100);
+  });
+});
+
+describe("pruneOldRows", () => {
+  it("keeps exactly 200 rows when given 205 rows", async () => {
+    for (let i = 0; i < 205; i++) {
+      await recordDelivery({ notifierId, status: "success", latencyMs: i });
+    }
+
+    const beforePrune = await getRecentForNotifier(notifierId, 300);
+    expect(beforePrune).toHaveLength(205);
+
+    await pruneOldRows();
+
+    const afterPrune = await getRecentForNotifier(notifierId, 300);
+    expect(afterPrune).toHaveLength(200);
+  });
+
+  it("does not prune when row count is at or below 200", async () => {
+    for (let i = 0; i < 200; i++) {
+      await recordDelivery({ notifierId, status: "success" });
+    }
+
+    await pruneOldRows();
+
+    const rows = await getRecentForNotifier(notifierId, 300);
+    expect(rows).toHaveLength(200);
+  });
+
+  it("keeps the most recent rows after pruning", async () => {
+    for (let i = 0; i < 205; i++) {
+      await recordDelivery({ notifierId, status: "success", latencyMs: i, eventKind: `event-${i}` });
+    }
+
+    await pruneOldRows();
+
+    const rows = await getRecentForNotifier(notifierId, 300);
+    expect(rows).toHaveLength(200);
+    // Most recent rows should have the highest latencyMs values (204, 203, ...)
+    const latencies = rows.map((r) => r.latencyMs ?? 0);
+    expect(latencies[0]).toBeGreaterThanOrEqual(5); // most recent = latencyMs 204
+  });
+});

--- a/server/db/repository/notification-log.ts
+++ b/server/db/repository/notification-log.ts
@@ -1,0 +1,142 @@
+import { eq, desc, and, gte, sql } from "drizzle-orm";
+import { getDb, notificationLog } from "../schema";
+import { traceDbQuery } from "../../tracing";
+
+export type NotificationLogRow = {
+  id: number;
+  notifierId: string;
+  attemptedAt: Date;
+  status: "success" | "failure" | "skipped";
+  latencyMs: number | null;
+  httpStatus: number | null;
+  errorMessage: string | null;
+  eventKind: string | null;
+};
+
+/**
+ * Records a single notification delivery attempt.
+ */
+export async function recordDelivery(params: {
+  notifierId: string;
+  status: "success" | "failure" | "skipped";
+  latencyMs?: number;
+  httpStatus?: number;
+  errorMessage?: string;
+  eventKind?: string;
+}): Promise<void> {
+  return traceDbQuery("recordDelivery", async () => {
+    const db = getDb();
+    await db
+      .insert(notificationLog)
+      .values({
+        notifierId: params.notifierId,
+        attemptedAt: new Date(),
+        status: params.status,
+        latencyMs: params.latencyMs ?? null,
+        httpStatus: params.httpStatus ?? null,
+        errorMessage: params.errorMessage ?? null,
+        eventKind: params.eventKind ?? null,
+      })
+      .run();
+  });
+}
+
+/**
+ * Returns the most recent `n` log rows for a notifier, newest first.
+ */
+export async function getRecentForNotifier(
+  notifierId: string,
+  n = 5
+): Promise<NotificationLogRow[]> {
+  return traceDbQuery("getRecentForNotifier", async () => {
+    const db = getDb();
+    const rows = await db
+      .select()
+      .from(notificationLog)
+      .where(eq(notificationLog.notifierId, notifierId))
+      .orderBy(desc(notificationLog.attemptedAt))
+      .limit(n)
+      .all();
+    return rows as NotificationLogRow[];
+  });
+}
+
+/**
+ * Returns the success rate (0-100) for a notifier over the last `days` days.
+ * Only success/failure rows count; skipped rows are excluded.
+ */
+export async function getSuccessRateForNotifier(
+  notifierId: string,
+  days = 7
+): Promise<number> {
+  return traceDbQuery("getSuccessRateForNotifier", async () => {
+    const db = getDb();
+    const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+    const rows = await db
+      .select()
+      .from(notificationLog)
+      .where(
+        and(
+          eq(notificationLog.notifierId, notifierId),
+          gte(notificationLog.attemptedAt, cutoff)
+        )
+      )
+      .all();
+
+    // Filter out "skipped" from the rate calculation
+    const relevant = rows.filter(
+      (r) => r.status === "success" || r.status === "failure"
+    );
+
+    if (relevant.length === 0) return 100; // no data → assume healthy
+    const successes = relevant.filter((r) => r.status === "success").length;
+    return Math.round((successes / relevant.length) * 100);
+  });
+}
+
+/**
+ * Prunes old rows, keeping at most 200 rows per notifier.
+ * Runs as a maintenance job to bound table growth.
+ */
+export async function pruneOldRows(): Promise<void> {
+  return traceDbQuery("pruneOldRows", async () => {
+    const db = getDb();
+
+    // Get distinct notifier IDs that have more than 200 rows
+    const counts = await db
+      .select({
+        notifierId: notificationLog.notifierId,
+        count: sql<number>`count(*)`.as("count"),
+      })
+      .from(notificationLog)
+      .groupBy(notificationLog.notifierId)
+      .all();
+
+    for (const { notifierId, count } of counts) {
+      if (count <= 200) continue;
+
+      // Find the ID cutoff: keep the 200 most recent rows
+      const cutoffRow = await db
+        .select({ id: notificationLog.id })
+        .from(notificationLog)
+        .where(eq(notificationLog.notifierId, notifierId))
+        .orderBy(desc(notificationLog.id))
+        .limit(1)
+        .offset(199)
+        .get();
+
+      if (!cutoffRow) continue;
+
+      await db
+        .delete(notificationLog)
+        .where(
+          and(
+            eq(notificationLog.notifierId, notifierId),
+            sql`${notificationLog.id} < ${cutoffRow.id}`
+          )
+        )
+        .run();
+    }
+  });
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -577,6 +577,23 @@ export const streamingAlerts = sqliteTable(
   ]
 );
 
+export const notificationLog = sqliteTable(
+  "notification_log",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    notifierId: text("notifier_id").notNull().references(() => notifiers.id, { onDelete: "cascade" }),
+    attemptedAt: integer("attempted_at", { mode: "timestamp_ms" }).notNull().$defaultFn(() => new Date()),
+    status: text("status", { enum: ["success", "failure", "skipped"] }).notNull(),
+    latencyMs: integer("latency_ms"),
+    httpStatus: integer("http_status"),
+    errorMessage: text("error_message"),
+    eventKind: text("event_kind"),
+  },
+  (table) => [
+    index("idx_notification_log_notifier").on(table.notifierId, table.attemptedAt),
+  ]
+);
+
 // ─── Relations ──────────────────────────────────────────────────────────────
 
 export const titlesRelations = relations(titles, ({ many, one }) => ({
@@ -661,8 +678,13 @@ export const watchedTitlesRelations = relations(watchedTitles, ({ one }) => ({
   user: one(users, { fields: [watchedTitles.userId], references: [users.id] }),
 }));
 
-export const notifiersRelations = relations(notifiers, ({ one }) => ({
+export const notifiersRelations = relations(notifiers, ({ one, many }) => ({
   user: one(users, { fields: [notifiers.userId], references: [users.id] }),
+  logs: many(notificationLog),
+}));
+
+export const notificationLogRelations = relations(notificationLog, ({ one }) => ({
+  notifier: one(notifiers, { fields: [notificationLog.notifierId], references: [notifiers.id] }),
 }));
 
 export const followsRelations = relations(follows, ({ one }) => ({
@@ -705,12 +727,12 @@ export const passkeyRelations = relations(passkey, ({ one }) => ({
 export const schemaExports = {
   titles, providers, offers, scores, titleGenres, episodes, users, sessions, account, verification, passkey, settings, tracked, watchedEpisodes, watchedTitles, notifiers, oidcStates, jobs, cronJobs,
   follows, ratings, episodeRatings, recommendations, recommendationReads, invitations, integrations, plexLibraryItems, titleTags,
-  watchHistory, streamingAlerts, activityKindVisibility, hiddenActivityEvents,
+  watchHistory, streamingAlerts, activityKindVisibility, hiddenActivityEvents, notificationLog,
   titlesRelations, providersRelations, offersRelations, scoresRelations, titleGenresRelations, episodesRelations,
   passkeyRelations,
   usersRelations, sessionsRelations, accountRelations, trackedRelations, watchedEpisodesRelations, watchedTitlesRelations, notifiersRelations,
   followsRelations, ratingsRelations, episodeRatingsRelations, recommendationsRelations, recommendationReadsRelations, invitationsRelations,
-  integrationsRelations, plexLibraryItemsRelations,
+  integrationsRelations, plexLibraryItemsRelations, notificationLogRelations,
 };
 
 // Re-export the union type from platform for convenience

--- a/server/index.ts
+++ b/server/index.ts
@@ -43,6 +43,7 @@ import { errorsByCategory } from "./metrics";
 import { registerSyncJobs } from "./jobs/sync";
 import { registerNotificationJobs } from "./jobs/notifications";
 import { registerBackupJob } from "./jobs/backup";
+import { registerPruneNotificationLogJob } from "./jobs/prune-notification-log";
 import { startWorker, stopWorker } from "./jobs/worker";
 import { createShutdownHandler } from "./graceful-shutdown";
 import { registerCron } from "./jobs/queue";
@@ -327,6 +328,7 @@ setScheduleCallback(registerCron);
 registerSyncJobs();
 await registerNotificationJobs();
 registerBackupJob();
+registerPruneNotificationLogJob();
 startWorker();
 
 const server = Bun.serve({

--- a/server/jobs/check-streaming-alerts.ts
+++ b/server/jobs/check-streaming-alerts.ts
@@ -6,6 +6,7 @@ import {
   markAlerted,
   getStreamingAlertNotifiersForUser,
   getTitleById,
+  recordDelivery,
 } from "../db/repository";
 import { getProvider } from "../notifications/registry";
 
@@ -82,8 +83,10 @@ export async function checkStreamingAlerts(titleIds: string[]): Promise<void> {
           for (const notifier of userNotifiers) {
             const notifierProvider = getProvider(notifier.provider);
             if (!notifierProvider) continue;
+            const alertStart = Date.now();
             try {
               await notifierProvider.send(notifier.config, content);
+              await recordDelivery({ notifierId: notifier.id, status: "success", latencyMs: Date.now() - alertStart, eventKind: "streaming_arrival" });
               log.info("Sent streaming alert", {
                 userId,
                 titleId,
@@ -92,6 +95,7 @@ export async function checkStreamingAlerts(titleIds: string[]): Promise<void> {
               });
             } catch (err) {
               const message = err instanceof Error ? err.message : String(err);
+              await recordDelivery({ notifierId: notifier.id, status: "failure", latencyMs: Date.now() - alertStart, errorMessage: message, eventKind: "streaming_arrival" });
               log.error("Failed to send streaming alert", {
                 notifierId: notifier.id,
                 userId,

--- a/server/jobs/notifications.ts
+++ b/server/jobs/notifications.ts
@@ -5,6 +5,7 @@ import {
   getDistinctNotifierTimezones,
   markNotifierSent,
   disableNotifier,
+  recordDelivery,
 } from "../db/repository";
 import { getProvider } from "../notifications/registry";
 import { buildNotificationContent, buildWeeklyDigestContent } from "../notifications/content";
@@ -104,7 +105,14 @@ export async function registerNotificationJobs() {
               continue;
             }
 
-            await provider.send(notifier.config, content);
+            const weeklyStart = Date.now();
+            try {
+              await provider.send(notifier.config, content);
+              await recordDelivery({ notifierId: notifier.id, status: "success", latencyMs: Date.now() - weeklyStart, eventKind: "digest" });
+            } catch (sendErr) {
+              await recordDelivery({ notifierId: notifier.id, status: "failure", latencyMs: Date.now() - weeklyStart, errorMessage: sendErr instanceof Error ? sendErr.message : String(sendErr), eventKind: "digest" });
+              throw sendErr;
+            }
             await markNotifierSent(notifier.id, notifier.todayDate);
             log.info("Sent weekly digest notification", { provider: notifier.provider, userId: notifier.user_id });
             continue;
@@ -128,7 +136,14 @@ export async function registerNotificationJobs() {
             continue;
           }
 
-          await provider.send(notifier.config, content);
+          const dailyStart = Date.now();
+          try {
+            await provider.send(notifier.config, content);
+            await recordDelivery({ notifierId: notifier.id, status: "success", latencyMs: Date.now() - dailyStart, eventKind: "episode_air" });
+          } catch (sendErr) {
+            await recordDelivery({ notifierId: notifier.id, status: "failure", latencyMs: Date.now() - dailyStart, errorMessage: sendErr instanceof Error ? sendErr.message : String(sendErr), eventKind: "episode_air" });
+            throw sendErr;
+          }
           await markNotifierSent(notifier.id, notifier.todayDate);
           log.info("Sent notification", { provider: notifier.provider, userId: notifier.user_id });
         } catch (err) {

--- a/server/jobs/prune-notification-log.ts
+++ b/server/jobs/prune-notification-log.ts
@@ -1,0 +1,16 @@
+import { logger } from "../logger";
+import { registerHandler } from "./worker";
+import { registerCron } from "./queue";
+import { pruneOldRows } from "../db/repository";
+
+const log = logger.child({ module: "prune-notification-log" });
+
+export function registerPruneNotificationLogJob() {
+  registerHandler("prune-notification-log", async () => {
+    await pruneOldRows();
+    log.info("Pruned old notification log rows");
+  });
+
+  // Run daily at 03:00 UTC (low-traffic time)
+  registerCron("prune-notification-log", "0 3 * * *");
+}

--- a/server/routes/notifiers.test.ts
+++ b/server/routes/notifiers.test.ts
@@ -589,6 +589,57 @@ describe("validation", () => {
   });
 });
 
+describe("GET /notifiers/:id/history", () => {
+  async function createDiscordNotifier() {
+    const res = await app.request("/notifiers", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify(validNotifier),
+    });
+    const { notifier } = await res.json();
+    return notifier;
+  }
+
+  it("returns 200 with rows and successRate for own notifier", async () => {
+    const notifier = await createDiscordNotifier();
+    const res = await app.request(`/notifiers/${notifier.id}/history`, {
+      headers: headers(),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.rows)).toBe(true);
+    expect(typeof body.successRate).toBe("number");
+  });
+
+  it("returns 401 without auth", async () => {
+    const notifier = await createDiscordNotifier();
+    const res = await app.request(`/notifiers/${notifier.id}/history`);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 for a notifier belonging to another user", async () => {
+    const notifier = await createDiscordNotifier();
+
+    const user2Id = await createUser("otheruser2", "hash");
+    const user2Token = await createSession(user2Id);
+    const user2Headers = {
+      Cookie: `better-auth.session_token=${user2Token}`,
+    };
+
+    const res = await app.request(`/notifiers/${notifier.id}/history`, {
+      headers: user2Headers,
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for a non-existent notifier", async () => {
+    const res = await app.request("/notifiers/nonexistent-id/history", {
+      headers: headers(),
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
 describe("ownership enforcement", () => {
   it("user cannot access another user's notifier", async () => {
     // Create notifier as user 1

--- a/server/routes/notifiers.ts
+++ b/server/routes/notifiers.ts
@@ -1,12 +1,16 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import type { AppEnv } from "../types";
+import { requireAuth } from "../middleware/auth";
 import {
   createNotifier,
   updateNotifier,
   deleteNotifier,
   getNotifiersByUser,
   getNotifierById,
+  recordDelivery,
+  getRecentForNotifier,
+  getSuccessRateForNotifier,
 } from "../db/repository";
 import { getProvider, getAvailableProviders } from "../notifications/registry";
 import { buildNotificationContent } from "../notifications/content";
@@ -267,10 +271,13 @@ app.post("/:id/test", async (c) => {
     };
   }
 
+  const start = Date.now();
   try {
     await providerImpl.send(notifier.config, content);
+    await recordDelivery({ notifierId: id, status: "success", latencyMs: Date.now() - start, eventKind: "test" });
     return c.json({ success: true, message: "Test notification sent" });
   } catch (err: unknown) {
+    await recordDelivery({ notifierId: id, status: "failure", latencyMs: Date.now() - start, errorMessage: err instanceof Error ? err.message : String(err), eventKind: "test" });
     if (!(err instanceof SubscriptionExpiredError)) {
       Sentry.captureException(err);
     }
@@ -279,6 +286,21 @@ app.post("/:id/test", async (c) => {
       { success: false, message: message || "Failed to send" },
     );
   }
+});
+
+// GET /:id/history — delivery history for a notifier (owner only)
+app.get("/:id/history", requireAuth, async (c) => {
+  const user = c.get("user")!;
+  const id = c.req.param("id");
+
+  const notifier = await getNotifierById(id, user.id);
+  if (!notifier) {
+    return err(c, "Notifier not found", 404);
+  }
+
+  const rows = await getRecentForNotifier(id, 5);
+  const successRate = await getSuccessRateForNotifier(id, 7);
+  return ok(c, { rows, successRate });
 });
 
 export default app;


### PR DESCRIPTION
## Summary
- New `notification_log` table — records every send attempt (success/failure/skipped) with latency, HTTP status, error message, and event kind
- All notification send paths wrapped with delivery logging: episode_air, digest, streaming_arrival, and test
- Nightly pruning cron (03:00 UTC) keeps last 200 rows per notifier
- `GET /api/notifiers/:id/history` endpoint (owner-only)
- Settings → Notifications: each notifier card now shows last 5 delivery attempts + 7-day success rate pill (green ≥90%, yellow 60-89%, red <60%)

## Test plan
- [ ] `bun run check` passes
- [ ] Test a notifier in Settings — a history row appears with `event_kind: test` and the success rate updates
- [ ] Break a webhook URL — next notification shows a failure row with the error message
- [ ] 7-day success rate renders correctly for mixed success/failure history
- [ ] Deleting a notifier cascades to remove its log rows (ON DELETE CASCADE)

Closes #476