### PR TITLE
fix: migration cascade wiped auth data + passkey RP ID on CF Workers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,16 @@ Inventory is large (~45 components). Broad groups:
 - Pass contextual data as the second argument: `log.info("message", { key: value })`
 - Frontend code may continue using `console.error`
 
+### Migration Safety Rules (Cloudflare D1)
+
+**NEVER recreate a FK-parent table via DROP TABLE on D1.** `PRAGMA foreign_keys=OFF` does not persist across `--> statement-breakpoint` boundaries on D1 — each statement runs in a separate connection context. If a migration drops a parent table (`users`, `titles`, `providers`) while child tables have `ON DELETE CASCADE` FKs, the cascade fires unconditionally and wipes all child rows.
+
+**Safe pattern for adding columns:** use `ALTER TABLE <table> ADD COLUMN <col> <type> DEFAULT <val>` instead of the table-recreate pattern (create new, insert from old, drop old, rename new). `ADD COLUMN` works for any `NOT NULL DEFAULT` column on SQLite/D1 and avoids the cascade risk entirely.
+
+The table-recreate pattern (with `PRAGMA foreign_keys=OFF`) is only safe for **child tables** (tables that reference a parent but have no FK children themselves). Examples of safe recreates: `tracked`, `watched_titles`, `watch_history`, `streaming_alerts`, `ratings`, `recommendations`.
+
+`server/db/migrations.test.ts` enforces this: it runs every migration with `foreign_keys=ON` throughout and asserts that `account`, `sessions`, and `passkey` rows seeded early survive all migrations. This test would have caught the 2026-04-29 production data-loss incident caused by migration 0037.
+
 ### Key Patterns
 - DB titles use snake_case, TMDB API search results use camelCase — `normalizeSearchTitle()` bridges the gap
 - Offers are deduplicated by provider ID with priority: FLATRATE > FREE > ADS

--- a/drizzle/0037_streaming_departure_alerts.sql
+++ b/drizzle/0037_streaming_departure_alerts.sql
@@ -32,66 +32,11 @@ ALTER TABLE new_streaming_alerts RENAME TO streaming_alerts;
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS idx_streaming_alerts_user_title ON streaming_alerts(user_id, title_id);
 --> statement-breakpoint
--- Recreate users table to add streaming_departures_enabled and departure_alert_lead_days.
--- Uses table recreation so this migration is idempotent whether or not a previous run
--- under a different migration filename already applied these columns.
-DROP TABLE IF EXISTS `__new_users`;
+-- Add new columns to users without table recreation.
+-- Table recreation with DROP TABLE users triggers ON DELETE CASCADE on child tables
+-- (account, passkey, sessions) on Cloudflare D1 because PRAGMA foreign_keys=OFF
+-- does not persist across statement-breakpoint boundaries on D1. Both columns have
+-- NOT NULL DEFAULT so ALTER TABLE ADD COLUMN is safe on SQLite/D1.
+ALTER TABLE `users` ADD COLUMN `streaming_departures_enabled` integer NOT NULL DEFAULT 1;
 --> statement-breakpoint
-CREATE TABLE IF NOT EXISTS `__new_users` (
-  `id` text PRIMARY KEY NOT NULL,
-  `username` text NOT NULL UNIQUE,
-  `display_username` text,
-  `email` text,
-  `email_verified` integer NOT NULL DEFAULT 0,
-  `name` text,
-  `image` text,
-  `role` text,
-  `banned` integer DEFAULT 0,
-  `ban_reason` text,
-  `ban_expires` integer,
-  `created_at` text DEFAULT (datetime('now')),
-  `updated_at` text DEFAULT (datetime('now')),
-  `password_hash` text,
-  `auth_provider` text NOT NULL DEFAULT 'local',
-  `provider_subject` text,
-  `is_admin` integer NOT NULL DEFAULT 0,
-  `profile_public` integer NOT NULL DEFAULT 0,
-  `profile_visibility` text NOT NULL DEFAULT 'private',
-  `homepage_layout` text,
-  `feed_token` text UNIQUE,
-  `kiosk_token` text UNIQUE,
-  `watchlist_share_token` text UNIQUE,
-  `bio` text,
-  `activity_stream_enabled` integer NOT NULL DEFAULT 0,
-  `streaming_departures_enabled` integer NOT NULL DEFAULT 1,
-  `departure_alert_lead_days` integer NOT NULL DEFAULT 7
-);
---> statement-breakpoint
-INSERT OR IGNORE INTO `__new_users` (
-  `id`, `username`, `display_username`, `email`, `email_verified`, `name`, `image`, `role`,
-  `banned`, `ban_reason`, `ban_expires`, `created_at`, `updated_at`, `password_hash`,
-  `auth_provider`, `provider_subject`, `is_admin`, `profile_public`, `profile_visibility`,
-  `homepage_layout`, `feed_token`, `kiosk_token`, `watchlist_share_token`, `bio`,
-  `activity_stream_enabled`
-)
-SELECT
-  `id`, `username`, `display_username`, `email`, `email_verified`, `name`, `image`, `role`,
-  `banned`, `ban_reason`, `ban_expires`, `created_at`, `updated_at`, `password_hash`,
-  `auth_provider`, `provider_subject`, `is_admin`, `profile_public`, `profile_visibility`,
-  `homepage_layout`, `feed_token`, `kiosk_token`, `watchlist_share_token`, `bio`,
-  `activity_stream_enabled`
-FROM `users`;
---> statement-breakpoint
-DROP TABLE `users`;
---> statement-breakpoint
-ALTER TABLE `__new_users` RENAME TO `users`;
---> statement-breakpoint
-CREATE UNIQUE INDEX IF NOT EXISTS `users_auth_provider_subject` ON `users` (`auth_provider`, `provider_subject`);
---> statement-breakpoint
-CREATE UNIQUE INDEX IF NOT EXISTS `users_feed_token_idx` ON `users` (`feed_token`);
---> statement-breakpoint
-CREATE UNIQUE INDEX IF NOT EXISTS `users_kiosk_token_idx` ON `users` (`kiosk_token`);
---> statement-breakpoint
-CREATE UNIQUE INDEX IF NOT EXISTS `users_watchlist_share_token_idx` ON `users` (`watchlist_share_token`);
---> statement-breakpoint
-PRAGMA foreign_keys=ON;
+ALTER TABLE `users` ADD COLUMN `departure_alert_lead_days` integer NOT NULL DEFAULT 7;

--- a/drizzle/0038_tracked_snooze_remind_on_release.sql
+++ b/drizzle/0038_tracked_snooze_remind_on_release.sql
@@ -1,30 +1,5 @@
--- Idempotent: add snooze_until and remind_on_release to tracked.
--- Uses table recreation so it is safe to apply even if these columns
--- were previously added under a different migration name (e.g. 0036).
-PRAGMA foreign_keys=OFF;
+-- Add snooze_until and remind_on_release to tracked without table recreation.
+-- Both columns have suitable defaults so ALTER TABLE ADD COLUMN is safe on SQLite/D1.
+ALTER TABLE `tracked` ADD COLUMN `snooze_until` text;
 --> statement-breakpoint
-CREATE TABLE IF NOT EXISTS `__new_tracked` (
-  `title_id` text NOT NULL,
-  `user_id` text NOT NULL,
-  `tracked_at` text DEFAULT (datetime('now')),
-  `notes` text,
-  `public` integer NOT NULL DEFAULT 1,
-  `user_status` text,
-  `notification_mode` text,
-  `snooze_until` text,
-  `remind_on_release` integer NOT NULL DEFAULT 0,
-  PRIMARY KEY(`title_id`, `user_id`),
-  FOREIGN KEY (`title_id`) REFERENCES `titles`(`id`) ON UPDATE no action ON DELETE cascade,
-  FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
-);
---> statement-breakpoint
-INSERT OR IGNORE INTO `__new_tracked` (`title_id`, `user_id`, `tracked_at`, `notes`, `public`, `user_status`, `notification_mode`)
-  SELECT `title_id`, `user_id`, `tracked_at`, `notes`, `public`, `user_status`, `notification_mode` FROM `tracked`;
---> statement-breakpoint
-DROP TABLE `tracked`;
---> statement-breakpoint
-ALTER TABLE `__new_tracked` RENAME TO `tracked`;
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS `idx_tracked_user_id` ON `tracked` (`user_id`);
---> statement-breakpoint
-PRAGMA foreign_keys=ON;
+ALTER TABLE `tracked` ADD COLUMN `remind_on_release` integer NOT NULL DEFAULT 0;

--- a/server/auth/better-auth-passkey.test.ts
+++ b/server/auth/better-auth-passkey.test.ts
@@ -2,9 +2,41 @@ import { describe, it, expect, beforeEach, afterAll, afterEach } from "bun:test"
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
 import { getDb, passkey as passkeyTable, users } from "../db/schema";
 import { sql } from "drizzle-orm";
-import { createAuth } from "./better-auth";
+import { createAuth, getPasskeyRpId, buildPasskeyOrigins } from "./better-auth";
 import { BunPlatform } from "../platform/bun";
 import { CONFIG } from "../config";
+
+describe("getPasskeyRpId", () => {
+  it("derives registrable domain from bare hostname", () => {
+    expect(getPasskeyRpId("https://remindarr.app")).toBe("remindarr.app");
+  });
+
+  it("strips www. prefix", () => {
+    expect(getPasskeyRpId("https://www.remindarr.app")).toBe("remindarr.app");
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(getPasskeyRpId("")).toBeUndefined();
+  });
+
+  it("returns undefined for invalid URL", () => {
+    expect(getPasskeyRpId("not a url")).toBeUndefined();
+  });
+});
+
+describe("buildPasskeyOrigins", () => {
+  it("returns both www and non-www variants for a bare domain", () => {
+    expect(buildPasskeyOrigins("https://remindarr.app").sort()).toEqual(
+      ["https://remindarr.app", "https://www.remindarr.app"]
+    );
+  });
+
+  it("returns both www and non-www variants for a www domain", () => {
+    expect(buildPasskeyOrigins("https://www.remindarr.app").sort()).toEqual(
+      ["https://remindarr.app", "https://www.remindarr.app"]
+    );
+  });
+});
 
 describe("passkey support", () => {
   beforeEach(() => {

--- a/server/auth/better-auth.ts
+++ b/server/auth/better-auth.ts
@@ -86,6 +86,10 @@ export function createAuth(db: DrizzleDb, platform: Platform, oidcConfig?: {
   const pendingOidcAdminStatus = new Map<string, boolean>(); // nonce → isAdmin
   const pendingNoncesByAccountId = new Map<string, string[]>(); // sub → nonce queue
 
+  if (!CONFIG.PASSKEY_RP_ID && !CONFIG.BASE_URL) {
+    log.warn("Passkey RP ID will fall back to localhost — set BASE_URL or PASSKEY_RP_ID for production deploys");
+  }
+
   const plugins: BetterAuthPlugin[] = [
     username({
       minUsernameLength: 1,

--- a/server/db/migrations.test.ts
+++ b/server/db/migrations.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "bun:test";
+import { Database } from "bun:sqlite";
+import path from "node:path";
+import fs from "node:fs";
+
+const MIGRATIONS_DIR = path.resolve(import.meta.dir, "../../drizzle");
+
+/**
+ * Regression guard: run every migration with PRAGMA foreign_keys=ON enforced
+ * throughout (simulating Cloudflare D1 where PRAGMA foreign_keys=OFF has no
+ * effect across statement-breakpoint boundaries).
+ *
+ * If any migration recreates a FK-parent table (users, titles, etc.) via
+ * DROP TABLE instead of ALTER TABLE ADD COLUMN, the cascade will delete the
+ * seeded FK-child rows and the assertions below will catch it.
+ *
+ * Background: drizzle/0037 caused a production data-loss incident (2026-04-29)
+ * by recreating the users table with DROP TABLE, triggering ON DELETE CASCADE
+ * on account, passkey, and sessions on D1. This test would have caught it.
+ */
+describe("migrations FK-cascade regression", () => {
+  it("account/session/passkey rows survive all migrations with foreign_keys=ON", () => {
+    const db = new Database(":memory:");
+    db.exec("PRAGMA foreign_keys = ON");
+
+    const sqlFiles = fs
+      .readdirSync(MIGRATIONS_DIR)
+      .filter((f) => f.endsWith(".sql"))
+      .sort();
+
+    let seededAuth = false;
+    let seededPasskey = false;
+
+    for (const file of sqlFiles) {
+      const content = fs.readFileSync(path.join(MIGRATIONS_DIR, file), "utf-8");
+      const statements = content
+        .split("--> statement-breakpoint")
+        .map((s) => s.trim())
+        .filter(Boolean)
+        // Simulate D1: PRAGMA foreign_keys=(ON|OFF) is a no-op across statement
+        // boundaries — statements run in separate connection contexts on D1.
+        .filter((s) => !/^PRAGMA\s+foreign_keys\s*=/i.test(s));
+
+      for (const stmt of statements) {
+        db.exec(stmt);
+      }
+
+      // After migration 0000 creates users/account/sessions, seed FK-child rows.
+      // These rows must survive every subsequent migration.
+      if (!seededAuth && file.startsWith("0000_")) {
+        db.exec(
+          `INSERT INTO users (id, username) VALUES ('u-1', 'regress_user')`
+        );
+        db.exec(
+          `INSERT INTO account (id, user_id, account_id, provider_id, password) ` +
+            `VALUES ('acct-1', 'u-1', 'u-1', 'credential', 'pbkdf2:100000:salt:hash')`
+        );
+        db.exec(
+          `INSERT INTO sessions (id, user_id, token, expires_at) ` +
+            `VALUES ('sess-1', 'u-1', 'tok-xyz', datetime('now', '+30 days'))`
+        );
+        seededAuth = true;
+      }
+
+      // After migration 0006 creates the passkey table, seed a passkey row.
+      // webauthn_user_id is NOT NULL in 0006 (made nullable in 0008).
+      if (!seededPasskey && file.startsWith("0006_")) {
+        db.exec(
+          `INSERT INTO passkey (id, public_key, user_id, webauthn_user_id, counter, credential_id) ` +
+            `VALUES ('pk-1', 'pub-key-bytes', 'u-1', 'webauthn-uid', 0, 'cred-1')`
+        );
+        seededPasskey = true;
+      }
+    }
+
+    const user = db.prepare("SELECT id FROM users WHERE id = 'u-1'").get();
+    expect(user).toBeDefined();
+
+    const acct = db.prepare("SELECT id FROM account WHERE id = 'acct-1'").get();
+    expect(acct).toBeDefined();
+
+    const sess = db.prepare("SELECT id FROM sessions WHERE id = 'sess-1'").get();
+    expect(sess).toBeDefined();
+
+    const pk = db.prepare("SELECT id FROM passkey WHERE id = 'pk-1'").get();
+    expect(pk).toBeDefined();
+
+    db.close();
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -43,6 +43,7 @@ new_sqlite_classes = ["JobQueueDO"]
 TMDB_COUNTRY = "HR"
 TMDB_LANGUAGE = "en"
 LOG_LEVEL = "info"
+BASE_URL = "https://remindarr.app"
 
 # Secrets (set via `wrangler secret put <NAME>`):
 # TMDB_API_KEY


### PR DESCRIPTION
## Summary

- **Migration cascade (production incident 2026-04-29)**: `drizzle/0037` recreated the `users` table and `DROP TABLE users` triggered `ON DELETE CASCADE` on `account`, `passkey`, and `sessions` — wiping all auth data. Root cause: `PRAGMA foreign_keys=OFF` does not persist across `--> statement-breakpoint` boundaries on Cloudflare D1. Fixed by replacing the users table recreation in 0037 (and the tracked recreation in 0038) with safe `ALTER TABLE ADD COLUMN` statements. Both new columns have `NOT NULL DEFAULT` so no recreation is needed.
- **Passkey RP ID = localhost**: `wrangler.toml` was missing `BASE_URL` in `[vars]`, so `CONFIG.BASE_URL` was always `""` on Workers. better-auth's passkey plugin defaulted `rpID` to `"localhost"`, which is invalid for `remindarr.app`. Fixed by adding `BASE_URL = "https://remindarr.app"` to `[vars]`.
- Added a startup warn when `BASE_URL` and `PASSKEY_RP_ID` are both unset.
- Added unit tests for `getPasskeyRpId` and `buildPasskeyOrigins`.

Production recovery was done before merging: D1 time-traveled to 2026-04-28T22:00:00Z, then fixed migrations were re-applied. All 3 users restored with `account`/`passkey` rows intact.

## Test plan

- [x] `bun run check` passes (2366 tests, 0 failures)
- [x] New `getPasskeyRpId` / `buildPasskeyOrigins` unit tests pass
- [ ] Sign in with password on `https://remindarr.app` ✓ (auth data restored)
- [ ] Re-register a passkey → rpID should be `remindarr.app` not `localhost`
- [ ] Sign in with passkey on both `remindarr.app` and `www.remindarr.app`

Closes #— (production incident)

🤖 Generated with [Claude Code](https://claude.com/claude-code)