### PR TITLE
feat: add robots.txt to block all bots

### DIFF
--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /
+Allow: /api/feed/calendar.ics


### PR DESCRIPTION
## Summary

- Adds `frontend/public/robots.txt` with `User-agent: * Disallow: /`
- Carves out `/api/feed/calendar.ics` so ICS calendar clients can still fetch the public feed
- Vite copies `frontend/public/` → `frontend/dist/`; Cloudflare's `[assets]` binding serves the file directly at the edge before the Worker is invoked (no billable invocation for the robots.txt fetch itself)

## Context

Cloudflare observability showed ~99% of all Worker traffic today was **Applebot** (~17–30k requests/hour, ~$X in billable D1 reads and Worker invocations). All major bots (Applebot 35×, ClaudeBot 22×, OAI-SearchBot 4×, facebookexternalhit 6×) were actively requesting `/robots.txt` over the last 2 days but receiving the SPA `index.html` back — no parseable rules, so they crawled freely.

Applebot was hitting high-cardinality public endpoints (`/api/details/*`, `/api/ratings/*`, `/api/watched/history/*`, `/title/*`) at ~5 rps continuously.

## Test plan

- [ ] `curl -i https://remindarr.app/robots.txt` → 200, body contains `Disallow: /`
- [ ] Cloudflare Observability: `Apple Inc.` ASN row drops toward 0 within ~24h of Applebot re-reading the file
- [ ] ICS calendar feed still accessible: `curl "https://remindarr.app/api/feed/calendar.ics?token=<token>"` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)