### PR TITLE
feat: circuit breaker for Streaming Availability API

### DIFF
--- a/server/jobs/processor.ts
+++ b/server/jobs/processor.ts
@@ -160,6 +160,7 @@ async function handleSyncDeepLinks(): Promise<void> {
   }
   const { enrichTitleDeepLinks } = await import("../streaming-availability/enrich");
   const { RateLimitError } = await import("../streaming-availability/types");
+  const { BreakerOpenError } = await import("../lib/circuit-breaker");
   const { getTitlesNeedingSaEnrichment } = await import("../db/repository");
 
   const titleRows = await getTitlesNeedingSaEnrichment();
@@ -179,6 +180,10 @@ async function handleSyncDeepLinks(): Promise<void> {
     } catch (err) {
       if (err instanceof RateLimitError) {
         log.warn("SA rate limit hit, stopping early", { processed, enriched });
+        break;
+      }
+      if (err instanceof BreakerOpenError) {
+        log.warn("SA breaker open, stopping early", { processed, enriched });
         break;
       }
       log.error("SA enrichment failed", { titleId: t.id, err });

--- a/server/jobs/sync.ts
+++ b/server/jobs/sync.ts
@@ -20,6 +20,7 @@ import { migrateBackdrops } from "./migrate-backdrops";
 import { migrateOffers } from "./migrate-offers";
 import { enrichTitleDeepLinks } from "../streaming-availability/enrich";
 import { RateLimitError } from "../streaming-availability/types";
+import { BreakerOpenError } from "../lib/circuit-breaker";
 import { getTitlesNeedingSaEnrichment } from "../db/repository";
 import { syncEachWithDelay } from "../tmdb/sync-utils";
 import { handleReleaseReminder } from "./release-reminders";
@@ -138,6 +139,10 @@ export function registerSyncJobs() {
       onError: (err, t) => {
         if (err instanceof RateLimitError) {
           log.warn("SA rate limit hit, stopping early", { processed, enriched });
+          return "stop";
+        }
+        if (err instanceof BreakerOpenError) {
+          log.warn("SA breaker open, stopping early", { processed, enriched });
           return "stop";
         }
         log.error("SA enrichment failed", { titleId: t.id, err });

--- a/server/lib/circuit-breaker.test.ts
+++ b/server/lib/circuit-breaker.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { CircuitBreaker, BreakerOpenError, getBreaker, _resetBreakersForTest } from "./circuit-breaker";
+import { resetMetrics, circuitBreakerStateChangesTotal } from "../metrics";
+
+// Helpers
+function makeBreaker(overrides?: { threshold?: number; windowMs?: number; openMs?: number }) {
+  let t = 0;
+  const now = () => t;
+  const advanceMs = (ms: number) => { t += ms; };
+  const breaker = new CircuitBreaker("test.host", {
+    failureThreshold: overrides?.threshold ?? 3,
+    failureWindowMs: overrides?.windowMs ?? 10_000,
+    defaultOpenDurationMs: overrides?.openMs ?? 5_000,
+    now,
+  });
+  return { breaker, advanceMs };
+}
+
+beforeEach(() => {
+  _resetBreakersForTest();
+  resetMetrics();
+});
+
+describe("CircuitBreaker — closed state", () => {
+  it("stays closed under the threshold", () => {
+    const { breaker } = makeBreaker();
+    breaker.recordFailure();
+    breaker.recordFailure();
+    expect(() => breaker.beforeCall()).not.toThrow();
+  });
+
+  it("opens when failure threshold is reached", () => {
+    const { breaker } = makeBreaker();
+    breaker.recordFailure();
+    breaker.recordFailure();
+    breaker.recordFailure();
+    expect(() => breaker.beforeCall()).toThrow(BreakerOpenError);
+  });
+
+  it("does not count failures older than the window", () => {
+    const { breaker, advanceMs } = makeBreaker({ threshold: 3, windowMs: 10_000 });
+    breaker.recordFailure();
+    breaker.recordFailure();
+    advanceMs(11_000);       // first two failures slide out of the window
+    breaker.recordFailure(); // only 1 in-window failure
+    expect(() => breaker.beforeCall()).not.toThrow();
+  });
+
+  it("opens for the default duration", () => {
+    const { breaker, advanceMs } = makeBreaker({ threshold: 2, openMs: 60_000 });
+    breaker.recordFailure();
+    breaker.recordFailure();
+    expect(() => breaker.beforeCall()).toThrow(BreakerOpenError);
+    advanceMs(59_999);
+    expect(() => breaker.beforeCall()).toThrow(BreakerOpenError);
+  });
+
+  it("opens for a custom duration when supplied to recordFailure", () => {
+    const { breaker, advanceMs } = makeBreaker({ threshold: 2, openMs: 5_000 });
+    const LONG = 86_400_000; // 24h
+    breaker.recordFailure(LONG);
+    breaker.recordFailure(LONG);
+    expect(() => breaker.beforeCall()).toThrow(BreakerOpenError);
+    advanceMs(30_000); // well past 5s default, still under 24h
+    expect(() => breaker.beforeCall()).toThrow(BreakerOpenError);
+  });
+
+  it("resets failure count after recordSuccess", () => {
+    const { breaker } = makeBreaker({ threshold: 3 });
+    breaker.recordFailure();
+    breaker.recordFailure();
+    breaker.recordSuccess(); // closed → still closed, history cleared
+    breaker.recordFailure();
+    breaker.recordFailure();
+    expect(() => breaker.beforeCall()).not.toThrow();
+  });
+});
+
+describe("CircuitBreaker — open state", () => {
+  it("rejects calls with BreakerOpenError while open", () => {
+    const { breaker } = makeBreaker({ threshold: 2 });
+    breaker.recordFailure();
+    breaker.recordFailure();
+    const err = (() => { try { breaker.beforeCall(); } catch (e) { return e; } })();
+    expect(err).toBeInstanceOf(BreakerOpenError);
+    expect((err as BreakerOpenError).host).toBe("test.host");
+  });
+
+  it("transitions to half-open after open duration elapses", () => {
+    const { breaker, advanceMs } = makeBreaker({ threshold: 2, openMs: 1_000 });
+    breaker.recordFailure();
+    breaker.recordFailure();
+    advanceMs(1_001);
+    expect(() => breaker.beforeCall()).not.toThrow(); // half-open probe admitted
+  });
+});
+
+describe("CircuitBreaker — half-open state", () => {
+  function openedBreaker() {
+    const { breaker, advanceMs } = makeBreaker({ threshold: 2, openMs: 1_000 });
+    breaker.recordFailure();
+    breaker.recordFailure();
+    advanceMs(1_001);
+    return { breaker, advanceMs };
+  }
+
+  it("admits exactly one probe call", () => {
+    const { breaker } = openedBreaker();
+    expect(() => breaker.beforeCall()).not.toThrow(); // probe
+    expect(() => breaker.beforeCall()).toThrow(BreakerOpenError); // second concurrent call blocked
+  });
+
+  it("closes on probe success and clears failure history", () => {
+    const { breaker } = openedBreaker();
+    breaker.beforeCall();    // probe admitted
+    breaker.recordSuccess(); // probe success
+    expect(() => breaker.beforeCall()).not.toThrow();
+    expect(() => breaker.beforeCall()).not.toThrow(); // subsequent calls normal
+  });
+
+  it("re-opens on probe failure with the supplied duration", () => {
+    const LONG = 10_000;
+    const { breaker, advanceMs } = openedBreaker();
+    breaker.beforeCall();             // probe admitted
+    breaker.recordFailure(LONG);      // probe fails
+    expect(() => breaker.beforeCall()).toThrow(BreakerOpenError);
+    advanceMs(5_000);
+    expect(() => breaker.beforeCall()).toThrow(BreakerOpenError); // still open
+  });
+
+  it("re-opens on probe failure for the default duration when none supplied", () => {
+    const { breaker, advanceMs } = makeBreaker({ threshold: 2, openMs: 2_000 });
+    breaker.recordFailure();
+    breaker.recordFailure();
+    advanceMs(2_001);
+    breaker.beforeCall();        // probe admitted
+    breaker.recordFailure();     // probe fails — re-open for another 2s
+    expect(() => breaker.beforeCall()).toThrow(BreakerOpenError);
+    advanceMs(2_001);
+    expect(() => breaker.beforeCall()).not.toThrow(); // half-open again
+  });
+});
+
+describe("CircuitBreaker — registry isolation", () => {
+  it("getBreaker returns the same instance for the same host", () => {
+    const a = getBreaker("host-a");
+    const b = getBreaker("host-a");
+    expect(a).toBe(b);
+  });
+
+  it("getBreaker keeps different hosts isolated", () => {
+    const opts = { failureThreshold: 2, failureWindowMs: 10_000, defaultOpenDurationMs: 5_000 };
+    // Open the breaker for host-x
+    const x = getBreaker("host-x", opts);
+    x.recordFailure();
+    x.recordFailure();
+    // host-y should still be closed
+    const y = getBreaker("host-y", opts);
+    expect(() => y.beforeCall()).not.toThrow();
+  });
+
+  it("_resetBreakersForTest clears the registry", () => {
+    const first = getBreaker("clean-host");
+    _resetBreakersForTest();
+    const second = getBreaker("clean-host");
+    expect(first).not.toBe(second);
+  });
+});
+
+describe("CircuitBreaker — metrics", () => {
+  it("increments counter on state transitions", () => {
+    const { breaker, advanceMs } = makeBreaker({ threshold: 2, openMs: 1_000 });
+    breaker.recordFailure();
+    breaker.recordFailure(); // closed → open
+    advanceMs(1_001);
+    breaker.beforeCall();    // open → half-open
+    breaker.recordSuccess(); // half-open → closed
+    const rendered = circuitBreakerStateChangesTotal.render();
+    expect(rendered).toContain('to="open"');
+    expect(rendered).toContain('to="half-open"');
+    expect(rendered).toContain('to="closed"');
+  });
+});

--- a/server/lib/circuit-breaker.ts
+++ b/server/lib/circuit-breaker.ts
@@ -1,0 +1,131 @@
+import { logger } from "../logger";
+import { circuitBreakerStateChangesTotal } from "../metrics";
+
+const log = logger.child({ module: "circuit-breaker" });
+
+const FAILURE_THRESHOLD = 5;
+const FAILURE_WINDOW_MS = 60_000;
+const DEFAULT_OPEN_DURATION_MS = 5 * 60_000;
+
+type State = "closed" | "open" | "half-open";
+
+export class BreakerOpenError extends Error {
+  override name = "BreakerOpenError";
+  constructor(
+    public readonly host: string,
+    public readonly openUntil: number,
+  ) {
+    super(`Circuit breaker open for ${host} until ${new Date(openUntil).toISOString()}`);
+  }
+}
+
+interface BreakerOpts {
+  failureThreshold?: number;
+  failureWindowMs?: number;
+  defaultOpenDurationMs?: number;
+  // Inject for deterministic tests; defaults to Date.now.
+  now?: () => number;
+}
+
+export class CircuitBreaker {
+  private state: State = "closed";
+  private failures: number[] = [];
+  private openUntil = 0;
+  private halfOpenInFlight = false;
+
+  private readonly threshold: number;
+  private readonly windowMs: number;
+  private readonly defaultOpenMs: number;
+  private readonly now: () => number;
+
+  constructor(
+    private readonly host: string,
+    opts?: BreakerOpts,
+  ) {
+    this.threshold = opts?.failureThreshold ?? FAILURE_THRESHOLD;
+    this.windowMs = opts?.failureWindowMs ?? FAILURE_WINDOW_MS;
+    this.defaultOpenMs = opts?.defaultOpenDurationMs ?? DEFAULT_OPEN_DURATION_MS;
+    this.now = opts?.now ?? (() => Date.now());
+  }
+
+  beforeCall(): void {
+    const now = this.now();
+    if (this.state === "closed") return;
+    if (this.state === "open") {
+      if (now < this.openUntil) {
+        throw new BreakerOpenError(this.host, this.openUntil);
+      }
+      // Cooldown elapsed — transition to half-open and admit one probe.
+      if (!this.halfOpenInFlight) {
+        this.transition("open", "half-open");
+        this.halfOpenInFlight = true;
+        return;
+      }
+      throw new BreakerOpenError(this.host, this.openUntil);
+    }
+    // half-open: only one in-flight probe allowed.
+    if (!this.halfOpenInFlight) {
+      this.halfOpenInFlight = true;
+      return;
+    }
+    throw new BreakerOpenError(this.host, this.openUntil);
+  }
+
+  recordSuccess(): void {
+    if (this.state === "half-open") {
+      this.transition("half-open", "closed");
+    }
+    this.failures = [];
+    this.halfOpenInFlight = false;
+  }
+
+  recordFailure(openDurationMs?: number): void {
+    const now = this.now();
+    const duration = openDurationMs ?? this.defaultOpenMs;
+
+    if (this.state === "half-open") {
+      this.openUntil = now + duration;
+      this.halfOpenInFlight = false;
+      this.transition("half-open", "open");
+      return;
+    }
+
+    this.failures.push(now);
+    // Prune failures outside the sliding window.
+    this.failures = this.failures.filter((t) => now - t <= this.windowMs);
+
+    if (this.failures.length >= this.threshold) {
+      this.openUntil = now + duration;
+      this.failures = [];
+      this.transition("closed", "open");
+    }
+  }
+
+  private transition(from: State, to: State): void {
+    this.state = to;
+    circuitBreakerStateChangesTotal.inc({ host: this.host, from, to });
+    if (to === "open") {
+      log.warn("Circuit breaker opened", { host: this.host, openUntil: new Date(this.openUntil).toISOString() });
+    } else if (to === "half-open") {
+      log.info("Circuit breaker half-open, probing", { host: this.host });
+    } else if (to === "closed") {
+      log.info("Circuit breaker closed", { host: this.host });
+    }
+  }
+}
+
+// In-memory per-host registry. State is per-isolate — acceptable for background jobs.
+const registry = new Map<string, CircuitBreaker>();
+
+export function getBreaker(host: string, opts?: BreakerOpts): CircuitBreaker {
+  let breaker = registry.get(host);
+  if (!breaker) {
+    breaker = new CircuitBreaker(host, opts);
+    registry.set(host, breaker);
+  }
+  return breaker;
+}
+
+export function _resetBreakersForTest(): void {
+  registry.clear();
+}

--- a/server/metrics/index.ts
+++ b/server/metrics/index.ts
@@ -73,6 +73,13 @@ export const errorsByCategory = new Counter(
 );
 
 
+// ─── Circuit Breaker Metrics ─────────────────────────────────────────────────
+
+export const circuitBreakerStateChangesTotal = new Counter(
+  "circuit_breaker_state_changes_total",
+  "Circuit breaker state transitions",
+);
+
 // ─── Registry ────────────────────────────────────────────────────────────────
 
 const allMetrics = [
@@ -87,6 +94,7 @@ const allMetrics = [
   syncFailureTotal,
   httpRetryTotal,
   errorsByCategory,
+  circuitBreakerStateChangesTotal,
 ];
 
 export function renderMetrics(): string {

--- a/server/streaming-availability/client.test.ts
+++ b/server/streaming-availability/client.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, spyOn, beforeEach, afterEach } from "bun:test";
 import Sentry from "../sentry";
 import { CONFIG } from "../config";
 import { RateLimitError } from "./types";
+import { BreakerOpenError, _resetBreakersForTest } from "../lib/circuit-breaker";
 import { MemoryCache } from "../cache/memory";
 import * as cacheModule from "../cache";
 
@@ -14,6 +15,7 @@ let testCache: MemoryCache;
 const originalApiKey = CONFIG.STREAMING_AVAILABILITY_API_KEY;
 
 beforeEach(() => {
+  _resetBreakersForTest();
   sentrySpy = spyOn(Sentry, "startSpan").mockImplementation((_opts: any, fn: any) => fn({}));
   fetchSpy = spyOn(globalThis, "fetch");
   testCache = new MemoryCache();
@@ -179,5 +181,82 @@ describe("fetchStreamingOptions", () => {
 
     const cached = await testCache.get("sa:streaming:movie/550:us");
     expect(cached).toBeNull();
+  });
+});
+
+describe("fetchStreamingOptions — circuit breaker", () => {
+  it("opens the breaker after 5 consecutive 500 errors and blocks subsequent calls", async () => {
+    fetchSpy.mockResolvedValue(new Response("Server Error", { status: 500, statusText: "Internal Server Error" }));
+
+    for (let i = 0; i < 5; i++) {
+      await expect(fetchStreamingOptions(i + 1, "MOVIE", "US")).rejects.toThrow("SA API error: 500");
+    }
+
+    // 6th call: breaker should be open — no fetch should be issued
+    await expect(fetchStreamingOptions(6, "MOVIE", "US")).rejects.toBeInstanceOf(BreakerOpenError);
+    expect(fetchSpy.mock.calls.length).toBe(5);
+  });
+
+  it("opens the breaker for 24h after 5 consecutive 429 errors", async () => {
+    fetchSpy.mockResolvedValue(new Response("Too Many Requests", { status: 429 }));
+
+    for (let i = 0; i < 5; i++) {
+      await expect(fetchStreamingOptions(i + 1, "MOVIE", "US")).rejects.toBeInstanceOf(RateLimitError);
+    }
+
+    // Breaker is open; 6th call should throw BreakerOpenError without calling fetch
+    await expect(fetchStreamingOptions(6, "MOVIE", "US")).rejects.toBeInstanceOf(BreakerOpenError);
+
+    // Confirm the error carries the 24h window — openUntil should be ~24h from now
+    let caughtErr: BreakerOpenError | undefined;
+    try {
+      await fetchStreamingOptions(7, "MOVIE", "US");
+    } catch (e) {
+      if (e instanceof BreakerOpenError) caughtErr = e;
+    }
+    expect(caughtErr).toBeInstanceOf(BreakerOpenError);
+    const remainingMs = caughtErr!.openUntil - Date.now();
+    // Should be between 23h and 24h (some test execution time elapsed)
+    expect(remainingMs).toBeGreaterThan(23 * 60 * 60 * 1000);
+    expect(remainingMs).toBeLessThanOrEqual(24 * 60 * 60 * 1000);
+
+    // Fetch should still only have been called 5 times (the 5 quota failures)
+    expect(fetchSpy.mock.calls.length).toBe(5);
+  });
+
+  it("does not open the breaker on 404 responses", async () => {
+    fetchSpy.mockResolvedValue(new Response("Not Found", { status: 404 }));
+
+    for (let i = 0; i < 5; i++) {
+      const result = await fetchStreamingOptions(i + 1, "MOVIE", "US");
+      expect(result).toEqual([]);
+    }
+
+    // Breaker should remain closed — next call goes through normally
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ streamingOptions: { us: [] } }), { status: 200 })
+    );
+    await expect(fetchStreamingOptions(6, "MOVIE", "US")).resolves.toEqual([]);
+    expect(fetchSpy.mock.calls.length).toBe(6);
+  });
+
+  it("cache hit bypasses the breaker even when it is open", async () => {
+    // Open the breaker by sending 5 failures for different tmdbIds
+    fetchSpy.mockResolvedValue(new Response("Server Error", { status: 500, statusText: "Internal Server Error" }));
+    for (let i = 1; i <= 5; i++) {
+      await expect(fetchStreamingOptions(i, "MOVIE", "US")).rejects.toThrow("SA API error: 500");
+    }
+    // Breaker is now open
+    await expect(fetchStreamingOptions(6, "MOVIE", "US")).rejects.toBeInstanceOf(BreakerOpenError);
+
+    // Pre-warm cache for tmdbId 999
+    const cachedOptions = [{ service: { id: "netflix" }, link: "https://netflix.com/999" }] as any;
+    await testCache.set("sa:streaming:movie/999:us", cachedOptions, 3600);
+
+    // Cache hit should succeed without touching the breaker
+    const result = await fetchStreamingOptions(999, "MOVIE", "US");
+    expect(result).toEqual(cachedOptions);
+    // fetch should still be 5 (only the initial failures, no new call for tmdbId 999)
+    expect(fetchSpy.mock.calls.length).toBe(5);
   });
 });

--- a/server/streaming-availability/client.ts
+++ b/server/streaming-availability/client.ts
@@ -3,12 +3,17 @@ import { traceHttp } from "../tracing";
 import { logger } from "../logger";
 import { getCache } from "../cache";
 import { httpFetch } from "../lib/http";
+import { getBreaker } from "../lib/circuit-breaker";
 import type { SAShow, SAStreamingOption } from "./types";
 import { RateLimitError } from "./types";
 
 const log = logger.child({ module: "streaming-availability" });
 
 const SA_BASE_URL = "https://streaming-availability.p.rapidapi.com";
+const SA_HOST = "streaming-availability.p.rapidapi.com";
+// Monthly quota resets — keep the breaker open for a full day so we don't
+// re-probe every 5 minutes for the rest of the billing cycle.
+const SA_QUOTA_OPEN_MS = 24 * 60 * 60 * 1000;
 
 /**
  * Fetch streaming options from the Streaming Availability API for a single title.
@@ -25,6 +30,10 @@ export async function fetchStreamingOptions(
   const cached = await cache.get<SAStreamingOption[]>(cacheKey);
   if (cached !== null) return cached;
 
+  // Breaker check sits after cache lookup so warm-cache hits bypass it.
+  const breaker = getBreaker(SA_HOST);
+  breaker.beforeCall();
+
   const showId = `${showType}/${tmdbId}`;
   const url = new URL(`${SA_BASE_URL}/shows/${showId}`);
   url.searchParams.set("country", country.toLowerCase());
@@ -33,6 +42,7 @@ export async function fetchStreamingOptions(
   return traceHttp("GET", url.toString(), async () => {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), CONFIG.TMDB_API_TIMEOUT_MS);
+    let failureRecorded = false;
     try {
       // maxRetries: 0 — SA has custom 429/403 handling; don't retry at the httpFetch layer
       const res = await httpFetch(
@@ -40,7 +50,7 @@ export async function fetchStreamingOptions(
         {
           headers: {
             "X-RapidAPI-Key": CONFIG.STREAMING_AVAILABILITY_API_KEY,
-            "X-RapidAPI-Host": "streaming-availability.p.rapidapi.com",
+            "X-RapidAPI-Host": SA_HOST,
           },
           signal: controller.signal,
         },
@@ -49,23 +59,35 @@ export async function fetchStreamingOptions(
 
       if (res.status === 404) {
         log.debug("Title not found on SA", { tmdbId, objectType });
+        breaker.recordSuccess();
         await cache.set(cacheKey, [], CONFIG.CACHE_TTL_STREAMING);
         return [];
       }
 
       if (res.status === 429 || res.status === 403) {
+        failureRecorded = true;
+        breaker.recordFailure(SA_QUOTA_OPEN_MS);
         throw new RateLimitError();
       }
 
       if (!res.ok) {
+        failureRecorded = true;
+        breaker.recordFailure();
         throw new Error(`SA API error: ${res.status} ${res.statusText}`);
       }
 
       const data = (await res.json()) as SAShow;
       const countryKey = country.toLowerCase();
       const result = data.streamingOptions?.[countryKey] ?? [];
+      breaker.recordSuccess();
       await cache.set(cacheKey, result, CONFIG.CACHE_TTL_STREAMING);
       return result;
+    } catch (err) {
+      // Record failure for network/abort errors not already counted above.
+      if (!failureRecorded) {
+        breaker.recordFailure();
+      }
+      throw err;
     } finally {
       clearTimeout(timeout);
     }


### PR DESCRIPTION
## Summary

- Adds a generic per-host circuit breaker (`server/lib/circuit-breaker.ts`) with a `closed → open → half-open` state machine
- Wires it into `fetchStreamingOptions` in the SA client; only the SA host is scoped in this PR per issue requirements
- Two-tier cooldown: **24h** for quota errors (429/403) to avoid re-probing all month, **5 min** for transient errors (5xx/network)
- Both job loops (`server/jobs/sync.ts` Bun path and `server/jobs/processor.ts` CF path) now stop immediately on `BreakerOpenError`
- New `circuit_breaker_state_changes_total` Prometheus counter with `{host, from, to}` labels
- 16 new unit tests covering the state machine, per-host isolation, and SA client integration

## Test plan

- [x] `bun run check` — 2412 pass, 0 fail, TypeScript + ESLint clean
- [ ] Manual: set `STREAMING_AVAILABILITY_API_KEY=invalid`, trigger `sync-deep-links` — expect 5 failures → `Circuit breaker opened` warn → `SA breaker open, stopping early`; re-trigger within 5 min → immediate abort with zero outbound fetches
- [ ] Metrics: `curl /metrics | grep circuit_breaker` — verify state-change counters with host/from/to labels

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)