### PR TITLE
Simplify title links to use unified /title/:id route

### DIFF
--- a/frontend/src/components/PinnedFavoritesCard.test.tsx
+++ b/frontend/src/components/PinnedFavoritesCard.test.tsx
@@ -217,5 +217,20 @@ describe("PinnedFavoritesCard", () => {
       const plusSlots = screen.getAllByText("+");
       expect(plusSlots.length).toBe(2);
     });
+
+    it("links each tile to /title/:id (matching the SPA route)", () => {
+      const pinned: PinnedTitle[] = [
+        { id: "42", title: "Foundation", poster_url: null, object_type: "SHOW", position: 0 },
+        { id: "99", title: "Blade Runner 2049", poster_url: null, object_type: "MOVIE", position: 1 },
+      ];
+      const { container } = render(
+        <PinnedFavoritesCard pinned={pinned} isOwnProfile={false} />,
+        { wrapper: Wrapper },
+      );
+      const hrefs = Array.from(container.querySelectorAll("a")).map((a) => a.getAttribute("href"));
+      expect(hrefs).toContain("/title/42");
+      expect(hrefs).toContain("/title/99");
+      expect(hrefs.some((h) => h?.startsWith("/details/"))).toBe(false);
+    });
   });
 });

--- a/frontend/src/components/PinnedFavoritesCard.tsx
+++ b/frontend/src/components/PinnedFavoritesCard.tsx
@@ -191,9 +191,7 @@ export default function PinnedFavoritesCard({ pinned, isOwnProfile, onPinnedChan
           <div className="grid grid-cols-4 gap-2">
             {visibleItems.map((title) => (
               <div key={title.id} className="relative">
-                <Link
-                  to={`/details/${title.object_type === "MOVIE" ? "movie" : "show"}/${title.id}`}
-                >
+                <Link to={`/title/${title.id}`}>
                   {title.poster_url ? (
                     <img
                       src={title.poster_url}


### PR DESCRIPTION
## Summary
Updated the PinnedFavoritesCard component to use a simplified, unified routing pattern for title links instead of the previous object-type-specific routes.

## Key Changes
- Changed link routing from `/details/{movie|show}/:id` to `/title/:id` for all pinned titles
- Updated the corresponding test to verify links match the new SPA route pattern
- Removed conditional logic that differentiated between MOVIE and SHOW object types in the route

## Implementation Details
The change simplifies the routing logic by eliminating the need to check `title.object_type` when constructing links. All titles now use the same `/title/:id` route, which presumably is handled by the SPA router to determine the appropriate content type based on the ID. This reduces component complexity and makes the routing more maintainable.

https://claude.ai/code/session_01JZpcBZbwCChPcyz83WuU1q