### PR TITLE
feat: shared per-IP rate-limit bucket store with global cap

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -35,6 +35,8 @@ export const CONFIG = {
   // Rate limit knob for /api/auth/* — keeps brute-force protection on by
   // default but lets e2e / CI raise the cap so test flows don't 429.
   AUTH_RATE_LIMIT_PER_MINUTE: Number(process.env.AUTH_RATE_LIMIT_PER_MINUTE) || 20,
+  // Global per-IP cap across all /api/* routes — guards against aggregate abuse.
+  GLOBAL_RATE_LIMIT_PER_MINUTE: Number(process.env.GLOBAL_RATE_LIMIT_PER_MINUTE) || 300,
 
   // Passkeys (WebAuthn)
   PASSKEY_RP_ID: process.env.PASSKEY_RP_ID || "",

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,7 +7,7 @@ import { CONFIG } from "./config";
 import { initBunDb, migrateTrackedData, getRawDb } from "./db/bun-db";
 import { getUserCount, createUser, getUserByWatchlistShareToken, getTrackedTitles } from "./db/repository";
 import { optionalAuth, requireAuth, requireAdmin } from "./middleware/auth";
-import { rateLimiter } from "./middleware/rate-limit";
+import { rateLimiter, MemoryRateLimitStore } from "./middleware/rate-limit";
 import syncRoutes from "./routes/sync";
 import titlesRoutes from "./routes/titles";
 import searchRoutes from "./routes/search";
@@ -67,6 +67,9 @@ initBunDb();
 // Initialize distributed cache
 const cache = await createCache();
 initCache(cache);
+
+// Shared rate-limit store — single instance so all middleware shares the same buckets.
+const rateLimitStore = new MemoryRateLimitStore();
 
 const platform = new BunPlatform();
 
@@ -176,6 +179,13 @@ if (CONFIG.CORS_ORIGIN) {
 // Request logging
 app.use("/api/*", requestLogger());
 
+// Global per-IP cap — applies to all /api/* before any per-route limiter.
+// Prevents aggregate abuse across routes from a single client.
+app.use(
+  "/api/*",
+  rateLimiter({ store: rateLimitStore, scope: "global", limit: CONFIG.GLOBAL_RATE_LIMIT_PER_MINUTE, windowMs: 60_000 })
+);
+
 // Health check (public — used by Sentry uptime monitoring)
 app.route("/api/health", healthRoutes);
 
@@ -187,7 +197,7 @@ app.route("/metrics", metricsRoutes);
 // need a higher cap.
 app.use(
   "/api/auth/*",
-  rateLimiter({ limit: CONFIG.AUTH_RATE_LIMIT_PER_MINUTE, windowMs: 60_000 })
+  rateLimiter({ store: rateLimitStore, scope: "auth", limit: CONFIG.AUTH_RATE_LIMIT_PER_MINUTE, windowMs: 60_000 })
 );
 
 // Custom auth routes (providers endpoint) — must be before better-auth catch-all
@@ -204,13 +214,12 @@ app.use("/api/titles", optionalAuth);
 app.route("/api/titles", titlesRoutes);
 
 // Rate limit search: 30 requests per minute
-app.use("/api/search/*", rateLimiter({ limit: 30, windowMs: 60_000 }));
-app.use("/api/search", rateLimiter({ limit: 30, windowMs: 60_000 }));
-app.use("/api/search/*", optionalAuth);
-app.use("/api/search", optionalAuth);
+const searchRateLimiter = rateLimiter({ store: rateLimitStore, scope: "search", limit: 30, windowMs: 60_000 });
+app.use("/api/search/*", searchRateLimiter, optionalAuth);
+app.use("/api/search", searchRateLimiter, optionalAuth);
 app.route("/api/search", searchRoutes);
 
-const browseRateLimiter = rateLimiter({ limit: 30, windowMs: 60_000 });
+const browseRateLimiter = rateLimiter({ store: rateLimitStore, scope: "browse", limit: 30, windowMs: 60_000 });
 app.use("/api/browse/*", browseRateLimiter, optionalAuth);
 app.use("/api/browse", browseRateLimiter, optionalAuth);
 app.route("/api/browse", browseRoutes);
@@ -234,7 +243,7 @@ app.route("/api/social", socialRoutes);
 
 // Rate limit write-heavy routes: 60 requests per minute per IP.
 // Applied before requireAuth so floods are rejected cheaply.
-const writeRateLimiter = rateLimiter({ limit: 60, windowMs: 60_000 });
+const writeRateLimiter = rateLimiter({ store: rateLimitStore, scope: "writes", limit: 60, windowMs: 60_000 });
 
 // Ratings routes — optionalAuth base, POST/DELETE check auth internally.
 // Rate-limit applies to all (reads + writes) so unauth scrapers get throttled too.
@@ -274,8 +283,9 @@ app.use("/api/integrations", writeRateLimiter, requireAuth);
 app.route("/api/integrations", integrationRoutes);
 
 // Import is more expensive per request — tighter cap.
-app.use("/api/import/*", rateLimiter({ limit: 10, windowMs: 60_000 }), requireAuth);
-app.use("/api/import", rateLimiter({ limit: 10, windowMs: 60_000 }), requireAuth);
+const importRateLimiter = rateLimiter({ store: rateLimitStore, scope: "import", limit: 10, windowMs: 60_000 });
+app.use("/api/import/*", importRateLimiter, requireAuth);
+app.use("/api/import", importRateLimiter, requireAuth);
 app.route("/api/import", importRoutes);
 
 app.use("/api/stats/*", requireAuth);
@@ -313,14 +323,15 @@ app.use("/api/jobs", requireAuth, requireAdmin);
 app.route("/api/jobs", jobsRoutes);
 
 // Detail pages (optionalAuth for is_tracked)
-const detailsRateLimiter = rateLimiter({ limit: 60, windowMs: 60_000 });
+const detailsRateLimiter = rateLimiter({ store: rateLimitStore, scope: "details", limit: 60, windowMs: 60_000 });
 app.use("/api/details/*", detailsRateLimiter, optionalAuth);
 app.use("/api/details", detailsRateLimiter, optionalAuth);
 app.route("/api/details", detailsRoutes);
 
 // Sync (admin only — rate limited + require admin)
-app.use("/api/sync/*", rateLimiter({ limit: 5, windowMs: 60_000 }));
-app.use("/api/sync", rateLimiter({ limit: 5, windowMs: 60_000 }));
+const syncRateLimiter = rateLimiter({ store: rateLimitStore, scope: "sync", limit: 5, windowMs: 60_000 });
+app.use("/api/sync/*", syncRateLimiter);
+app.use("/api/sync", syncRateLimiter);
 app.use("/api/sync/*", requireAuth, requireAdmin);
 app.use("/api/sync", requireAuth, requireAdmin);
 app.route("/api/sync", syncRoutes);

--- a/server/middleware/rate-limit.test.ts
+++ b/server/middleware/rate-limit.test.ts
@@ -1,18 +1,16 @@
 import { describe, it, expect, spyOn } from "bun:test";
 import { Hono } from "hono";
-import { rateLimiter } from "./rate-limit";
+import { rateLimiter, MemoryRateLimitStore, KvRateLimitStore } from "./rate-limit";
 import type { AppEnv } from "../types";
 
-function createApp(limit: number, windowMs: number) {
-  const app = new Hono<AppEnv>();
-  app.use("/test/*", rateLimiter({ limit, windowMs }));
-  app.get("/test/hello", (c) => c.json({ ok: true }));
-  return app;
-}
+// ─── MemoryRateLimitStore tests ─────────────────────────────────────────────
 
-describe("rateLimiter", () => {
+describe("MemoryRateLimitStore", () => {
   it("allows requests under the limit", async () => {
-    const app = createApp(3, 60_000);
+    const store = new MemoryRateLimitStore();
+    const app = new Hono<AppEnv>();
+    app.use("/test/*", rateLimiter({ store, limit: 3, windowMs: 60_000 }));
+    app.get("/test/hello", (c) => c.json({ ok: true }));
 
     for (let i = 0; i < 3; i++) {
       const res = await app.request("/test/hello");
@@ -21,7 +19,10 @@ describe("rateLimiter", () => {
   });
 
   it("returns 429 when limit is exceeded", async () => {
-    const app = createApp(2, 60_000);
+    const store = new MemoryRateLimitStore();
+    const app = new Hono<AppEnv>();
+    app.use("/test/*", rateLimiter({ store, limit: 2, windowMs: 60_000 }));
+    app.get("/test/hello", (c) => c.json({ ok: true }));
 
     await app.request("/test/hello");
     await app.request("/test/hello");
@@ -30,11 +31,14 @@ describe("rateLimiter", () => {
     expect(res.status).toBe(429);
     const body = await res.json();
     expect(body.error).toBe("Too many requests");
-    expect(res.headers.get("Retry-After")).toBe("60");
+    expect(Number(res.headers.get("Retry-After"))).toBeGreaterThan(0);
   });
 
   it("uses x-forwarded-for to differentiate clients", async () => {
-    const app = createApp(1, 60_000);
+    const store = new MemoryRateLimitStore();
+    const app = new Hono<AppEnv>();
+    app.use("/test/*", rateLimiter({ store, limit: 1, windowMs: 60_000 }));
+    app.get("/test/hello", (c) => c.json({ ok: true }));
 
     const res1 = await app.request("/test/hello", {
       headers: { "x-forwarded-for": "1.1.1.1" },
@@ -54,9 +58,9 @@ describe("rateLimiter", () => {
   });
 
   it("refills tokens over time", async () => {
+    const store = new MemoryRateLimitStore();
     const app = new Hono<AppEnv>();
-    // Use a very short window so tokens refill quickly
-    app.use("/test/*", rateLimiter({ limit: 1, windowMs: 50 }));
+    app.use("/test/*", rateLimiter({ store, limit: 1, windowMs: 50 }));
     app.get("/test/hello", (c) => c.json({ ok: true }));
 
     const res1 = await app.request("/test/hello");
@@ -82,7 +86,7 @@ describe("rateLimiter", () => {
       }) as typeof setInterval
     );
 
-    createApp(3, 60_000);
+    new MemoryRateLimitStore(60_000);
 
     expect(spy).toHaveBeenCalledTimes(1);
     expect(capturedCallback).not.toBeNull();
@@ -100,11 +104,9 @@ describe("rateLimiter", () => {
       }) as typeof setInterval
     );
 
+    const store = new MemoryRateLimitStore(50);
     const app = new Hono<AppEnv>();
-    app.use(
-      "/test/*",
-      rateLimiter({ limit: 1, windowMs: 10, cleanupIntervalMs: 50 })
-    );
+    app.use("/test/*", rateLimiter({ store, limit: 1, windowMs: 10 }));
     app.get("/test/hello", (c) => c.json({ ok: true }));
 
     spy.mockRestore();
@@ -114,8 +116,12 @@ describe("rateLimiter", () => {
     const limited = await app.request("/test/hello", { headers: { "x-forwarded-for": "5.5.5.5" } });
     expect(limited.status).toBe(429);
 
-    // Simulate time passing beyond the stale threshold (windowMs * 2 = 20ms)
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    // Simulate time passing beyond the stale threshold (5 min from the store cleanup)
+    // by reaching into the bucket map and backdating the entry
+    const buckets = store.getBuckets();
+    for (const [, bucket] of buckets) {
+      bucket.lastRefill = Date.now() - 6 * 60 * 1000;
+    }
 
     // Manually invoke the cleanup callback (simulating the interval firing)
     expect(capturedCallback).not.toBeNull();
@@ -127,10 +133,12 @@ describe("rateLimiter", () => {
   });
 
   it("supports custom keyGenerator", async () => {
+    const store = new MemoryRateLimitStore();
     const app = new Hono<AppEnv>();
     app.use(
       "/test/*",
       rateLimiter({
+        store,
         limit: 1,
         windowMs: 60_000,
         keyGenerator: () => "same-key",
@@ -148,5 +156,171 @@ describe("rateLimiter", () => {
       headers: { "x-forwarded-for": "2.2.2.2" },
     });
     expect(res2.status).toBe(429);
+  });
+});
+
+// ─── Cross-route enforcement tests ─────────────────────────────────────────
+
+describe("rateLimiter — cross-route enforcement", () => {
+  it("enforces shared budget across routes with same scope", async () => {
+    const store = new MemoryRateLimitStore();
+    const limiter = rateLimiter({ store, scope: "global", limit: 3, windowMs: 60_000 });
+    const app = new Hono<AppEnv>();
+    app.use("/api/*", limiter);
+    app.get("/api/foo", (c) => c.json({ ok: true }));
+    app.get("/api/bar", (c) => c.json({ ok: true }));
+
+    const ip = { headers: { "x-forwarded-for": "9.9.9.9" } };
+
+    const r1 = await app.request("/api/foo", ip);
+    const r2 = await app.request("/api/bar", ip);
+    const r3 = await app.request("/api/foo", ip);
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect(r3.status).toBe(200);
+
+    // Budget exhausted — any route is now blocked
+    const r4 = await app.request("/api/bar", ip);
+    expect(r4.status).toBe(429);
+  });
+
+  it("isolates budgets across different scopes for the same store", async () => {
+    const store = new MemoryRateLimitStore();
+    const searchLimiter = rateLimiter({ store, scope: "search", limit: 2, windowMs: 60_000 });
+    const browseLimiter = rateLimiter({ store, scope: "browse", limit: 2, windowMs: 60_000 });
+    const app = new Hono<AppEnv>();
+    app.use("/api/search", searchLimiter);
+    app.use("/api/browse", browseLimiter);
+    app.get("/api/search", (c) => c.json({ ok: true }));
+    app.get("/api/browse", (c) => c.json({ ok: true }));
+
+    const ip = { headers: { "x-forwarded-for": "8.8.8.8" } };
+
+    // Exhaust search budget
+    await app.request("/api/search", ip);
+    await app.request("/api/search", ip);
+    expect((await app.request("/api/search", ip)).status).toBe(429);
+
+    // Browse budget is independent — should still allow
+    expect((await app.request("/api/browse", ip)).status).toBe(200);
+  });
+
+  it("layers global cap on top of per-route cap", async () => {
+    const store = new MemoryRateLimitStore();
+    const globalLimiter = rateLimiter({ store, scope: "global", limit: 10, windowMs: 60_000 });
+    const searchLimiter = rateLimiter({ store, scope: "search", limit: 3, windowMs: 60_000 });
+    const app = new Hono<AppEnv>();
+    app.use("/api/*", globalLimiter);
+    app.use("/api/search", searchLimiter);
+    app.get("/api/search", (c) => c.json({ ok: true }));
+    app.get("/api/other", (c) => c.json({ ok: true }));
+
+    const ip = { headers: { "x-forwarded-for": "7.7.7.7" } };
+
+    // Hit search 3 times — hits per-route cap
+    for (let i = 0; i < 3; i++) {
+      expect((await app.request("/api/search", ip)).status).toBe(200);
+    }
+    expect((await app.request("/api/search", ip)).status).toBe(429);
+
+    // /api/other still works (only 3 out of 10 global tokens consumed so far)
+    expect((await app.request("/api/other", ip)).status).toBe(200);
+  });
+});
+
+// ─── KvRateLimitStore tests ─────────────────────────────────────────────────
+
+/** Minimal in-memory KVNamespace mock for testing. */
+class MockKvNamespace {
+  private readonly store = new Map<string, { value: string; expires: number }>();
+  readonly putCalls: Array<{ key: string; ttl: number }> = [];
+
+  async get(key: string, _type: "text"): Promise<string | null> {
+    const entry = this.store.get(key);
+    if (!entry) return null;
+    if (Date.now() > entry.expires) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  async put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void> {
+    const ttl = options?.expirationTtl ?? 60;
+    this.putCalls.push({ key, ttl });
+    this.store.set(key, { value, expires: Date.now() + ttl * 1000 });
+  }
+
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+}
+
+describe("KvRateLimitStore", () => {
+  it("allows requests under the fixed-window limit", async () => {
+    const kv = new MockKvNamespace() as unknown as KVNamespace;
+    const store = new KvRateLimitStore(kv);
+    const now = Date.now();
+
+    for (let i = 0; i < 3; i++) {
+      const result = await store.consume("search:1.2.3.4", 3, 60_000, now);
+      expect(result.allowed).toBe(true);
+    }
+  });
+
+  it("blocks at the limit within the same window", async () => {
+    const kv = new MockKvNamespace() as unknown as KVNamespace;
+    const store = new KvRateLimitStore(kv);
+    const now = Date.now();
+
+    await store.consume("search:1.2.3.4", 2, 60_000, now);
+    await store.consume("search:1.2.3.4", 2, 60_000, now);
+    const result = await store.consume("search:1.2.3.4", 2, 60_000, now);
+    expect(result.allowed).toBe(false);
+    expect(result.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it("allows again after window rolls over", async () => {
+    const kv = new MockKvNamespace() as unknown as KVNamespace;
+    const store = new KvRateLimitStore(kv);
+    const windowMs = 60_000;
+    const now = Date.now();
+
+    // Exhaust this window
+    await store.consume("search:1.2.3.4", 1, windowMs, now);
+    const blocked = await store.consume("search:1.2.3.4", 1, windowMs, now);
+    expect(blocked.allowed).toBe(false);
+
+    // Next window — key is different because windowStart changes
+    const nextWindow = now + windowMs;
+    const result = await store.consume("search:1.2.3.4", 1, windowMs, nextWindow);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("passes minimum 60s TTL to KV", async () => {
+    const kv = new MockKvNamespace() as unknown as KVNamespace;
+    const store = new KvRateLimitStore(kv);
+    const now = Date.now();
+
+    await store.consume("search:1.2.3.4", 5, 60_000, now);
+    const mock = kv as unknown as MockKvNamespace;
+    expect(mock.putCalls.length).toBeGreaterThan(0);
+    // 60_000ms → 60s, which satisfies KV minimum
+    expect(mock.putCalls[0].ttl).toBeGreaterThanOrEqual(60);
+  });
+
+  it("isolates different keys within the same window", async () => {
+    const kv = new MockKvNamespace() as unknown as KVNamespace;
+    const store = new KvRateLimitStore(kv);
+    const now = Date.now();
+
+    // Exhaust IP A
+    await store.consume("search:1.1.1.1", 1, 60_000, now);
+    const blockedA = await store.consume("search:1.1.1.1", 1, 60_000, now);
+    expect(blockedA.allowed).toBe(false);
+
+    // IP B is unaffected
+    const allowedB = await store.consume("search:2.2.2.2", 1, 60_000, now);
+    expect(allowedB.allowed).toBe(true);
   });
 });

--- a/server/middleware/rate-limit.ts
+++ b/server/middleware/rate-limit.ts
@@ -4,73 +4,161 @@ import { logger } from "../logger";
 
 const log = logger.child({ module: "rate-limit" });
 
+// ─── Store interface ────────────────────────────────────────────────────────
+
+export interface RateLimitStore {
+  /** Consume one request token. Returns whether the request is allowed. */
+  consume(
+    key: string,
+    limit: number,
+    windowMs: number,
+    now: number,
+  ): Promise<{ allowed: boolean; retryAfterMs: number }>;
+}
+
+// ─── In-memory token-bucket store (Bun) ────────────────────────────────────
+
 interface TokenBucket {
   tokens: number;
   lastRefill: number;
 }
 
-interface RateLimitOptions {
-  /** Maximum number of requests allowed in the window */
-  limit: number;
-  /** Window duration in milliseconds */
-  windowMs: number;
-  /** How often to run periodic cleanup of stale buckets (ms). Defaults to max(2*windowMs, 5 minutes). */
-  cleanupIntervalMs?: number;
-  /** Function to derive a key from the request (defaults to x-forwarded-for or "anonymous") */
-  keyGenerator?: (c: { req: { header: (name: string) => string | undefined } }) => string;
-}
+export class MemoryRateLimitStore implements RateLimitStore {
+  private readonly buckets = new Map<string, TokenBucket>();
+  private readonly cleanupTimer: ReturnType<typeof setInterval>;
 
-/**
- * In-memory token bucket rate limiter.
- * Each call creates an independent store, so different routes can have different limits.
- */
-export function rateLimiter(options: RateLimitOptions) {
-  const { limit, windowMs } = options;
-  const cleanupIntervalMs =
-    options.cleanupIntervalMs ?? Math.max(windowMs * 2, 5 * 60 * 1000);
-  const keyGenerator =
-    options.keyGenerator ??
-    ((c) => c.req.header("x-forwarded-for") ?? "anonymous");
-
-  const buckets = new Map<string, TokenBucket>();
-
-  // Periodic cleanup so stale entries are removed even on low-traffic instances.
-  // unref() ensures the timer doesn't prevent the process from exiting (Node/Bun only).
-  const cleanupTimer = setInterval(() => {
-    const now = Date.now();
-    for (const [k, bucket] of buckets) {
-      if (now - bucket.lastRefill > windowMs * 2) {
-        buckets.delete(k);
+  constructor(cleanupIntervalMs = 5 * 60 * 1000) {
+    this.cleanupTimer = setInterval(() => {
+      const now = Date.now();
+      for (const [k, bucket] of this.buckets) {
+        // Remove buckets that have been inactive for 2× the longest possible window.
+        // We don't know windowMs per bucket, so use a generous 5-minute threshold.
+        if (now - bucket.lastRefill > 5 * 60 * 1000) {
+          this.buckets.delete(k);
+        }
       }
+    }, cleanupIntervalMs);
+
+    if (typeof this.cleanupTimer === "object" && "unref" in this.cleanupTimer) {
+      (this.cleanupTimer as NodeJS.Timeout).unref();
     }
-  }, cleanupIntervalMs);
-  if (typeof cleanupTimer === "object" && "unref" in cleanupTimer) {
-    cleanupTimer.unref();
   }
 
-  return createMiddleware<AppEnv>(async (c, next) => {
-    const key = keyGenerator(c);
-    const now = Date.now();
-
-    let bucket = buckets.get(key);
+  async consume(
+    key: string,
+    limit: number,
+    windowMs: number,
+    now: number,
+  ): Promise<{ allowed: boolean; retryAfterMs: number }> {
+    let bucket = this.buckets.get(key);
     if (!bucket) {
       bucket = { tokens: limit, lastRefill: now };
-      buckets.set(key, bucket);
+      this.buckets.set(key, bucket);
     }
 
-    // Refill tokens based on elapsed time
     const elapsed = now - bucket.lastRefill;
     const tokensToAdd = (elapsed / windowMs) * limit;
     bucket.tokens = Math.min(limit, bucket.tokens + tokensToAdd);
     bucket.lastRefill = now;
 
     if (bucket.tokens < 1) {
-      log.info("Rate limit exceeded", { key, path: c.req.path });
-      c.header("Retry-After", String(Math.ceil(windowMs / 1000)));
-      return c.json({ error: "Too many requests" }, 429);
+      const retryAfterMs = Math.ceil(((1 - bucket.tokens) / limit) * windowMs);
+      return { allowed: false, retryAfterMs };
     }
 
     bucket.tokens -= 1;
+    return { allowed: true, retryAfterMs: 0 };
+  }
+
+  /** Exposed for testing — allows direct inspection of the cleanup callback. */
+  getCleanupTimer(): ReturnType<typeof setInterval> {
+    return this.cleanupTimer;
+  }
+
+  /** For testing: expose bucket map to allow simulating stale entries. */
+  getBuckets(): Map<string, TokenBucket> {
+    return this.buckets;
+  }
+}
+
+// ─── KV-backed fixed-window store (Cloudflare Workers) ─────────────────────
+
+interface KVRecord {
+  count: number;
+  windowStart: number;
+}
+
+export class KvRateLimitStore implements RateLimitStore {
+  constructor(private readonly kv: KVNamespace) {}
+
+  async consume(
+    key: string,
+    limit: number,
+    windowMs: number,
+    now: number,
+  ): Promise<{ allowed: boolean; retryAfterMs: number }> {
+    const windowStart = Math.floor(now / windowMs) * windowMs;
+    const kvKey = `rl:${key}:${windowStart}`;
+    const ttlSeconds = Math.max(60, Math.ceil(windowMs / 1000));
+
+    const raw = await this.kv.get(kvKey, "text");
+    let record: KVRecord;
+    if (raw !== null) {
+      try {
+        record = JSON.parse(raw) as KVRecord;
+      } catch {
+        record = { count: 0, windowStart };
+      }
+    } else {
+      record = { count: 0, windowStart };
+    }
+
+    if (record.count >= limit) {
+      const windowEnd = windowStart + windowMs;
+      return { allowed: false, retryAfterMs: windowEnd - now };
+    }
+
+    record.count += 1;
+    await this.kv.put(kvKey, JSON.stringify(record), { expirationTtl: ttlSeconds });
+    return { allowed: true, retryAfterMs: 0 };
+  }
+}
+
+// ─── Middleware factory ─────────────────────────────────────────────────────
+
+interface RateLimitOptions {
+  /** Shared store instance (MemoryRateLimitStore or KvRateLimitStore). */
+  store: RateLimitStore;
+  /** Bucket scope — buckets are keyed by `${scope}:${ip}`. Defaults to "global". */
+  scope?: string;
+  /** Maximum requests allowed per window. */
+  limit: number;
+  /** Window duration in milliseconds. */
+  windowMs: number;
+  /** Function to derive a key from the request (defaults to x-forwarded-for or "anonymous"). */
+  keyGenerator?: (c: { req: { header: (name: string) => string | undefined } }) => string;
+}
+
+export function rateLimiter(options: RateLimitOptions) {
+  const { store, limit, windowMs } = options;
+  const scope = options.scope ?? "global";
+  const keyGenerator =
+    options.keyGenerator ??
+    ((c) => c.req.header("x-forwarded-for") ?? "anonymous");
+
+  return createMiddleware<AppEnv>(async (c, next) => {
+    const ip = keyGenerator(c);
+    const key = `${scope}:${ip}`;
+    const now = Date.now();
+
+    const { allowed, retryAfterMs } = await store.consume(key, limit, windowMs, now);
+
+    if (!allowed) {
+      log.info("Rate limit exceeded", { scope, ip, path: c.req.path });
+      c.header("Retry-After", String(Math.ceil(retryAfterMs / 1000)));
+      return c.json({ error: "Too many requests" }, 429);
+    }
+
     await next();
   });
 }

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -42,7 +42,7 @@ import { drizzle } from "drizzle-orm/d1";
 import { getDb, runWithDb, schemaExports } from "./db/schema";
 import { getUserCount, createUser, isOidcConfigured, getOidcConfig, getUserByWatchlistShareToken, getTrackedTitles } from "./db/repository";
 import { optionalAuth, requireAuth, requireAdmin } from "./middleware/auth";
-import { rateLimiter } from "./middleware/rate-limit";
+import { rateLimiter, MemoryRateLimitStore, KvRateLimitStore } from "./middleware/rate-limit";
 import syncRoutes from "./routes/sync";
 import titlesRoutes from "./routes/titles";
 import searchRoutes from "./routes/search";
@@ -195,6 +195,12 @@ async function resolveOidcConfig(): Promise<typeof cachedOidcConfig> {
 function createApp(env: Env) {
   const app = new Hono<AppEnv>();
 
+  // Shared rate-limit store — KV-backed when available so all isolates share buckets;
+  // falls back to in-memory when CACHE_KV binding is not configured.
+  const rateLimitStore = env.CACHE_KV
+    ? new KvRateLimitStore(env.CACHE_KV)
+    : new MemoryRateLimitStore();
+
   // Per-request setup: inject platform and auth into context.
   // One-time initialization (migration, admin creation, OIDC config) is
   // guarded by module-level flags so it only runs on the first request.
@@ -255,11 +261,17 @@ function createApp(env: Env) {
   // Request logging
   app.use("/api/*", requestLogger());
 
+  // Global per-IP cap — applies to all /api/* before any per-route limiter.
+  app.use(
+    "/api/*",
+    rateLimiter({ store: rateLimitStore, scope: "global", limit: CONFIG.GLOBAL_RATE_LIMIT_PER_MINUTE, windowMs: 60_000 })
+  );
+
   // Health check
   app.route("/api/health", healthRoutes);
 
   // Rate limit auth routes: 20 requests per minute to prevent brute-force attacks
-  app.use("/api/auth/*", rateLimiter({ limit: 20, windowMs: 60_000 }));
+  app.use("/api/auth/*", rateLimiter({ store: rateLimitStore, scope: "auth", limit: CONFIG.AUTH_RATE_LIMIT_PER_MINUTE, windowMs: 60_000 }));
 
   // Custom auth routes (providers endpoint) — must be before better-auth catch-all
   app.route("/api/auth/custom", authCustomRoutes);
@@ -279,13 +291,12 @@ function createApp(env: Env) {
   app.route("/api/titles", titlesRoutes);
 
   // Rate limit search
-  app.use("/api/search/*", rateLimiter({ limit: 30, windowMs: 60_000 }));
-  app.use("/api/search", rateLimiter({ limit: 30, windowMs: 60_000 }));
-  app.use("/api/search/*", optionalAuth);
-  app.use("/api/search", optionalAuth);
+  const searchRateLimiter = rateLimiter({ store: rateLimitStore, scope: "search", limit: 30, windowMs: 60_000 });
+  app.use("/api/search/*", searchRateLimiter, optionalAuth);
+  app.use("/api/search", searchRateLimiter, optionalAuth);
   app.route("/api/search", searchRoutes);
 
-  const browseRateLimiter = rateLimiter({ limit: 30, windowMs: 60_000 });
+  const browseRateLimiter = rateLimiter({ store: rateLimitStore, scope: "browse", limit: 30, windowMs: 60_000 });
   app.use("/api/browse/*", browseRateLimiter, optionalAuth);
   app.use("/api/browse", browseRateLimiter, optionalAuth);
   app.route("/api/browse", browseRoutes);
@@ -308,7 +319,7 @@ function createApp(env: Env) {
   app.route("/api/social", socialRoutes);
 
   // Ratings routes — optionalAuth base, POST/DELETE check auth internally
-  const ratingsRateLimiter = rateLimiter({ limit: 60, windowMs: 60_000 });
+  const ratingsRateLimiter = rateLimiter({ store: rateLimitStore, scope: "ratings", limit: 60, windowMs: 60_000 });
   app.use("/api/ratings/*", ratingsRateLimiter, optionalAuth);
   app.use("/api/ratings", ratingsRateLimiter, optionalAuth);
   app.route("/api/ratings", ratingsRoutes);
@@ -383,14 +394,15 @@ function createApp(env: Env) {
   app.route("/api/jobs", jobsCfRoutes);
 
   // Detail pages
-  const detailsRateLimiter = rateLimiter({ limit: 60, windowMs: 60_000 });
+  const detailsRateLimiter = rateLimiter({ store: rateLimitStore, scope: "details", limit: 60, windowMs: 60_000 });
   app.use("/api/details/*", detailsRateLimiter, optionalAuth);
   app.use("/api/details", detailsRateLimiter, optionalAuth);
   app.route("/api/details", detailsRoutes);
 
   // Sync (admin only — rate limited + require admin)
-  app.use("/api/sync/*", rateLimiter({ limit: 5, windowMs: 60_000 }));
-  app.use("/api/sync", rateLimiter({ limit: 5, windowMs: 60_000 }));
+  const syncRateLimiter = rateLimiter({ store: rateLimitStore, scope: "sync", limit: 5, windowMs: 60_000 });
+  app.use("/api/sync/*", syncRateLimiter);
+  app.use("/api/sync", syncRateLimiter);
   app.use("/api/sync/*", requireAuth, requireAdmin);
   app.use("/api/sync", requireAuth, requireAdmin);
   app.route("/api/sync", syncRoutes);


### PR DESCRIPTION
## Summary

- Introduces a `RateLimitStore` interface with two backends: `MemoryRateLimitStore` (token-bucket, Bun — single instance shared across all middleware) and `KvRateLimitStore` (fixed-window, Cloudflare Workers — KV-backed so all isolates see the same counters, keyed by `rl:{scope}:{ip}:{windowStart}`)
- Adds a **global 300 req/min/IP cap** on all `/api/*` routes (configurable via `GLOBAL_RATE_LIMIT_PER_MINUTE`) layered on top of per-route limits (auth, search, browse, details, ratings, writes, import, sync). `/metrics` is excluded
- Periodic cleanup timer collapses from ~10 independent intervals to one per-store timer
- Cross-route enforcement, scope isolation, KV fixed-window behavior, and global-cap layering are all covered by new unit tests

## Test plan

- [x] `bun run check` — 2392 tests pass, zero type errors, zero lint warnings
- [ ] Manual smoke: hit `/api/search` 31× from one IP → 31st returns 429; `/api/browse` from same IP still works (different scope)
- [ ] Manual smoke: burst 301 requests to `/api/health` from one IP → 301st returns 429 (global cap)
- [ ] Cloudflare: `CACHE_KV` writes visible with `wrangler kv:key list --binding CACHE_KV --preview` showing `rl:…` keys with TTL

Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)