### PR TITLE
feat: add country, locale and display name editing to profile

### DIFF
--- a/drizzle/0041_users_locale_country.sql
+++ b/drizzle/0041_users_locale_country.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `users` ADD COLUMN `country_code` text;
+--> statement-breakpoint
+ALTER TABLE `users` ADD COLUMN `locale` text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1746144000000,
       "tag": "0040_users_appearance_prefs",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "6",
+      "when": 1746230400000,
+      "tag": "0041_users_locale_country",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -233,6 +233,26 @@ export async function updateMyBio(bio: string | null): Promise<{ bio: string | n
   });
 }
 
+export interface MyProfile {
+  display_name: string | null;
+  bio: string | null;
+  country_code: string | null;
+  locale: string | null;
+}
+
+export async function getMyProfile(signal?: AbortSignal): Promise<MyProfile> {
+  return fetchJson("/user/me/profile", { signal });
+}
+
+export async function updateMyProfile(
+  data: Partial<MyProfile>,
+): Promise<MyProfile> {
+  return fetchJson("/user/me/profile", {
+    method: "PATCH",
+    body: JSON.stringify(data),
+  });
+}
+
 export async function getActivitySettings(signal?: AbortSignal): Promise<ActivitySettings> {
   return fetchJson("/user/me/activity-settings", { signal });
 }

--- a/frontend/src/components/profile/ProfileHero.tsx
+++ b/frontend/src/components/profile/ProfileHero.tsx
@@ -42,6 +42,11 @@ export default function ProfileHero({
   const { t } = useTranslation();
   const displayName = user.display_name || user.username;
 
+  function countryFlag(code: string): string {
+    const offset = 0x1F1E6 - 65;
+    return Array.from(code.toUpperCase()).map((c) => String.fromCodePoint(c.charCodeAt(0) + offset)).join("");
+  }
+
   async function handleShare() {
     const shareUrl = window.location.href;
     const payload = {
@@ -159,8 +164,13 @@ export default function ProfileHero({
               >
                 {displayName}
               </h1>
-              <div className="mt-2 font-mono text-[13px] text-zinc-300">
+              <div className="mt-2 font-mono text-[13px] text-zinc-300 flex items-center gap-2">
                 @{user.username}
+                {user.country_code && (
+                  <span title={user.country_code} aria-label={user.country_code}>
+                    {countryFlag(user.country_code)}
+                  </span>
+                )}
               </div>
             </div>
           </div>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -227,7 +227,13 @@
     "renamePasskey": "Rename",
     "renamingPasskey": "Renaming...",
     "noPasskeys": "No passkeys registered. Add one to enable passwordless sign-in.",
-    "passkeyUnnamed": "Unnamed passkey"
+    "passkeyUnnamed": "Unnamed passkey",
+    "editProfile": "Edit Profile",
+    "bio": "Bio",
+    "bioPlaceholder": "A short bio about yourself...",
+    "country": "Country",
+    "noCountry": "— Select country —",
+    "profileSaved": "Profile saved"
   },
   "filter": {
     "all": "All",
@@ -569,6 +575,7 @@
     "loading": "Loading...",
     "error": "An error occurred",
     "save": "Save",
+    "saving": "Saving...",
     "cancel": "Cancel"
   },
   "feed": {

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, mock, afterEach, beforeEach } from "bun:test";
-import { render, screen, waitFor, cleanup, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor, cleanup, fireEvent, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import type { ReactNode } from "react";
 
@@ -321,7 +321,7 @@ describe("PasskeySection", () => {
     const editInput = screen.getByRole("textbox", { name: "Passkey name" });
     fireEvent.change(editInput, { target: { value: "New Name" } });
 
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    fireEvent.click(within(editInput.closest("form")!).getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(screen.getByText("Passkey renamed")).toBeDefined());
 
@@ -346,7 +346,7 @@ describe("PasskeySection", () => {
     const editInput = screen.getByRole("textbox", { name: "Passkey name" });
     fireEvent.change(editInput, { target: { value: "New Name" } });
 
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    fireEvent.click(within(editInput.closest("form")!).getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(screen.getByText("Rename failed")).toBeDefined());
 

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -116,6 +116,8 @@ mock.module("../api", () => ({
   getKioskToken: mock(() => Promise.resolve({ token: null })),
   regenerateKioskToken: mock(() => Promise.resolve({ token: "kiosk-token-123" })),
   revokeKioskToken: mock(() => Promise.resolve()),
+  getMyProfile: mock(() => Promise.resolve({ display_name: null, bio: null, country_code: null, locale: null })),
+  updateMyProfile: mock(() => Promise.resolve({ display_name: null, bio: null, country_code: null, locale: null })),
 }));
 
 // Import after mocks

--- a/frontend/src/pages/settings/AccountTab.tsx
+++ b/frontend/src/pages/settings/AccountTab.tsx
@@ -21,6 +21,123 @@ import {
 } from "../../components/settings/kit";
 import { cn } from "@/lib/utils";
 
+const COUNTRIES = [
+  { code: "AR", name: "Argentina" },
+  { code: "AU", name: "Australia" },
+  { code: "BR", name: "Brazil" },
+  { code: "CA", name: "Canada" },
+  { code: "CN", name: "China" },
+  { code: "DE", name: "Germany" },
+  { code: "DK", name: "Denmark" },
+  { code: "ES", name: "Spain" },
+  { code: "FI", name: "Finland" },
+  { code: "FR", name: "France" },
+  { code: "GB", name: "United Kingdom" },
+  { code: "HR", name: "Croatia" },
+  { code: "IN", name: "India" },
+  { code: "IT", name: "Italy" },
+  { code: "JP", name: "Japan" },
+  { code: "KR", name: "South Korea" },
+  { code: "MX", name: "Mexico" },
+  { code: "NL", name: "Netherlands" },
+  { code: "NO", name: "Norway" },
+  { code: "NZ", name: "New Zealand" },
+  { code: "PL", name: "Poland" },
+  { code: "PT", name: "Portugal" },
+  { code: "RU", name: "Russia" },
+  { code: "SE", name: "Sweden" },
+  { code: "TR", name: "Turkey" },
+  { code: "US", name: "United States" },
+  { code: "ZA", name: "South Africa" },
+];
+
+function ProfileEditSection() {
+  const { user } = useAuth();
+  const { t } = useTranslation();
+  const [displayName, setDisplayName] = useState("");
+  const [bio, setBio] = useState("");
+  const [countryCode, setCountryCode] = useState("");
+  const [loaded, setLoaded] = useState(false);
+  const [msg, setMsg] = useState("");
+  const { run, error: saveErr, pending: saving } = useAsyncError();
+
+  useEffect(() => {
+    let mounted = true;
+    const controller = new AbortController();
+    api.getMyProfile(controller.signal).then((data) => {
+      if (!mounted) return;
+      setDisplayName(data.display_name ?? "");
+      setBio(data.bio ?? "");
+      setCountryCode(data.country_code ?? "");
+      setLoaded(true);
+    }).catch(() => { if (mounted) setLoaded(true); });
+    return () => { mounted = false; controller.abort(); };
+  }, []);
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setMsg("");
+    await run(async () => {
+      await api.updateMyProfile({
+        display_name: displayName.trim() || null,
+        bio: bio.trim() || null,
+        country_code: countryCode || null,
+      });
+      setMsg(t("profile.profileSaved"));
+    });
+  }
+
+  if (!loaded) return null;
+
+  return (
+    <SCard
+      title={t("profile.editProfile")}
+      subtitle="Your display name, bio, and country appear on your public profile."
+    >
+      <form onSubmit={handleSave} className="space-y-3.5 max-w-[640px]">
+        {msg && <SMessage kind="success">{msg}</SMessage>}
+        {saveErr && <SMessage kind="error">{saveErr}</SMessage>}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3.5">
+          <SFormRow label={t("profile.displayName")}>
+            <SInput
+              value={displayName}
+              onChange={setDisplayName}
+              placeholder={user?.username ?? ""}
+            />
+          </SFormRow>
+          <SFormRow label={t("profile.country")}>
+            <select
+              value={countryCode}
+              onChange={(e) => setCountryCode(e.target.value)}
+              className="w-full px-3 py-2.5 bg-zinc-800 border border-white/[0.08] rounded-lg text-zinc-100 text-[13px] focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/40 focus:border-transparent"
+            >
+              <option value="">{t("profile.noCountry")}</option>
+              {COUNTRIES.map((c) => (
+                <option key={c.code} value={c.code}>{c.name}</option>
+              ))}
+            </select>
+          </SFormRow>
+        </div>
+        <SFormRow label={t("profile.bio")}>
+          <textarea
+            value={bio}
+            onChange={(e) => setBio(e.target.value)}
+            placeholder={t("profile.bioPlaceholder")}
+            maxLength={280}
+            rows={3}
+            className="w-full px-3 py-2.5 bg-zinc-800 border border-white/[0.08] rounded-lg text-zinc-100 placeholder-zinc-500 text-[13px] focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/40 resize-none"
+          />
+        </SFormRow>
+        <div>
+          <SButton type="submit" disabled={saving}>
+            {saving ? t("common.saving") : t("common.save")}
+          </SButton>
+        </div>
+      </form>
+    </SCard>
+  );
+}
+
 function passwordStrength(pw: string): number {
   if (!pw) return 0;
   let score = 0;
@@ -721,6 +838,7 @@ export default function AccountTab() {
   return (
     <>
       <UserSection />
+      <ProfileEditSection />
       <PasskeySection />
       <ProfileVisibilitySection />
       <ActivityStreamSection />

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -508,6 +508,7 @@ export interface UserProfileUser {
   image: string | null;
   member_since: string | null;
   bio: string | null;
+  country_code: string | null;
 }
 
 export interface UserProfileStats {

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -133,6 +133,6 @@ describe("fixSkippedMigrations", () => {
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(42);
+    expect(migrations.cnt).toBe(43);
   });
 });

--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -84,6 +84,8 @@ export {
   getActivityKindVisibilityMap,
   setActivitySettings,
   getActivitySettings,
+  getMyProfile,
+  updateMyProfile,
 } from "./profile";
 export type { ProfileVisibility } from "./profile";
 

--- a/server/db/repository/profile.ts
+++ b/server/db/repository/profile.ts
@@ -37,6 +37,7 @@ export async function getUserPublicProfile(username: string, isOwnProfile = fals
         image: users.image,
         member_since: users.createdAt,
         bio: users.bio,
+        country_code: users.countryCode,
         profile_public: users.profilePublic,
         profile_visibility: users.profileVisibility,
         activity_stream_enabled: users.activityStreamEnabled,
@@ -167,6 +168,7 @@ export async function getUserPublicProfile(username: string, isOwnProfile = fals
         image: user.image,
         member_since: user.member_since,
         bio: user.bio,
+        country_code: user.country_code,
       },
       stats: {
         tracked_count: trackedCount,
@@ -320,6 +322,39 @@ export async function updateUserBio(userId: string, bio: string | null) {
       .set({ bio })
       .where(eq(users.id, userId))
       .run();
+  });
+}
+
+export async function getMyProfile(userId: string) {
+  return traceDbQuery("getMyProfile", async () => {
+    const db = getDb();
+    const row = await db
+      .select({
+        display_name: users.name,
+        bio: users.bio,
+        country_code: users.countryCode,
+        locale: users.locale,
+      })
+      .from(users)
+      .where(eq(users.id, userId))
+      .get();
+    return row ?? null;
+  });
+}
+
+export async function updateMyProfile(
+  userId: string,
+  data: { display_name?: string | null; bio?: string | null; country_code?: string | null; locale?: string | null }
+): Promise<void> {
+  return traceDbQuery("updateMyProfile", async () => {
+    const db = getDb();
+    const patch: Partial<typeof users.$inferInsert> = {};
+    if (data.display_name !== undefined) patch.name = data.display_name;
+    if (data.bio !== undefined) patch.bio = data.bio;
+    if (data.country_code !== undefined) patch.countryCode = data.country_code;
+    if (data.locale !== undefined) patch.locale = data.locale;
+    if (Object.keys(patch).length === 0) return;
+    await db.update(users).set(patch).where(eq(users.id, userId)).run();
   });
 }
 

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -165,6 +165,8 @@ export const users = sqliteTable(
     kioskToken: text("kiosk_token"),
     watchlistShareToken: text("watchlist_share_token"),
     bio: text("bio"),
+    countryCode: text("country_code"),
+    locale: text("locale"),
     activityStreamEnabled: integer("activity_stream_enabled").notNull().default(0),
     streamingDeparturesEnabled: integer("streaming_departures_enabled").notNull().default(1),
     departureAlertLeadDays: integer("departure_alert_lead_days").notNull().default(7),

--- a/server/routes/profile.test.ts
+++ b/server/routes/profile.test.ts
@@ -807,3 +807,153 @@ describe("GET /user/:username — pinned field", () => {
     expect(body.pinned).toEqual([]);
   });
 });
+
+// ─── Profile extras (country / locale / display_name) ──────────────────────
+
+describe("GET /user/me/profile", () => {
+  it("returns profile fields for authenticated user", async () => {
+    const res = await app.request("/user/me/profile", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const body = await res.json() as AnyRecord;
+    expect("display_name" in body).toBe(true);
+    expect(body.bio).toBeNull();
+    expect(body.country_code).toBeNull();
+    expect(body.locale).toBeNull();
+  });
+
+  it("returns 401 without authentication", async () => {
+    const res = await app.request("/user/me/profile");
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("PATCH /user/me/profile", () => {
+  it("happy path: saves display_name, bio, and country_code", async () => {
+    const res = await app.request("/user/me/profile", {
+      method: "PATCH",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ display_name: "My Name", bio: "Hello world", country_code: "US" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as AnyRecord;
+    expect(body.display_name).toBe("My Name");
+    expect(body.bio).toBe("Hello world");
+    expect(body.country_code).toBe("US");
+  });
+
+  it("persists changes and GET reflects them", async () => {
+    await app.request("/user/me/profile", {
+      method: "PATCH",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ display_name: "Updated", country_code: "DE", locale: "de" }),
+    });
+    const res = await app.request("/user/me/profile", { headers: authHeaders() });
+    const body = await res.json() as AnyRecord;
+    expect(body.display_name).toBe("Updated");
+    expect(body.country_code).toBe("DE");
+    expect(body.locale).toBe("de");
+  });
+
+  it("can clear fields by passing null", async () => {
+    await app.request("/user/me/profile", {
+      method: "PATCH",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ display_name: "Name", country_code: "US" }),
+    });
+    const res = await app.request("/user/me/profile", {
+      method: "PATCH",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ display_name: null, country_code: null }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as AnyRecord;
+    expect(body.display_name).toBeNull();
+    expect(body.country_code).toBeNull();
+  });
+
+  it("returns 401 without authentication", async () => {
+    const res = await app.request("/user/me/profile", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ display_name: "Name" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("public profile includes country_code after update", async () => {
+    await app.request("/user/me/profile", {
+      method: "PATCH",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ country_code: "FR" }),
+    });
+    const res = await app.request("/user/testuser");
+    expect(res.status).toBe(200);
+    const body = await res.json() as AnyRecord;
+    expect(body.user.country_code).toBe("FR");
+  });
+});
+
+describe("validation — profile extras", () => {
+  it("returns 400 for invalid country_code (lowercase)", async () => {
+    const res = await app.request("/user/me/profile", {
+      method: "PATCH",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ country_code: "us" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json() as AnyRecord;
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("returns 400 for country_code longer than 2 chars", async () => {
+    const res = await app.request("/user/me/profile", {
+      method: "PATCH",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ country_code: "USA" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for bio exceeding 280 chars", async () => {
+    const res = await app.request("/user/me/profile", {
+      method: "PATCH",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ bio: "x".repeat(281) }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json() as AnyRecord;
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("returns 400 for invalid locale format", async () => {
+    const res = await app.request("/user/me/profile", {
+      method: "PATCH",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ locale: "EN" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts valid locale with region (en-US)", async () => {
+    const res = await app.request("/user/me/profile", {
+      method: "PATCH",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ locale: "en-US" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as AnyRecord;
+    expect(body.locale).toBe("en-US");
+  });
+
+  it("happy path: empty body returns 200 (all fields optional)", async () => {
+    const res = await app.request("/user/me/profile", {
+      method: "PATCH",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(200);
+  });
+});
+

--- a/server/routes/profile.ts
+++ b/server/routes/profile.ts
@@ -5,6 +5,8 @@ import {
   updateProfilePublic,
   searchUsers,
   updateUserBio,
+  getMyProfile,
+  updateMyProfile,
   getUserActivity,
   getUserVisibilityByUsername,
   areMutualFollowers,
@@ -50,6 +52,34 @@ app.patch("/me/bio", zValidator("json", bioSchema), async (c) => {
   const normalized = bio === null ? null : bio.trim() || null;
   await updateUserBio(user.id, normalized);
   return ok(c, { bio: normalized });
+});
+
+const profileSchema = z.object({
+  display_name: z.string().max(100).nullable().optional(),
+  bio: z.string().max(280).nullable().optional(),
+  country_code: z.string().regex(/^[A-Z]{2}$/).nullable().optional(),
+  locale: z.string().regex(/^[a-z]{2}(-[A-Z]{2})?$/).nullable().optional(),
+});
+
+app.get("/me/profile", async (c) => {
+  const user = c.get("user");
+  if (!user) return err(c, "Authentication required", 401);
+  const profile = await getMyProfile(user.id);
+  return ok(c, profile ?? { display_name: null, bio: null, country_code: null, locale: null });
+});
+
+app.patch("/me/profile", zValidator("json", profileSchema), async (c) => {
+  const user = c.get("user");
+  if (!user) return err(c, "Authentication required", 401);
+  const body = c.req.valid("json");
+  await updateMyProfile(user.id, {
+    display_name: body.display_name === undefined ? undefined : (body.display_name === null ? null : body.display_name.trim() || null),
+    bio: body.bio === undefined ? undefined : (body.bio === null ? null : body.bio.trim() || null),
+    country_code: body.country_code,
+    locale: body.locale,
+  });
+  const profile = await getMyProfile(user.id);
+  return ok(c, profile ?? { display_name: null, bio: null, country_code: null, locale: null });
 });
 
 const activityKindEnum = z.enum([


### PR DESCRIPTION
## Summary
- Adds `country_code` and `locale` columns to the `users` table via a safe D1-compatible `ALTER TABLE ADD COLUMN` migration (0041)
- Exposes `GET /user/me/profile` and `PATCH /user/me/profile` with zod-validated schema (display_name, bio, country_code, locale)
- Adds a **Profile** edit card to the Account settings tab: editable display name, bio textarea, and country picker (27 countries)
- Public profile (`/u/:username`) now renders a country flag emoji next to `@username` when `country_code` is set

## Test plan
- [x] `server/routes/profile.test.ts` — `GET` / `PATCH /user/me/profile`: happy path, persistence, null clearing, 401, validation rejections (invalid country code, bio too long, invalid locale), public profile includes country_code
- [x] `frontend/src/pages/SettingsPage.test.tsx` — api mock updated with `getMyProfile` / `updateMyProfile` so existing Account tab tests remain green
- [x] `bun run check` passes (server tsc + frontend tsc + ESLint + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #460