### PR TITLE
Refactor episode countdown display into EpisodeShowCard

### DIFF
--- a/frontend/src/components/EpisodeShowCard.tsx
+++ b/frontend/src/components/EpisodeShowCard.tsx
@@ -9,12 +9,14 @@ import {
   isEpisodeReleased,
 } from "./EpisodeComponents";
 import WatchButtonGroup from "./WatchButtonGroup";
+import EpisodeCountdown from "./EpisodeCountdown";
 
 /** Shared card component used across Unwatched, Today, Coming Up, and Calendar sections */
 export const EpisodeShowCard = memo(function EpisodeShowCard({
   episode,
   episodeCount,
   showActions,
+  showCountdown,
   allEpisodeIds,
   onToggleWatched,
   onMarkAllWatched,
@@ -23,6 +25,7 @@ export const EpisodeShowCard = memo(function EpisodeShowCard({
   episode: Episode;
   episodeCount: number;
   showActions?: boolean;
+  showCountdown?: boolean;
   allEpisodeIds?: number[];
   onToggleWatched?: (id: number, current: boolean) => void;
   onMarkAllWatched?: (episodeIds: number[]) => void;
@@ -64,10 +67,16 @@ export const EpisodeShowCard = memo(function EpisodeShowCard({
           </p>
         </Link>
 
-        {/* Season + progress */}
-        <p className="text-xs text-zinc-500 mt-1.5">
-          {t("home.season", { number: episode.season_number })} · {t("home.episodesRemaining", { count: episodeCount })}
-        </p>
+        {/* Season + progress / countdown */}
+        {showCountdown ? (
+          <div className="mt-1.5">
+            <EpisodeCountdown airDate={episode.air_date} />
+          </div>
+        ) : (
+          <p className="text-xs text-zinc-500 mt-1.5">
+            {t("home.season", { number: episode.season_number })} · {t("home.episodesRemaining", { count: episodeCount })}
+          </p>
+        )}
 
         {/* Stream button — only for released episodes */}
         {isEpisodeReleased(episode) && (

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -13,7 +13,6 @@ import TitleList from "../components/TitleList";
 import { EpisodeListSkeleton } from "../components/SkeletonComponents";
 import { groupByShow, formatUpcomingDate } from "../components/EpisodeComponents";
 import { EpisodeShowCard, DeckCardWrapper } from "../components/EpisodeShowCard";
-import EpisodeCountdown from "../components/EpisodeCountdown";
 import HeroBanner from "../components/HeroBanner";
 import FullBleedCarousel from "../components/FullBleedCarousel";
 import { Kicker } from "../components/design";
@@ -721,15 +720,10 @@ export default function HomePage() {
             </div>
             <FullBleedCarousel>
               {airingEntries.map((ep) => (
-                <div key={ep.id} className="w-80 flex-shrink-0 relative" style={{ scrollSnapAlign: "start" }}>
+                <div key={ep.id} className="w-80 flex-shrink-0" style={{ scrollSnapAlign: "start" }}>
                   <DeckCardWrapper episodeCount={1}>
-                    <EpisodeShowCard episode={ep} episodeCount={1} />
+                    <EpisodeShowCard episode={ep} episodeCount={1} showCountdown />
                   </DeckCardWrapper>
-                  {ep.air_date && (
-                    <div className="absolute bottom-4 left-3 z-10">
-                      <EpisodeCountdown airDate={ep.air_date} />
-                    </div>
-                  )}
                 </div>
               ))}
             </FullBleedCarousel>


### PR DESCRIPTION
## Summary
Moved the episode countdown display logic from the HomePage carousel into the EpisodeShowCard component, making it more reusable and improving code organization.

## Key Changes
- Added `showCountdown` optional prop to EpisodeShowCard to conditionally display countdown instead of season/progress info
- Integrated EpisodeCountdown component directly into EpisodeShowCard's rendering logic
- Removed duplicate countdown rendering from HomePage's airing episodes carousel
- Removed unnecessary `relative` positioning class from carousel item wrapper
- Removed EpisodeCountdown import from HomePage (now only imported in EpisodeShowCard)

## Implementation Details
- The countdown display is now controlled via the `showCountdown` prop, allowing the same card component to display different information based on context
- When `showCountdown` is true, the countdown replaces the season/episodes remaining text
- This reduces code duplication and makes the component more flexible for future use cases

https://claude.ai/code/session_01KsdDVgendRFD6aH6v2VNyc