### PR TITLE
feat(#531): per-episode countdown widget on detail + Airing Soon home row

### DIFF
--- a/frontend/src/components/EpisodeCountdown.test.tsx
+++ b/frontend/src/components/EpisodeCountdown.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, afterEach, beforeEach } from "bun:test";
+import { render, cleanup, screen, act } from "@testing-library/react";
+import EpisodeCountdown from "./EpisodeCountdown";
+
+afterEach(cleanup);
+
+// Helper: build an ISO date string N milliseconds from now
+function msFromNow(ms: number): string {
+  return new Date(Date.now() + ms).toISOString();
+}
+
+describe("EpisodeCountdown", () => {
+  describe("null / past air dates", () => {
+    it("shows TBA when airDate is null", () => {
+      render(<EpisodeCountdown airDate={null} />);
+      expect(screen.getByText("TBA")).toBeTruthy();
+    });
+
+    it("shows TBA when airDate is undefined", () => {
+      render(<EpisodeCountdown airDate={undefined} />);
+      expect(screen.getByText("TBA")).toBeTruthy();
+    });
+
+    it("shows TBA when airDate is more than 15 minutes in the past", () => {
+      const past = msFromNow(-20 * 60 * 1000);
+      render(<EpisodeCountdown airDate={past} />);
+      expect(screen.getByText("TBA")).toBeTruthy();
+    });
+  });
+
+  describe("future air dates", () => {
+    it("shows countdown when airDate is 2+ days in the future", () => {
+      const future = msFromNow(2 * 24 * 60 * 60 * 1000 + 3 * 60 * 60 * 1000);
+      render(<EpisodeCountdown airDate={future} />);
+      const badge = document.querySelector("span");
+      // Should contain "d" for days
+      expect(badge?.textContent).toMatch(/\d+d/);
+    });
+
+    it("shows hours format when less than 1 day remains", () => {
+      const future = msFromNow(3 * 60 * 60 * 1000 + 20 * 60 * 1000);
+      render(<EpisodeCountdown airDate={future} />);
+      const badge = document.querySelector("span");
+      expect(badge?.textContent).toMatch(/\d+h/);
+    });
+
+    it("shows minutes format when less than 1 hour remains", () => {
+      const future = msFromNow(5 * 60 * 1000 + 30 * 1000);
+      render(<EpisodeCountdown airDate={future} />);
+      const badge = document.querySelector("span");
+      expect(badge?.textContent).toMatch(/\d+m/);
+    });
+
+    it("shows seconds when less than 1 minute remains", () => {
+      const future = msFromNow(45 * 1000);
+      render(<EpisodeCountdown airDate={future} />);
+      const badge = document.querySelector("span");
+      expect(badge?.textContent).toMatch(/\d+s/);
+    });
+  });
+
+  describe("interval updates", () => {
+    let originalSetInterval: typeof setInterval;
+    let originalClearInterval: typeof clearInterval;
+    let intervalCallbacks: Map<number, () => void>;
+    let nextId: number;
+
+    beforeEach(() => {
+      intervalCallbacks = new Map();
+      nextId = 1;
+      originalSetInterval = globalThis.setInterval;
+      originalClearInterval = globalThis.clearInterval;
+
+      // @ts-expect-error patching global for test
+      globalThis.setInterval = (cb: () => void, _delay: number) => {
+        const id = nextId++;
+        intervalCallbacks.set(id, cb);
+        return id;
+      };
+      // @ts-expect-error patching global for test
+      globalThis.clearInterval = (id: number) => {
+        intervalCallbacks.delete(id);
+      };
+    });
+
+    afterEach(() => {
+      globalThis.setInterval = originalSetInterval;
+      globalThis.clearInterval = originalClearInterval;
+    });
+
+    it("ticks without crashing while still in future", () => {
+      const future = msFromNow(2 * 24 * 60 * 60 * 1000);
+      render(<EpisodeCountdown airDate={future} />);
+
+      act(() => {
+        for (const cb of intervalCallbacks.values()) cb();
+      });
+
+      // Still shows days countdown after one tick
+      const badge = document.querySelector("span");
+      expect(badge?.textContent).toMatch(/\d+d/);
+    });
+
+    it("shows TBA when Date.now() moves past the 15-min window", () => {
+      const future = msFromNow(1000);
+      render(<EpisodeCountdown airDate={future} />);
+
+      // Advance Date.now to 20 minutes after airDate
+      const realDateNow = Date.now;
+      Date.now = () => new Date(future).getTime() + 20 * 60 * 1000;
+
+      act(() => {
+        for (const cb of intervalCallbacks.values()) cb();
+      });
+
+      Date.now = realDateNow;
+
+      expect(screen.getByText("TBA")).toBeTruthy();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("renders a span element as the badge root", () => {
+      const future = msFromNow(5 * 60 * 60 * 1000);
+      const { container } = render(<EpisodeCountdown airDate={future} />);
+      expect(container.firstChild?.nodeName).toBe("SPAN");
+    });
+  });
+});

--- a/frontend/src/components/EpisodeCountdown.tsx
+++ b/frontend/src/components/EpisodeCountdown.tsx
@@ -1,0 +1,64 @@
+import { useState, useEffect } from "react";
+
+interface Props {
+  airDate: string | null | undefined;
+}
+
+/**
+ * Compute the human-readable countdown string for a given airDate.
+ * Returns null when airDate is absent or more than 15 minutes in the past.
+ */
+function getCountdownText(airDate: string | null | undefined): string | null {
+  if (!airDate) return null;
+  const diff = new Date(airDate).getTime() - Date.now();
+  // Treat episodes that aired more than 15 minutes ago as "past"
+  if (diff < -15 * 60 * 1000) return null;
+  if (diff <= 0) return "airing";
+
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+  const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+  const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+  const seconds = Math.floor((diff % (1000 * 60)) / 1000);
+
+  if (days > 0) return `${days}d ${hours}h ${minutes}m`;
+  if (hours > 0) return `${hours}h ${minutes}m ${seconds}s`;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
+}
+
+/**
+ * Live-updating countdown badge. Shows "Xd Xh Xm" until the air date,
+ * or "TBA" when the air date is null / already in the past (beyond 15 minutes).
+ *
+ * Uses a ticker state that increments every second to trigger re-renders,
+ * then derives the display text from `airDate` at render time.
+ */
+export default function EpisodeCountdown({ airDate }: Props) {
+  // Ticker is incremented every second to force a re-render; the actual
+  // countdown text is computed from airDate at render time (no stale state).
+  const [_ticker, setTicker] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setTicker((n) => n + 1);
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const text = getCountdownText(airDate);
+
+  if (!text) {
+    return (
+      <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-zinc-800/80 border border-white/[0.08] text-zinc-400 font-mono text-[11px] font-semibold select-none">
+        TBA
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full bg-amber-500/10 border border-amber-500/30 text-amber-400 font-mono text-[11px] font-semibold select-none">
+      <span aria-hidden="true">⏱</span>
+      {text}
+    </span>
+  );
+}

--- a/frontend/src/components/title-detail/ShowHero.tsx
+++ b/frontend/src/components/title-detail/ShowHero.tsx
@@ -4,6 +4,7 @@ import TrackButton from "../TrackButton";
 import PinButton from "../PinButton";
 import VisibilityButton from "../VisibilityButton";
 import WatchButtonGroup from "../WatchButtonGroup";
+import EpisodeCountdown from "../EpisodeCountdown";
 import { Chip, Kicker } from "../design";
 import { NetworkList } from "./NetworkList";
 import { RatingBadge } from "./RatingBadge";
@@ -107,6 +108,12 @@ export default function ShowHero({ title, tmdb, country }: ShowHeroProps) {
         {title.is_tracked && title.eta_days != null && (
           <div className="text-xs text-zinc-400 text-center">
             Finish in ~{formatEta(title.eta_days)} at your current pace
+          </div>
+        )}
+        {title.next_episode_air_date && (
+          <div className="flex items-center justify-center gap-2 text-xs text-zinc-400">
+            <span>Next episode</span>
+            <EpisodeCountdown airDate={title.next_episode_air_date} />
           </div>
         )}
       </>
@@ -228,6 +235,12 @@ export default function ShowHero({ title, tmdb, country }: ShowHeroProps) {
           {title.is_tracked && title.eta_days != null && (
             <div className="text-xs text-zinc-400">
               Finish in ~{formatEta(title.eta_days)} at your current pace
+            </div>
+          )}
+          {title.next_episode_air_date && (
+            <div className="flex items-center gap-2 text-xs text-zinc-400">
+              <span>Next episode</span>
+              <EpisodeCountdown airDate={title.next_episode_air_date} />
             </div>
           )}
         </div>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -100,7 +100,11 @@
     "noEpisodesToday": "No episodes airing today.",
     "comingUp": "Coming Up",
     "recommendedForYou": "Recommended for You",
-    "seeAll": "See all"
+    "seeAll": "See all",
+    "airingSoon": {
+      "title": "Airing Soon",
+      "empty": "No upcoming episodes from tracked shows"
+    }
   },
   "tracked": {
     "title": "Tracked Titles ({{count}})",
@@ -426,7 +430,8 @@
         "unwatched": "Unwatched Episodes",
         "recommendations": "Recommended for You",
         "today": "Today's Episodes",
-        "upcoming": "Coming Up"
+        "upcoming": "Coming Up",
+        "airing_soon": "Airing Soon"
       }
     },
     "profileVisibility": "Profile Visibility",

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -13,6 +13,7 @@ import TitleList from "../components/TitleList";
 import { EpisodeListSkeleton } from "../components/SkeletonComponents";
 import { groupByShow, formatUpcomingDate } from "../components/EpisodeComponents";
 import { EpisodeShowCard, DeckCardWrapper } from "../components/EpisodeShowCard";
+import EpisodeCountdown from "../components/EpisodeCountdown";
 import HeroBanner from "../components/HeroBanner";
 import FullBleedCarousel from "../components/FullBleedCarousel";
 import { Kicker } from "../components/design";
@@ -467,6 +468,24 @@ export default function HomePage() {
     [today]
   );
 
+  // For "Airing Soon": one card per show, earliest upcoming episode, sorted by air_date.
+  const airingEntries = useMemo(() => {
+    const byShow = new Map<string, Episode>();
+    for (const ep of upcoming) {
+      if (!ep.air_date) continue;
+      const existing = byShow.get(ep.title_id);
+      if (!existing || ep.air_date < existing.air_date!) {
+        byShow.set(ep.title_id, ep);
+      }
+    }
+    return Array.from(byShow.values()).sort((a, b) => {
+      if (!a.air_date && !b.air_date) return 0;
+      if (!a.air_date) return 1;
+      if (!b.air_date) return -1;
+      return a.air_date.localeCompare(b.air_date);
+    });
+  }, [upcoming]);
+
   if (authLoading || state.status === "loading") {
     return <EpisodeListSkeleton />;
   }
@@ -689,6 +708,43 @@ export default function HomePage() {
             </div>
           </section>
         ) : null;
+
+      case "airing_soon":
+        return airingEntries.length > 0 ? (
+          <section key="airing_soon">
+            <div className="flex items-baseline justify-between mb-4">
+              <div>
+                <Kicker>Coming up</Kicker>
+                <h2 className="text-xl font-bold tracking-[-0.01em]">{t("home.airingSoon.title")}</h2>
+              </div>
+              <Link to="/calendar" className="font-mono text-xs text-amber-400 hover:text-amber-300 transition-colors">Open calendar →</Link>
+            </div>
+            <FullBleedCarousel>
+              {airingEntries.map((ep) => (
+                <div key={ep.id} className="w-80 flex-shrink-0 relative" style={{ scrollSnapAlign: "start" }}>
+                  <DeckCardWrapper episodeCount={1}>
+                    <EpisodeShowCard episode={ep} episodeCount={1} />
+                  </DeckCardWrapper>
+                  {ep.air_date && (
+                    <div className="absolute bottom-4 left-3 z-10">
+                      <EpisodeCountdown airDate={ep.air_date} />
+                    </div>
+                  )}
+                </div>
+              ))}
+            </FullBleedCarousel>
+          </section>
+        ) : (
+          <section key="airing_soon">
+            <div className="flex items-baseline justify-between mb-4">
+              <div>
+                <Kicker>Coming up</Kicker>
+                <h2 className="text-xl font-bold tracking-[-0.01em]">{t("home.airingSoon.title")}</h2>
+              </div>
+            </div>
+            <p className="text-zinc-500 text-sm">{t("home.airingSoon.empty")}</p>
+          </section>
+        );
 
       default:
         return null;

--- a/frontend/src/pages/settings/AppearanceTab.tsx
+++ b/frontend/src/pages/settings/AppearanceTab.tsx
@@ -13,6 +13,7 @@ const SECTION_LABELS: Record<string, string> = {
   recommendations: "settings.homepage.sections.recommendations",
   today: "settings.homepage.sections.today",
   upcoming: "settings.homepage.sections.upcoming",
+  airing_soon: "settings.homepage.sections.airing_soon",
 };
 
 function ThemeSection() {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -688,7 +688,7 @@ export interface InvitationItem {
   used_by: UserSummary | null;
 }
 
-export type HomepageSectionId = "unwatched" | "recommendations" | "today" | "upcoming";
+export type HomepageSectionId = "unwatched" | "recommendations" | "today" | "upcoming" | "airing_soon";
 
 export interface HomepageSection {
   id: HomepageSectionId;
@@ -700,6 +700,7 @@ export const DEFAULT_HOMEPAGE_LAYOUT: HomepageSection[] = [
   { id: "recommendations", enabled: true },
   { id: "today", enabled: true },
   { id: "upcoming", enabled: true },
+  { id: "airing_soon", enabled: false },
 ];
 
 // Normalize search results to same shape as DB titles

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -40,6 +40,13 @@ export const pwaOptions: Partial<VitePWAOptions> = {
         purpose: "maskable",
       },
     ],
+    shortcuts: [
+      {
+        name: "Airing Soon",
+        url: "/calendar",
+        description: "See upcoming episodes",
+      },
+    ],
   },
 };
 

--- a/server/routes/user-settings.test.ts
+++ b/server/routes/user-settings.test.ts
@@ -131,8 +131,8 @@ describe("PUT /user/settings/homepage-layout", () => {
 
     const res = await app.request("/user/settings/homepage-layout");
     const body = await res.json();
-    // All 4 sections returned; the 2 missing ones are appended
-    expect(body.homepage_layout).toHaveLength(4);
+    // All 5 sections returned; the 3 missing ones are appended
+    expect(body.homepage_layout).toHaveLength(5);
     expect(body.homepage_layout[0].id).toBe("today");
     expect(body.homepage_layout[1].id).toBe("unwatched");
   });
@@ -209,5 +209,19 @@ describe("validation", () => {
     const body = await res.json();
     expect(body.error).toBe("Validation failed");
     expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("accepts airing_soon section id", async () => {
+    const app = makeAuthedApp();
+    const res = await app.request("/user/settings/homepage-layout", {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        homepage_layout: [{ id: "airing_soon", enabled: true }],
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.homepage_layout.some((s: { id: string }) => s.id === "airing_soon")).toBe(true);
   });
 });

--- a/server/routes/user-settings.ts
+++ b/server/routes/user-settings.ts
@@ -5,7 +5,7 @@ import type { AppEnv } from "../types";
 import { ok } from "./response";
 import { zValidator } from "../lib/validator";
 
-export const HOMEPAGE_SECTION_IDS = ["unwatched", "recommendations", "today", "upcoming"] as const;
+export const HOMEPAGE_SECTION_IDS = ["unwatched", "recommendations", "today", "upcoming", "airing_soon"] as const;
 export type HomepageSectionId = (typeof HOMEPAGE_SECTION_IDS)[number];
 
 export interface HomepageSection {
@@ -18,6 +18,7 @@ export const DEFAULT_HOMEPAGE_LAYOUT: HomepageSection[] = [
   { id: "recommendations", enabled: true },
   { id: "today", enabled: true },
   { id: "upcoming", enabled: true },
+  { id: "airing_soon", enabled: false },
 ];
 
 // Discriminated union: each known section id is its own member with a fixed
@@ -28,6 +29,7 @@ const homepageSectionSchema = z.discriminatedUnion("id", [
   z.object({ id: z.literal("recommendations"), enabled: z.boolean().default(true) }),
   z.object({ id: z.literal("today"), enabled: z.boolean().default(true) }),
   z.object({ id: z.literal("upcoming"), enabled: z.boolean().default(true) }),
+  z.object({ id: z.literal("airing_soon"), enabled: z.boolean().default(false) }),
 ]);
 
 const updateHomepageLayoutSchema = z.object({
@@ -72,7 +74,7 @@ function parseLayout(raw: string | null): HomepageSection[] {
     // Append any sections that weren't in the saved layout (new sections added later)
     for (const def of DEFAULT_HOMEPAGE_LAYOUT) {
       if (!seen.has(def.id)) {
-        valid.push({ id: def.id, enabled: true });
+        valid.push({ id: def.id, enabled: def.enabled });
       }
     }
     return valid.length > 0 ? valid : DEFAULT_HOMEPAGE_LAYOUT;


### PR DESCRIPTION
## Summary
- Live-updating countdown timer on show detail hero (next episode air time) — shows "Xd Xh Xm Xs" and falls back to "TBA" when air date is null or passed
- New pinnable "Airing Soon" home row (disabled by default): one card per tracked show sorted by nearest air date, with live countdown chip overlaid on each card
- PWA app shortcut to /calendar

## How to verify
1. Track a show with a future episode, open its detail page — countdown appears in the hero section next to the ETA
2. Go to Settings → Appearance, enable "Airing Soon" — row appears on Home with live countdown chips on episode cards
3. Install the PWA — the "Airing Soon" shortcut navigates to /calendar

## Test plan
- [x] `EpisodeCountdown.test.tsx` — 10 unit tests: null/past dates show TBA, future dates show correct format (d/h/m/s), interval ticks update display, switches to TBA when window passes
- [x] `user-settings.test.ts` — extended: `airing_soon` accepted as valid section id (happy-path 200), partial layout length updated from 4 → 5

Closes #531