### PR TITLE
feat(#529): public shareable watchlist via unguessable token

### DIFF
--- a/drizzle/0036_users_watchlist_share_token.sql
+++ b/drizzle/0036_users_watchlist_share_token.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `users` ADD `watchlist_share_token` text;--> statement-breakpoint
+CREATE UNIQUE INDEX `users_watchlist_share_token_idx` ON `users` (`watchlist_share_token`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1778112000000,
       "tag": "0035_notification_log",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "6",
+      "when": 1778198400000,
+      "tag": "0036_users_watchlist_share_token",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,6 +38,7 @@ const AdminUsersPage = lazyWithRetry(() => import("./pages/AdminUsersPage"));
 const NotFoundPage = lazyWithRetry(() => import("./pages/NotFoundPage"));
 const MorePage = lazyWithRetry(() => import("./pages/MorePage"));
 const KioskPage = lazyWithRetry(() => import("./pages/KioskPage"));
+const SharedWatchlistPage = lazyWithRetry(() => import("./pages/SharedWatchlistPage"));
 
 // Wraps a route element in an inline ErrorBoundary so a single page crash
 // shows a contained fallback instead of taking down the whole shell.
@@ -205,6 +206,7 @@ export default function App() {
             <Route path="/title/:id/season/:season/episode/:episode" element={<Page><EpisodeDetailPage /></Page>} />
             <Route path="/person/:personId" element={<Page><PersonPage /></Page>} />
             <Route path="/kiosk/:token" element={<Page><KioskPage /></Page>} />
+            <Route path="/share/watchlist/:token" element={<Page><SharedWatchlistPage /></Page>} />
             <Route path="*" element={<Page><NotFoundPage /></Page>} />
           </Routes>
         </Suspense>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -918,6 +918,24 @@ export async function revokeKioskToken(): Promise<void> {
   await doFetch("/kiosk/token", { method: "DELETE" });
 }
 
+// ─── Watchlist Share ──────────────────────────────────────────────────────────
+
+export async function getWatchlistShareToken(signal?: AbortSignal): Promise<{ token: string | null }> {
+  return fetchJson("/share/token", { signal });
+}
+
+export async function regenerateWatchlistShareToken(): Promise<{ token: string }> {
+  return fetchJson("/share/token", { method: "POST" });
+}
+
+export async function revokeWatchlistShareToken(): Promise<void> {
+  await doFetch("/share/token", { method: "DELETE" });
+}
+
+export async function getSharedWatchlist(token: string, signal?: AbortSignal): Promise<{ username: string; titles: Title[] }> {
+  return fetchJson(`/share/watchlist/${encodeURIComponent(token)}`, { signal });
+}
+
 // ─── Title Notes & Tags ───────────────────────────────────────────────────────
 
 export async function updateTrackedNotes(titleId: string, notes: string | null): Promise<void> {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -536,6 +536,19 @@
     "copied": "Copied!",
     "warning": "Anyone with this URL can view your kiosk dashboard. Keep it private."
   },
+  "share": {
+    "title": "Watchlist Share Link",
+    "description": "Share a read-only link to your watchlist with anyone — no account required.",
+    "copyUrl": "Copy link",
+    "copied": "Copied!",
+    "generate": "Generate link",
+    "generating": "Generating...",
+    "regenerate": "Regenerate",
+    "regenerating": "Regenerating...",
+    "revoke": "Revoke",
+    "revoking": "Revoking...",
+    "warning": "Anyone with this link can view your full tracked list. Regenerating invalidates the old link."
+  },
   "tags": {
     "placeholder": "Add tag...",
     "tooMany": "Max 10 tags",

--- a/frontend/src/pages/SharedWatchlistPage.test.tsx
+++ b/frontend/src/pages/SharedWatchlistPage.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+
+import "../i18n";
+
+import type { Title } from "../types";
+
+function makeTitle(overrides: Partial<Title> = {}): Title {
+  return {
+    id: "title-1",
+    object_type: "MOVIE",
+    title: "Test Movie",
+    original_title: null,
+    release_year: 2023,
+    release_date: "2023-06-01",
+    runtime_minutes: 120,
+    short_description: "A test movie",
+    genres: ["Action"],
+    imdb_id: null,
+    tmdb_id: "12345",
+    poster_url: "/poster.jpg",
+    age_certification: null,
+    original_language: "en",
+    tmdb_url: null,
+    imdb_score: null,
+    imdb_votes: null,
+    tmdb_score: null,
+    is_tracked: true,
+    offers: [],
+    ...overrides,
+  };
+}
+
+const mockFetch = mock((_url: string, _init?: RequestInit) =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ username: "testuser", titles: [makeTitle()] }),
+  } as Response)
+);
+
+const { default: SharedWatchlistPage } = await import("./SharedWatchlistPage");
+
+function Wrapper({ token = "abc123" }: { token?: string }) {
+  return (
+    <MemoryRouter initialEntries={[`/share/watchlist/${token}`]}>
+      <Routes>
+        <Route path="/share/watchlist/:token" element={<SharedWatchlistPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  globalThis.fetch = mockFetch as any;
+  mockFetch.mockImplementation((_url: string) =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ username: "testuser", titles: [makeTitle()] }),
+    } as Response)
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  mockFetch.mockReset();
+  // @ts-expect-error — restore to undefined so other test files are unaffected
+  globalThis.fetch = undefined;
+});
+
+describe("SharedWatchlistPage", () => {
+  it("renders title count and username when API returns data", async () => {
+    render(<Wrapper />);
+    await waitFor(() => {
+      expect(screen.getByText(/1 title/i)).toBeTruthy();
+      expect(screen.getByText(/@testuser/i)).toBeTruthy();
+    });
+  });
+
+  it("renders poster for each title", async () => {
+    render(<Wrapper />);
+    await waitFor(() => {
+      expect(screen.getByAltText("Test Movie")).toBeTruthy();
+    });
+  });
+
+  it("shows 'This watchlist is empty' when titles array is empty", async () => {
+    mockFetch.mockImplementation((_url: string) =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ username: "emptyuser", titles: [] }),
+      } as Response)
+    );
+    render(<Wrapper />);
+    await waitFor(() => {
+      expect(screen.getByText(/this watchlist is empty/i)).toBeTruthy();
+    });
+  });
+
+  it("shows error state when fetch throws", async () => {
+    mockFetch.mockImplementation((_url: string) =>
+      Promise.reject(new Error("Not found"))
+    );
+    render(<Wrapper />);
+    await waitFor(() => {
+      expect(screen.getByText(/invalid or has been revoked/i)).toBeTruthy();
+    });
+  });
+
+  it("shows plural titles count correctly", async () => {
+    mockFetch.mockImplementation((_url: string) =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            username: "multiuser",
+            titles: [makeTitle({ id: "t1", title: "Movie A" }), makeTitle({ id: "t2", title: "Movie B" })],
+          }),
+      } as Response)
+    );
+    render(<Wrapper />);
+    await waitFor(() => {
+      expect(screen.getByText(/2 titles/i)).toBeTruthy();
+    });
+  });
+});

--- a/frontend/src/pages/SharedWatchlistPage.tsx
+++ b/frontend/src/pages/SharedWatchlistPage.tsx
@@ -1,6 +1,6 @@
 import { useParams, Link } from "react-router";
 import { getSharedWatchlist } from "../api";
-import type { Title } from "../api";
+import type { Title } from "../types";
 import { TitleGridSkeleton } from "../components/SkeletonComponents";
 import { useApiCall } from "../hooks/useApiCall";
 

--- a/frontend/src/pages/SharedWatchlistPage.tsx
+++ b/frontend/src/pages/SharedWatchlistPage.tsx
@@ -1,0 +1,96 @@
+import { useParams, Link } from "react-router";
+import { getSharedWatchlist } from "../api";
+import type { Title } from "../api";
+import { TitleGridSkeleton } from "../components/SkeletonComponents";
+import { useApiCall } from "../hooks/useApiCall";
+
+export default function SharedWatchlistPage() {
+  const { token } = useParams<{ token: string }>();
+
+  const { data, loading, error } = useApiCall(
+    (signal) => getSharedWatchlist(token!, signal),
+    [token],
+  );
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <div className="h-8 w-64 bg-zinc-800 rounded animate-pulse" />
+        <TitleGridSkeleton count={12} />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center space-y-4">
+        <div className="text-4xl">🔗</div>
+        <h1 className="text-xl font-bold text-zinc-100">This link is invalid or has been revoked</h1>
+        <p className="text-sm text-zinc-500">The watchlist you are looking for is no longer available.</p>
+        <Link to="/" className="text-amber-400 hover:text-amber-300 text-sm transition-colors">
+          Go to Remindarr
+        </Link>
+      </div>
+    );
+  }
+
+  const { username, titles } = data as { username: string; titles: Title[] };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-1">
+        <h1 className="text-2xl font-bold text-zinc-100">
+          {titles.length} title{titles.length !== 1 ? "s" : ""} shared by{" "}
+          <span className="text-amber-400">@{username}</span>
+        </h1>
+        <p className="text-sm text-zinc-500">Read-only view — sign in to track these titles</p>
+      </div>
+
+      {titles.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-24 text-center space-y-2">
+          <p className="text-zinc-400 text-sm">This watchlist is empty</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+          {titles.map((title) => (
+            <Link
+              key={title.id}
+              to={`/title/${title.id}`}
+              className="group bg-zinc-900 rounded-xl overflow-hidden flex flex-col hover:ring-2 hover:ring-amber-400/40 transition-all"
+            >
+              <div className="aspect-[2/3] w-full bg-zinc-800 overflow-hidden">
+                {title.poster_url ? (
+                  <img
+                    src={`https://image.tmdb.org/t/p/w342${title.poster_url}`}
+                    alt={title.title}
+                    className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                    loading="lazy"
+                  />
+                ) : (
+                  <div className="w-full h-full flex items-center justify-center text-zinc-600 text-xs font-medium px-2 text-center">
+                    {title.title}
+                  </div>
+                )}
+              </div>
+              <div className="p-2 space-y-0.5">
+                <div className="text-xs font-semibold text-zinc-100 line-clamp-2 leading-tight">
+                  {title.title}
+                </div>
+                {title.release_year && (
+                  <div className="text-[10px] text-zinc-500">{title.release_year}</div>
+                )}
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+
+      <footer className="text-center text-xs text-zinc-600 pt-8 pb-4">
+        Powered by{" "}
+        <a href="/" className="text-amber-400 hover:text-amber-300 transition-colors">
+          Remindarr
+        </a>
+      </footer>
+    </div>
+  );
+}

--- a/frontend/src/pages/settings/IntegrationsTab.tsx
+++ b/frontend/src/pages/settings/IntegrationsTab.tsx
@@ -551,6 +551,97 @@ function KioskSection() {
   );
 }
 
+function WatchlistShareSection() {
+  const { t } = useTranslation();
+  const [token, setToken] = useState<string | null>(null);
+  const [loadingToken, setLoadingToken] = useState(true);
+  const [regenerating, setRegenerating] = useState(false);
+  const [revoking, setRevoking] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    api.getWatchlistShareToken(controller.signal)
+      .then(({ token: tok }) => { if (!controller.signal.aborted) { setToken(tok); setLoadingToken(false); } })
+      .catch(() => { if (!controller.signal.aborted) setLoadingToken(false); });
+    return () => controller.abort();
+  }, []);
+
+  const shareUrl = token ? `${window.location.origin}/share/watchlist/${token}` : null;
+
+  async function handleRegenerate() {
+    setRegenerating(true);
+    try {
+      const { token: newToken } = await api.regenerateWatchlistShareToken();
+      setToken(newToken);
+    } finally {
+      setRegenerating(false);
+    }
+  }
+
+  async function handleRevoke() {
+    setRevoking(true);
+    try {
+      await api.revokeWatchlistShareToken();
+      setToken(null);
+    } finally {
+      setRevoking(false);
+    }
+  }
+
+  async function handleCopy() {
+    if (!shareUrl) return;
+    await navigator.clipboard.writeText(shareUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <SCard title={t("share.title")} subtitle={t("share.description")}>
+      {loadingToken ? (
+        <p className="text-sm text-zinc-500">{t("common.loading")}</p>
+      ) : token ? (
+        <div className="space-y-3">
+          <div className="flex flex-col sm:flex-row gap-2">
+            <SInput
+              value={shareUrl!}
+              mono
+              readOnly
+              aria-label={t("share.title")}
+            />
+            <div className="flex gap-2 shrink-0">
+              <SButton variant="ghost" small onClick={handleCopy}>
+                {copied ? t("share.copied") : t("share.copyUrl")}
+              </SButton>
+              <SButton
+                variant="ghost"
+                small
+                onClick={handleRegenerate}
+                disabled={regenerating}
+              >
+                {regenerating ? t("share.regenerating") : t("share.regenerate")}
+              </SButton>
+              <SButton
+                variant="ghost"
+                small
+                onClick={handleRevoke}
+                disabled={revoking}
+              >
+                {revoking ? t("share.revoking") : t("share.revoke")}
+              </SButton>
+            </div>
+          </div>
+          <SHint kind="info">{t("share.warning")}</SHint>
+        </div>
+      ) : (
+        <SButton onClick={handleRegenerate} disabled={regenerating}>
+          {regenerating ? t("share.generating") : t("share.generate")}
+        </SButton>
+      )}
+    </SCard>
+  );
+}
+
 function WatchlistSection() {
   const [exporting, setExporting] = useState(false);
   const [importing, setImporting] = useState(false);
@@ -757,6 +848,7 @@ export default function IntegrationsTab() {
       <PlexSection />
       <CalendarFeedSection />
       <KioskSection />
+      <WatchlistShareSection />
       <WatchlistSection />
       <CsvImportSection />
     </>

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -133,6 +133,6 @@ describe("fixSkippedMigrations", () => {
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(36);
+    expect(migrations.cnt).toBe(37);
   });
 });

--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -112,6 +112,9 @@ export {
   getKioskToken,
   setKioskToken,
   getUserByKioskToken,
+  getWatchlistShareToken,
+  setWatchlistShareToken,
+  getUserByWatchlistShareToken,
 } from "./users";
 
 export {

--- a/server/db/repository/users.test.ts
+++ b/server/db/repository/users.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
+import { createUser } from "./users";
+import {
+  getWatchlistShareToken,
+  setWatchlistShareToken,
+  getUserByWatchlistShareToken,
+} from "./users";
+
+beforeEach(() => {
+  setupTestDb();
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+describe("Watchlist share token", () => {
+  it("returns null when no token is set", async () => {
+    const userId = await createUser("tokenuser1", "hash");
+    const token = await getWatchlistShareToken(userId);
+    expect(token).toBeNull();
+  });
+
+  it("set → get returns the token", async () => {
+    const userId = await createUser("tokenuser2", "hash");
+    await setWatchlistShareToken(userId, "mytoken123");
+    const token = await getWatchlistShareToken(userId);
+    expect(token).toBe("mytoken123");
+  });
+
+  it("getUserByWatchlistShareToken resolves correct user", async () => {
+    const userId = await createUser("tokenuser3", "hash");
+    await setWatchlistShareToken(userId, "findmetoken");
+    const user = await getUserByWatchlistShareToken("findmetoken");
+    expect(user).not.toBeNull();
+    expect(user!.id).toBe(userId);
+    expect(user!.username).toBe("tokenuser3");
+  });
+
+  it("getUserByWatchlistShareToken returns null for unknown token", async () => {
+    const user = await getUserByWatchlistShareToken("doesnotexist");
+    expect(user).toBeNull();
+  });
+
+  it("revoke (set null) → get returns null", async () => {
+    const userId = await createUser("tokenuser4", "hash");
+    await setWatchlistShareToken(userId, "revoketoken");
+    await setWatchlistShareToken(userId, null);
+    const token = await getWatchlistShareToken(userId);
+    expect(token).toBeNull();
+  });
+
+  it("revoked token no longer resolves a user", async () => {
+    const userId = await createUser("tokenuser5", "hash");
+    await setWatchlistShareToken(userId, "revokeme");
+    await setWatchlistShareToken(userId, null);
+    const user = await getUserByWatchlistShareToken("revokeme");
+    expect(user).toBeNull();
+  });
+});

--- a/server/db/repository/users.ts
+++ b/server/db/repository/users.ts
@@ -420,3 +420,32 @@ export async function getUserByKioskToken(token: string): Promise<{ id: string; 
     return row ?? null;
   });
 }
+
+// ─── Watchlist share token ────────────────────────────────────────────────────
+
+export async function getWatchlistShareToken(userId: string): Promise<string | null> {
+  return traceDbQuery("getWatchlistShareToken", async () => {
+    const db = getDb();
+    const row = await db.select({ watchlistShareToken: users.watchlistShareToken }).from(users).where(eq(users.id, userId)).get();
+    return row?.watchlistShareToken ?? null;
+  });
+}
+
+export async function setWatchlistShareToken(userId: string, token: string | null): Promise<void> {
+  return traceDbQuery("setWatchlistShareToken", async () => {
+    const db = getDb();
+    await db.update(users).set({ watchlistShareToken: token }).where(eq(users.id, userId)).run();
+  });
+}
+
+export async function getUserByWatchlistShareToken(token: string): Promise<{ id: string; username: string; displayUsername: string | null } | null> {
+  return traceDbQuery("getUserByWatchlistShareToken", async () => {
+    const db = getDb();
+    const row = await db
+      .select({ id: users.id, username: users.username, displayUsername: users.displayUsername })
+      .from(users)
+      .where(eq(users.watchlistShareToken, token))
+      .get();
+    return row ?? null;
+  });
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -163,6 +163,7 @@ export const users = sqliteTable(
     homepageLayout: text("homepage_layout"),
     feedToken: text("feed_token"),
     kioskToken: text("kiosk_token"),
+    watchlistShareToken: text("watchlist_share_token"),
     bio: text("bio"),
     activityStreamEnabled: integer("activity_stream_enabled").notNull().default(0),
   },
@@ -173,6 +174,7 @@ export const users = sqliteTable(
     ),
     uniqueIndex("users_feed_token_idx").on(table.feedToken),
     uniqueIndex("users_kiosk_token_idx").on(table.kioskToken),
+    uniqueIndex("users_watchlist_share_token_idx").on(table.watchlistShareToken),
   ]
 );
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,7 +5,7 @@ import { HTTPException } from "hono/http-exception";
 import { serveStatic } from "hono/bun";
 import { CONFIG } from "./config";
 import { initBunDb, migrateTrackedData, getRawDb } from "./db/bun-db";
-import { getUserCount, createUser } from "./db/repository";
+import { getUserCount, createUser, getUserByWatchlistShareToken, getTrackedTitles } from "./db/repository";
 import { optionalAuth, requireAuth, requireAdmin } from "./middleware/auth";
 import { rateLimiter } from "./middleware/rate-limit";
 import syncRoutes from "./routes/sync";
@@ -36,6 +36,7 @@ import userSettingsRoutes from "./routes/user-settings";
 import feedRoutes from "./routes/feed";
 import kioskRoutes from "./routes/kiosk";
 import upNextRoutes from "./routes/up-next";
+import shareRoutes from "./routes/share";
 import type { AppEnv } from "./types";
 import Sentry from "./sentry";
 import { logger, requestLogger } from "./logger";
@@ -298,6 +299,10 @@ app.route("/api/feed", feedRoutes);
 app.use("/api/kiosk/token*", requireAuth);
 app.route("/api/kiosk", kioskRoutes);
 
+// Share — /watchlist/:token is public; /token endpoints require session
+app.use("/api/share/token*", requireAuth);
+app.route("/api/share", shareRoutes);
+
 // Admin routes
 app.use("/api/admin/*", requireAuth, requireAdmin);
 app.use("/api/admin", requireAuth, requireAdmin);
@@ -324,6 +329,47 @@ app.route("/api/sync", syncRoutes);
 app.use("/api/episodes/*", optionalAuth);
 app.use("/api/episodes", optionalAuth);
 app.route("/api/episodes", episodesRoutes);
+
+// OG meta tags for shared watchlist page — must be before the SPA static fallback
+app.get("/share/watchlist/:token", async (c) => {
+  const token = c.req.param("token");
+  const user = await getUserByWatchlistShareToken(token);
+  let ogTags = "";
+  if (user) {
+    const titles = await getTrackedTitles(user.id);
+    const count = titles.length;
+    const username = user.displayUsername ?? user.username;
+    const firstPoster = titles[0]?.poster_url
+      ? `https://image.tmdb.org/t/p/w342${titles[0].poster_url}`
+      : null;
+    const description = `${count} title${count !== 1 ? "s" : ""} tracked by @${username}`;
+    const imageTag = firstPoster
+      ? `<meta property="og:image" content="${firstPoster}" />`
+      : "";
+    ogTags = `
+    <meta property="og:title" content="${username}'s Watchlist — Remindarr" />
+    <meta property="og:description" content="${description}" />
+    <meta property="og:type" content="website" />
+    ${imageTag}
+    <meta name="twitter:card" content="${firstPoster ? "summary_large_image" : "summary"}" />
+    <meta name="twitter:title" content="${username}'s Watchlist — Remindarr" />
+    <meta name="twitter:description" content="${description}" />
+    ${firstPoster ? `<meta name="twitter:image" content="${firstPoster}" />` : ""}`;
+  }
+  try {
+    const indexHtml = await Bun.file("./frontend/dist/index.html").text();
+    const injected = ogTags
+      ? indexHtml.replace("</head>", `${ogTags}\n  </head>`)
+      : indexHtml;
+    return new Response(injected, {
+      status: 200,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  } catch {
+    // Fall through to static serving if dist/index.html doesn't exist (dev mode)
+  }
+  return c.html("<!DOCTYPE html><html><head><title>Remindarr</title></head><body></body></html>");
+});
 
 // Serve frontend static files in production
 app.use("/*", serveStatic({ root: "./frontend/dist" }));

--- a/server/routes/share.test.ts
+++ b/server/routes/share.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { createUser, createSession, getSessionWithUser } from "../db/repository";
+import { requireAuth } from "../middleware/auth";
+import shareApp from "./share";
+import type { AppEnv } from "../types";
+
+function createMockAuth() {
+  return {
+    api: {
+      getSession: async ({ headers }: { headers: Headers }) => {
+        const cookieHeader = headers.get("cookie") || "";
+        const match = cookieHeader.match(/better-auth\.session_token=([^;]+)/);
+        const token = match?.[1];
+        if (!token) return null;
+        const user = await getSessionWithUser(token);
+        if (!user) return null;
+        return {
+          session: { id: "session-id", userId: user.id },
+          user: {
+            id: user.id,
+            name: user.display_name,
+            username: user.username,
+            role: user.role || (user.is_admin ? "admin" : "user"),
+          },
+        };
+      },
+    },
+  };
+}
+
+let app: Hono<AppEnv>;
+let userToken: string;
+let userId: string;
+
+beforeEach(async () => {
+  setupTestDb();
+
+  userId = await createUser("shareuser", "hash");
+  userToken = await createSession(userId);
+
+  app = new Hono<AppEnv>();
+  app.use("*", async (c, next) => {
+    c.set("auth", createMockAuth() as any);
+    await next();
+  });
+  app.use("/share/token*", requireAuth);
+  app.route("/share", shareApp);
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+function authHeaders() {
+  return { Cookie: `better-auth.session_token=${userToken}` };
+}
+
+describe("GET /share/token (auth)", () => {
+  it("returns 401 without session", async () => {
+    const res = await app.request("/share/token");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns { token: null } before any token is generated", async () => {
+    const res = await app.request("/share/token", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.token).toBeNull();
+  });
+
+  it("returns token after generation", async () => {
+    await app.request("/share/token", { method: "POST", headers: authHeaders() });
+    const res = await app.request("/share/token", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(typeof body.token).toBe("string");
+    expect(body.token.length).toBeGreaterThan(0);
+  });
+});
+
+describe("POST /share/token (auth)", () => {
+  it("returns 401 without session", async () => {
+    const res = await app.request("/share/token", { method: "POST" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns a new token", async () => {
+    const res = await app.request("/share/token", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(typeof body.token).toBe("string");
+    expect(body.token.length).toBeGreaterThan(0);
+  });
+
+  it("rotation replaces old token", async () => {
+    const res1 = await app.request("/share/token", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    const { token: t1 } = (await res1.json()) as { token: string };
+
+    await app.request("/share/token", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+
+    // Old token should no longer resolve a watchlist
+    const watchlistRes = await app.request(`/share/watchlist/${t1}`);
+    expect(watchlistRes.status).toBe(404);
+  });
+});
+
+describe("DELETE /share/token (auth)", () => {
+  it("returns 401 without session", async () => {
+    const res = await app.request("/share/token", { method: "DELETE" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 on success", async () => {
+    const res = await app.request("/share/token", {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.success).toBe(true);
+  });
+
+  it("subsequent GET token returns null after revoke", async () => {
+    await app.request("/share/token", { method: "POST", headers: authHeaders() });
+    await app.request("/share/token", { method: "DELETE", headers: authHeaders() });
+    const res = await app.request("/share/token", { headers: authHeaders() });
+    const body = (await res.json()) as any;
+    expect(body.token).toBeNull();
+  });
+
+  it("revoked token returns 404 on watchlist", async () => {
+    const genRes = await app.request("/share/token", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    const { token } = (await genRes.json()) as { token: string };
+
+    await app.request("/share/token", { method: "DELETE", headers: authHeaders() });
+
+    const watchlistRes = await app.request(`/share/watchlist/${token}`);
+    expect(watchlistRes.status).toBe(404);
+  });
+});
+
+describe("GET /share/watchlist/:token (public)", () => {
+  it("returns 404 for unknown token", async () => {
+    const res = await app.request("/share/watchlist/unknowntoken12345");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 200 with username and empty titles array for valid token", async () => {
+    const genRes = await app.request("/share/token", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    const { token } = (await genRes.json()) as { token: string };
+
+    const res = await app.request(`/share/watchlist/${token}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.username).toBe("shareuser");
+    expect(Array.isArray(body.titles)).toBe(true);
+  });
+});
+
+describe("validation", () => {
+  it("unknown token returns 404", async () => {
+    const res = await app.request("/share/watchlist/notarealtoken");
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as any;
+    expect(body.error).toBeDefined();
+  });
+});

--- a/server/routes/share.ts
+++ b/server/routes/share.ts
@@ -1,0 +1,53 @@
+import { Hono } from "hono";
+import {
+  getUserByWatchlistShareToken,
+  getWatchlistShareToken,
+  setWatchlistShareToken,
+  getTrackedTitles,
+} from "../db/repository";
+import { requireAuth } from "../middleware/auth";
+import { logger } from "../logger";
+import type { AppEnv } from "../types";
+
+const log = logger.child({ module: "share" });
+
+const app = new Hono<AppEnv>();
+
+// GET /api/share/token  (requireAuth)
+app.get("/token", requireAuth, async (c) => {
+  const user = c.get("user")!;
+  const token = await getWatchlistShareToken(user.id);
+  return c.json({ token });
+});
+
+// POST /api/share/token  (requireAuth)
+app.post("/token", requireAuth, async (c) => {
+  const user = c.get("user")!;
+  const token = crypto.randomUUID().replace(/-/g, "");
+  await setWatchlistShareToken(user.id, token);
+  log.info("Watchlist share token generated", { userId: user.id });
+  return c.json({ token });
+});
+
+// DELETE /api/share/token  (requireAuth)
+app.delete("/token", requireAuth, async (c) => {
+  const user = c.get("user")!;
+  await setWatchlistShareToken(user.id, null);
+  log.info("Watchlist share token revoked", { userId: user.id });
+  return c.json({ success: true });
+});
+
+// GET /api/share/watchlist/:token  (public)
+app.get("/watchlist/:token", async (c) => {
+  const token = c.req.param("token");
+  const user = await getUserByWatchlistShareToken(token);
+  if (!user) {
+    return c.json({ error: "Not found" }, 404);
+  }
+  const titles = await getTrackedTitles(user.id);
+  const username = user.displayUsername ?? user.username;
+  log.debug("Shared watchlist served", { userId: user.id, count: titles.length });
+  return c.json({ username, titles });
+});
+
+export default app;

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -40,7 +40,7 @@ import { cors } from "hono/cors";
 import { HTTPException } from "hono/http-exception";
 import { drizzle } from "drizzle-orm/d1";
 import { getDb, runWithDb, schemaExports } from "./db/schema";
-import { getUserCount, createUser, isOidcConfigured, getOidcConfig } from "./db/repository";
+import { getUserCount, createUser, isOidcConfigured, getOidcConfig, getUserByWatchlistShareToken, getTrackedTitles } from "./db/repository";
 import { optionalAuth, requireAuth, requireAdmin } from "./middleware/auth";
 import { rateLimiter } from "./middleware/rate-limit";
 import syncRoutes from "./routes/sync";
@@ -70,6 +70,7 @@ import statsRoutes from "./routes/stats";
 import userSettingsRoutes from "./routes/user-settings";
 import feedRoutes from "./routes/feed";
 import kioskRoutes from "./routes/kiosk";
+import shareRoutes from "./routes/share";
 import importRoutes from "./routes/import";
 import upNextRoutes from "./routes/up-next";
 import type { AppEnv } from "./types";
@@ -367,6 +368,10 @@ function createApp(env: Env) {
   app.use("/api/kiosk/token*", requireAuth);
   app.route("/api/kiosk", kioskRoutes);
 
+  // Share — /watchlist/:token is public; /token endpoints require session
+  app.use("/api/share/token*", requireAuth);
+  app.route("/api/share", shareRoutes);
+
   // Admin routes
   app.use("/api/admin/*", requireAuth, requireAdmin);
   app.use("/api/admin", requireAuth, requireAdmin);
@@ -394,6 +399,54 @@ function createApp(env: Env) {
   app.use("/api/episodes/*", optionalAuth);
   app.use("/api/episodes", optionalAuth);
   app.route("/api/episodes", episodesRoutes);
+
+  // OG meta tags for shared watchlist — before the generic SPA fallback
+  app.get("/share/watchlist/:token", async (c) => {
+    const token = c.req.param("token");
+    const user = await getUserByWatchlistShareToken(token);
+    let ogTags = "";
+    if (user) {
+      const titles = await getTrackedTitles(user.id);
+      const count = titles.length;
+      const username = user.displayUsername ?? user.username;
+      const firstPoster = titles[0]?.poster_url
+        ? `https://image.tmdb.org/t/p/w342${titles[0].poster_url}`
+        : null;
+      const description = `${count} title${count !== 1 ? "s" : ""} tracked by @${username}`;
+      const imageTag = firstPoster
+        ? `<meta property="og:image" content="${firstPoster}" />`
+        : "";
+      ogTags = `
+    <meta property="og:title" content="${username}'s Watchlist — Remindarr" />
+    <meta property="og:description" content="${description}" />
+    <meta property="og:type" content="website" />
+    ${imageTag}
+    <meta name="twitter:card" content="${firstPoster ? "summary_large_image" : "summary"}" />
+    <meta name="twitter:title" content="${username}'s Watchlist — Remindarr" />
+    <meta name="twitter:description" content="${description}" />
+    ${firstPoster ? `<meta name="twitter:image" content="${firstPoster}" />` : ""}`;
+    }
+    try {
+      const assets = (c.env as unknown as Env).ASSETS;
+      if (assets?.fetch) {
+        const url = new URL("/index.html", c.req.url);
+        const resp = await assets.fetch(url.toString());
+        if (resp.ok) {
+          const html = await resp.text();
+          const injected = ogTags ? html.replace("</head>", `${ogTags}\n  </head>`) : html;
+          return new Response(injected, {
+            status: 200,
+            headers: { "content-type": "text/html; charset=utf-8" },
+          });
+        }
+      }
+    } catch (err) {
+      logger.error("Share OG fallback error", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return c.html("<!DOCTYPE html><html><head><title>Remindarr</title></head><body></body></html>");
+  });
 
   // SPA fallback — serve index.html for client-side routes (mirrors serveStatic in index.ts)
   app.get("*", async (c) => {


### PR DESCRIPTION
## Summary
- Per-user watchlist share token (generate / rotate / revoke) via Settings → Integrations
- Public read-only `/share/watchlist/:token` page — no login required
- Server-rendered OG meta tags for link preview cards (Bun + Cloudflare Workers)
- Mirrors existing kiosk-token pattern throughout

## How to verify
1. Settings → Integrations → Watchlist Share → Generate link
2. Open the URL in incognito — watchlist renders without login prompt
3. Paste in Slack/Discord — OG card shows title count

Closes #529