### PR TITLE
feat: add calendar week view and density toggle

### DIFF
--- a/frontend/src/components/AgendaCalendar.tsx
+++ b/frontend/src/components/AgendaCalendar.tsx
@@ -6,8 +6,10 @@ import {
   CalendarIcon,
   LayoutGridIcon,
   ListIcon,
+  CalendarDaysIcon,
   EyeIcon,
   EyeOffIcon,
+  AlignJustifyIcon,
 } from "lucide-react";
 import { Popover } from "@base-ui/react/popover";
 import { Calendar } from "../components/ui/calendar";
@@ -39,7 +41,9 @@ export const typeFilters = [
   { label: "Shows", value: "SHOW" },
 ] as const;
 
-export type ViewMode = "grid" | "agenda";
+export type ViewMode = "grid" | "agenda" | "week";
+
+export type DensityMode = "compact" | "comfortable" | "spacious";
 
 export function formatMonth(date: Date): string {
   const y = date.getFullYear();
@@ -153,6 +157,19 @@ export function ViewToggle({
         <LayoutGridIcon className="size-4" />
       </button>
       <button
+        onClick={() => onViewModeChange("week")}
+        aria-label={t("calendar.weekView")}
+        aria-pressed={viewMode === "week"}
+        className={`p-1.5 rounded-md transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 focus-visible:ring-offset-1 focus-visible:ring-offset-zinc-800 ${
+          viewMode === "week"
+            ? "bg-amber-500 text-zinc-950"
+            : "text-zinc-400 hover:text-white"
+        }`}
+        title="Week view"
+      >
+        <CalendarDaysIcon className="size-4" />
+      </button>
+      <button
         onClick={() => onViewModeChange("agenda")}
         aria-label={t("calendar.agendaView")}
         aria-pressed={viewMode === "agenda"}
@@ -165,6 +182,43 @@ export function ViewToggle({
       >
         <ListIcon className="size-4" />
       </button>
+    </div>
+  );
+}
+
+// ─── Density Toggle ─────────────────────────────────────────────────────────
+
+export function DensityToggle({
+  density,
+  onDensityChange,
+}: {
+  density: DensityMode;
+  onDensityChange: (mode: DensityMode) => void;
+}) {
+  const { t } = useTranslation();
+  const options: { value: DensityMode; label: string }[] = [
+    { value: "compact", label: t("calendar.densityCompact") },
+    { value: "comfortable", label: t("calendar.densityComfortable") },
+    { value: "spacious", label: t("calendar.densitySpacious") },
+  ];
+  return (
+    <div className="flex items-center bg-zinc-800 rounded-lg p-0.5 gap-0.5" title="Density">
+      <AlignJustifyIcon className="size-3.5 text-zinc-500 mx-1 flex-shrink-0" />
+      {options.map((opt) => (
+        <button
+          key={opt.value}
+          onClick={() => onDensityChange(opt.value)}
+          aria-label={opt.label}
+          aria-pressed={density === opt.value}
+          className={`px-2 py-1 rounded-md text-[11px] font-medium transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 focus-visible:ring-offset-1 focus-visible:ring-offset-zinc-800 ${
+            density === opt.value
+              ? "bg-amber-500 text-zinc-950"
+              : "text-zinc-400 hover:text-white"
+          }`}
+        >
+          {opt.label.charAt(0).toUpperCase()}
+        </button>
+      ))}
     </div>
   );
 }
@@ -229,6 +283,8 @@ interface AgendaMonth {
 interface AgendaCalendarProps {
   viewMode?: ViewMode;
   onViewModeChange?: (mode: ViewMode) => void;
+  density?: DensityMode;
+  onDensityChange?: (mode: DensityMode) => void;
   searchParams: URLSearchParams;
   setSearchParams: ReturnType<typeof useSearchParams>[1];
 }
@@ -236,6 +292,8 @@ interface AgendaCalendarProps {
 function AgendaCalendarImpl({
   viewMode,
   onViewModeChange,
+  density = "comfortable",
+  onDensityChange,
   searchParams,
   setSearchParams,
 }: AgendaCalendarProps) {
@@ -750,6 +808,12 @@ function AgendaCalendarImpl({
                 onViewModeChange={onViewModeChange}
               />
             )}
+            {onDensityChange && (
+              <DensityToggle
+                density={density}
+                onDensityChange={onDensityChange}
+              />
+            )}
           </div>
           <div className="flex items-center gap-2">
             {typeFilters.map((f) => (
@@ -888,7 +952,7 @@ function AgendaCalendarImpl({
                                         <div className="w-full aspect-video bg-gradient-to-b from-zinc-800 to-zinc-950" />
                                       )}
                                     </Link>
-                                    <div className="p-3">
+                                    <div className={density === "compact" ? "p-1.5" : density === "spacious" ? "p-4" : "p-3"}>
                                       <div className="flex items-center justify-between gap-2">
                                         <Link
                                           to={`/title/${ep.title_id}`}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -299,9 +299,13 @@
     "hideWatched": "Hide watched",
     "showWatched": "Show watched",
     "gridView": "Grid view",
+    "weekView": "Week view",
     "agendaView": "Agenda view",
     "close": "Close",
-    "goToDay": "Go to {{date}}"
+    "goToDay": "Go to {{date}}",
+    "densityCompact": "Compact",
+    "densityComfortable": "Comfortable",
+    "densitySpacious": "Spacious"
   },
   "landing": {
     "tagline": "Track movies & TV shows you love",

--- a/frontend/src/pages/CalendarPage.test.tsx
+++ b/frontend/src/pages/CalendarPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, mock, afterEach, beforeEach } from "bun:test";
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import type { ReactNode } from "react";
 
@@ -20,6 +20,9 @@ mock.module("../api", () => ({
   watchEpisode: mock(() => Promise.resolve()),
   unwatchEpisode: mock(() => Promise.resolve()),
   watchEpisodesBulk: mock(() => Promise.resolve()),
+  getCrowdedWeekSettings: mock(() =>
+    Promise.resolve({ crowdedWeekThreshold: 5, crowdedWeekBadgeEnabled: 1 })
+  ),
 }));
 
 // Must import after mocks
@@ -165,5 +168,87 @@ describe("CalendarPage", () => {
     const toggle = screen.getByRole("button", { name: /hide watched/i });
     expect(toggle).toBeDefined();
     expect(toggle.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("renders week view toggle button on desktop", () => {
+    render(<CalendarPage />, { wrapper: Wrapper });
+    expect(screen.getByTitle("Week view")).toBeDefined();
+  });
+
+  it("switches to week view when week toggle is clicked", async () => {
+    render(<CalendarPage />, { wrapper: Wrapper });
+
+    // Verify we're in grid mode
+    expect(screen.getByText("Mon")).toBeDefined();
+
+    // Click week view toggle
+    fireEvent.click(screen.getByTitle("Week view"));
+
+    // Week view renders 7 day-column headers (date numbers in header row)
+    const weekDayNumbers = await waitFor(() => screen.getAllByTestId("week-day-number"));
+    expect(weekDayNumbers.length).toBe(7);
+  });
+
+  it("week view renders 7 day columns", async () => {
+    render(<CalendarPage />, { wrapper: Wrapper });
+    fireEvent.click(screen.getByTitle("Week view"));
+
+    const columns = await waitFor(() => screen.getAllByTestId("week-day-column"));
+    expect(columns.length).toBe(7);
+  });
+
+  it("?view=week param activates week view", async () => {
+    render(
+      <MemoryRouter initialEntries={["/?view=week"]}>
+        <CalendarPage />
+      </MemoryRouter>
+    );
+    const columns = await waitFor(() => screen.getAllByTestId("week-day-column"));
+    expect(columns.length).toBe(7);
+  });
+
+  it("renders density toggle buttons on desktop", () => {
+    render(<CalendarPage />, { wrapper: Wrapper });
+
+    // Density toggle renders C / C / S (compact / comfortable / spacious initials)
+    const compactBtn = screen.getByRole("button", { name: /compact/i });
+    const comfortableBtn = screen.getByRole("button", { name: /comfortable/i });
+    const spaciousBtn = screen.getByRole("button", { name: /spacious/i });
+    expect(compactBtn).toBeDefined();
+    expect(comfortableBtn).toBeDefined();
+    expect(spaciousBtn).toBeDefined();
+  });
+
+  it("comfortable density is active by default", () => {
+    render(<CalendarPage />, { wrapper: Wrapper });
+
+    const comfortableBtn = screen.getByRole("button", { name: /comfortable/i });
+    expect(comfortableBtn.getAttribute("aria-pressed")).toBe("true");
+    expect(comfortableBtn.className).toContain("bg-amber-500");
+  });
+
+  it("compact density reduces item cap vs comfortable", () => {
+    render(<CalendarPage />, { wrapper: Wrapper });
+
+    // Compact density button
+    const compactBtn = screen.getByRole("button", { name: /compact/i });
+    fireEvent.click(compactBtn);
+
+    expect(compactBtn.getAttribute("aria-pressed")).toBe("true");
+    expect(compactBtn.className).toContain("bg-amber-500");
+
+    // Comfortable should no longer be active
+    const comfortableBtn = screen.getByRole("button", { name: /comfortable/i });
+    expect(comfortableBtn.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("?density=compact param activates compact density", () => {
+    render(
+      <MemoryRouter initialEntries={["/?density=compact"]}>
+        <CalendarPage />
+      </MemoryRouter>
+    );
+    const compactBtn = screen.getByRole("button", { name: /compact/i });
+    expect(compactBtn.getAttribute("aria-pressed")).toBe("true");
   });
 });

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -24,12 +24,14 @@ import WatchButtonGroup from "../components/WatchButtonGroup";
 import AgendaCalendar, {
   type CalendarItem,
   type ViewMode,
+  type DensityMode,
   typeFilters,
   formatMonth,
   formatDateKey,
   getCellBorderColor,
   useCalendarParam,
   ViewToggle,
+  DensityToggle,
 } from "../components/AgendaCalendar";
 import { PageHeader } from "../components/design";
 
@@ -446,8 +448,25 @@ export default function CalendarPage() {
     "view",
     "grid"
   );
-  const viewMode = (viewParam === "agenda" ? "agenda" : "grid") as ViewMode;
+  const viewMode = (
+    viewParam === "agenda" ? "agenda" : viewParam === "week" ? "week" : "grid"
+  ) as ViewMode;
   const setViewMode = (mode: ViewMode) => setViewParam(mode);
+
+  const [densityParam, setDensityParam] = useCalendarParam(
+    searchParams,
+    setSearchParams,
+    "density",
+    "comfortable"
+  );
+  const density = (
+    densityParam === "compact"
+      ? "compact"
+      : densityParam === "spacious"
+        ? "spacious"
+        : "comfortable"
+  ) as DensityMode;
+  const setDensity = (mode: DensityMode) => setDensityParam(mode);
 
   if (isMobile) {
     return (
@@ -463,6 +482,21 @@ export default function CalendarPage() {
       <AgendaCalendar
         viewMode={viewMode}
         onViewModeChange={setViewMode}
+        density={density}
+        onDensityChange={setDensity}
+        searchParams={searchParams}
+        setSearchParams={setSearchParams}
+      />
+    );
+  }
+
+  if (viewMode === "week") {
+    return (
+      <WeekCalendar
+        viewMode={viewMode}
+        onViewModeChange={setViewMode}
+        density={density}
+        onDensityChange={setDensity}
         searchParams={searchParams}
         setSearchParams={setSearchParams}
       />
@@ -473,6 +507,8 @@ export default function CalendarPage() {
     <GridCalendar
       viewMode={viewMode}
       onViewModeChange={setViewMode}
+      density={density}
+      onDensityChange={setDensity}
       searchParams={searchParams}
       setSearchParams={setSearchParams}
     />
@@ -484,11 +520,15 @@ export default function CalendarPage() {
 function GridCalendar({
   viewMode,
   onViewModeChange,
+  density,
+  onDensityChange,
   searchParams,
   setSearchParams,
 }: {
   viewMode: ViewMode;
   onViewModeChange: (mode: ViewMode) => void;
+  density: DensityMode;
+  onDensityChange: (mode: DensityMode) => void;
   searchParams: URLSearchParams;
   setSearchParams: ReturnType<typeof useSearchParams>[1];
 }) {
@@ -778,6 +818,7 @@ function GridCalendar({
           <EyeIcon className="size-4" />
         )}
       </button>
+      <DensityToggle density={density} onDensityChange={onDensityChange} />
       <ViewToggle viewMode={viewMode} onViewModeChange={onViewModeChange} />
     </div>
   );
@@ -844,6 +885,14 @@ function GridCalendar({
                 const isToday = dateKey === today;
                 const isSelected = dateKey === selectedDate;
                 const borderColor = getCellBorderColor(dayItems);
+                const minHClass =
+                  density === "compact"
+                    ? "min-h-20"
+                    : density === "spacious"
+                      ? "min-h-52"
+                      : "min-h-36";
+                const itemCap =
+                  density === "compact" ? 2 : density === "spacious" ? dayItems.length : 3;
 
                 return (
                   <button
@@ -851,7 +900,7 @@ function GridCalendar({
                     onClick={() =>
                       setSelectedDate(isSelected ? "" : dateKey)
                     }
-                    className={`min-h-36 p-1.5 text-left transition-colors cursor-pointer bg-zinc-950 ${
+                    className={`${minHClass} p-1.5 text-left transition-colors cursor-pointer bg-zinc-950 ${
                       borderColor ? `border-l-2 ${borderColor}` : ""
                     } ${
                       isSelected
@@ -879,7 +928,7 @@ function GridCalendar({
                     {/* Episode + title pills */}
                     {dayItems.length > 0 && (
                       <div className="space-y-0.5">
-                        {dayItems.slice(0, 3).map((item, idx) => {
+                        {dayItems.slice(0, itemCap).map((item, idx) => {
                           const isEp = item.type === "episode";
                           const label = isEp
                             ? item.data.show_title
@@ -901,9 +950,9 @@ function GridCalendar({
                             </div>
                           );
                         })}
-                        {dayItems.length > 3 && (
+                        {itemCap < dayItems.length && (
                           <div className="text-[10px] text-zinc-500 pl-1.5">
-                            +{dayItems.length - 3} more
+                            +{dayItems.length - itemCap} more
                           </div>
                         )}
                       </div>
@@ -949,6 +998,296 @@ function GridCalendar({
           onToggleWatched={toggleWatched}
           onBulkToggle={toggleBulkWatched}
         />
+      )}
+    </div>
+  );
+}
+
+// ─── Week Calendar ───────────────────────────────────────────────────────────
+
+/** Returns the Monday of the ISO week containing `date`. */
+function getWeekStart(date: Date): Date {
+  const d = new Date(date);
+  const dow = d.getDay(); // 0 = Sun
+  const diff = (dow + 6) % 7; // days since Monday
+  d.setDate(d.getDate() - diff);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function WeekCalendar({
+  viewMode,
+  onViewModeChange,
+  density,
+  onDensityChange,
+  searchParams,
+  setSearchParams,
+}: {
+  viewMode: ViewMode;
+  onViewModeChange: (mode: ViewMode) => void;
+  density: DensityMode;
+  onDensityChange: (mode: DensityMode) => void;
+  searchParams: URLSearchParams;
+  setSearchParams: ReturnType<typeof useSearchParams>[1];
+}) {
+  const [typeFilter, setTypeFilter] = useCalendarParam(
+    searchParams,
+    setSearchParams,
+    "type"
+  );
+  const [weekParam, setWeekParam] = useCalendarParam(
+    searchParams,
+    setSearchParams,
+    "week",
+    formatDateKey(getWeekStart(new Date()))
+  );
+  const [hideWatched, setHideWatched] = useState(false);
+
+  // Derive week start from param (or default to current week's Monday)
+  const weekStart = useMemo(() => {
+    if (weekParam) {
+      const d = new Date(weekParam + "T00:00:00");
+      if (!isNaN(d.getTime())) return getWeekStart(d);
+    }
+    return getWeekStart(new Date());
+  }, [weekParam]);
+
+  // The 7 days of the week
+  const weekDays = useMemo<Date[]>(() => {
+    return Array.from({ length: 7 }, (_, i) => {
+      const d = new Date(weekStart);
+      d.setDate(d.getDate() + i);
+      return d;
+    });
+  }, [weekStart]);
+
+  // Data loading — fetch the month(s) that overlap the week
+  const [titles, setTitles] = useState<Title[]>([]);
+  const [episodes, setEpisodes] = useState<Episode[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const { signal } = controller;
+    setLoading(true);
+
+    // The week may span two months; fetch both if needed
+    const startMonth = formatMonth(weekStart);
+    const weekEnd = weekDays[6];
+    const endMonth = formatMonth(weekEnd);
+    const months =
+      startMonth === endMonth ? [startMonth] : [startMonth, endMonth];
+
+    Promise.all(
+      months.map((m) =>
+        getCalendarTitles({ month: m, type: typeFilter || undefined }, signal)
+      )
+    )
+      .then((results) => {
+        if (signal.aborted) return;
+        const allTitles: Title[] = [];
+        const allEpisodes: Episode[] = [];
+        for (const data of results) {
+          allTitles.push(...data.titles);
+          allEpisodes.push(...(data.episodes || []));
+        }
+        // Deduplicate by id
+        const seenTitles = new Set<string>();
+        const seenEps = new Set<number>();
+        setTitles(allTitles.filter((t) => { if (seenTitles.has(t.id)) return false; seenTitles.add(t.id); return true; }));
+        setEpisodes(allEpisodes.filter((e) => { if (seenEps.has(e.id)) return false; seenEps.add(e.id); return true; }));
+      })
+      .catch((err) => { if (!signal.aborted) console.error(err); })
+      .finally(() => { if (!signal.aborted) setLoading(false); });
+
+    return () => controller.abort();
+  }, [weekStart, weekDays, typeFilter]);
+
+  const itemsByDate = useMemo(() => {
+    const map = new Map<string, CalendarItem[]>();
+    for (const t of titles) {
+      if (!t.release_date) continue;
+      const item: CalendarItem = { type: "title", data: t };
+      const arr = map.get(t.release_date);
+      if (arr) arr.push(item);
+      else map.set(t.release_date, [item]);
+    }
+    for (const ep of episodes) {
+      if (!ep.air_date) continue;
+      if (hideWatched && ep.is_watched) continue;
+      const item: CalendarItem = { type: "episode", data: ep };
+      const arr = map.get(ep.air_date);
+      if (arr) arr.push(item);
+      else map.set(ep.air_date, [item]);
+    }
+    return map;
+  }, [titles, episodes, hideWatched]);
+
+  const today = formatDateKey(new Date());
+
+  const prevWeek = () => {
+    const d = new Date(weekStart);
+    d.setDate(d.getDate() - 7);
+    setWeekParam(formatDateKey(d));
+  };
+  const nextWeek = () => {
+    const d = new Date(weekStart);
+    d.setDate(d.getDate() + 7);
+    setWeekParam(formatDateKey(d));
+  };
+  const goToThisWeek = () => setWeekParam(formatDateKey(getWeekStart(new Date())));
+
+  const weekLabel = (() => {
+    const start = weekDays[0].toLocaleDateString("en-US", { month: "short", day: "numeric" });
+    const end = weekDays[6].toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    return `${start} – ${end}`;
+  })();
+
+  const minHClass =
+    density === "compact" ? "min-h-20" : density === "spacious" ? "min-h-96" : "min-h-48";
+
+  const headerRight = (
+    <div className="flex items-center gap-2">
+      <button
+        onClick={prevWeek}
+        className="p-1.5 rounded-lg hover:bg-zinc-800 text-zinc-400 hover:text-white transition-colors cursor-pointer"
+      >
+        <ChevronLeftIcon className="size-5" />
+      </button>
+      <button
+        onClick={goToThisWeek}
+        className="px-3 py-1.5 rounded-lg text-sm font-medium text-zinc-400 hover:text-white hover:bg-zinc-800 transition-colors cursor-pointer"
+      >
+        This week
+      </button>
+      <button
+        onClick={nextWeek}
+        className="p-1.5 rounded-lg hover:bg-zinc-800 text-zinc-400 hover:text-white transition-colors cursor-pointer"
+      >
+        <ChevronRightIcon className="size-5" />
+      </button>
+      <div className="w-px h-5 bg-white/10 mx-1" />
+      {typeFilters.map((f) => (
+        <button
+          key={f.value}
+          onClick={() => setTypeFilter(f.value)}
+          className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
+            typeFilter === f.value
+              ? "bg-amber-500 text-zinc-950"
+              : "text-zinc-400 hover:text-white hover:bg-zinc-800"
+          }`}
+        >
+          {f.label}
+        </button>
+      ))}
+      <button
+        onClick={() => setHideWatched((v) => !v)}
+        className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
+          hideWatched
+            ? "bg-amber-500 text-zinc-950"
+            : "text-zinc-400 hover:text-white hover:bg-zinc-800"
+        }`}
+        title={hideWatched ? "Show watched" : "Hide watched"}
+      >
+        {hideWatched ? (
+          <EyeOffIcon className="size-4" />
+        ) : (
+          <EyeIcon className="size-4" />
+        )}
+      </button>
+      <DensityToggle density={density} onDensityChange={onDensityChange} />
+      <ViewToggle viewMode={viewMode} onViewModeChange={onViewModeChange} />
+    </div>
+  );
+
+  return (
+    <div className="space-y-4">
+      <PageHeader
+        kicker={`Week view · ${Intl.DateTimeFormat().resolvedOptions().timeZone}`}
+        title={weekLabel}
+        right={headerRight}
+      />
+
+      {loading ? (
+        <GridCalendarSkeleton />
+      ) : (
+        <div className="border border-white/[0.06] rounded-xl overflow-hidden">
+          {/* Day column headers */}
+          <div className="grid grid-cols-7 bg-zinc-900 border-b border-white/[0.06]">
+            {weekDays.map((day) => {
+              const dateKey = formatDateKey(day);
+              const isToday = dateKey === today;
+              return (
+                <div
+                  key={dateKey}
+                  className={`px-2 py-2 text-center ${
+                    isToday ? "text-amber-400" : "text-zinc-500"
+                  }`}
+                >
+                  <div className="font-mono text-[11px] font-semibold uppercase tracking-[0.15em]">
+                    {day.toLocaleDateString("en-US", { weekday: "short" })}
+                  </div>
+                  <div
+                    className={`font-mono text-lg font-bold mt-0.5 ${
+                      isToday ? "text-amber-400" : "text-zinc-300"
+                    }`}
+                    data-testid="week-day-number"
+                  >
+                    {day.getDate()}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Day columns body */}
+          <div className="grid grid-cols-7 gap-px bg-white/[0.06]">
+            {weekDays.map((day) => {
+              const dateKey = formatDateKey(day);
+              const dayItems = itemsByDate.get(dateKey) ?? [];
+              const isToday = dateKey === today;
+              const borderColor = getCellBorderColor(dayItems);
+
+              return (
+                <div
+                  key={dateKey}
+                  data-testid="week-day-column"
+                  className={`${minHClass} p-1.5 bg-zinc-950 ${
+                    borderColor ? `border-l-2 ${borderColor}` : ""
+                  } ${isToday ? "outline-2 outline-amber-400 outline-offset-[-2px] relative z-10" : ""}`}
+                >
+                  {dayItems.map((item, idx) => {
+                    const isEp = item.type === "episode";
+                    const label = isEp
+                      ? item.data.show_title
+                      : item.type === "title"
+                        ? item.data.title
+                        : "";
+                    const prefix = isEp
+                      ? `S${item.data.season_number}E${item.data.episode_number} `
+                      : item.type === "title"
+                        ? (item.data.object_type === "MOVIE" ? "FILM " : "SHOW ")
+                        : "";
+                    return (
+                      <Link
+                        key={idx}
+                        to={
+                          isEp
+                            ? `/title/${item.data.title_id}/season/${item.data.season_number}/episode/${item.data.episode_number}`
+                            : `/title/${item.data.id}`
+                        }
+                        className="block mb-0.5 bg-amber-400/10 text-amber-400 border-l-2 border-amber-400 px-1.5 py-0.5 rounded-sm text-[10px] font-medium leading-tight overflow-hidden text-ellipsis whitespace-nowrap hover:bg-amber-400/20 transition-colors"
+                      >
+                        <span className="font-mono">{prefix}</span>
+                        {label}
+                      </Link>
+                    );
+                  })}
+                </div>
+              );
+            })}
+          </div>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Adds a Week view to CalendarPage showing 7 columns (Mon–Sun) for the selected ISO week
- Extends `ViewMode` type and `<ViewToggle>` with a third pill button (`?view=week`)
- Adds `<DensityToggle>` with compact / comfortable / spacious options (`?density=`) in both calendar headers
- Density affects item count caps and padding in both grid and agenda views

## Test plan
- [ ] `bun run check` passes
- [ ] `/calendar?view=week` renders 7 day columns
- [ ] `/calendar?density=compact` reduces visible item count
- [ ] Density toggle and view toggle persist in URL params across navigation

Closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)