### PR TITLE
Reposition trailer embed to top of hero section

### DIFF
--- a/frontend/src/components/title-detail/MovieHero.tsx
+++ b/frontend/src/components/title-detail/MovieHero.tsx
@@ -42,6 +42,11 @@ export default function MovieHero({ title, tmdb, watchedActions, watchHistoryPan
           : undefined
       }
     >
+      {showTrailer && videos.length > 0 && (
+        <div className="mb-6 sm:mb-8 lg:mb-10 max-w-[1100px] mx-auto">
+          <TrailerEmbed videos={videos} />
+        </div>
+      )}
       <div className="flex flex-col sm:flex-row gap-6 sm:gap-8 lg:gap-10 items-end">
         {/* Poster */}
         <div className="w-48 sm:w-56 lg:w-60 shrink-0 mx-auto sm:mx-0">
@@ -140,11 +145,6 @@ export default function MovieHero({ title, tmdb, watchedActions, watchHistoryPan
             )}
           </div>
           {watchHistoryPanel}
-          {showTrailer && videos.length > 0 && (
-            <div className="mt-4">
-              <TrailerEmbed videos={videos} />
-            </div>
-          )}
         </div>
       </div>
     </div>

--- a/frontend/src/components/title-detail/ShowHero.tsx
+++ b/frontend/src/components/title-detail/ShowHero.tsx
@@ -137,6 +137,11 @@ export default function ShowHero({ title, tmdb, country }: ShowHeroProps) {
           : undefined
       }
     >
+      {showTrailer && videos.length > 0 && (
+        <div className="mb-6 sm:mb-8 lg:mb-10 max-w-[1100px] mx-auto">
+          <TrailerEmbed videos={videos} />
+        </div>
+      )}
       <div className="flex flex-col sm:flex-row gap-6 sm:gap-8 lg:gap-10 items-end">
         <div className="w-48 sm:w-56 lg:w-60 shrink-0 mx-auto sm:mx-0">
           {posterUrl ? (
@@ -257,11 +262,6 @@ export default function ShowHero({ title, tmdb, country }: ShowHeroProps) {
             <div className="flex items-center gap-2 text-xs text-zinc-400">
               <span>Next episode</span>
               <EpisodeCountdown airDate={title.next_episode_air_date} />
-            </div>
-          )}
-          {showTrailer && videos.length > 0 && (
-            <div className="mt-4">
-              <TrailerEmbed videos={videos} />
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
Moved the trailer embed component from the bottom of the content area to the top of the hero section in both Movie and Show detail pages. This improves the visual hierarchy and user experience by displaying the trailer prominently before other content.

## Key Changes
- **MovieHero.tsx**: Relocated `TrailerEmbed` component from bottom of right column (after watch history panel) to top of hero section with improved spacing
- **ShowHero.tsx**: Applied the same repositioning pattern, moving `TrailerEmbed` from bottom of right column to top of hero section
- Updated styling from `mt-4` (margin-top) to `mb-6 sm:mb-8 lg:mb-10` (margin-bottom) with responsive spacing
- Added `max-w-[1100px] mx-auto` container styling for consistent width and centering

## Implementation Details
- The trailer now appears as a full-width element at the top of the hero section, before the poster and content layout
- Responsive margin-bottom values ensure proper spacing on mobile (`mb-6`), tablet (`sm:mb-8`), and desktop (`lg:mb-10`) viewports
- The conditional rendering logic remains unchanged (`showTrailer && videos.length > 0`)
- This change applies consistently across both movie and show detail pages

https://claude.ai/code/session_01GHsHpgHT3hxHyePiukTn2v