### PR TITLE
fix: add PlexResource type to eliminate r: any in getServers()

### DIFF
--- a/server/plex/client.test.ts
+++ b/server/plex/client.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, spyOn, beforeEach } from "bun:test";
+
+// Mock Sentry before any other imports that might trigger it
+import Sentry from "../sentry";
+spyOn(Sentry, "startSpan").mockImplementation((_opts: any, fn: any) => fn({}));
+spyOn(Sentry, "captureException").mockImplementation(() => "");
+
+import * as http from "../lib/http";
+import { getServers } from "./client";
+
+function makeResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("getServers()", () => {
+  let fetchSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = spyOn(http, "httpFetch");
+  });
+
+  it("returns only resources whose provides field includes 'server'", async () => {
+    const resources = [
+      {
+        name: "My Server",
+        clientIdentifier: "abc123",
+        provides: "server",
+        connections: [{ uri: "http://192.168.1.10:32400", local: true, relay: false }],
+      },
+      {
+        name: "My Player",
+        clientIdentifier: "def456",
+        provides: "player",
+        connections: [],
+      },
+      {
+        name: "Server and Player",
+        clientIdentifier: "ghi789",
+        provides: "server,player",
+        connections: [{ uri: "http://192.168.1.11:32400", local: true, relay: false }],
+      },
+    ];
+
+    fetchSpy.mockResolvedValue(makeResponse(resources));
+
+    const result = await getServers("test-token");
+
+    expect(result).toHaveLength(2);
+    expect(result.map((s) => s.clientIdentifier)).toEqual(["abc123", "ghi789"]);
+  });
+
+  it("returns an empty array when no resources have provides containing 'server'", async () => {
+    const resources = [
+      {
+        name: "Player Only",
+        clientIdentifier: "ppp111",
+        provides: "player",
+        connections: [],
+      },
+      {
+        name: "No provides",
+        clientIdentifier: "ppp222",
+        connections: [],
+      },
+    ];
+
+    fetchSpy.mockResolvedValue(makeResponse(resources));
+
+    const result = await getServers("test-token");
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns an empty array when the API returns an empty list", async () => {
+    fetchSpy.mockResolvedValue(makeResponse([]));
+
+    const result = await getServers("test-token");
+
+    expect(result).toHaveLength(0);
+  });
+});

--- a/server/plex/client.test.ts
+++ b/server/plex/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, spyOn, beforeEach } from "bun:test";
+import { describe, it, expect, spyOn, beforeEach, afterEach } from "bun:test";
 
 // Mock Sentry before any other imports that might trigger it
 import Sentry from "../sentry";
@@ -20,6 +20,10 @@ describe("getServers()", () => {
 
   beforeEach(() => {
     fetchSpy = spyOn(http, "httpFetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
   });
 
   it("returns only resources whose provides field includes 'server'", async () => {

--- a/server/plex/client.ts
+++ b/server/plex/client.ts
@@ -83,11 +83,17 @@ export type PlexServer = {
   connections: Array<{ uri: string; local: boolean; relay: boolean }>;
 };
 
+/** Raw shape returned by the Plex /api/v2/resources endpoint. */
+interface PlexResource extends PlexServer {
+  /** Comma-separated capability list, e.g. "server,player" */
+  provides?: string;
+}
+
 export async function getServers(token: string): Promise<PlexServer[]> {
   const url = `${PLEX_TV_BASE}/api/v2/resources?includeHttps=1&includeRelay=1`;
-  const data = await plexFetch<PlexServer[]>(url, { headers: plexHeaders(token) });
+  const data = await plexFetch<PlexResource[]>(url, { headers: plexHeaders(token) });
   // Only return MediaServer resources
-  return data.filter((r: any) => r.provides?.includes("server"));
+  return data.filter((r: PlexResource) => r.provides?.includes("server"));
 }
 
 // ─── Library ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Introduces internal `PlexResource` interface with `provides?: string` field (comma-separated capability string, e.g. `"server,player"`)
- Removes `r: any` cast in `getServers()` filter predicate, replacing it with the typed interface
- Adds `server/plex/client.test.ts` regression test covering the server-filter logic

## Test plan
- [ ] `bun run check` passes (server tsc, frontend tsc, lint, all tests)
- [ ] New `client.test.ts` verifies only resources with `provides` containing "server" are returned

Closes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)