### PR TITLE
feat: targeted recommendations to single recipient

### DIFF
--- a/drizzle/0039_recommendations_target_user.sql
+++ b/drizzle/0039_recommendations_target_user.sql
@@ -1,0 +1,11 @@
+-- Add target_user_id to recommendations for single-recipient targeting.
+-- NULL means broadcast to all followers; non-NULL means direct to one user.
+-- Also replaces the (from_user_id, title_id) UNIQUE index with a regular index
+-- so the same sender can recommend the same title to multiple different recipients.
+ALTER TABLE `recommendations` ADD COLUMN `target_user_id` text REFERENCES `users`(`id`) ON DELETE cascade;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_recommendations_from_title`;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_recommendations_from_title` ON `recommendations` (`from_user_id`, `title_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_recommendations_target_user` ON `recommendations` (`target_user_id`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1778457600000,
       "tag": "0039_users_crowded_week_settings",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "6",
+      "when": 1746057600000,
+      "tag": "0039_recommendations_target_user",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -628,10 +628,10 @@ export async function getSeasonEpisodeRatings(titleId: string, season: number, s
 
 // ─── Recommendations ──────────────────────────────────────────────────────────
 
-export async function sendRecommendation(titleId: string, message?: string): Promise<{ id: string }> {
+export async function sendRecommendation(titleId: string, message?: string, targetUserId?: string): Promise<{ id: string }> {
   return fetchJson("/recommendations", {
     method: "POST",
-    body: JSON.stringify({ titleId, message }),
+    body: JSON.stringify({ titleId, message, targetUserId }),
   });
 }
 

--- a/frontend/src/components/RecommendButton.test.tsx
+++ b/frontend/src/components/RecommendButton.test.tsx
@@ -121,7 +121,7 @@ describe("RecommendButton", () => {
     fireEvent.click(screen.getByTestId("recommend-send"));
 
     await waitFor(() => {
-      expect(api.sendRecommendation).toHaveBeenCalledWith("movie-123", "You should watch this!");
+      expect(api.sendRecommendation).toHaveBeenCalledWith("movie-123", "You should watch this!", undefined);
     });
   });
 
@@ -141,7 +141,7 @@ describe("RecommendButton", () => {
     fireEvent.click(screen.getByTestId("recommend-send"));
 
     await waitFor(() => {
-      expect(sonner.toast.success).toHaveBeenCalledWith("Recommendation sent!");
+      expect(sonner.toast.success).toHaveBeenCalledWith("Recommendation sent to all followers!");
     });
   });
 
@@ -183,7 +183,7 @@ describe("RecommendButton", () => {
     fireEvent.click(screen.getByTestId("recommend-send"));
 
     await waitFor(() => {
-      expect(api.sendRecommendation).toHaveBeenCalledWith("movie-123", undefined);
+      expect(api.sendRecommendation).toHaveBeenCalledWith("movie-123", undefined, undefined);
     });
   });
 

--- a/frontend/src/components/RecommendButton.tsx
+++ b/frontend/src/components/RecommendButton.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Send, Check } from "lucide-react";
+import { Send, Check, Users, User } from "lucide-react";
 import { toast } from "sonner";
 import * as api from "../api";
 import { useAuth } from "../context/AuthContext";
@@ -9,10 +9,13 @@ import {
   AlertDialogTitle,
   AlertDialogClose,
 } from "./ui/alert-dialog";
+import UserSearchDropdown, { type SelectedUser } from "./UserSearchDropdown";
 
 interface Props {
   titleId: string;
 }
+
+type AudienceMode = "all" | "pick";
 
 export default function RecommendButton({ titleId }: Props) {
   const { user } = useAuth();
@@ -21,6 +24,8 @@ export default function RecommendButton({ titleId }: Props) {
   const [sending, setSending] = useState(false);
   const [recommended, setRecommended] = useState(false);
   const [recId, setRecId] = useState<string | null>(null);
+  const [audienceMode, setAudienceMode] = useState<AudienceMode>("all");
+  const [targetUser, setTargetUser] = useState<SelectedUser | null>(null);
 
   useEffect(() => {
     if (!user) return;
@@ -44,6 +49,8 @@ export default function RecommendButton({ titleId }: Props) {
       return;
     }
     setMessage("");
+    setAudienceMode("all");
+    setTargetUser(null);
     setDialogOpen(true);
   }
 
@@ -64,12 +71,24 @@ export default function RecommendButton({ titleId }: Props) {
   }
 
   async function handleSend() {
+    if (audienceMode === "pick" && !targetUser) {
+      toast.error("Please select a recipient");
+      return;
+    }
     setSending(true);
     try {
-      const result = await api.sendRecommendation(titleId, message || undefined);
-      toast.success("Recommendation sent!");
+      const result = await api.sendRecommendation(
+        titleId,
+        message || undefined,
+        audienceMode === "pick" ? targetUser?.id : undefined,
+      );
+      const successMsg = audienceMode === "pick" && targetUser
+        ? `Recommendation sent to @${targetUser.username}!`
+        : "Recommendation sent to all followers!";
+      toast.success(successMsg);
       setDialogOpen(false);
       setMessage("");
+      setTargetUser(null);
       setRecommended(true);
       setRecId(result.id);
     } catch (err: unknown) {
@@ -101,6 +120,52 @@ export default function RecommendButton({ titleId }: Props) {
           <AlertDialogTitle>Recommend this title</AlertDialogTitle>
 
           <div className="mt-4 space-y-4">
+            {/* Audience picker */}
+            <div>
+              <label className="block text-sm text-zinc-400 mb-1.5">Send to</label>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => { setAudienceMode("all"); setTargetUser(null); }}
+                  className={`flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2 rounded-md text-xs font-medium border transition-colors cursor-pointer ${
+                    audienceMode === "all"
+                      ? "bg-amber-500/20 text-amber-400 border-amber-500/40"
+                      : "bg-zinc-800 text-zinc-400 border-zinc-700 hover:bg-zinc-700"
+                  }`}
+                  data-testid="audience-all"
+                >
+                  <Users className="size-3.5" />
+                  All followers
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setAudienceMode("pick")}
+                  className={`flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2 rounded-md text-xs font-medium border transition-colors cursor-pointer ${
+                    audienceMode === "pick"
+                      ? "bg-amber-500/20 text-amber-400 border-amber-500/40"
+                      : "bg-zinc-800 text-zinc-400 border-zinc-700 hover:bg-zinc-700"
+                  }`}
+                  data-testid="audience-pick"
+                >
+                  <User className="size-3.5" />
+                  Pick a person
+                </button>
+              </div>
+            </div>
+
+            {/* User picker — shown when "Pick a person" is selected */}
+            {audienceMode === "pick" && (
+              <div>
+                <label className="block text-sm text-zinc-400 mb-1.5">Recipient</label>
+                <UserSearchDropdown
+                  selected={targetUser}
+                  onSelect={(u) => setTargetUser(u)}
+                  onClear={() => setTargetUser(null)}
+                />
+              </div>
+            )}
+
+            {/* Message */}
             <div>
               <label className="block text-sm text-zinc-400 mb-1.5">
                 Message <span className="text-zinc-500">(optional)</span>
@@ -128,7 +193,7 @@ export default function RecommendButton({ titleId }: Props) {
             </AlertDialogClose>
             <button
               onClick={handleSend}
-              disabled={sending}
+              disabled={sending || (audienceMode === "pick" && !targetUser)}
               className="inline-flex items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium bg-amber-500 text-zinc-950 hover:bg-amber-400 cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               data-testid="recommend-send"
             >

--- a/frontend/src/pages/DiscoveryPage.tsx
+++ b/frontend/src/pages/DiscoveryPage.tsx
@@ -111,6 +111,11 @@ function RecommendationCard({
           </div>
         )}
         <span className="text-sm text-zinc-300 font-medium">{senderName}</span>
+        {rec.is_targeted && (
+          <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-500/15 text-amber-400 border border-amber-500/30">
+            Direct
+          </span>
+        )}
         <span className="text-xs text-zinc-500 ml-auto">{formatRelativeTime(rec.created_at)}</span>
       </div>
 
@@ -204,7 +209,7 @@ function HeroCard({
 
       {/* Info */}
       <div className="flex flex-col min-w-0 py-2">
-        <Kicker>Pick of the week{senderName ? ` · from @${rec.from_user.username}` : ""}</Kicker>
+        <Kicker>{rec.is_targeted ? "Just for you" : "Pick of the week"}{senderName ? ` · from @${rec.from_user.username}` : ""}</Kicker>
 
         <h2 className="text-[30px] sm:text-[36px] lg:text-[44px] font-extrabold tracking-[-0.03em] leading-[1.02] text-zinc-100 mb-3.5">
           {rec.title.title}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -676,6 +676,8 @@ export interface Recommendation {
   message: string | null;
   created_at: string;
   read_at: string | null;
+  /** true when the recommendation was sent directly to the current user (not a broadcast) */
+  is_targeted?: boolean;
 }
 
 export interface SentRecommendation {
@@ -683,6 +685,8 @@ export interface SentRecommendation {
   title: { id: string; title: string; object_type: string; poster_url: string | null };
   message: string | null;
   created_at: string;
+  /** Present when sent to a specific user; null means broadcast to all followers */
+  target_user: { id: string; username: string; display_name: string | null } | null;
 }
 
 export interface RecommendationsResponse {

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -133,6 +133,6 @@ describe("fixSkippedMigrations", () => {
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(40);
+    expect(migrations.cnt).toBe(41);
   });
 });

--- a/server/db/repository/recommendations.ts
+++ b/server/db/repository/recommendations.ts
@@ -1,4 +1,4 @@
-import { eq, and, sql, desc, count, inArray } from "drizzle-orm";
+import { eq, and, sql, desc, count, inArray, isNull, or } from "drizzle-orm";
 import { getDb } from "../schema";
 import { recommendations, recommendationReads, users, titles, follows } from "../schema";
 import { traceDbQuery } from "../../tracing";
@@ -7,6 +7,7 @@ export async function createRecommendation(
   fromUserId: string,
   titleId: string,
   message?: string,
+  targetUserId?: string,
 ): Promise<string> {
   return traceDbQuery("createRecommendation", async () => {
     const db = getDb();
@@ -17,19 +18,33 @@ export async function createRecommendation(
         fromUserId,
         titleId,
         message: message ?? null,
+        targetUserId: targetUserId ?? null,
       })
       .run();
     return id;
   });
 }
 
-export async function getUserRecommendation(userId: string, titleId: string) {
+export async function getUserRecommendation(
+  userId: string,
+  titleId: string,
+  targetUserId?: string,
+) {
   return traceDbQuery("getUserRecommendation", async () => {
     const db = getDb();
+    const targetCondition = targetUserId != null
+      ? eq(recommendations.targetUserId, targetUserId)
+      : isNull(recommendations.targetUserId);
     return await db
       .select({ id: recommendations.id })
       .from(recommendations)
-      .where(and(eq(recommendations.fromUserId, userId), eq(recommendations.titleId, titleId)))
+      .where(
+        and(
+          eq(recommendations.fromUserId, userId),
+          eq(recommendations.titleId, titleId),
+          targetCondition,
+        ),
+      )
       .get();
   });
 }
@@ -45,9 +60,19 @@ export async function getDiscoveryFeed(userId: string, limit = 20, offset = 0) {
       .all();
 
     const followedIds = followedUsers.map((u) => u.id);
-    if (followedIds.length === 0) {
-      return [];
-    }
+
+    // A recommendation is visible if:
+    //   a) it is directly targeted at this user, OR
+    //   b) it is a broadcast (no target) from someone the user follows
+    const visibilityCondition = followedIds.length === 0
+      ? eq(recommendations.targetUserId, userId)
+      : or(
+          eq(recommendations.targetUserId, userId),
+          and(
+            isNull(recommendations.targetUserId),
+            inArray(recommendations.fromUserId, followedIds),
+          ),
+        );
 
     return await db
       .select({
@@ -63,6 +88,7 @@ export async function getDiscoveryFeed(userId: string, limit = 20, offset = 0) {
         message: recommendations.message,
         createdAt: recommendations.createdAt,
         readAt: recommendationReads.readAt,
+        targetUserId: recommendations.targetUserId,
       })
       .from(recommendations)
       .innerJoin(users, eq(users.id, recommendations.fromUserId))
@@ -74,7 +100,7 @@ export async function getDiscoveryFeed(userId: string, limit = 20, offset = 0) {
           eq(recommendationReads.userId, sql`${userId}`),
         ),
       )
-      .where(inArray(recommendations.fromUserId, followedIds))
+      .where(visibilityCondition)
       .orderBy(desc(recommendations.createdAt))
       .limit(limit)
       .offset(offset)
@@ -92,14 +118,21 @@ export async function getDiscoveryFeedCount(userId: string): Promise<number> {
       .all();
 
     const followedIds = followedUsers.map((u) => u.id);
-    if (followedIds.length === 0) {
-      return 0;
-    }
+
+    const visibilityCondition = followedIds.length === 0
+      ? eq(recommendations.targetUserId, userId)
+      : or(
+          eq(recommendations.targetUserId, userId),
+          and(
+            isNull(recommendations.targetUserId),
+            inArray(recommendations.fromUserId, followedIds),
+          ),
+        );
 
     const row = await db
       .select({ count: count() })
       .from(recommendations)
-      .where(inArray(recommendations.fromUserId, followedIds))
+      .where(visibilityCondition)
       .get();
     return row?.count ?? 0;
   });
@@ -108,21 +141,37 @@ export async function getDiscoveryFeedCount(userId: string): Promise<number> {
 export async function getSentRecommendations(userId: string) {
   return traceDbQuery("getSentRecommendations", async () => {
     const db = getDb();
-    return await db
-      .select({
-        id: recommendations.id,
-        titleId: recommendations.titleId,
-        titleName: titles.title,
-        titleObjectType: titles.objectType,
-        posterUrl: titles.posterUrl,
-        message: recommendations.message,
-        createdAt: recommendations.createdAt,
-      })
-      .from(recommendations)
-      .innerJoin(titles, eq(titles.id, recommendations.titleId))
-      .where(eq(recommendations.fromUserId, userId))
-      .orderBy(desc(recommendations.createdAt))
-      .all();
+    // Raw query to support LEFT JOIN on target user without Drizzle alias complexity
+    type Row = {
+      id: string;
+      titleId: string;
+      titleName: string;
+      titleObjectType: string;
+      posterUrl: string | null;
+      message: string | null;
+      createdAt: string | null;
+      targetUserId: string | null;
+      targetUsername: string | null;
+      targetDisplayName: string | null;
+    };
+    return db.all<Row>(sql`
+      SELECT
+        r.id AS id,
+        r.title_id AS titleId,
+        t.title AS titleName,
+        t.object_type AS titleObjectType,
+        t.poster_url AS posterUrl,
+        r.message AS message,
+        r.created_at AS createdAt,
+        r.target_user_id AS targetUserId,
+        tu.username AS targetUsername,
+        tu.name AS targetDisplayName
+      FROM recommendations r
+      INNER JOIN titles t ON t.id = r.title_id
+      LEFT JOIN users tu ON tu.id = r.target_user_id
+      WHERE r.from_user_id = ${userId}
+      ORDER BY r.created_at DESC
+    `);
   });
 }
 
@@ -165,9 +214,16 @@ export async function getUnreadCount(userId: string): Promise<number> {
       .all();
 
     const followedIds = followedUsers.map((u) => u.id);
-    if (followedIds.length === 0) {
-      return 0;
-    }
+
+    const visibilityCondition = followedIds.length === 0
+      ? eq(recommendations.targetUserId, userId)
+      : or(
+          eq(recommendations.targetUserId, userId),
+          and(
+            isNull(recommendations.targetUserId),
+            inArray(recommendations.fromUserId, followedIds),
+          ),
+        );
 
     const row = await db
       .select({ count: count() })
@@ -181,7 +237,7 @@ export async function getUnreadCount(userId: string): Promise<number> {
       )
       .where(
         and(
-          inArray(recommendations.fromUserId, followedIds),
+          visibilityCondition,
           sql`${recommendationReads.readAt} IS NULL`,
         ),
       )

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -396,12 +396,14 @@ export const recommendations = sqliteTable(
     id: text("id").primaryKey(),
     fromUserId: text("from_user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
     titleId: text("title_id").notNull().references(() => titles.id, { onDelete: "cascade" }),
+    targetUserId: text("target_user_id").references(() => users.id, { onDelete: "cascade" }),
     message: text("message"),
     createdAt: text("created_at").default(sql`(datetime('now'))`),
   },
   (table) => [
-    uniqueIndex("idx_recommendations_from_title").on(table.fromUserId, table.titleId),
+    index("idx_recommendations_from_title").on(table.fromUserId, table.titleId),
     index("idx_recommendations_from_user").on(table.fromUserId),
+    index("idx_recommendations_target_user").on(table.targetUserId),
   ]
 );
 

--- a/server/routes/recommendations.test.ts
+++ b/server/routes/recommendations.test.ts
@@ -7,6 +7,7 @@ import { requireAuth } from "../middleware/auth";
 import recommendationsApp from "./recommendations";
 import type { AppEnv } from "../types";
 
+
 function createMockAuth() {
   return {
     api: {
@@ -444,6 +445,194 @@ describe("validation", () => {
   it("rejects GET / with negative offset", async () => {
     const res = await app.request("/recommendations?offset=-1", {
       headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+});
+
+describe("POST /recommendations — targeted", () => {
+  it("allows sending to a followed user", async () => {
+    // Alice follows Bob
+    await follow(userAId, userBId);
+
+    const res = await app.request("/recommendations", {
+      method: "POST",
+      headers: { ...authHeaders(userAToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ titleId: "movie-123", message: "Just for you!", targetUserId: userBId }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.id).toBeDefined();
+  });
+
+  it("returns 400 when targeting yourself", async () => {
+    const res = await app.request("/recommendations", {
+      method: "POST",
+      headers: { ...authHeaders(userAToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ titleId: "movie-123", targetUserId: userAId }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("yourself");
+  });
+
+  it("returns 403 when targeting a non-followed user", async () => {
+    // Alice does not follow Carol
+    const res = await app.request("/recommendations", {
+      method: "POST",
+      headers: { ...authHeaders(userAToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ titleId: "movie-123", targetUserId: userCId }),
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("follow");
+  });
+
+  it("allows same title targeted to different recipients", async () => {
+    await follow(userAId, userBId);
+    await follow(userAId, userCId);
+
+    const resB = await app.request("/recommendations", {
+      method: "POST",
+      headers: { ...authHeaders(userAToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ titleId: "movie-123", targetUserId: userBId }),
+    });
+    expect(resB.status).toBe(201);
+
+    const resC = await app.request("/recommendations", {
+      method: "POST",
+      headers: { ...authHeaders(userAToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ titleId: "movie-123", targetUserId: userCId }),
+    });
+    expect(resC.status).toBe(201);
+  });
+
+  it("returns 409 for duplicate targeted recommendation to same recipient", async () => {
+    await follow(userAId, userBId);
+
+    await app.request("/recommendations", {
+      method: "POST",
+      headers: { ...authHeaders(userAToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ titleId: "movie-123", targetUserId: userBId }),
+    });
+
+    const res = await app.request("/recommendations", {
+      method: "POST",
+      headers: { ...authHeaders(userAToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ titleId: "movie-123", targetUserId: userBId }),
+    });
+    expect(res.status).toBe(409);
+  });
+
+  it("targeted rec appears in recipient feed even without following the sender", async () => {
+    // Alice follows Bob so she can target him; Bob does NOT follow Alice
+    await follow(userAId, userBId);
+
+    await app.request("/recommendations", {
+      method: "POST",
+      headers: { ...authHeaders(userAToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ titleId: "movie-123", message: "Direct rec!", targetUserId: userBId }),
+    });
+
+    // Bob should see it in his feed despite not following Alice
+    const res = await app.request("/recommendations", {
+      headers: authHeaders(userBToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.recommendations).toHaveLength(1);
+    expect(body.recommendations[0].is_targeted).toBe(true);
+    expect(body.recommendations[0].message).toBe("Direct rec!");
+  });
+
+  it("targeted rec does NOT appear in a third-party's feed", async () => {
+    // Alice follows Bob so she can target him; Carol follows Alice
+    await follow(userAId, userBId);
+    await follow(userCId, userAId);
+
+    // Alice sends a targeted rec to Bob
+    await app.request("/recommendations", {
+      method: "POST",
+      headers: { ...authHeaders(userAToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ titleId: "movie-123", targetUserId: userBId }),
+    });
+
+    // Carol follows Alice but should NOT see the targeted rec (it's for Bob)
+    const res = await app.request("/recommendations", {
+      headers: authHeaders(userCToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.recommendations).toHaveLength(0);
+  });
+
+  it("broadcast rec is visible to all followers, targeted rec is only visible to recipient", async () => {
+    // Carol follows Alice
+    await follow(userCId, userAId);
+    // Alice follows Bob so she can target him
+    await follow(userAId, userBId);
+
+    // Alice sends a broadcast
+    await app.request("/recommendations", {
+      method: "POST",
+      headers: { ...authHeaders(userAToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ titleId: "movie-123" }),
+    });
+
+    // Alice sends a targeted rec to Bob
+    await app.request("/recommendations", {
+      method: "POST",
+      headers: { ...authHeaders(userAToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ titleId: "show-456", targetUserId: userBId }),
+    });
+
+    // Carol (follower) sees the broadcast but not the targeted rec
+    const carolRes = await app.request("/recommendations", {
+      headers: authHeaders(userCToken),
+    });
+    const carolBody = await carolRes.json();
+    expect(carolBody.recommendations).toHaveLength(1);
+    expect(carolBody.recommendations[0].is_targeted).toBeFalsy();
+
+    // Bob sees the targeted rec but not the broadcast (Bob doesn't follow Alice)
+    const bobRes = await app.request("/recommendations", {
+      headers: authHeaders(userBToken),
+    });
+    const bobBody = await bobRes.json();
+    expect(bobBody.recommendations).toHaveLength(1);
+    expect(bobBody.recommendations[0].is_targeted).toBe(true);
+  });
+});
+
+describe("GET /recommendations — targeted visibility", () => {
+  it("shows targeted recs in recipient feed even without follow", async () => {
+    await follow(userAId, userBId); // Alice follows Bob so she can target him
+
+    await app.request("/recommendations", {
+      method: "POST",
+      headers: { ...authHeaders(userAToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ titleId: "movie-123", targetUserId: userBId }),
+    });
+
+    const res = await app.request("/recommendations", {
+      headers: authHeaders(userBToken),
+    });
+    const body = await res.json();
+    expect(body.recommendations).toHaveLength(1);
+    expect(body.count).toBe(1);
+  });
+});
+
+describe("validation — targetUserId", () => {
+  it("rejects POST / with targetUserId as a number (not string)", async () => {
+    const res = await app.request("/recommendations", {
+      method: "POST",
+      headers: { ...authHeaders(userAToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ titleId: "movie-123", targetUserId: 123 }),
     });
     expect(res.status).toBe(400);
     const body = await res.json();

--- a/server/routes/recommendations.ts
+++ b/server/routes/recommendations.ts
@@ -10,6 +10,7 @@ import {
   deleteRecommendation,
   getUnreadCount,
 } from "../db/repository";
+import { isFollowing } from "../db/repository/follows";
 import type { AppEnv } from "../types";
 import { logger } from "../logger";
 import { ok, err } from "./response";
@@ -20,6 +21,7 @@ const log = logger.child({ module: "recommendations" });
 const createRecommendationSchema = z.object({
   titleId: z.string().min(1),
   message: z.string().max(500).optional(),
+  targetUserId: z.string().optional(),
 });
 
 const discoveryFeedQuerySchema = z.object({
@@ -29,7 +31,7 @@ const discoveryFeedQuerySchema = z.object({
 
 const app = new Hono<AppEnv>();
 
-// POST / — Broadcast a recommendation (no toUserId needed)
+// POST / — Send a recommendation (broadcast to all followers, or targeted to one user)
 app.post("/", zValidator("json", createRecommendationSchema), async (c) => {
   const user = c.get("user");
   if (!user) {
@@ -37,15 +39,27 @@ app.post("/", zValidator("json", createRecommendationSchema), async (c) => {
   }
 
   const body = c.req.valid("json");
+  const { targetUserId } = body;
 
-  // Check for duplicate recommendation
-  const existing = await getUserRecommendation(user.id, body.titleId);
-  if (existing) {
-    return err(c, "You have already recommended this title", 409);
+  // Validate targeted recommendation
+  if (targetUserId != null) {
+    if (targetUserId === user.id) {
+      return err(c, "Cannot send a recommendation to yourself", 400);
+    }
+    const following = await isFollowing(user.id, targetUserId);
+    if (!following) {
+      return err(c, "You can only send targeted recommendations to users you follow", 403);
+    }
   }
 
-  const id = await createRecommendation(user.id, body.titleId, body.message);
-  log.info("Recommendation created", { fromUserId: user.id, titleId: body.titleId });
+  // Check for duplicate recommendation (same sender, same title, same target)
+  const existing = await getUserRecommendation(user.id, body.titleId, targetUserId);
+  if (existing) {
+    return err(c, "You have already recommended this title to this recipient", 409);
+  }
+
+  const id = await createRecommendation(user.id, body.titleId, body.message, targetUserId);
+  log.info("Recommendation created", { fromUserId: user.id, titleId: body.titleId, targetUserId: targetUserId ?? null });
   return c.json({ success: true, id }, 201);
 });
 
@@ -78,6 +92,9 @@ app.get("/sent", async (c) => {
     },
     message: r.message,
     created_at: r.createdAt,
+    target_user: r.targetUserId != null
+      ? { id: r.targetUserId, username: r.targetUsername ?? "", display_name: r.targetDisplayName ?? null }
+      : null,
   }));
 
   return ok(c, { recommendations });
@@ -126,6 +143,7 @@ app.get("/", zValidator("query", discoveryFeedQuerySchema), async (c) => {
     message: r.message,
     created_at: r.createdAt,
     read_at: r.readAt,
+    is_targeted: r.targetUserId != null,
   }));
 
   return ok(c, { recommendations, count });


### PR DESCRIPTION
## Summary

- Adds optional `targetUserId` to recommendations so a sender can direct a recommendation at one specific followed user instead of broadcasting to all followers
- Targeted recs appear in the recipient's feed even if they don't follow the sender; hidden from all other followers
- Same sender can now recommend the same title to different people (the old `UNIQUE(fromUserId, titleId)` index is replaced with a regular index)

## Changes

- **Migration 0039**: `ALTER TABLE recommendations ADD COLUMN target_user_id TEXT REFERENCES users(id) ON DELETE CASCADE`; drops the unique index and replaces with a regular index + new `idx_recommendations_target_user`
- **Schema**: `targetUserId` nullable column added to `recommendations` table
- **Repository**: `createRecommendation`, `getUserRecommendation`, `getDiscoveryFeed`, `getDiscoveryFeedCount`, `getUnreadCount`, `getSentRecommendations` all updated to handle targeting
- **Route `POST /api/recommendations`**: zod schema extended with optional `targetUserId: string`; validates sender follows the target; blocks self-targeting
- **Frontend types**: `Recommendation.is_targeted` and `SentRecommendation.target_user` added
- **`api.ts`**: `sendRecommendation` accepts optional `targetUserId`
- **`RecommendButton`**: new "All followers" / "Pick a person" segmented control; uses existing `UserSearchDropdown` for recipient selection
- **`DiscoveryPage`**: "Direct" badge shown on targeted recommendations; HeroCard shows "Just for you" kicker

## Test plan

- [x] `bun run check` passes (2422 tests, 0 failures)
- [x] `POST /` with no `targetUserId` → broadcast, 201
- [x] `POST /` with valid `targetUserId` of a followed user → 201
- [x] `POST /` with `targetUserId` = self → 400
- [x] `POST /` with `targetUserId` of non-followed user → 403
- [x] `POST /` with `targetUserId: 123` (number) → 400 Zod validation
- [x] Same title can be targeted to two different users → both 201
- [x] Duplicate targeted rec to same recipient → 409
- [x] Targeted rec appears in recipient's feed (even without follow-back)
- [x] Targeted rec does NOT appear in third-party's feed
- [x] Broadcast visible to all followers; targeted rec only to recipient
- [x] RecommendButton updated tests: new call signature + success message

Closes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)