### PR TITLE
fix: appearance settings revert and GET flood after toggling

### DIFF
--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -43,6 +43,12 @@ function subscribe(callback: () => void) {
   return () => { listeners.delete(callback); };
 }
 
+function setTheme(newTheme: Theme) {
+  localStorage.setItem(STORAGE_KEY, newTheme);
+  applyTheme(newTheme);
+  listeners.forEach((fn) => fn());
+}
+
 export function useTheme(): { theme: Theme; setTheme: (theme: Theme) => void } {
   const theme = useSyncExternalStore(subscribe, getStoredTheme);
 
@@ -56,12 +62,6 @@ export function useTheme(): { theme: Theme; setTheme: (theme: Theme) => void } {
     mq.addEventListener("change", handler);
     return () => mq.removeEventListener("change", handler);
   }, [theme]);
-
-  function setTheme(newTheme: Theme) {
-    localStorage.setItem(STORAGE_KEY, newTheme);
-    applyTheme(newTheme);
-    listeners.forEach((fn) => fn());
-  }
 
   return { theme, setTheme };
 }

--- a/frontend/src/pages/settings/AppearanceTab.tsx
+++ b/frontend/src/pages/settings/AppearanceTab.tsx
@@ -66,7 +66,8 @@ function AppearanceSection() {
       })
       .catch(() => {});
     return () => controller.abort();
-  }, [setTheme]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only load
+  }, []);
 
   async function save(patch: Partial<AppearanceSettings>) {
     const next = { ...settings, ...patch };


### PR DESCRIPTION
## Summary

- `setTheme` was defined inside `useTheme()`'s render body, so calling it (which notifies `useSyncExternalStore` listeners) produced a new function reference on every render
- `AppearanceSection`'s load effect had `[setTheme]` as a dep, so it re-fired after every toggle — `GET /api/user/settings/appearance` resolved with the old server value and overwrote optimistic local state before the in-flight `PUT` could land → settings snapped back
- Same loop caused GET flooding: each listener notification → new `setTheme` ref → effect re-runs

## Fix

- Hoisted `setTheme` to module scope in `useTheme.ts` (stable reference — no React dependencies)
- Tightened `AppearanceSection`'s load effect dep array to `[]` (mount-only)

## Related

Closes #649
Follow-up: #650 — `ThemePicker` should also persist `themeVariant` to the server

## Test plan

- [ ] `bun run check` — 2527 tests pass, zero lint errors
- [ ] Open Appearance tab in DevTools → Network, filter to `appearance`
- [ ] Toggle each display switch → expect 1 `PUT`, 0 extra `GET`s, switch state stays
- [ ] Change accent and density → same
- [ ] Click a theme tile → theme applies and stays, 0 extra `GET`s
- [ ] Reload → saved values restored from server

🤖 Generated with [Claude Code](https://claude.com/claude-code)