### PR TITLE
feat: inline trailer playback with click-to-load YouTube facade

### DIFF
--- a/frontend/src/components/title-detail/MovieHero.tsx
+++ b/frontend/src/components/title-detail/MovieHero.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import type { MovieDetailsResponse, Title } from "../../types";
 import TrackButton from "../TrackButton";
 import PinButton from "../PinButton";
@@ -8,6 +8,7 @@ import { Chip, Kicker } from "../design";
 import { RatingBadge } from "./RatingBadge";
 import { backdropUrl as mkBackdropUrl, posterUrl as mkPosterUrl } from "../../lib/tmdb-images";
 import { formatRuntime } from "./utils";
+import TrailerEmbed from "./TrailerEmbed";
 
 export interface MovieHeroProps {
   title: Title;
@@ -19,6 +20,8 @@ export interface MovieHeroProps {
 }
 
 export default function MovieHero({ title, tmdb, watchedActions, watchHistoryPanel }: MovieHeroProps) {
+  const [showTrailer, setShowTrailer] = useState(false);
+  const videos = tmdb?.videos?.results ?? [];
   const genres = tmdb?.genres?.map((g) => g.name) || title.genres;
   const certification = title.age_certification;
   const backdropUrl = mkBackdropUrl(tmdb?.backdrop_path, "w1280") ?? null;
@@ -123,8 +126,25 @@ export default function MovieHero({ title, tmdb, watchedActions, watchHistoryPan
             />
             {watchedActions}
             <WatchButtonGroup offers={title.offers} variant="inline" maxVisible={3} />
+            {videos.length > 0 && (
+              <button
+                type="button"
+                onClick={() => setShowTrailer((prev) => !prev)}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium bg-white/[0.08] hover:bg-white/[0.14] border border-white/[0.12] text-zinc-200 transition-colors"
+              >
+                <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                  <path d="M3 3.5A1.5 1.5 0 0 1 4.5 2h7A1.5 1.5 0 0 1 13 3.5v9A1.5 1.5 0 0 1 11.5 14h-7A1.5 1.5 0 0 1 3 12.5v-9ZM6 5.5v5l4.5-2.5L6 5.5Z" />
+                </svg>
+                {showTrailer ? "Hide Trailer" : "Watch Trailer"}
+              </button>
+            )}
           </div>
           {watchHistoryPanel}
+          {showTrailer && videos.length > 0 && (
+            <div className="mt-4">
+              <TrailerEmbed videos={videos} />
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/components/title-detail/ShowHero.tsx
+++ b/frontend/src/components/title-detail/ShowHero.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { ShowDetailsResponse, Title } from "../../types";
 import { useIsMobile } from "../../hooks/useIsMobile";
 import TrackButton from "../TrackButton";
@@ -11,6 +12,7 @@ import { RatingBadge } from "./RatingBadge";
 import { backdropUrl as mkBackdropUrl, posterUrl as mkPosterUrl } from "../../lib/tmdb-images";
 import { getCertification } from "./utils";
 import { formatEta } from "../../pages/StatsPage";
+import TrailerEmbed from "./TrailerEmbed";
 
 export interface ShowHeroProps {
   title: Title;
@@ -19,7 +21,9 @@ export interface ShowHeroProps {
 }
 
 export default function ShowHero({ title, tmdb, country }: ShowHeroProps) {
+  const [showTrailer, setShowTrailer] = useState(false);
   const isMobile = useIsMobile();
+  const videos = tmdb?.videos?.results ?? [];
   const genres = tmdb?.genres?.map((g) => g.name) || title.genres;
   const certification =
     getCertification(tmdb?.content_ratings?.results, country) || title.age_certification;
@@ -231,6 +235,18 @@ export default function ShowHero({ title, tmdb, country }: ShowHeroProps) {
               isTracked={title.is_tracked}
             />
             <WatchButtonGroup offers={title.offers} variant="inline" maxVisible={3} />
+            {videos.length > 0 && (
+              <button
+                type="button"
+                onClick={() => setShowTrailer((prev) => !prev)}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium bg-white/[0.08] hover:bg-white/[0.14] border border-white/[0.12] text-zinc-200 transition-colors"
+              >
+                <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                  <path d="M3 3.5A1.5 1.5 0 0 1 4.5 2h7A1.5 1.5 0 0 1 13 3.5v9A1.5 1.5 0 0 1 11.5 14h-7A1.5 1.5 0 0 1 3 12.5v-9ZM6 5.5v5l4.5-2.5L6 5.5Z" />
+                </svg>
+                {showTrailer ? "Hide Trailer" : "Watch Trailer"}
+              </button>
+            )}
           </div>
           {title.is_tracked && title.eta_days != null && (
             <div className="text-xs text-zinc-400">
@@ -241,6 +257,11 @@ export default function ShowHero({ title, tmdb, country }: ShowHeroProps) {
             <div className="flex items-center gap-2 text-xs text-zinc-400">
               <span>Next episode</span>
               <EpisodeCountdown airDate={title.next_episode_air_date} />
+            </div>
+          )}
+          {showTrailer && videos.length > 0 && (
+            <div className="mt-4">
+              <TrailerEmbed videos={videos} />
             </div>
           )}
         </div>

--- a/frontend/src/components/title-detail/TrailerEmbed.test.tsx
+++ b/frontend/src/components/title-detail/TrailerEmbed.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, mock, afterEach } from "bun:test";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import TrailerEmbed from "./TrailerEmbed";
+import type { TmdbVideo } from "../../types";
+
+// happy-dom does not implement window.matchMedia; provide a stub that survives
+// cross-file test runs (Object.defineProperty can only be called once per
+// property; subsequent calls on the same property throw a TypeError).
+const matchMediaStub = mock(() => ({ matches: false }));
+
+if (typeof window !== "undefined" && !window.matchMedia) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: matchMediaStub,
+  });
+} else if (typeof window !== "undefined") {
+  window.matchMedia = matchMediaStub as typeof window.matchMedia;
+}
+
+beforeEach(() => {
+  window.matchMedia = matchMediaStub as typeof window.matchMedia;
+});
+
+afterEach(cleanup);
+
+function makeVideo(overrides: Partial<TmdbVideo> = {}): TmdbVideo {
+  return {
+    key: "abc123",
+    site: "YouTube",
+    type: "Trailer",
+    official: true,
+    size: 1080,
+    published_at: "2024-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("TrailerEmbed", () => {
+  it("renders the thumbnail facade when videos contain a YouTube Trailer", () => {
+    const videos = [makeVideo()];
+    render(<TrailerEmbed videos={videos} />);
+
+    const img = screen.getByRole("img", { name: /thumbnail/i });
+    expect(img).toBeDefined();
+    expect((img as HTMLImageElement).src).toContain("img.youtube.com/vi/abc123/hqdefault.jpg");
+  });
+
+  it("swaps to an iframe after clicking the thumbnail facade", () => {
+    const videos = [makeVideo()];
+    render(<TrailerEmbed videos={videos} />);
+
+    // Before click: no iframe
+    expect(screen.queryByTitle("Trailer")).toBeNull();
+
+    // Click the facade container
+    const container = screen.getByRole("img", { name: /thumbnail/i }).closest("div") as HTMLElement;
+    fireEvent.click(container);
+
+    const iframe = screen.getByTitle("Trailer") as HTMLIFrameElement;
+    expect(iframe).toBeDefined();
+    expect(iframe.src).toContain("youtube-nocookie.com/embed/abc123");
+  });
+
+  it("returns null when videos contain only non-Trailer types", () => {
+    const videos = [makeVideo({ type: "Featurette" }), makeVideo({ type: "Teaser" })];
+    const { container } = render(<TrailerEmbed videos={videos} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null when videos array is empty", () => {
+    const { container } = render(<TrailerEmbed videos={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("prefers official trailers over unofficial", () => {
+    const videos = [
+      makeVideo({ key: "unofficial", official: false, size: 1080 }),
+      makeVideo({ key: "official", official: true, size: 720 }),
+    ];
+    render(<TrailerEmbed videos={videos} />);
+
+    const img = screen.getByRole("img", { name: /thumbnail/i }) as HTMLImageElement;
+    expect(img.src).toContain("vi/official/");
+  });
+
+  it("among equal official status, prefers highest size", () => {
+    const videos = [
+      makeVideo({ key: "hd", official: true, size: 1080 }),
+      makeVideo({ key: "sd", official: true, size: 480 }),
+    ];
+    render(<TrailerEmbed videos={videos} />);
+
+    const img = screen.getByRole("img", { name: /thumbnail/i }) as HTMLImageElement;
+    expect(img.src).toContain("vi/hd/");
+  });
+
+  it("filters out non-YouTube videos even if type is Trailer", () => {
+    const videos = [makeVideo({ site: "Vimeo", key: "vimeo-key" })];
+    const { container } = render(<TrailerEmbed videos={videos} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/src/components/title-detail/TrailerEmbed.tsx
+++ b/frontend/src/components/title-detail/TrailerEmbed.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react";
+import type { TmdbVideo } from "../../types";
+
+export type TrailerEmbedProps = {
+  videos: TmdbVideo[];
+};
+
+function pickBestTrailer(videos: TmdbVideo[]): TmdbVideo | null {
+  const trailers = videos.filter((v) => v.site === "YouTube" && v.type === "Trailer");
+  if (trailers.length === 0) return null;
+
+  // Sort: official first, then highest size, then most recent published_at
+  const sorted = [...trailers].sort((a, b) => {
+    if (a.official !== b.official) return a.official ? -1 : 1;
+    if (b.size !== a.size) return b.size - a.size;
+    return b.published_at.localeCompare(a.published_at);
+  });
+
+  return sorted[0] ?? null;
+}
+
+export default function TrailerEmbed({ videos }: TrailerEmbedProps) {
+  const [playing, setPlaying] = useState(false);
+  const trailer = pickBestTrailer(videos);
+
+  if (!trailer) return null;
+
+  const { key } = trailer;
+  const prefersReducedMotion =
+    typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  const autoplay = prefersReducedMotion ? 0 : 1;
+
+  if (playing) {
+    return (
+      <div className="relative w-full aspect-video rounded-xl overflow-hidden">
+        <iframe
+          className="w-full h-full"
+          src={`https://www.youtube-nocookie.com/embed/${key}?autoplay=${autoplay}`}
+          title="Trailer"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+        />
+      </div>
+    );
+  }
+
+  const thumbnailUrl = `https://img.youtube.com/vi/${key}/hqdefault.jpg`;
+
+  return (
+    <div className="relative w-full aspect-video rounded-xl overflow-hidden cursor-pointer group" onClick={() => setPlaying(true)}>
+      <img
+        src={thumbnailUrl}
+        alt="Trailer thumbnail"
+        className="w-full h-full object-cover"
+        width={480}
+        height={360}
+      />
+      {/* Dark overlay */}
+      <div className="absolute inset-0 bg-black/30 group-hover:bg-black/50 transition-colors" />
+      {/* Play button */}
+      <div className="absolute inset-0 flex items-center justify-center">
+        <svg
+          className="w-16 h-16 text-white drop-shadow-lg group-hover:scale-110 transition-transform"
+          viewBox="0 0 64 64"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-label="Play trailer"
+        >
+          <circle cx="32" cy="32" r="30" fill="rgba(0,0,0,0.6)" stroke="rgba(255,255,255,0.8)" strokeWidth="2" />
+          <polygon points="26,20 26,44 46,32" fill="white" />
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -132,6 +132,17 @@ export interface WatchHistoryEntry {
   note: string | null;
 }
 
+// ─── Video Types ─────────────────────────────────────────────────────────────
+
+export interface TmdbVideo {
+  key: string;
+  site: string;
+  type: string;
+  official: boolean;
+  size: number;
+  published_at: string;
+}
+
 // ─── Detail Types ────────────────────────────────────────────────────────────
 
 export interface CastMember {
@@ -241,6 +252,7 @@ export interface MovieDetailsResponse {
     release_dates: { results: ReleaseDatesResult[] };
     "watch/providers": { results: Record<string, WatchProviderCountry> };
     external_ids?: ExternalIds;
+    videos?: { results: TmdbVideo[] };
   } | null;
   country: string;
 }
@@ -276,6 +288,7 @@ export interface ShowDetailsResponse {
     content_ratings: { results: { iso_3166_1: string; rating: string }[] };
     "watch/providers": { results: Record<string, WatchProviderCountry> };
     external_ids?: ExternalIds;
+    videos?: { results: TmdbVideo[] };
   } | null;
   country: string;
 }

--- a/server/routes/details.test.ts
+++ b/server/routes/details.test.ts
@@ -86,6 +86,56 @@ describe("GET /details/movie/:id", () => {
   });
 });
 
+describe("GET /details/movie/:id — videos field", () => {
+  it("passes videos.results through when TMDB returns them", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-123", title: "Movie With Trailer", tmdbId: "123" })]);
+
+    (tmdbClient.fetchMovieFullDetails as any).mockResolvedValueOnce({
+      id: 123,
+      title: "Movie With Trailer",
+      videos: {
+        results: [
+          {
+            id: "vid1",
+            key: "dQw4w9WgXcQ",
+            site: "YouTube",
+            type: "Trailer",
+            official: true,
+            size: 1080,
+            published_at: "2024-01-01T00:00:00.000Z",
+            name: "Official Trailer",
+            iso_639_1: "en",
+            iso_3166_1: "US",
+          },
+        ],
+      },
+    });
+
+    const res = await app.request("/details/movie/movie-123");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.tmdb.videos.results)).toBe(true);
+    expect(body.tmdb.videos.results[0].key).toBe("dQw4w9WgXcQ");
+    expect(body.tmdb.videos.results[0].type).toBe("Trailer");
+  });
+
+  it("tmdb.videos is present as empty results when TMDB returns none", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-123", title: "Movie No Trailer", tmdbId: "123" })]);
+
+    (tmdbClient.fetchMovieFullDetails as any).mockResolvedValueOnce({
+      id: 123,
+      title: "Movie No Trailer",
+      videos: { results: [] },
+    });
+
+    const res = await app.request("/details/movie/movie-123");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.tmdb.videos.results)).toBe(true);
+    expect(body.tmdb.videos.results).toHaveLength(0);
+  });
+});
+
 describe("GET /details/show/:id", () => {
   it("returns title from DB without TMDB fallback", async () => {
     await upsertTitles([makeParsedTitle({ id: "tv-456", objectType: "SHOW", title: "DB Show", tmdbId: "456" })]);

--- a/server/tmdb/client.test.ts
+++ b/server/tmdb/client.test.ts
@@ -160,7 +160,7 @@ describe("fetchMovieFullDetails", () => {
     await fetchMovieFullDetails("55");
     const url = new URL((fetchSpy.mock.calls[0] as [string])[0]);
     expect(url.pathname).toBe("/3/movie/55");
-    expect(url.searchParams.get("append_to_response")).toBe("credits,release_dates,watch/providers,external_ids");
+    expect(url.searchParams.get("append_to_response")).toBe("credits,release_dates,watch/providers,external_ids,videos");
   });
 });
 
@@ -172,7 +172,7 @@ describe("fetchShowFullDetails", () => {
     await fetchShowFullDetails("77");
     const url = new URL((fetchSpy.mock.calls[0] as [string])[0]);
     expect(url.pathname).toBe("/3/tv/77");
-    expect(url.searchParams.get("append_to_response")).toBe("credits,content_ratings,watch/providers,external_ids");
+    expect(url.searchParams.get("append_to_response")).toBe("credits,content_ratings,watch/providers,external_ids,videos");
   });
 });
 

--- a/server/tmdb/client.ts
+++ b/server/tmdb/client.ts
@@ -86,14 +86,14 @@ export async function fetchTvDetails(tmdbId: number): Promise<TmdbTvDetails> {
 export async function fetchMovieFullDetails(tmdbId: string): Promise<TmdbMovieFullDetails> {
   return tmdbRequest<TmdbMovieFullDetails>(`/movie/${tmdbId}`, {
     language: tmdbLanguage(),
-    append_to_response: "credits,release_dates,watch/providers,external_ids",
+    append_to_response: "credits,release_dates,watch/providers,external_ids,videos",
   });
 }
 
 export async function fetchShowFullDetails(tmdbId: string): Promise<TmdbShowFullDetails> {
   return tmdbRequest<TmdbShowFullDetails>(`/tv/${tmdbId}`, {
     language: tmdbLanguage(),
-    append_to_response: "credits,content_ratings,watch/providers,external_ids",
+    append_to_response: "credits,content_ratings,watch/providers,external_ids,videos",
   });
 }
 

--- a/server/tmdb/types.ts
+++ b/server/tmdb/types.ts
@@ -193,6 +193,21 @@ export interface TmdbLanguage {
   name: string;
 }
 
+// ─── Video Types ─────────────────────────────────────────────────────────────
+
+export interface TmdbVideo {
+  id: string;
+  key: string;
+  site: "YouTube" | "Vimeo" | string;
+  type: "Trailer" | "Teaser" | "Clip" | "Featurette" | "Behind the Scenes" | "Bloopers" | string;
+  official: boolean;
+  size: number;
+  published_at: string;
+  name: string;
+  iso_639_1: string;
+  iso_3166_1: string;
+}
+
 // ─── Full Detail Types (for detail pages with credits, release dates) ───────
 
 export interface TmdbCastMember {
@@ -301,6 +316,7 @@ export interface TmdbMovieFullDetails {
   release_dates: { results: TmdbReleaseDatesResult[] };
   "watch/providers": { results: Record<string, TmdbWatchProviderCountry> };
   external_ids?: TmdbExternalIds;
+  videos?: { results: TmdbVideo[] };
 }
 
 export interface TmdbShowFullDetails {
@@ -334,6 +350,7 @@ export interface TmdbShowFullDetails {
   content_ratings: { results: TmdbContentRatingResult[] };
   "watch/providers": { results: Record<string, TmdbWatchProviderCountry> };
   external_ids?: TmdbExternalIds;
+  videos?: { results: TmdbVideo[] };
 }
 
 export interface TmdbSeasonDetails {


### PR DESCRIPTION
## Summary

- Adds `TmdbVideo` type to server and frontend type definitions
- Appends `videos` to `append_to_response` in `fetchMovieFullDetails` and `fetchShowFullDetails` TMDB client calls (trailers are never persisted to DB)
- New `TrailerEmbed` component: shows YouTube thumbnail facade, swaps to `youtube-nocookie.com` iframe on click, respects `prefers-reduced-motion`, picks best trailer (official > highest resolution > most recent)
- "Watch Trailer" toggle button wired into `MovieHero` and `ShowHero` desktop action rows; reveals embed inline below the action area

## Test plan

- [ ] `bun run check` passes (2421 tests, 0 failures)
- [ ] `TrailerEmbed.test.tsx` — 7 unit tests: thumbnail render, iframe on click, null for no trailers/empty, trailer selection priority, Vimeo filter
- [ ] `details.test.ts` — 2 new tests: `tmdb.videos.results` passes through with content and as empty array
- [ ] `client.test.ts` — updated assertions for `append_to_response` now including `,videos`
- [ ] Visually: on a movie/show detail page with a trailer, "Watch Trailer" button appears; clicking expands a 16:9 facade with YouTube thumbnail and SVG play button; clicking play loads the iframe

Closes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)