### PR TITLE
feat(#515): time-to-finish estimator on tracked shows

### DIFF
--- a/frontend/src/components/title-detail/ShowHero.tsx
+++ b/frontend/src/components/title-detail/ShowHero.tsx
@@ -8,6 +8,7 @@ import { NetworkList } from "./NetworkList";
 import { RatingBadge } from "./RatingBadge";
 import { backdropUrl as mkBackdropUrl, posterUrl as mkPosterUrl } from "../../lib/tmdb-images";
 import { getCertification } from "./utils";
+import { formatEta } from "../../pages/StatsPage";
 
 export interface ShowHeroProps {
   title: Title;
@@ -101,6 +102,11 @@ export default function ShowHero({ title, tmdb, country }: ShowHeroProps) {
           )}
           <TrackButton titleId={title.id} isTracked={title.is_tracked} titleData={title} />
         </div>
+        {title.is_tracked && title.eta_days != null && (
+          <div className="text-xs text-zinc-400 text-center">
+            Finish in ~{formatEta(title.eta_days)} at your current pace
+          </div>
+        )}
       </>
     );
   }
@@ -216,6 +222,11 @@ export default function ShowHero({ title, tmdb, country }: ShowHeroProps) {
             />
             <WatchButtonGroup offers={title.offers} variant="inline" maxVisible={3} />
           </div>
+          {title.is_tracked && title.eta_days != null && (
+            <div className="text-xs text-zinc-400">
+              Finish in ~{formatEta(title.eta_days)} at your current pace
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/pages/StatsPage.test.tsx
+++ b/frontend/src/pages/StatsPage.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, mock, afterEach } from "bun:test";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import type { ReactNode } from "react";
+import type { StatsResponse } from "../types";
+
+const baseStats: StatsResponse = {
+  overview: {
+    tracked_movies: 5,
+    tracked_shows: 10,
+    watched_movies: 3,
+    watched_episodes: 50,
+    watch_time_minutes: 3000,
+    watch_time_minutes_movies: 360,
+    watch_time_minutes_shows: 2640,
+  },
+  genres: [],
+  languages: [],
+  monthly: [],
+  shows_by_status: {
+    watching: 0,
+    caught_up: 0,
+    completed: 0,
+    not_started: 0,
+    unreleased: 0,
+    on_hold: 0,
+    dropped: 0,
+    plan_to_watch: 0,
+  },
+};
+
+const mockGetStats = mock(() => Promise.resolve(baseStats));
+
+mock.module("../api", () => ({
+  getStats: mockGetStats,
+}));
+
+const { default: StatsPage, formatEta } = await import("./StatsPage");
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
+
+afterEach(() => {
+  cleanup();
+  mockGetStats.mockReset();
+  mockGetStats.mockImplementation(() => Promise.resolve(baseStats));
+});
+
+describe("StatsPage", () => {
+  it("renders the Watchlist ETA tile with dash when pace is undefined", async () => {
+    render(<StatsPage />, { wrapper: Wrapper });
+    await waitFor(() => {
+      expect(screen.getByText("Watchlist ETA")).toBeDefined();
+    });
+    expect(screen.getByText("—")).toBeDefined();
+  });
+
+  it("renders the Watchlist ETA tile with dash when pace.watchlistEtaDays is null", async () => {
+    mockGetStats.mockImplementation(() =>
+      Promise.resolve({
+        ...baseStats,
+        pace: { minutesPerDay: null, watchlistEtaDays: null },
+      })
+    );
+    render(<StatsPage />, { wrapper: Wrapper });
+    await waitFor(() => {
+      expect(screen.getByText("Watchlist ETA")).toBeDefined();
+    });
+    expect(screen.getByText("—")).toBeDefined();
+  });
+
+  it("renders the Watchlist ETA tile with days value when pace is set", async () => {
+    mockGetStats.mockImplementation(() =>
+      Promise.resolve({
+        ...baseStats,
+        pace: { minutesPerDay: 60, watchlistEtaDays: 5 },
+      })
+    );
+    render(<StatsPage />, { wrapper: Wrapper });
+    await waitFor(() => {
+      expect(screen.getByText("Watchlist ETA")).toBeDefined();
+    });
+    expect(screen.getByText("5d")).toBeDefined();
+  });
+});
+
+describe("formatEta", () => {
+  it("returns — for null", () => {
+    expect(formatEta(null)).toBe("—");
+  });
+
+  it("returns '< 1 day' for 0 days", () => {
+    expect(formatEta(0)).toBe("< 1 day");
+  });
+
+  it("returns days for < 7", () => {
+    expect(formatEta(3)).toBe("3d");
+    expect(formatEta(6)).toBe("6d");
+  });
+
+  it("returns weeks for 7–29 days", () => {
+    expect(formatEta(7)).toBe("~1w");
+    expect(formatEta(14)).toBe("~2w");
+    expect(formatEta(21)).toBe("~3w");
+  });
+
+  it("returns months for 30+ days", () => {
+    expect(formatEta(30)).toBe("~1mo");
+    expect(formatEta(90)).toBe("~3mo");
+  });
+});

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -4,6 +4,14 @@ import { useApiCall } from "../hooks/useApiCall";
 
 const MONTH_NAMES = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
+export function formatEta(days: number | null): string {
+  if (days === null) return "—";
+  if (days === 0) return "< 1 day";
+  if (days < 7) return `${days}d`;
+  if (days < 30) return `~${Math.round(days / 7)}w`;
+  return `~${Math.round(days / 30)}mo`;
+}
+
 function formatMonth(ym: string): string {
   const [, m] = ym.split("-");
   return MONTH_NAMES[parseInt(m, 10) - 1] ?? ym;
@@ -118,8 +126,8 @@ export function StatsView() {
   if (loading || !data) {
     return (
       <div className="space-y-6">
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
-          {Array.from({ length: 5 }).map((_, i) => (
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4">
+          {Array.from({ length: 6 }).map((_, i) => (
             <div key={i} className="bg-zinc-900 rounded-xl p-4 h-20 animate-pulse" />
           ))}
         </div>
@@ -127,19 +135,24 @@ export function StatsView() {
     );
   }
 
-  const { overview, genres, languages, monthly, shows_by_status } = data;
+  const { overview, genres, languages, monthly, shows_by_status, pace } = data;
   const maxGenre = genres[0]?.count ?? 0;
   const maxLang = languages[0]?.count ?? 0;
 
   return (
     <div className="space-y-8 pb-8">
       {/* Overview */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4">
         <OverviewCard label="Movies Watched" value={overview.watched_movies} />
         <OverviewCard label="Episodes Watched" value={overview.watched_episodes} />
         <OverviewCard label="Shows Tracked" value={overview.tracked_shows} />
         <OverviewCard label="Movies Tracked" value={overview.tracked_movies} />
         <OverviewCard label="Watch Time" value={formatTime(overview.watch_time_minutes)} sub="total" />
+        <OverviewCard
+          label="Watchlist ETA"
+          value={formatEta(pace?.watchlistEtaDays ?? null)}
+          sub="at your current pace"
+        />
       </div>
 
       {/* Watch time breakdown */}

--- a/frontend/src/pages/TrackedPage.tsx
+++ b/frontend/src/pages/TrackedPage.tsx
@@ -14,7 +14,7 @@ import { useScrollRestoration } from "../hooks/useScrollRestoration";
 import { useIsMobile } from "../hooks/useIsMobile";
 import { PageHeader, Pill } from "../components/design";
 import BackdateWatchedButton from "../components/BackdateWatchedButton";
-import { StatsView } from "./StatsPage";
+import { StatsView, formatEta } from "./StatsPage";
 import {
   AlertDialog,
   AlertDialogPopup,
@@ -388,6 +388,9 @@ function TrackedTable({ titles, onRefetch, selectMode = false, selectedIds = new
                     <span className="font-mono text-[10px] text-zinc-400 shrink-0">{watched}/{total}</span>
                   </div>
                 )}
+                {title.eta_days != null && (
+                  <span className="font-mono text-[10px] text-zinc-500">ETA: {formatEta(title.eta_days)}</span>
+                )}
               </div>
             </>
           );
@@ -525,6 +528,9 @@ function TrackedTable({ titles, onRefetch, selectMode = false, selectedIds = new
                     </div>
                     <span className="font-mono text-[11px] text-zinc-400 shrink-0">{watched}/{total}</span>
                   </div>
+                  {title.eta_days != null && (
+                    <span className="font-mono text-[10px] text-zinc-500">ETA: {formatEta(title.eta_days)}</span>
+                  )}
                 </div>
               ) : (
                 <div className="font-mono text-[11px] text-zinc-600">—</div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -54,6 +54,8 @@ export interface Title {
   tracked_at?: string;
   notes?: string;
   tags?: string[];
+  remaining_minutes?: number | null;
+  eta_days?: number | null;
 }
 
 export interface Episode {
@@ -407,6 +409,10 @@ export interface StatsResponse {
     on_hold: number;
     dropped: number;
     plan_to_watch: number;
+  };
+  pace?: {
+    minutesPerDay: number | null;
+    watchlistEtaDays: number | null;
   };
 }
 

--- a/server/db/repository/stats.test.ts
+++ b/server/db/repository/stats.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
+import { makeParsedTitle } from "../../test-utils/fixtures";
+import { upsertTitles, createUser, upsertEpisodes, watchEpisode } from "../repository";
+import { logWatch } from "./watch-history";
+import { getUserPace, computeEta } from "./stats";
+import { getRawDb } from "../bun-db";
+
+let userId: string;
+
+beforeEach(async () => {
+  setupTestDb();
+  userId = await createUser("testuser", "hash");
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+async function insertShow(id: string, runtimeMinutes: number | null = 45) {
+  await upsertTitles([
+    makeParsedTitle({ id, objectType: "SHOW", title: `Show ${id}`, runtimeMinutes }),
+  ]);
+}
+
+async function insertEpisodeForShow(
+  showId: string,
+  season: number,
+  episode: number,
+  airDate: string,
+): Promise<number> {
+  await upsertEpisodes([
+    {
+      title_id: showId,
+      season_number: season,
+      episode_number: episode,
+      name: `S${season}E${episode}`,
+      overview: null,
+      air_date: airDate,
+      still_path: null,
+    },
+  ]);
+  const db = getRawDb();
+  const row = db
+    .prepare(
+      `SELECT id FROM episodes WHERE title_id = ? AND season_number = ? AND episode_number = ?`,
+    )
+    .get(showId, season, episode) as { id: number } | undefined;
+  if (!row) throw new Error("Episode not found after insert");
+  return row.id;
+}
+
+// Insert a watch_history row with a specific watched_at date
+async function insertWatchHistory(
+  titleId: string,
+  episodeId: number,
+  watchedAt: string,
+) {
+  await logWatch(userId, titleId, episodeId, watchedAt);
+}
+
+describe("getUserPace", () => {
+  it("returns null when no watch history", async () => {
+    const pace = await getUserPace(userId);
+    expect(pace.minutesPerDay).toBeNull();
+  });
+
+  it("computes pace from watch_history", async () => {
+    await insertShow("show-1", 60);
+    const epId = await insertEpisodeForShow("show-1", 1, 1, "2024-01-01");
+    // Watch within last 30 days
+    const recentDate = new Date();
+    recentDate.setDate(recentDate.getDate() - 5);
+    await insertWatchHistory("show-1", epId, recentDate.toISOString());
+
+    const pace = await getUserPace(userId);
+    // 1 episode * 60 min / 30 days = 2 min/day
+    expect(pace.minutesPerDay).toBeCloseTo(2, 5);
+  });
+
+  it("falls back to watched_episodes when watch_history empty", async () => {
+    await insertShow("show-2", 30);
+    const epId = await insertEpisodeForShow("show-2", 1, 1, "2024-01-01");
+    // Mark as watched (goes into watched_episodes) with recent date
+    const recentDate = new Date();
+    recentDate.setDate(recentDate.getDate() - 10);
+    // Insert directly into watched_episodes with a recent watchedAt
+    const db = getRawDb();
+    db.prepare(
+      `INSERT OR IGNORE INTO watched_episodes (episode_id, user_id, watched_at) VALUES (?, ?, ?)`,
+    ).run(epId, userId, recentDate.toISOString());
+
+    const pace = await getUserPace(userId);
+    // 1 episode * 30 min / 30 days = 1 min/day
+    expect(pace.minutesPerDay).toBeCloseTo(1, 5);
+  });
+
+  it("returns null (not 0) when pace is 0 — no episodes watched in last 30 days", async () => {
+    await insertShow("show-3", 45);
+    const epId = await insertEpisodeForShow("show-3", 1, 1, "2023-01-01");
+    // Watched 60 days ago — outside the 30-day window
+    const oldDate = new Date();
+    oldDate.setDate(oldDate.getDate() - 60);
+    await insertWatchHistory("show-3", epId, oldDate.toISOString());
+
+    const pace = await getUserPace(userId);
+    expect(pace.minutesPerDay).toBeNull();
+  });
+
+  it("ignores episodes from shows with null runtime_minutes", async () => {
+    await insertShow("show-4", null); // no runtime set
+    const epId = await insertEpisodeForShow("show-4", 1, 1, "2024-01-01");
+    const recentDate = new Date();
+    recentDate.setDate(recentDate.getDate() - 5);
+    await insertWatchHistory("show-4", epId, recentDate.toISOString());
+
+    const pace = await getUserPace(userId);
+    expect(pace.minutesPerDay).toBeNull();
+  });
+});
+
+describe("computeEta", () => {
+  it("returns null when minutesPerDay is null", () => {
+    expect(computeEta(300, null)).toBeNull();
+  });
+
+  it("returns null when minutesPerDay is 0", () => {
+    expect(computeEta(300, 0)).toBeNull();
+  });
+
+  it("returns null when minutesPerDay is negative", () => {
+    expect(computeEta(300, -5)).toBeNull();
+  });
+
+  it("computes correct ETA", () => {
+    // 600 minutes remaining, 60 min/day => 10 days
+    expect(computeEta(600, 60)).toBe(10);
+  });
+
+  it("rounds up fractional days", () => {
+    // 61 minutes remaining, 60 min/day => ceil(61/60) = 2
+    expect(computeEta(61, 60)).toBe(2);
+  });
+
+  it("returns 0 days when remaining is 0", () => {
+    expect(computeEta(0, 60)).toBe(0);
+  });
+});

--- a/server/db/repository/stats.ts
+++ b/server/db/repository/stats.ts
@@ -200,6 +200,39 @@ export async function getShowsByStatus(userId: string): Promise<ShowsByStatus> {
   });
 }
 
+export interface UserPace {
+  minutesPerDay: number | null;
+}
+
+export async function getUserPace(userId: string): Promise<UserPace> {
+  return traceDbQuery("getUserPace", async () => {
+    const db = getDb();
+    // Episodes don't have per-episode runtime; use the parent title's runtime_minutes
+    // as a proxy for each episode's duration (typical for shows).
+    const rows = await db.all<{ total_minutes: number }>(sql`
+      SELECT COALESCE(SUM(ti.runtime_minutes), 0) AS total_minutes
+      FROM (
+        SELECT episode_id FROM watch_history
+        WHERE user_id = ${userId} AND watched_at >= datetime('now', '-30 days')
+        UNION
+        SELECT episode_id FROM watched_episodes
+        WHERE user_id = ${userId} AND watched_at >= datetime('now', '-30 days')
+      ) watched
+      JOIN episodes e ON e.id = watched.episode_id
+      JOIN titles ti ON ti.id = e.title_id
+      WHERE ti.runtime_minutes IS NOT NULL
+    `);
+    const total = rows[0]?.total_minutes ?? 0;
+    if (total === 0) return { minutesPerDay: null };
+    return { minutesPerDay: total / 30 };
+  });
+}
+
+export function computeEta(remainingMinutes: number, minutesPerDay: number | null): number | null {
+  if (!minutesPerDay || minutesPerDay <= 0) return null;
+  return Math.ceil(remainingMinutes / minutesPerDay);
+}
+
 /** Returns an array of YYYY-MM strings for the last N months (oldest first). */
 export function buildMonthRange(count: number): string[] {
   const months: string[] = [];

--- a/server/db/repository/tracked.ts
+++ b/server/db/repository/tracked.ts
@@ -92,6 +92,18 @@ export async function getTrackedTitles(userId: string) {
         released_episodes_count: sql<number>`(SELECT COUNT(*) FROM episodes e WHERE e.title_id = ${titles.id} AND e.air_date <= date('now'))`,
         latest_released_air_date: sql<string | null>`(SELECT MAX(e.air_date) FROM episodes e WHERE e.title_id = ${titles.id} AND e.air_date <= date('now'))`,
         next_episode_air_date: sql<string | null>`(SELECT MIN(e.air_date) FROM episodes e WHERE e.title_id = ${titles.id} AND e.air_date > date('now'))`,
+        remaining_runtime_minutes: sql<number | null>`(
+          CASE WHEN ${titles.runtimeMinutes} IS NULL THEN NULL
+          ELSE (
+            SELECT COUNT(e2.id) * ${titles.runtimeMinutes}
+            FROM episodes e2
+            WHERE e2.title_id = ${titles.id}
+              AND e2.air_date <= date('now')
+              AND e2.id NOT IN (
+                SELECT we2.episode_id FROM watched_episodes we2 WHERE we2.user_id = ${userId}
+              )
+          ) END
+        )`,
       })
       .from(tracked)
       .innerJoin(titles, eq(titles.id, tracked.titleId))

--- a/server/routes/details.ts
+++ b/server/routes/details.ts
@@ -14,6 +14,9 @@ import { parseMovieDetails, parseTvDetails } from "../tmdb/parser";
 import type { AppEnv } from "../types";
 import { logger } from "../logger";
 import { ok, err } from "./response";
+import { getUserPace, computeEta } from "../db/repository/stats";
+import { getDb } from "../db/schema";
+import { sql } from "drizzle-orm";
 
 const log = logger.child({ module: "details" });
 
@@ -73,7 +76,8 @@ app.get("/movie/:id", async (c) => {
 
 app.get("/show/:id", async (c) => {
   const user = c.get("user");
-  const title = await getOrFetchTitle(c.req.param("id"), user?.id);
+  const titleId = c.req.param("id");
+  const title = await getOrFetchTitle(titleId, user?.id);
   if (!title) return err(c, "Title not found", 404);
 
   let tmdb = null;
@@ -85,7 +89,34 @@ app.get("/show/:id", async (c) => {
     }
   }
 
-  return ok(c, { title, tmdb, country });
+  let etaDays: number | null = null;
+  if (user && title.is_tracked) {
+    try {
+      const db = getDb();
+      // Episodes don't store per-episode runtime; use the title's runtime_minutes as proxy
+      const remainingRows = await db.all<{ remaining_minutes: number }>(sql`
+        SELECT COALESCE(
+          (SELECT COUNT(e.id) FROM episodes e
+           WHERE e.title_id = ${titleId}
+             AND e.air_date <= date('now')
+             AND e.id NOT IN (
+               SELECT we.episode_id FROM watched_episodes we WHERE we.user_id = ${user.id}
+             )
+          ) * (SELECT t.runtime_minutes FROM titles t WHERE t.id = ${titleId}),
+          0
+        ) AS remaining_minutes
+      `);
+      const remainingMinutes = remainingRows[0]?.remaining_minutes ?? 0;
+      if (remainingMinutes > 0) {
+        const pace = await getUserPace(user.id);
+        etaDays = computeEta(remainingMinutes, pace.minutesPerDay);
+      }
+    } catch (e) {
+      log.error("ETA computation failed", { titleId, err: e });
+    }
+  }
+
+  return ok(c, { title: { ...title, eta_days: etaDays }, tmdb, country });
 });
 
 app.get("/show/:id/season/:season", async (c) => {

--- a/server/routes/stats.test.ts
+++ b/server/routes/stats.test.ts
@@ -51,6 +51,10 @@ describe("GET /stats", () => {
     expect(body.languages).toHaveLength(0);
     expect(body.monthly).toHaveLength(13);
     expect(body.monthly[0].movies_watched).toBe(0);
+    // pace field should be present with nulls when no watch history
+    expect(body.pace).toBeDefined();
+    expect(body.pace.minutesPerDay).toBeNull();
+    expect(body.pace.watchlistEtaDays).toBeNull();
     expect(body.monthly[0].episodes_watched).toBe(0);
   });
 

--- a/server/routes/stats.ts
+++ b/server/routes/stats.ts
@@ -7,25 +7,41 @@ import {
   getUserLanguageBreakdown,
   getMonthlyActivity,
   getShowsByStatus,
+  getUserPace,
+  computeEta,
 } from "../db/repository/stats";
+import { getTrackedTitles } from "../db/repository/tracked";
 
 const app = new Hono<AppEnv>();
 
 app.get("/", async (c) => {
   const user = c.get("user")!;
-  const [overview, genres, languages, monthly, showsByStatus] = await Promise.all([
+  const [overview, genres, languages, monthly, showsByStatus, pace, tracked] = await Promise.all([
     getStatsOverview(user.id),
     getUserGenreBreakdown(user.id, 10),
     getUserLanguageBreakdown(user.id, 10),
     getMonthlyActivity(user.id, 13),
     getShowsByStatus(user.id),
+    getUserPace(user.id),
+    getTrackedTitles(user.id),
   ]);
+
+  const totalRemainingMinutes = tracked.reduce(
+    (sum, t) => sum + (t.remaining_runtime_minutes ?? 0),
+    0,
+  );
+  const watchlistEtaDays = computeEta(totalRemainingMinutes, pace.minutesPerDay);
+
   return ok(c, {
     overview,
     genres,
     languages,
     monthly,
     shows_by_status: showsByStatus,
+    pace: {
+      minutesPerDay: pace.minutesPerDay,
+      watchlistEtaDays,
+    },
   });
 });
 

--- a/server/routes/track.ts
+++ b/server/routes/track.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { trackTitle, untrackTitle, getTrackedTitles, upsertTitles, getWatchedEpisodesForExport, getEpisodeIdsBySE, watchEpisodesBulk, getWatchedTitleIds, watchTitle, updateTrackedVisibility, updateAllTrackedVisibility, updateProfilePublic, getUserById, updateTrackedStatus, updateNotificationMode, updateTrackedNotes, setTags, getTagsForTitle } from "../db/repository";
+import { getUserPace, computeEta } from "../db/repository/stats";
 import type { UserStatus, NotificationMode } from "../db/repository";
 import type { ParsedTitle } from "../tmdb/parser";
 import { CONFIG } from "../config";
@@ -16,13 +17,19 @@ const app = new Hono<AppEnv>();
 
 app.get("/", async (c) => {
   const user = c.get("user")!;
-  const [titles, fullUser] = await Promise.all([
+  const [titles, fullUser, pace] = await Promise.all([
     getTrackedTitles(user.id),
     getUserById(user.id),
+    getUserPace(user.id),
   ]);
+  const titlesWithEta = titles.map((t) => ({
+    ...t,
+    remaining_minutes: t.remaining_runtime_minutes ?? null,
+    eta_days: computeEta(t.remaining_runtime_minutes ?? 0, pace.minutesPerDay),
+  }));
   return ok(c, {
-    titles,
-    count: titles.length,
+    titles: titlesWithEta,
+    count: titlesWithEta.length,
     profile_public: Boolean(fullUser?.profile_public),
     profile_visibility: fullUser?.profile_visibility ?? (fullUser?.profile_public ? "public" : "private"),
   });


### PR DESCRIPTION
## Summary
- `getUserPace()`: trailing-30-day avg viewing pace (minutes/day), with UNION fallback to `watched_episodes` for import-only users; uses title `runtime_minutes` as a proxy for per-episode duration (episodes table has no per-episode runtime column)
- Per-show `remaining_runtime_minutes` and `eta_days` in tracked list and show detail responses
- Watchlist ETA (sum of all remaining minutes / pace) in Stats
- TrackedPage: ETA badge per show card (mobile + desktop list view)
- ShowHero: "Finish in ~Xd at your current pace" badge for tracked shows (mobile + desktop)
- StatsPage: Watchlist ETA tile with `formatEta()` helper
- Edge cases: pace=0 or unknown → renders "—", never NaN/Infinity

## Test plan
- [ ] `bun run check` passes (2198 tests, 0 failures)
- [ ] Track an in-progress show, mark some episodes watched → ETA appears on TrackedPage and ShowHero
- [ ] User with zero history → "—" everywhere (no crash)
- [ ] Stats page shows Watchlist ETA tile
- [ ] `getUserPace` unit tests cover: no history, watch_history pace, watched_episodes fallback, outside-window returns null, null runtime ignored
- [ ] `formatEta` tests cover: null, 0, days, weeks, months

Closes #515