### PR TITLE
docs: add branch naming convention to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,12 @@ docker compose up --build
 bun run deploy:cf            # Deploy to Cloudflare
 ```
 
+## Branch naming
+
+- Claude-authored branches: `claude/NNN-short-description` where NNN is the issue number (e.g. `claude/524-pinned-favorites`)
+- Human-authored branches use `feat/`, `fix/`, or `refactor/` prefixes (e.g. `fix/498-semantic-button-chips`)
+- Never create branches without a prefix — bare names like `pinned-favorites` or `notification-log` are non-standard
+
 ## Testing Rules
 
 **Every change must include tests.** New features need unit tests. Bug fixes need regression tests.


### PR DESCRIPTION
## Summary
- Documents the `claude/NNN-description` naming pattern for Claude-authored branches
- Documents `feat/`/`fix/`/`refactor/` prefixes for human-authored branches
- Prevents bare branch names like `pinned-favorites` or `notification-log`

Noticed during the parallel PR batch (#608–#612) where agent branches lacked the standard prefix.