### PR TITLE
fix: recover from stale chunk errors after deploy

### DIFF
--- a/frontend/src/components/ErrorBoundary.test.ts
+++ b/frontend/src/components/ErrorBoundary.test.ts
@@ -1,18 +1,30 @@
-import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, spyOn, mock } from "bun:test";
 import * as Sentry from "@sentry/react";
+
+const mockReloadPage = mock(() => {});
+
+mock.module("../lib/reloadPage", () => ({
+  reloadPage: mockReloadPage,
+}));
+
 import ErrorBoundary from "./ErrorBoundary";
 
-let spies: ReturnType<typeof spyOn>[] = [];
+let spyCapture: ReturnType<typeof spyOn>;
 
 beforeEach(() => {
-  spies = [
-    spyOn(Sentry, "captureException").mockImplementation(() => ""),
-  ];
+  mockReloadPage.mockReset();
+  spyCapture = spyOn(Sentry, "captureException").mockImplementation(() => "");
+
+  // Shim caches (not implemented in happy-dom)
+  Object.defineProperty(globalThis, "caches", {
+    value: { delete: mock(() => Promise.resolve(true)) },
+    writable: true,
+    configurable: true,
+  });
 });
 
 afterEach(() => {
-  for (const spy of spies) spy.mockRestore();
-  spies = [];
+  spyCapture.mockRestore();
 });
 
 describe("ErrorBoundary", () => {
@@ -41,22 +53,48 @@ describe("ErrorBoundary", () => {
     expect(instance.state.error).toBeNull();
   });
 
-  it("componentDidCatch reports to Sentry", async () => {
+  it("componentDidCatch tags non-chunk errors as 'render' in Sentry", async () => {
     const instance = new ErrorBoundary({ children: null });
     const error = new Error("render crash");
     const info = { componentStack: "<App>\n<ErrorBoundary>", digest: undefined };
 
-    // Suppress structured log output during test
     const origError = console.error;
     console.error = () => {};
     instance.componentDidCatch(error, info);
     console.error = origError;
 
-    // Wait for the dynamic import to resolve
     await new Promise((r) => setTimeout(r, 0));
 
-    expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+    expect(spyCapture).toHaveBeenCalledWith(error, {
+      tags: { errorType: "render" },
       contexts: { react: { componentStack: info.componentStack } },
     });
+  });
+
+  it("componentDidCatch tags chunk-load errors as 'chunk-load' in Sentry", async () => {
+    const instance = new ErrorBoundary({ children: null });
+    const error = new Error("error loading dynamically imported module: /assets/Foo.js");
+    const info = { componentStack: "<App>", digest: undefined };
+
+    const origError = console.error;
+    console.error = () => {};
+    instance.componentDidCatch(error, info);
+    console.error = origError;
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(spyCapture).toHaveBeenCalledWith(error, {
+      tags: { errorType: "chunk-load" },
+      contexts: { react: { componentStack: info.componentStack } },
+    });
+  });
+
+  it("handleReload deletes pages cache and reloads the page", async () => {
+    const instance = new ErrorBoundary({ children: null });
+
+    await instance.handleReload();
+
+    expect((caches.delete as ReturnType<typeof mock>)).toHaveBeenCalledWith("pages");
+    expect(mockReloadPage).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,5 +1,7 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
 import { logger } from "../logger";
+import { isChunkLoadError } from "../lib/lazyWithRetry";
+import { reloadPage } from "../lib/reloadPage";
 
 const log = logger.child({ module: "error-boundary" });
 
@@ -33,6 +35,7 @@ export default class ErrorBoundary extends Component<Props, State> {
     import("@sentry/react")
       .then((Sentry) => {
         Sentry.captureException(error, {
+          tags: { errorType: isChunkLoadError(error) ? "chunk-load" : "render" },
           contexts: { react: { componentStack: info.componentStack } },
         });
       })
@@ -43,6 +46,10 @@ export default class ErrorBoundary extends Component<Props, State> {
     this.setState({ hasError: false, error: null });
   };
 
+  handleReload = (): Promise<void> => {
+    return caches.delete("pages").then(() => {}).catch(() => {}).finally(() => reloadPage());
+  };
+
   render() {
     if (this.state.hasError) {
       const variant = this.props.variant ?? "page";
@@ -50,6 +57,28 @@ export default class ErrorBoundary extends Component<Props, State> {
         variant === "inline"
           ? "py-12 px-4 flex items-center justify-center"
           : "min-h-screen bg-zinc-950 flex items-center justify-center p-4";
+
+      if (isChunkLoadError(this.state.error)) {
+        return (
+          <div className={outerClass}>
+            <div className="max-w-md w-full bg-zinc-900 border border-red-800 rounded-lg p-6 text-center">
+              <h1 className="text-xl font-bold text-red-400 mb-2">
+                A new version is available
+              </h1>
+              <p className="text-zinc-400 text-sm mb-4">
+                Refresh to load the latest version.
+              </p>
+              <button
+                onClick={this.handleReload}
+                className="px-4 py-2 bg-amber-500 hover:bg-amber-400 text-zinc-950 text-sm font-medium rounded-lg transition-colors cursor-pointer"
+              >
+                Refresh
+              </button>
+            </div>
+          </div>
+        );
+      }
+
       return (
         <div className={outerClass}>
           <div className="max-w-md w-full bg-zinc-900 border border-red-800 rounded-lg p-6 text-center">

--- a/frontend/src/lib/lazyWithRetry.test.ts
+++ b/frontend/src/lib/lazyWithRetry.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+
+const mockUpdateAllRegistrations = mock(() => Promise.resolve());
+const mockClearPagesCache = mock(() => Promise.resolve());
+
+mock.module("./swControl", () => ({
+  updateAllRegistrations: mockUpdateAllRegistrations,
+  clearPagesCache: mockClearPagesCache,
+}));
+
+const mockReloadPage = mock(() => {});
+
+mock.module("./reloadPage", () => ({
+  reloadPage: mockReloadPage,
+}));
+
+import { isChunkLoadError, loadWithRetry } from "./lazyWithRetry";
+
+const LAZY_RETRY_KEY = "__lazy_retry";
+const MOD = { default: (() => null) as React.ComponentType };
+
+// Runs loadWithRetry but races with a 100ms timeout since retry paths return a never-resolving promise.
+async function runWithTimeout(factory: () => Promise<{ default: React.ComponentType }>) {
+  return Promise.race([
+    loadWithRetry(factory).catch((e: unknown) => ({ threw: e })),
+    new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 100)),
+  ]);
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+  mockUpdateAllRegistrations.mockReset();
+  mockClearPagesCache.mockReset();
+  mockReloadPage.mockReset();
+  mockUpdateAllRegistrations.mockImplementation(() => Promise.resolve());
+  mockClearPagesCache.mockImplementation(() => Promise.resolve());
+});
+
+afterEach(() => {
+  sessionStorage.clear();
+});
+
+describe("isChunkLoadError", () => {
+  it("matches Chrome error message", () => {
+    expect(isChunkLoadError(new Error("Failed to fetch dynamically imported module: https://example.com/assets/foo.js"))).toBe(true);
+  });
+
+  it("matches Firefox error message", () => {
+    expect(isChunkLoadError(new Error("error loading dynamically imported module: https://example.com/assets/bar.js"))).toBe(true);
+  });
+
+  it("matches Safari error message", () => {
+    expect(isChunkLoadError(new Error("Importing a module script failed."))).toBe(true);
+  });
+
+  it("matches webpack/vite chunk error", () => {
+    expect(isChunkLoadError(new Error("Loading chunk 42 failed."))).toBe(true);
+  });
+
+  it("does not match unrelated errors", () => {
+    expect(isChunkLoadError(new Error("Cannot read property 'foo' of undefined"))).toBe(false);
+    expect(isChunkLoadError(new Error("Network request failed"))).toBe(false);
+    expect(isChunkLoadError(null)).toBe(false);
+    expect(isChunkLoadError("string error")).toBe(false);
+  });
+});
+
+describe("loadWithRetry", () => {
+  it("returns module and resets retry counter on success", async () => {
+    sessionStorage.setItem(LAZY_RETRY_KEY, "1");
+    const factory = mock(() => Promise.resolve(MOD));
+
+    const result = await loadWithRetry(factory);
+
+    expect(result).toBe(MOD);
+    expect(sessionStorage.getItem(LAZY_RETRY_KEY)).toBeNull();
+    expect(mockReloadPage).not.toHaveBeenCalled();
+  });
+
+  it("rethrows non-chunk errors immediately without reload", async () => {
+    const runtimeError = new Error("Cannot read properties of undefined");
+    const factory = mock(() => Promise.reject(runtimeError));
+
+    const result = await runWithTimeout(factory);
+
+    expect(result).toMatchObject({ threw: runtimeError });
+    expect(mockReloadPage).not.toHaveBeenCalled();
+    expect(mockUpdateAllRegistrations).not.toHaveBeenCalled();
+    expect(mockClearPagesCache).not.toHaveBeenCalled();
+  });
+
+  it("retry 0 → 1: calls updateAllRegistrations then reloadPage", async () => {
+    const chunkError = new Error("Failed to fetch dynamically imported module: /assets/Foo.js");
+    const factory = mock(() => Promise.reject(chunkError));
+
+    await runWithTimeout(factory);
+
+    expect(sessionStorage.getItem(LAZY_RETRY_KEY)).toBe("1");
+    expect(mockUpdateAllRegistrations).toHaveBeenCalledTimes(1);
+    expect(mockClearPagesCache).not.toHaveBeenCalled();
+    expect(mockReloadPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("retry 1 → 2: calls clearPagesCache then reloadPage", async () => {
+    sessionStorage.setItem(LAZY_RETRY_KEY, "1");
+    const chunkError = new Error("error loading dynamically imported module: /assets/Bar.js");
+    const factory = mock(() => Promise.reject(chunkError));
+
+    await runWithTimeout(factory);
+
+    expect(sessionStorage.getItem(LAZY_RETRY_KEY)).toBe("2");
+    expect(mockUpdateAllRegistrations).not.toHaveBeenCalled();
+    expect(mockClearPagesCache).toHaveBeenCalledTimes(1);
+    expect(mockReloadPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("retry 2 → 3: tags error with isChunkLoadError=true and clears counter", async () => {
+    sessionStorage.setItem(LAZY_RETRY_KEY, "2");
+    const chunkError = new Error("Importing a module script failed.");
+    const factory = mock(() => Promise.reject(chunkError));
+
+    const result = await runWithTimeout(factory);
+
+    expect(result).toMatchObject({ threw: expect.objectContaining({ isChunkLoadError: true }) });
+    expect(sessionStorage.getItem(LAZY_RETRY_KEY)).toBeNull();
+    expect(mockReloadPage).not.toHaveBeenCalled();
+  });
+
+  it("all browser error variants trigger retry", async () => {
+    const messages = [
+      "Failed to fetch dynamically imported module: /a.js",
+      "error loading dynamically imported module: /b.js",
+      "Importing a module script failed.",
+      "Loading chunk 99 failed.",
+    ];
+
+    for (const message of messages) {
+      sessionStorage.clear();
+      mockReloadPage.mockReset();
+      const factory = mock(() => Promise.reject(new Error(message)));
+      await runWithTimeout(factory);
+      expect(mockReloadPage).toHaveBeenCalledTimes(1);
+    }
+  });
+});

--- a/frontend/src/lib/lazyWithRetry.ts
+++ b/frontend/src/lib/lazyWithRetry.ts
@@ -1,18 +1,46 @@
 import { lazy } from "react";
+import { updateAllRegistrations, clearPagesCache } from "./swControl";
+import { reloadPage } from "./reloadPage";
 
 const LAZY_RETRY_KEY = "__lazy_retry";
 
-export function lazyWithRetry(factory: () => Promise<{ default: React.ComponentType }>) {
-  return lazy(() =>
-    factory().catch((importError: unknown) => {
-      const retries = parseInt(sessionStorage.getItem(LAZY_RETRY_KEY) ?? "0", 10);
-      if (retries < 2) {
-        sessionStorage.setItem(LAZY_RETRY_KEY, String(retries + 1));
-        window.location.reload();
-        return new Promise<never>(() => {});
-      }
-      sessionStorage.removeItem(LAZY_RETRY_KEY);
-      throw importError;
-    })
+export function isChunkLoadError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return /failed to fetch dynamically imported module|error loading dynamically imported module|importing a module script failed|loading chunk \d+ failed/i.test(
+    error.message,
   );
+}
+
+export async function loadWithRetry(
+  factory: () => Promise<{ default: React.ComponentType }>,
+): Promise<{ default: React.ComponentType }> {
+  try {
+    const mod = await factory();
+    sessionStorage.removeItem(LAZY_RETRY_KEY);
+    return mod;
+  } catch (importError: unknown) {
+    if (!isChunkLoadError(importError)) throw importError;
+
+    const retries = parseInt(sessionStorage.getItem(LAZY_RETRY_KEY) ?? "0", 10);
+    if (retries >= 2) {
+      sessionStorage.removeItem(LAZY_RETRY_KEY);
+      (importError as Record<string, unknown>).isChunkLoadError = true;
+      throw importError;
+    }
+
+    sessionStorage.setItem(LAZY_RETRY_KEY, String(retries + 1));
+
+    if (retries === 0) {
+      await updateAllRegistrations();
+    } else {
+      await clearPagesCache();
+    }
+
+    reloadPage();
+    return new Promise<never>(() => {});
+  }
+}
+
+export function lazyWithRetry(factory: () => Promise<{ default: React.ComponentType }>) {
+  return lazy(() => loadWithRetry(factory));
 }

--- a/frontend/src/lib/reloadPage.ts
+++ b/frontend/src/lib/reloadPage.ts
@@ -1,0 +1,3 @@
+export function reloadPage(): void {
+  window.location.reload();
+}

--- a/frontend/src/lib/swControl.ts
+++ b/frontend/src/lib/swControl.ts
@@ -1,0 +1,19 @@
+export async function updateAllRegistrations(): Promise<void> {
+  if (!("serviceWorker" in navigator)) return;
+  try {
+    const registrations = await navigator.serviceWorker.getRegistrations();
+    await Promise.all(registrations.map((r) => r.update()));
+  } catch {
+    // best effort
+  }
+}
+
+export async function clearPagesCache(): Promise<void> {
+  if (!("serviceWorker" in navigator)) return;
+  try {
+    const registration = await navigator.serviceWorker.ready;
+    registration.active?.postMessage({ type: "CLEAR_PAGES_CACHE" });
+  } catch {
+    // best effort
+  }
+}

--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -1,6 +1,6 @@
 /// <reference lib="webworker" />
-import { precacheAndRoute, cleanupOutdatedCaches, createHandlerBoundToURL } from "workbox-precaching";
-import { registerRoute, NavigationRoute } from "workbox-routing";
+import { precacheAndRoute, cleanupOutdatedCaches, matchPrecache } from "workbox-precaching";
+import { registerRoute, NavigationRoute, setCatchHandler } from "workbox-routing";
 import { StaleWhileRevalidate, NetworkFirst, NetworkOnly } from "workbox-strategies";
 import { ExpirationPlugin } from "workbox-expiration";
 import { BackgroundSyncPlugin } from "workbox-background-sync";
@@ -10,12 +10,29 @@ declare let self: ServiceWorkerGlobalScope;
 precacheAndRoute(self.__WB_MANIFEST);
 cleanupOutdatedCaches();
 
-// Navigation fallback — serve index.html for all navigation requests except /api/
-const navigationRoute = new NavigationRoute(
-  createHandlerBoundToURL("/index.html"),
-  { denylist: [/^\/api\//] }
+// Navigation: try fresh network first (ensures post-deploy HTML has current chunk hashes),
+// fall back to the "pages" runtime cache when offline. /api/ and /share/watchlist/ are
+// excluded — the former are API calls; the latter gets per-token OG tags injected at
+// request time by the Worker and must not be served from cache.
+const navigationStrategy = new NetworkFirst({
+  cacheName: "pages",
+  networkTimeoutSeconds: 2,
+  plugins: [new ExpirationPlugin({ maxEntries: 10 })],
+});
+registerRoute(
+  new NavigationRoute(navigationStrategy, {
+    denylist: [/^\/api\//, /^\/share\/watchlist\//],
+  }),
 );
-registerRoute(navigationRoute);
+
+// When a navigation fails (offline and no pages cache hit), serve the
+// precached index.html so the SPA shell still loads.
+setCatchHandler(async ({ request }) => {
+  if (request.destination === "document") {
+    return (await matchPrecache("/index.html")) ?? Response.error();
+  }
+  return Response.error();
+});
 
 const CACHE_PREFIXES = [
   "api-static-v",
@@ -162,8 +179,18 @@ registerRoute(
   "DELETE"
 );
 
-// Message handler: pre-cache a tracked title's detail data on demand + cache age queries
+// Message handler: SW lifecycle control + cache queries + on-demand precaching
 self.addEventListener("message", (event) => {
+  if (event.data?.type === "SKIP_WAITING") {
+    self.skipWaiting();
+    return;
+  }
+
+  if (event.data?.type === "CLEAR_PAGES_CACHE") {
+    event.waitUntil(caches.delete("pages"));
+    return;
+  }
+
   if (event.data?.type === "GET_CACHE_AGE") {
     const ts = lastFetchTime.get(event.data.cacheName as string) ?? null;
     const ageMs = ts !== null ? Date.now() - ts : null;
@@ -181,9 +208,6 @@ self.addEventListener("message", (event) => {
     caches.open(`api-details-v${__APP_VERSION__}`).then((c) => c.add(path)).catch(() => {})
   );
 });
-
-// Skip waiting so the new SW activates immediately on update
-self.skipWaiting();
 
 self.addEventListener("activate", (event) => {
   event.waitUntil(

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -436,7 +436,10 @@ function createApp(env: Env) {
           const injected = ogTags ? html.replace("</head>", `${ogTags}\n  </head>`) : html;
           return new Response(injected, {
             status: 200,
-            headers: { "content-type": "text/html; charset=utf-8" },
+            headers: {
+              "content-type": "text/html; charset=utf-8",
+              "cache-control": "no-cache, must-revalidate",
+            },
           });
         }
       }
@@ -462,7 +465,10 @@ function createApp(env: Env) {
         if (resp.ok) {
           return new Response(resp.body, {
             status: 200,
-            headers: { "content-type": "text/html; charset=utf-8" },
+            headers: {
+              "content-type": "text/html; charset=utf-8",
+              "cache-control": "no-cache, must-revalidate",
+            },
           });
         }
       }


### PR DESCRIPTION
## Summary

- **SW navigation strategy**: replaced precache-bound `NavigationRoute` with `NetworkFirst` (2s timeout, stable `pages` cache) so post-deploy navigations always fetch fresh HTML from the network rather than the old cached shell
- **Browser HTTP cache**: added `Cache-Control: no-cache, must-revalidate` to both `index.html` response paths in `server/worker.ts`
- **lazyWithRetry**: narrowed retry to real chunk-load errors (Chrome/Firefox/Safari variants), escalates from `registration.update()` on retry 1 → `CLEAR_PAGES_CACHE` message on retry 2 (preserves BackgroundSync queues), resets counter on success
- **ErrorBoundary**: chunk-load errors now render "A new version is available" + **Refresh** button (drops `pages` cache + reloads) instead of the useless "Try Again" that re-threw the same cached rejection; Sentry events tagged `errorType: chunk-load | render`

## Root causes fixed

The error happened via three independent paths, all addressed:
1. SW served old precached `index.html` referencing stale chunk hashes until the new SW activated
2. Browser HTTP cache could serve stale `index.html` (no `Cache-Control` was set)
3. Even without the SW, long-lived tabs with old HTML in memory would 404 on lazy chunk imports — and the `lazyWithRetry` reload loop didn't update the SW before reloading, so it cycled through the same dead URL twice then gave up

## Test plan

- [ ] `bun run check` passes (2380 tests, 0 failures — verified locally)
- [ ] `frontend/src/lib/lazyWithRetry.test.ts` — 11 new unit tests covering all browser error message variants, retry escalation, counter reset on success, exhausted-retry tagging
- [ ] `frontend/src/components/ErrorBoundary.test.ts` — extended with chunk-load Sentry tag and `handleReload` tests
- [ ] Manual: build, install SW, redeploy with new chunk hashes, navigate to `/settings` — should no longer error
- [ ] After deploy: check Sentry for `errorType:chunk-load` tag rate drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)