### PR TITLE
feat: edge-cache SPA shell and public API routes to cut bot invocation costs

### DIFF
--- a/server/routes/browse.ts
+++ b/server/routes/browse.ts
@@ -24,6 +24,7 @@ import type { AppEnv } from "../types";
 import { logger } from "../logger";
 import { syncFailureTotal } from "../metrics";
 import { ok, err } from "./response";
+import { setPublicCacheIfAnon } from "./cache-headers";
 import { toCanonicalGenre, expandGenreIds } from "../genres";
 import { CONFIG } from "../config";
 
@@ -226,6 +227,7 @@ app.get("/", async (c) => {
       .filter((l) => prioritySet.has(l.code))
       .map((l) => l.code);
 
+    setPublicCacheIfAnon(c, 1800);
     return ok(c, { titles: titlesWithTracked, page, totalPages, totalResults, availableGenres, availableProviders, availableLanguages, regionProviderIds, priorityLanguageCodes });
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : String(e);

--- a/server/routes/cache-headers.test.ts
+++ b/server/routes/cache-headers.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "../types";
+import { setPublicCacheIfAnon } from "./cache-headers";
+
+const ANON_RE = /^public, s-maxage=\d+, stale-while-revalidate=\d+$/;
+
+function fakeUser() {
+  return { id: "u1", username: "alice", name: null, role: null, is_admin: false };
+}
+
+describe("setPublicCacheIfAnon", () => {
+  it("emits public cache header for anonymous requests", async () => {
+    const app = new Hono<AppEnv>();
+    app.get("/", (c) => {
+      setPublicCacheIfAnon(c, 3600);
+      return c.json({ ok: true });
+    });
+    const res = await app.request("/");
+    expect(res.headers.get("cache-control")).toMatch(ANON_RE);
+    expect(res.headers.get("cache-control")).toContain("s-maxage=3600");
+    expect(res.headers.get("cache-control")).toContain("stale-while-revalidate=604800");
+  });
+
+  it("emits private no-store for authenticated requests", async () => {
+    const app = new Hono<AppEnv>();
+    app.get("/", (c) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      c.set("user", fakeUser() as any);
+      setPublicCacheIfAnon(c, 3600);
+      return c.json({ ok: true });
+    });
+    const res = await app.request("/");
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
+  });
+
+  it("respects a custom stale-while-revalidate", async () => {
+    const app = new Hono<AppEnv>();
+    app.get("/", (c) => {
+      setPublicCacheIfAnon(c, 600, 86400);
+      return c.json({ ok: true });
+    });
+    const res = await app.request("/");
+    expect(res.headers.get("cache-control")).toContain("stale-while-revalidate=86400");
+  });
+
+  it("does not bleed authed user header into subsequent anon response", async () => {
+    const authedApp = new Hono<AppEnv>();
+    authedApp.get("/", (c) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      c.set("user", fakeUser() as any);
+      setPublicCacheIfAnon(c, 3600);
+      return c.json({ ok: true });
+    });
+
+    const anonApp = new Hono<AppEnv>();
+    anonApp.get("/", (c) => {
+      setPublicCacheIfAnon(c, 3600);
+      return c.json({ ok: true });
+    });
+
+    const authedRes = await authedApp.request("/");
+    const anonRes = await anonApp.request("/");
+
+    expect(authedRes.headers.get("cache-control")).toBe("private, no-store");
+    expect(anonRes.headers.get("cache-control")).toMatch(ANON_RE);
+  });
+});

--- a/server/routes/cache-headers.ts
+++ b/server/routes/cache-headers.ts
@@ -1,0 +1,17 @@
+import type { Context } from "hono";
+import type { AppEnv } from "../types";
+
+export function setPublicCacheIfAnon(
+  c: Context<AppEnv>,
+  sMaxAge: number,
+  staleWhileRevalidate = 604800,
+): void {
+  if (c.get("user")) {
+    c.header("Cache-Control", "private, no-store");
+  } else {
+    c.header(
+      "Cache-Control",
+      `public, s-maxage=${sMaxAge}, stale-while-revalidate=${staleWhileRevalidate}`,
+    );
+  }
+}

--- a/server/routes/calendar.ts
+++ b/server/routes/calendar.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { getTitlesByMonth, getEpisodesByMonth } from "../db/repository";
 import type { AppEnv } from "../types";
 import { ok, err } from "./response";
+import { setPublicCacheIfAnon } from "./cache-headers";
 
 const app = new Hono<AppEnv>();
 
@@ -21,6 +22,7 @@ app.get("/", async (c) => {
 
   const titles = await getTitlesByMonth({ month, objectType, provider }, user?.id);
   const episodes = await getEpisodesByMonth({ month, objectType, provider }, user?.id);
+  setPublicCacheIfAnon(c, 1800);
   return ok(c, { titles, episodes, count: titles.length });
 });
 

--- a/server/routes/details.ts
+++ b/server/routes/details.ts
@@ -14,6 +14,7 @@ import { parseMovieDetails, parseTvDetails } from "../tmdb/parser";
 import type { AppEnv } from "../types";
 import { logger } from "../logger";
 import { ok, err } from "./response";
+import { setPublicCacheIfAnon } from "./cache-headers";
 import { getUserPace, computeEta } from "../db/repository/stats";
 import { getDb } from "../db/schema";
 import { sql } from "drizzle-orm";
@@ -71,6 +72,7 @@ app.get("/movie/:id", async (c) => {
     }
   }
 
+  setPublicCacheIfAnon(c, 3600);
   return ok(c, { title, tmdb, country });
 });
 
@@ -116,6 +118,7 @@ app.get("/show/:id", async (c) => {
     }
   }
 
+  setPublicCacheIfAnon(c, 3600);
   return ok(c, { title: { ...title, eta_days: etaDays }, tmdb, country });
 });
 
@@ -156,6 +159,7 @@ app.get("/show/:id/season/:season", async (c) => {
     }
   }
 
+  setPublicCacheIfAnon(c, 3600);
   return ok(c, { title, tmdb, seasonNumber, country, seasons });
 });
 

--- a/server/routes/titles.ts
+++ b/server/routes/titles.ts
@@ -5,6 +5,7 @@ import { expandGenreGroup } from "../genres";
 import { CONFIG } from "../config";
 import type { AppEnv } from "../types";
 import { ok } from "./response";
+import { setPublicCacheIfAnon } from "./cache-headers";
 
 const PRIORITY_LANGUAGES = ["en", "es", "fr", "de", "pt", "ja", "ko", "zh", "hi", "it", "ar"];
 
@@ -27,6 +28,7 @@ app.get("/", async (c) => {
   const languages = languageParam ? languageParam.split(",").filter(Boolean) : [];
 
   const titles = await getRecentTitles({ daysBack, objectTypes, providers, genres, languages, excludeTracked, limit, offset }, user?.id);
+  setPublicCacheIfAnon(c, 600);
   return ok(c, { titles, count: titles.length });
 });
 

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -467,7 +467,7 @@ function createApp(env: Env) {
             status: 200,
             headers: {
               "content-type": "text/html; charset=utf-8",
-              "cache-control": "no-cache, must-revalidate",
+              "cache-control": "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800",
             },
           });
         }


### PR DESCRIPTION
## Summary

Applebot was generating ~17k Worker invocations/hour (99% of all traffic) before `robots.txt` was added in #621. Robots.txt is a polite request; well-behaved crawlers honour it, but the general scraper population doesn't. This PR makes the Cloudflare edge cache absorb repeat hits from crawlers so they never reach the Worker.

- **SPA shell** (`server/worker.ts`): changed `cache-control: no-cache, must-revalidate` → `public, max-age=300, s-maxage=86400, stale-while-revalidate=604800`. Every non-API path (`/`, `/title/:id`, `/calendar`, etc.) returns the same static `index.html` bytes — after the first miss, CF serves them from cache for 24h. Browser TTL is 5 min so deploys roll out quickly. The `/share/watchlist/:token` handler is unchanged (dynamic OG tags per token).
- **New `setPublicCacheIfAnon` helper** (`server/routes/cache-headers.ts`): emits `public, s-maxage=…` for anonymous requests, `private, no-store` for authenticated requests. This prevents authed responses (which include `is_tracked` flags and `eta_days`) from bleeding into the shared edge cache.
- **Applied to high-traffic public APIs**:
  - `GET /api/titles` — 10 min TTL
  - `GET /api/details/movie/:id`, `/show/:id`, `/show/:id/season/:n` — 1 h TTL
  - `GET /api/calendar` — 30 min TTL
  - `GET /api/browse` — 30 min TTL

## Test plan

- [ ] `bun run check` passes (2384 tests, 0 failures) ✅
- [ ] After deploy: `curl -I https://remindarr.app/title/123` — second hit shows `cf-cache-status: HIT`
- [ ] `curl -I https://remindarr.app/api/details/movie/550` with no cookie — second hit shows `HIT`; same request with a session cookie shows `Cache-Control: private, no-store`
- [ ] Worker invocation metrics in CF dashboard drop sharply as edge cache fills
- [ ] Enable **Bot Fight Mode** in CF dashboard (Security → Bots) as a complementary layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)