### PR TITLE
feat: persist themeVariant to server when user picks a theme

### DIFF
--- a/frontend/src/components/ThemePicker.test.tsx
+++ b/frontend/src/components/ThemePicker.test.tsx
@@ -1,11 +1,30 @@
-import { describe, it, expect, afterEach, mock, spyOn } from "bun:test";
+import { describe, it, expect, afterEach, beforeEach, mock, spyOn } from "bun:test";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import "../i18n";
 import ThemePicker from "./ThemePicker";
 import * as useThemeModule from "../hooks/useTheme";
+import * as api from "../api";
+import type { AppearanceSettings } from "../types";
+
+const mockAppearance: AppearanceSettings = {
+  themeVariant: "dark",
+  accentColor: "indigo",
+  density: "comfortable",
+  reduceMotion: 0,
+  highContrast: 0,
+  hideEpisodeSpoilers: 0,
+  autoplayTrailers: 0,
+};
+
+let apiSpy: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+  apiSpy = spyOn(api, "updateAppearanceSettings").mockResolvedValue(mockAppearance);
+});
 
 afterEach(() => {
   cleanup();
+  apiSpy.mockRestore();
 });
 
 describe("ThemePicker", () => {
@@ -141,6 +160,19 @@ describe("ThemePicker", () => {
     render(<ThemePicker />);
     fireEvent.click(screen.getByRole("button", { name: "Auto" }));
     expect(setTheme).toHaveBeenCalledWith("auto");
+
+    spy.mockRestore();
+  });
+
+  it("clicking a theme persists themeVariant to the server", () => {
+    const spy = spyOn(useThemeModule, "useTheme").mockReturnValue({
+      theme: "dark",
+      setTheme: mock(() => {}),
+    });
+
+    render(<ThemePicker />);
+    fireEvent.click(screen.getByRole("button", { name: "Moss" }));
+    expect(apiSpy).toHaveBeenCalledWith({ themeVariant: "moss" });
 
     spy.mockRestore();
   });

--- a/frontend/src/components/ThemePicker.tsx
+++ b/frontend/src/components/ThemePicker.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import * as api from "../api";
 import { useTheme, type Theme } from "../hooks/useTheme";
 import { cn } from "@/lib/utils";
 
@@ -32,7 +33,10 @@ export default function ThemePicker() {
         return (
           <button
             key={meta.value}
-            onClick={() => setTheme(meta.value)}
+            onClick={() => {
+              setTheme(meta.value);
+              api.updateAppearanceSettings({ themeVariant: meta.value }).catch(() => {});
+            }}
             aria-pressed={isActive}
             aria-label={label}
             className={cn(


### PR DESCRIPTION
## Summary

- `ThemePicker` now calls `api.updateAppearanceSettings({ themeVariant })` after each `setTheme` so the choice is persisted server-side
- Uses fire-and-forget (`.catch(() => {})`) so a network error never reverts the user's local theme
- Adds `beforeEach`/`afterEach` spy on `api.updateAppearanceSettings` in the test file (prevents real `fetchJson` calls in tests and avoids mock leaks on Linux CI), plus a new test asserting the server call is made

## Test plan

- [x] `bun run check` passes (2528 tests, 0 failures)
- [ ] Open Settings → Appearance, pick "Moss", reload — theme should persist
- [ ] Open the same account in a second browser — should load as Moss

Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)