### PR TITLE
fix: bootstrap script must accept all theme variants on refresh

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,8 +14,11 @@
     <script>
       (function () {
         var theme = localStorage.getItem('remindarr-theme');
-        var valid = ['dark', 'light', 'oled'];
-        if (!theme || !valid.includes(theme)) theme = 'dark';
+        var valid = ['dark', 'light', 'oled', 'midnight', 'moss', 'plum', 'auto'];
+        if (!theme || valid.indexOf(theme) === -1) theme = 'dark';
+        if (theme === 'auto') {
+          theme = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+        }
         document.documentElement.classList.add('theme-' + theme);
       })();
     </script>


### PR DESCRIPTION
## Summary

The inline pre-React bootstrap script in `frontend/index.html` only whitelisted `dark`/`light`/`oled` and silently fell back to `dark` for any other stored value. After picking moss, midnight, plum, or auto, refreshing reverted the page to dark — `useTheme()` reads the stored value into React state but never re-applies the DOM class on mount; only `setTheme()` calls `applyTheme()`.

Also resolves `auto` via `prefers-color-scheme` inline so the bootstrap emits a real theme class rather than a non-existent `theme-auto`.

Follow-up to #653 (which fixed the write side); this fixes the read side on refresh.

## Test plan

- [x] `bun run check` passes (2528 tests, 0 failures)
- [ ] Pick "Moss" in Settings → Appearance, refresh — page stays Moss
- [ ] Pick "Auto" with system in light mode, refresh — page is light; switch system to dark, refresh — page is dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)