### PR TITLE
feat: per-user subscribed streaming services

### DIFF
--- a/drizzle/0042_user_subscribed_providers.sql
+++ b/drizzle/0042_user_subscribed_providers.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `user_subscribed_providers` (
+	`user_id` text NOT NULL,
+	`provider_id` integer NOT NULL,
+	`created_at` text DEFAULT (datetime('now')),
+	PRIMARY KEY(`user_id`, `provider_id`),
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`provider_id`) REFERENCES `providers`(`id`) ON UPDATE no action ON DELETE restrict
+);
+--> statement-breakpoint
+CREATE INDEX `idx_user_subscribed_providers_user_id` ON `user_subscribed_providers` (`user_id`);
+--> statement-breakpoint
+ALTER TABLE `users` ADD COLUMN `only_mine_filter` integer NOT NULL DEFAULT 0;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1746316800000,
       "tag": "0041_notifier_quiet_hours",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "6",
+      "when": 1746403200000,
+      "tag": "0042_user_subscribed_providers",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -31,6 +31,7 @@ import type {
   OverlapResponse,
   FriendsLovedItem,
   AppearanceSettings,
+  UserSubscriptions,
 } from "./types";
 
 const BASE = "/api";
@@ -80,6 +81,7 @@ export async function getTitles(params: {
   genre?: string;
   language?: string;
   excludeTracked?: boolean;
+  onlyMine?: boolean;
   limit?: number;
   offset?: number;
 } = {}, signal?: AbortSignal): Promise<{ titles: Title[]; count: number }> {
@@ -90,6 +92,7 @@ export async function getTitles(params: {
   if (params.genre) qs.set("genre", params.genre);
   if (params.language) qs.set("language", params.language);
   if (params.excludeTracked) qs.set("excludeTracked", "1");
+  if (params.onlyMine) qs.set("onlyMine", "true");
   if (params.limit != null) qs.set("limit", String(params.limit));
   if (params.offset != null) qs.set("offset", String(params.offset));
   return fetchJson(`/titles?${qs}`, { signal });
@@ -126,6 +129,7 @@ export async function browseTitles(params: {
   yearMin?: number;
   yearMax?: number;
   minRating?: number;
+  onlyMine?: boolean;
 }, signal?: AbortSignal): Promise<{
   titles: SearchTitle[];
   page: number;
@@ -147,6 +151,7 @@ export async function browseTitles(params: {
   if (params.yearMin != null) qs.set("year_min", String(params.yearMin));
   if (params.yearMax != null) qs.set("year_max", String(params.yearMax));
   if (params.minRating != null) qs.set("min_rating", String(params.minRating));
+  if (params.onlyMine) qs.set("onlyMine", "true");
   return fetchJson(`/browse?${qs}`, { signal });
 }
 
@@ -918,6 +923,24 @@ export async function updateAppearanceSettings(settings: Partial<AppearanceSetti
   return fetchJson("/user/settings/appearance", {
     method: "PUT",
     body: JSON.stringify(settings),
+  });
+}
+
+export async function getSubscriptions(signal?: AbortSignal): Promise<UserSubscriptions> {
+  return fetchJson("/user/settings/subscriptions", { signal });
+}
+
+export async function updateSubscriptions(providerIds: number[]): Promise<{ providerIds: number[] }> {
+  return fetchJson("/user/settings/subscriptions", {
+    method: "PUT",
+    body: JSON.stringify({ providerIds }),
+  });
+}
+
+export async function updateOnlyMine(onlyMine: boolean): Promise<{ onlyMine: boolean }> {
+  return fetchJson("/user/settings/subscriptions/only-mine", {
+    method: "PUT",
+    body: JSON.stringify({ onlyMine }),
   });
 }
 

--- a/frontend/src/components/CategoryBrowse.tsx
+++ b/frontend/src/components/CategoryBrowse.tsx
@@ -78,6 +78,7 @@ interface Props {
   showProviderBadge?: boolean;
   showRating?: boolean;
   onResultsCount?: (count: number) => void;
+  onlyMine?: boolean;
 }
 
 export default function CategoryBrowse({
@@ -100,6 +101,7 @@ export default function CategoryBrowse({
   showProviderBadge,
   showRating,
   onResultsCount,
+  onlyMine,
 }: Props) {
   const [titles, setTitles] = useState<Title[]>([]);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -132,6 +134,7 @@ export default function CategoryBrowse({
           yearMin: yearMinNum != null && Number.isFinite(yearMinNum) ? yearMinNum : undefined,
           yearMax: yearMaxNum != null && Number.isFinite(yearMaxNum) ? yearMaxNum : undefined,
           minRating: minRatingNum != null && Number.isFinite(minRatingNum) ? minRatingNum : undefined,
+          onlyMine: onlyMine || undefined,
         });
         const normalized = res.titles.map(normalizeSearchTitle);
         if (append) {
@@ -163,7 +166,7 @@ export default function CategoryBrowse({
         setLoadingMore(false);
       }
     });
-  }, [run, category, type, genre, provider, language, yearMin, yearMax, minRating, onResultsCount]);
+  }, [run, category, type, genre, provider, language, yearMin, yearMax, minRating, onlyMine, onResultsCount]);
 
   useEffect(() => {
     fetchTitles(1, false);

--- a/frontend/src/components/EpisodeShowCard.test.tsx
+++ b/frontend/src/components/EpisodeShowCard.test.tsx
@@ -2,11 +2,28 @@ import { describe, it, expect, afterEach } from "bun:test";
 import { render, cleanup } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { EpisodeShowCard } from "./EpisodeShowCard";
+import { AuthContext } from "../context/AuthContext";
 import type { Episode, Offer } from "../types";
 import type { ReactNode } from "react";
 
+const baseAuth = {
+  user: null,
+  providers: null,
+  loading: false,
+  subscriptions: null,
+  refreshSubscriptions: async () => {},
+  login: async () => {},
+  signup: async () => {},
+  logout: async () => {},
+  refresh: async () => {},
+};
+
 function Wrapper({ children }: { children: ReactNode }) {
-  return <MemoryRouter>{children}</MemoryRouter>;
+  return (
+    <AuthContext value={baseAuth as any}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </AuthContext>
+  );
 }
 
 afterEach(cleanup);

--- a/frontend/src/components/NewReleases.tsx
+++ b/frontend/src/components/NewReleases.tsx
@@ -25,6 +25,7 @@ interface Props {
   showProviderBadge?: boolean;
   showRating?: boolean;
   onResultsCount?: (count: number) => void;
+  onlyMine?: boolean;
 }
 
 export default function NewReleases({
@@ -45,6 +46,7 @@ export default function NewReleases({
   showProviderBadge,
   showRating,
   onResultsCount,
+  onlyMine,
 }: Props) {
   const { t } = useTranslation();
   const [titles, setTitles] = useState<Title[]>([]);
@@ -74,10 +76,11 @@ export default function NewReleases({
       provider: provider.length ? provider.join(",") : undefined,
       language: language.length ? language.join(",") : undefined,
       excludeTracked: hideTracked || undefined,
+      onlyMine: onlyMine || undefined,
     });
     setTitles(res.titles);
     onResultsCount?.(res.titles.length);
-  }), [run, daysBack, type, genre, provider, language, hideTracked, onResultsCount]);
+  }), [run, daysBack, type, genre, provider, language, hideTracked, onlyMine, onResultsCount]);
 
   useEffect(() => {
     fetchTitles();

--- a/frontend/src/components/WatchButtonGroup.test.tsx
+++ b/frontend/src/components/WatchButtonGroup.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, afterEach } from "bun:test";
 import { render, screen, cleanup } from "@testing-library/react";
 import WatchButtonGroup from "./WatchButtonGroup";
+import { AuthContext } from "../context/AuthContext";
 import type { Offer } from "../types";
+import type { ReactNode } from "react";
 
 afterEach(cleanup);
 
@@ -23,21 +25,57 @@ function makeOffer(overrides: Partial<Offer> = {}): Offer {
   };
 }
 
+const baseAuth = {
+  user: null,
+  providers: null,
+  loading: false,
+  subscriptions: null,
+  refreshSubscriptions: async () => {},
+  login: async () => {},
+  signup: async () => {},
+  logout: async () => {},
+  refresh: async () => {},
+};
+
+function Wrapper({
+  children,
+  subscriptions = null,
+}: {
+  children: ReactNode;
+  subscriptions?: { providerIds: number[]; onlyMine: boolean } | null;
+}) {
+  return (
+    <AuthContext value={{ ...baseAuth, subscriptions } as any}>
+      {children}
+    </AuthContext>
+  );
+}
+
 describe("WatchButtonGroup", () => {
   it("returns null for empty offers", () => {
-    const { container } = render(<WatchButtonGroup offers={[]} />);
+    const { container } = render(
+      <Wrapper>
+        <WatchButtonGroup offers={[]} />
+      </Wrapper>
+    );
     expect(container.firstChild).toBeNull();
   });
 
   it("returns null for RENT/BUY-only offers", () => {
     const { container } = render(
-      <WatchButtonGroup offers={[makeOffer({ monetization_type: "RENT" }), makeOffer({ monetization_type: "BUY", id: 2 })]} />
+      <Wrapper>
+        <WatchButtonGroup offers={[makeOffer({ monetization_type: "RENT" }), makeOffer({ monetization_type: "BUY", id: 2 })]} />
+      </Wrapper>
     );
     expect(container.firstChild).toBeNull();
   });
 
   it("renders a single provider link without caret", () => {
-    render(<WatchButtonGroup offers={[makeOffer()]} />);
+    render(
+      <Wrapper>
+        <WatchButtonGroup offers={[makeOffer()]} />
+      </Wrapper>
+    );
     const link = screen.getByRole("link");
     expect(link.getAttribute("href")).toBe("https://netflix.com/watch");
     expect(screen.queryByLabelText(/More streaming options/)).toBeNull();
@@ -48,7 +86,11 @@ describe("WatchButtonGroup", () => {
       makeOffer(),
       makeOffer({ id: 2, provider_id: 15, provider_name: "Hulu", url: "https://hulu.com/watch", provider_icon_url: "https://example.com/hulu.png" }),
     ];
-    render(<WatchButtonGroup offers={offers} />);
+    render(
+      <Wrapper>
+        <WatchButtonGroup offers={offers} />
+      </Wrapper>
+    );
     const primaryLink = screen.getByRole("link");
     expect(primaryLink.getAttribute("href")).toBe("https://netflix.com/watch");
     const caretBtn = screen.getByLabelText(/More streaming options/);
@@ -60,7 +102,11 @@ describe("WatchButtonGroup", () => {
       makeOffer({ id: 1, presentation_type: "HD" }),
       makeOffer({ id: 2, presentation_type: "4K", url: "https://netflix.com/4k" }),
     ];
-    render(<WatchButtonGroup offers={offers} />);
+    render(
+      <Wrapper>
+        <WatchButtonGroup offers={offers} />
+      </Wrapper>
+    );
     // Same provider_id=8, deduped → single provider, no caret
     const links = screen.getAllByRole("link");
     expect(links.length).toBe(1);
@@ -72,7 +118,11 @@ describe("WatchButtonGroup", () => {
       makeOffer(),
       makeOffer({ id: 2, provider_id: 15, provider_name: "Hulu", url: "https://hulu.com/watch", provider_icon_url: "https://example.com/hulu.png" }),
     ];
-    render(<WatchButtonGroup offers={offers} variant="inline" />);
+    render(
+      <Wrapper>
+        <WatchButtonGroup offers={offers} variant="inline" />
+      </Wrapper>
+    );
     const links = screen.getAllByRole("link");
     expect(links.length).toBe(2);
   });
@@ -83,18 +133,92 @@ describe("WatchButtonGroup", () => {
       makeOffer({ id: 2, provider_id: 2, url: "https://b.com" }),
       makeOffer({ id: 3, provider_id: 3, url: "https://c.com" }),
     ];
-    render(<WatchButtonGroup offers={offers} variant="inline" maxVisible={2} />);
+    render(
+      <Wrapper>
+        <WatchButtonGroup offers={offers} variant="inline" maxVisible={2} />
+      </Wrapper>
+    );
     const links = screen.getAllByRole("link");
     expect(links.length).toBe(2);
   });
 
   it("shows Stream label for FLATRATE offer", () => {
-    render(<WatchButtonGroup offers={[makeOffer()]} />);
+    render(
+      <Wrapper>
+        <WatchButtonGroup offers={[makeOffer()]} />
+      </Wrapper>
+    );
     expect(screen.getByText("Stream")).toBeDefined();
   });
 
   it("shows Free label for FREE offer", () => {
-    render(<WatchButtonGroup offers={[makeOffer({ monetization_type: "FREE" })]} />);
+    render(
+      <Wrapper>
+        <WatchButtonGroup offers={[makeOffer({ monetization_type: "FREE" })]} />
+      </Wrapper>
+    );
     expect(screen.getByText("Free")).toBeDefined();
+  });
+});
+
+describe("WatchButtonGroup subscription dimming", () => {
+  const netflixOffer = makeOffer({ id: 1, provider_id: 8, provider_name: "Netflix" });
+  const disneyOffer = makeOffer({
+    id: 2,
+    provider_id: 337,
+    provider_name: "Disney+",
+    url: "https://disneyplus.com/watch",
+    provider_icon_url: "https://example.com/disney.png",
+  });
+
+  it("dims non-subscribed offer in inline variant", () => {
+    render(
+      <Wrapper subscriptions={{ providerIds: [8], onlyMine: false }}>
+        <WatchButtonGroup offers={[netflixOffer, disneyOffer]} variant="inline" />
+      </Wrapper>
+    );
+    // Disney+ wrapper should have opacity-50
+    const disneyLink = screen.getByRole("link", { name: /disney/i });
+    const disneyWrapper = disneyLink.parentElement;
+    expect(disneyWrapper?.className).toContain("opacity-50");
+    // Netflix wrapper should NOT have opacity-50
+    const netflixLink = screen.getByRole("link", { name: /netflix/i });
+    const netflixWrapper = netflixLink.parentElement;
+    expect(netflixWrapper?.className ?? "").not.toContain("opacity-50");
+  });
+
+  it("does not dim when user has no subscriptions", () => {
+    render(
+      <Wrapper subscriptions={null}>
+        <WatchButtonGroup offers={[netflixOffer, disneyOffer]} variant="inline" />
+      </Wrapper>
+    );
+    const links = screen.getAllByRole("link");
+    for (const link of links) {
+      expect(link.parentElement?.className ?? "").not.toContain("opacity-50");
+    }
+  });
+
+  it("sorts subscribed providers first in dropdown variant", () => {
+    // Disney (337) is subscribed; Netflix (8) is not — Disney should be primary
+    render(
+      <Wrapper subscriptions={{ providerIds: [337], onlyMine: false }}>
+        <WatchButtonGroup offers={[netflixOffer, disneyOffer]} />
+      </Wrapper>
+    );
+    // Primary link should point to Disney+ (subscribed provider sorts first)
+    const primaryLink = screen.getByRole("link");
+    expect(primaryLink.getAttribute("href")).toBe("https://disneyplus.com/watch");
+  });
+
+  it("marks non-subscribed dropdown item with aria-label suffix", () => {
+    render(
+      <Wrapper subscriptions={{ providerIds: [8], onlyMine: false }}>
+        <WatchButtonGroup offers={[netflixOffer, disneyOffer]} />
+      </Wrapper>
+    );
+    // The dropdown trigger exists (2 providers → split button)
+    const trigger = screen.getByLabelText(/More streaming options/);
+    expect(trigger).toBeDefined();
   });
 });

--- a/frontend/src/components/WatchButtonGroup.tsx
+++ b/frontend/src/components/WatchButtonGroup.tsx
@@ -1,10 +1,11 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useMemo } from "react";
 import { ChevronDown, ExternalLink } from "lucide-react";
 import { Popover } from "@base-ui/react/popover";
 import type { Offer } from "../types";
 import WatchButton, { monetizationLabel, PLEX_PROVIDER_ID, plexDeepLink, getPlexPlatform } from "./WatchButton";
 import { getUniqueProviders } from "./EpisodeComponents";
 import { getProviderColor } from "../data/providerColors";
+import { useAuth } from "../context/AuthContext";
 
 interface Props {
   offers: Offer[];
@@ -15,22 +16,41 @@ interface Props {
 }
 
 export default function WatchButtonGroup({ offers, variant = "dropdown", maxVisible = 4, size = "sm", fullWidth }: Props) {
-  const providers = getUniqueProviders(offers);
-  if (providers.length === 0) return null;
+  const { subscriptions } = useAuth();
+  const subscribedSet = useMemo(
+    () => new Set(subscriptions?.providerIds ?? []),
+    [subscriptions]
+  );
+
+  const rawProviders = getUniqueProviders(offers);
+  if (rawProviders.length === 0) return null;
+
+  // Sort subscribed providers first; stable sort preserves relative order within each group
+  const providers = subscribedSet.size > 0
+    ? [...rawProviders].sort((a, b) => {
+        const aS = subscribedSet.has(a.provider_id) ? 0 : 1;
+        const bS = subscribedSet.has(b.provider_id) ? 0 : 1;
+        return aS - bS;
+      })
+    : rawProviders;
 
   if (variant === "inline") {
     return (
       <div className="flex flex-wrap gap-2">
         {providers.slice(0, maxVisible).map((o) => (
-          <WatchButton
+          <div
             key={o.provider_id}
-            url={o.url}
-            providerId={o.provider_id}
-            providerName={o.provider_name}
-            providerIconUrl={o.provider_icon_url}
-            monetizationType={o.monetization_type}
-            variant="full"
-          />
+            className={subscribedSet.size > 0 && !subscribedSet.has(o.provider_id) ? "opacity-50" : undefined}
+          >
+            <WatchButton
+              url={o.url}
+              providerId={o.provider_id}
+              providerName={o.provider_name}
+              providerIconUrl={o.provider_icon_url}
+              monetizationType={o.monetization_type}
+              variant="full"
+            />
+          </div>
         ))}
       </div>
     );
@@ -52,10 +72,10 @@ export default function WatchButtonGroup({ offers, variant = "dropdown", maxVisi
     );
   }
 
-  return <SplitWatchButton providers={providers} size={size} fullWidth={fullWidth} />;
+  return <SplitWatchButton providers={providers} subscribedSet={subscribedSet} size={size} fullWidth={fullWidth} />;
 }
 
-function DropdownProviderItem({ offer, isLg }: { offer: Offer; isLg: boolean }) {
+function DropdownProviderItem({ offer, isLg, isSubscribed }: { offer: Offer; isLg: boolean; isSubscribed: boolean }) {
   const [hovered, setHovered] = useState(false);
   const c = getProviderColor(offer.provider_id);
   const lbl = monetizationLabel(offer.monetization_type);
@@ -68,9 +88,11 @@ function DropdownProviderItem({ offer, isLg }: { offer: Offer; isLg: boolean }) 
       href={effectiveUrl}
       target={useMobileDeepLink ? undefined : "_blank"}
       rel="noopener noreferrer"
+      aria-label={`Watch on ${offer.provider_name}${!isSubscribed ? " (not subscribed)" : ""}`}
+      data-subscribed={isSubscribed}
       className={`flex items-center justify-center gap-1.5 font-semibold transition-colors duration-200 ${
         isLg ? "rounded-xl px-6 py-3 text-base" : "rounded-lg px-3 py-1.5 text-xs"
-      }`}
+      }${!isSubscribed ? " opacity-50" : ""}`}
       style={{ backgroundColor: hovered ? c.bg : c.hover, color: c.text }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
@@ -82,7 +104,7 @@ function DropdownProviderItem({ offer, isLg }: { offer: Offer; isLg: boolean }) 
   );
 }
 
-function SplitWatchButton({ providers, size, fullWidth }: { providers: Offer[]; size: "sm" | "lg"; fullWidth?: boolean }) {
+function SplitWatchButton({ providers, subscribedSet, size, fullWidth }: { providers: Offer[]; subscribedSet: Set<number>; size: "sm" | "lg"; fullWidth?: boolean }) {
   const [primaryHovered, setPrimaryHovered] = useState(false);
   const [caretHovered, setCaretHovered] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -141,7 +163,7 @@ function SplitWatchButton({ providers, size, fullWidth }: { providers: Offer[]; 
           >
             <Popover.Popup className="flex flex-col gap-1 p-1">
               {rest.map((o) => (
-                <DropdownProviderItem key={o.provider_id} offer={o} isLg={isLg} />
+                <DropdownProviderItem key={o.provider_id} offer={o} isLg={isLg} isSubscribed={subscribedSet.size === 0 || subscribedSet.has(o.provider_id)} />
               ))}
             </Popover.Popup>
           </Popover.Positioner>

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,6 +1,8 @@
 import { createContext, useContext, useState, useEffect, useCallback } from "react";
 import type { ReactNode } from "react";
 import { authClient } from "../lib/auth-client";
+import { getSubscriptions } from "../api";
+import type { UserSubscriptions } from "../types";
 
 interface User {
   id: string;
@@ -20,6 +22,8 @@ interface AuthContextType {
   user: User | null;
   providers: AuthProviders | null;
   loading: boolean;
+  subscriptions: UserSubscriptions | null;
+  refreshSubscriptions: () => Promise<void>;
   login: (username: string, password: string) => Promise<void>;
   signup: (username: string, email: string, password: string, name: string) => Promise<void>;
   logout: () => Promise<void>;
@@ -57,6 +61,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [providers, setProviders] = useState<AuthProviders | null>(null);
   const [loading, setLoading] = useState(true);
+  const [subscriptions, setSubscriptions] = useState<UserSubscriptions | null>(null);
+
+  const refreshSubscriptions = useCallback(async () => {
+    try {
+      const data = await getSubscriptions();
+      setSubscriptions(data);
+    } catch {
+      setSubscriptions(null);
+    }
+  }, []);
 
   const refresh = useCallback(async () => {
     try {
@@ -74,13 +88,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           authClient.getSession().then((r) => r.data),
           fetch("/api/auth/custom/providers").then((r) => r.json()),
         ]);
-        setUser(
-          sessionResult.status === "fulfilled"
-            ? mapSessionToUser(sessionResult.value)
-            : null
-        );
+        const resolvedUser = sessionResult.status === "fulfilled"
+          ? mapSessionToUser(sessionResult.value)
+          : null;
+        setUser(resolvedUser);
         if (provData.status === "fulfilled") {
           setProviders(provData.value);
+        }
+        if (resolvedUser) {
+          getSubscriptions().then(setSubscriptions).catch(() => {});
         }
       } catch {
         setUser(null);
@@ -108,6 +124,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
     const session = await authClient.getSession();
     setUser(mapSessionToUser(session.data));
+    getSubscriptions().then(setSubscriptions).catch(() => {});
 
     // Refresh providers in case OIDC was configured
     fetch("/api/auth/custom/providers")
@@ -128,15 +145,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
     const session = await authClient.getSession();
     setUser(mapSessionToUser(session.data));
+    getSubscriptions().then(setSubscriptions).catch(() => {});
   };
 
   const logout = async () => {
     await authClient.signOut();
     setUser(null);
+    setSubscriptions(null);
   };
 
   return (
-    <AuthContext value={{ user, providers, loading, login, signup, logout, refresh }}>
+    <AuthContext value={{ user, providers, loading, subscriptions, refreshSubscriptions, login, signup, logout, refresh }}>
       {children}
     </AuthContext>
   );

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -425,9 +425,21 @@
     "tabs": {
       "account": "Account",
       "appearance": "Appearance",
+      "subscriptions": "Subscriptions",
       "notifications": "Notifications",
       "integrations": "Integrations",
       "admin": "Admin"
+    },
+    "subscriptions": {
+      "title": "My Streaming Services",
+      "subtitle": "Select the services you're subscribed to. This preselects the provider filter when browsing and dims unavailable offers on title cards.",
+      "onlyMine": {
+        "label": "Only show titles on my services",
+        "description": "When on, browsing always filters to titles available on your subscribed services."
+      },
+      "empty": "No providers found.",
+      "regionProviders": "My Region",
+      "otherProviders": "Other"
     },
     "theme": {
       "title": "Theme",

--- a/frontend/src/pages/BrowsePage.test.tsx
+++ b/frontend/src/pages/BrowsePage.test.tsx
@@ -1,8 +1,28 @@
 import { describe, it, expect, mock, afterEach } from "bun:test";
 import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, useSearchParams } from "react-router";
+import { useEffect } from "react";
 import type { ReactNode } from "react";
 import "../i18n";
+
+// Mutable so individual tests can override subscriptions without re-mocking
+let mockSubscriptions: { providerIds: number[]; onlyMine: boolean } | null = null;
+
+mock.module("../context/AuthContext", () => ({
+  useAuth: () => ({
+    user: null,
+    providers: null,
+    loading: false,
+    subscriptions: mockSubscriptions,
+    refreshSubscriptions: mock(() => Promise.resolve()),
+    login: mock(() => Promise.resolve()),
+    signup: mock(() => Promise.resolve()),
+    logout: mock(() => Promise.resolve()),
+    refresh: mock(() => Promise.resolve()),
+  }),
+  AuthContext: { Provider: ({ children }: { children: ReactNode }) => children },
+  AuthProvider: ({ children }: { children: ReactNode }) => children,
+}));
 
 mock.module("../hooks/useIsMobile", () => ({ useIsMobile: () => false }));
 mock.module("../hooks/useGridNavigation", () => ({ useGridNavigation: () => undefined }));
@@ -18,9 +38,6 @@ mock.module("../components/loadFilters", () => ({
     }),
 }));
 
-// Stub out child components that make API calls or have complex browser deps.
-// We do not mock ../api here to avoid leaking into other test files — the only
-// on-mount API call (getLanguages) is silently swallowed by the component on failure.
 mock.module("../components/SearchBar", () => ({
   default: ({ onSearch }: any) => (
     <input data-testid="search-bar" onChange={(e) => onSearch(e.target.value)} />
@@ -39,6 +56,7 @@ function makeWrapper(initialPath: string) {
 
 afterEach(() => {
   cleanup();
+  mockSubscriptions = null;
 });
 
 describe("BrowsePage active filter chips", () => {
@@ -102,5 +120,66 @@ describe("BrowsePage active filter chips", () => {
     expect(screen.queryByRole("button", { name: /remove movies filter/i })).toBeNull();
     // Genre chip for Action should still be present
     expect(screen.getByRole("button", { name: /remove action filter/i })).toBeDefined();
+  });
+});
+
+describe("BrowsePage subscription preselect", () => {
+  // Helper that captures the current URLSearchParams from inside the router tree
+  function SearchParamsSpy({ onCapture }: { onCapture: (p: URLSearchParams) => void }) {
+    const [sp] = useSearchParams();
+    useEffect(() => { onCapture(sp); }, [sp, onCapture]);
+    return null;
+  }
+
+  it("preselects subscribed providers when no provider param in URL", async () => {
+    mockSubscriptions = { providerIds: [8, 337], onlyMine: false };
+
+    let captured: URLSearchParams | null = null;
+
+    await act(async () => {
+      render(
+        <MemoryRouter initialEntries={["/browse"]}>
+          <BrowsePage />
+          <SearchParamsSpy onCapture={(sp) => { captured = sp; }} />
+        </MemoryRouter>
+      );
+    });
+
+    expect(captured?.get("provider")).toBe("8,337");
+  });
+
+  it("does not overwrite an existing provider param in the URL", async () => {
+    mockSubscriptions = { providerIds: [8, 337], onlyMine: false };
+
+    let captured: URLSearchParams | null = null;
+
+    await act(async () => {
+      render(
+        <MemoryRouter initialEntries={["/browse?provider=15"]}>
+          <BrowsePage />
+          <SearchParamsSpy onCapture={(sp) => { captured = sp; }} />
+        </MemoryRouter>
+      );
+    });
+
+    // The existing provider=15 should be preserved, not overwritten
+    expect(captured?.get("provider")).toBe("15");
+  });
+
+  it("does not preselect when user has no subscriptions", async () => {
+    mockSubscriptions = null;
+
+    let captured: URLSearchParams | null = null;
+
+    await act(async () => {
+      render(
+        <MemoryRouter initialEntries={["/browse"]}>
+          <BrowsePage />
+          <SearchParamsSpy onCapture={(sp) => { captured = sp; }} />
+        </MemoryRouter>
+      );
+    });
+
+    expect(captured?.get("provider")).toBeNull();
   });
 });

--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, useReducer } from "react";
+import { useCallback, useEffect, useRef, useState, useReducer } from "react";
 import { useSearchParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import SearchBar from "../components/SearchBar";
@@ -17,6 +17,7 @@ import { useIsMobile } from "../hooks/useIsMobile";
 import { PageHeader } from "../components/design";
 import { useAsyncError } from "../hooks/useAsyncError";
 import { Card } from "../components/ui/card";
+import { useAuth } from "../context/AuthContext";
 
 const VALID_CATEGORIES: BrowseCategory[] = ["new_releases", "popular", "upcoming", "top_rated"];
 
@@ -122,6 +123,7 @@ export default function BrowsePage() {
   const { run: runAsync, error: searchError, reset: resetSearchError } = useAsyncError();
   const { t } = useTranslation();
   const isMobile = useIsMobile();
+  const { subscriptions } = useAuth();
   useGridNavigation();
 
   // ── Browse filter data (loaded once) ────────────────────────────────────────
@@ -224,6 +226,23 @@ export default function BrowsePage() {
     (value: boolean) => setHideTrackedStr(value ? "1" : ""),
     [setHideTrackedStr]
   );
+
+  const [onlyMineStr, setOnlyMineStr] = useQueryParam(searchParams, setSearchParams, "onlyMine");
+  const onlyMine = onlyMineStr === "true";
+  const setOnlyMine = useCallback(
+    (value: boolean) => setOnlyMineStr(value ? "true" : ""),
+    [setOnlyMineStr]
+  );
+
+  // Preselect provider filter with subscribed providers on first load (when no provider param is set)
+  const preselectedRef = useRef(false);
+  useEffect(() => {
+    if (preselectedRef.current) return;
+    if (!subscriptions || subscriptions.providerIds.length === 0) return;
+    if (searchParams.get("provider")) return;
+    preselectedRef.current = true;
+    setProvider(subscriptions.providerIds.map(String));
+  }, [subscriptions, searchParams, setProvider]);
 
   async function runSearch(
     query: string,
@@ -484,10 +503,38 @@ export default function BrowsePage() {
         )
       )}
 
+      {/* On my services toggle chip — shown when user has subscribed providers */}
+      {searchResults === null && subscriptions && subscriptions.providerIds.length > 0 && (
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setOnlyMine(!onlyMine)}
+            className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[11px] font-semibold font-mono border transition-colors ${
+              onlyMine
+                ? "bg-amber-400 text-black border-amber-400"
+                : "bg-white/[0.06] text-zinc-300 border-white/[0.08] hover:border-zinc-500"
+            }`}
+            aria-pressed={onlyMine}
+          >
+            {onlyMine ? "✓ " : ""}On my services
+          </button>
+        </div>
+      )}
+
       {/* Active filter chips */}
-      {searchResults === null && (type.length > 0 || genre.length > 0 || provider.length > 0 || language.length > 0 || browseYearMin !== "" || browseYearMax !== "" || browseMinRating !== "") && (
+      {searchResults === null && (onlyMine || type.length > 0 || genre.length > 0 || provider.length > 0 || language.length > 0 || browseYearMin !== "" || browseYearMax !== "" || browseMinRating !== "") && (
         <div className="flex flex-wrap items-center gap-2">
           <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-500 mr-1">Active</span>
+          {onlyMine && (
+            <button
+              type="button"
+              onClick={() => setOnlyMine(false)}
+              aria-label="Remove 'On my services' filter"
+              className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-semibold bg-amber-400/[0.12] text-amber-400 border border-amber-400/[0.25] cursor-pointer hover:bg-amber-400/20 transition-colors"
+            >
+              On my services ×
+            </button>
+          )}
           {type.map((t) => (
             <button
               key={t}
@@ -596,6 +643,7 @@ export default function BrowsePage() {
               showProviderBadge
               showRating
               onResultsCount={setResultsCount}
+              onlyMine={onlyMine}
             />
           ) : (
             <CategoryBrowse
@@ -619,6 +667,7 @@ export default function BrowsePage() {
               showProviderBadge
               showRating
               onResultsCount={setResultsCount}
+              onlyMine={onlyMine}
             />
           )}
         </div>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -8,11 +8,12 @@ import { lazyWithRetry } from "../lib/lazyWithRetry";
 
 const AccountTab = lazyWithRetry(() => import("./settings/AccountTab"));
 const AppearanceTab = lazyWithRetry(() => import("./settings/AppearanceTab"));
+const SubscriptionsTab = lazyWithRetry(() => import("./settings/SubscriptionsTab"));
 const NotificationsTab = lazyWithRetry(() => import("./settings/NotificationsTab"));
 const IntegrationsTab = lazyWithRetry(() => import("./settings/IntegrationsTab"));
 const AdminTab = lazyWithRetry(() => import("./settings/AdminTab"));
 
-const VALID_TABS = ["account", "appearance", "notifications", "integrations", "admin"] as const;
+const VALID_TABS = ["account", "appearance", "subscriptions", "notifications", "integrations", "admin"] as const;
 type SettingsTab = (typeof VALID_TABS)[number];
 
 export default function SettingsPage() {
@@ -47,6 +48,7 @@ export default function SettingsPage() {
   const TABS = [
     { value: "account", label: t("settings.tabs.account") },
     { value: "appearance", label: t("settings.tabs.appearance") },
+    { value: "subscriptions", label: t("settings.tabs.subscriptions") },
     { value: "notifications", label: t("settings.tabs.notifications") },
     { value: "integrations", label: t("settings.tabs.integrations") },
     ...(user.is_admin ? [{ value: "admin", label: t("settings.tabs.admin") }] : []),
@@ -90,6 +92,7 @@ export default function SettingsPage() {
           <Suspense fallback={<div className="p-8 text-zinc-400">Loading…</div>}>
             {activeTab === "account" && <AccountTab />}
             {activeTab === "appearance" && <AppearanceTab />}
+            {activeTab === "subscriptions" && <SubscriptionsTab />}
             {activeTab === "notifications" && <NotificationsTab />}
             {activeTab === "integrations" && <IntegrationsTab />}
             {activeTab === "admin" && user.is_admin && <AdminTab />}

--- a/frontend/src/pages/settings/SubscriptionsTab.test.tsx
+++ b/frontend/src/pages/settings/SubscriptionsTab.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, mock, beforeEach, afterEach, spyOn } from "bun:test";
+import { render, screen, fireEvent, waitFor, cleanup, act } from "@testing-library/react";
+import "../../i18n";
+import * as api from "../../api";
+
+const mockRefreshSubscriptions = mock(() => Promise.resolve());
+// Stable reference — SubscriptionsTab's useEffect([subscriptions]) uses reference equality
+const STABLE_SUBSCRIPTIONS = { providerIds: [] as number[], onlyMine: false };
+
+mock.module("../../context/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: "u1", username: "testuser", display_name: null, auth_provider: "local", is_admin: false },
+    providers: null,
+    loading: false,
+    subscriptions: STABLE_SUBSCRIPTIONS,
+    refreshSubscriptions: mockRefreshSubscriptions,
+    login: mock(() => Promise.resolve()),
+    signup: mock(() => Promise.resolve()),
+    logout: mock(() => Promise.resolve()),
+    refresh: mock(() => Promise.resolve()),
+  }),
+}));
+
+const { default: SubscriptionsTab } = await import("./SubscriptionsTab");
+
+let spies: ReturnType<typeof spyOn>[] = [];
+
+beforeEach(() => {
+  mockRefreshSubscriptions.mockClear();
+  spies = [
+    spyOn(api, "getProviders").mockResolvedValue({
+      providers: [
+        { id: 8, name: "Netflix", technical_name: "netflix", icon_url: "https://example.com/netflix.png" },
+        { id: 337, name: "Disney+", technical_name: "disneyplus", icon_url: "https://example.com/disney.png" },
+      ],
+      regionProviderIds: [8, 337],
+    } as any),
+    spyOn(api, "updateSubscriptions").mockResolvedValue({ providerIds: [8] } as any),
+    spyOn(api, "updateOnlyMine").mockResolvedValue({ onlyMine: true } as any),
+  ];
+});
+
+afterEach(() => {
+  cleanup();
+  for (const spy of spies) spy.mockRestore();
+  spies = [];
+});
+
+describe("SubscriptionsTab", () => {
+  it("renders providers fetched from the API", async () => {
+    render(<SubscriptionsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Netflix")).toBeDefined();
+      expect(screen.getByText("Disney+")).toBeDefined();
+    });
+  });
+
+  it("calls updateSubscriptions when a provider checkbox is toggled", async () => {
+    render(<SubscriptionsTab />);
+
+    await waitFor(() => screen.getByText("Netflix"));
+
+    const netflixLabel = screen.getByText("Netflix").closest("label")!;
+    await act(async () => {
+      fireEvent.click(netflixLabel);
+    });
+
+    await waitFor(() => {
+      expect(api.updateSubscriptions).toHaveBeenCalledTimes(1);
+      const call = (api.updateSubscriptions as ReturnType<typeof spyOn>).mock.calls[0];
+      expect((call[0] as number[]).includes(8)).toBe(true);
+    });
+  });
+
+  it("calls refreshSubscriptions after updating providers", async () => {
+    render(<SubscriptionsTab />);
+
+    await waitFor(() => screen.getByText("Netflix"));
+
+    const netflixLabel = screen.getByText("Netflix").closest("label")!;
+    await act(async () => {
+      fireEvent.click(netflixLabel);
+    });
+
+    await waitFor(() => {
+      expect(mockRefreshSubscriptions).toHaveBeenCalled();
+    });
+  });
+
+  it("calls updateOnlyMine when the Apply Automatically switch is toggled", async () => {
+    render(<SubscriptionsTab />);
+
+    await waitFor(() => screen.getByText("Netflix"));
+
+    // The onlyMine switch renders as a button with role="switch"
+    const switchEl = screen.getByRole("switch");
+    await act(async () => {
+      fireEvent.click(switchEl);
+    });
+
+    await waitFor(() => {
+      expect(api.updateOnlyMine).toHaveBeenCalledTimes(1);
+      const call = (api.updateOnlyMine as ReturnType<typeof spyOn>).mock.calls[0];
+      expect(call[0]).toBe(true);
+    });
+  });
+});

--- a/frontend/src/pages/settings/SubscriptionsTab.tsx
+++ b/frontend/src/pages/settings/SubscriptionsTab.tsx
@@ -1,0 +1,135 @@
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import * as api from "../../api";
+import type { Provider } from "../../types";
+import { SCard, SSwitch } from "../../components/settings/kit";
+import { useAuth } from "../../context/AuthContext";
+
+export default function SubscriptionsTab() {
+  const { t } = useTranslation();
+  const { subscriptions, refreshSubscriptions } = useAuth();
+
+  const [allProviders, setAllProviders] = useState<Provider[]>([]);
+  const [regionProviderIds, setRegionProviderIds] = useState<number[]>([]);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [onlyMine, setOnlyMine] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    api.getProviders(controller.signal).then((data) => {
+      setAllProviders(data.providers);
+      setRegionProviderIds(data.regionProviderIds);
+    }).catch(() => {});
+    return () => controller.abort();
+  }, []);
+
+  useEffect(() => {
+    if (subscriptions) {
+      setSelectedIds(new Set(subscriptions.providerIds));
+      setOnlyMine(subscriptions.onlyMine);
+    }
+  }, [subscriptions]);
+
+  async function toggleProvider(id: number) {
+    const next = new Set(selectedIds);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    setSelectedIds(next);
+    setSaving(true);
+    try {
+      await api.updateSubscriptions(Array.from(next));
+      await refreshSubscriptions();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function toggleOnlyMine(value: boolean) {
+    setOnlyMine(value);
+    try {
+      await api.updateOnlyMine(value);
+      await refreshSubscriptions();
+    } catch {
+      setOnlyMine(!value);
+    }
+  }
+
+  const regionIds = new Set(regionProviderIds);
+  const regionProviders = allProviders.filter((p) => regionIds.has(p.id));
+  const otherProviders = allProviders.filter((p) => !regionIds.has(p.id));
+
+  function ProviderRow({ provider }: { provider: Provider }) {
+    const checked = selectedIds.has(provider.id);
+    return (
+      <label className="flex items-center gap-3 py-2.5 cursor-pointer hover:bg-white/[0.03] rounded-lg px-2 -mx-2 transition-colors">
+        <input
+          type="checkbox"
+          className="sr-only"
+          checked={checked}
+          onChange={() => toggleProvider(provider.id)}
+          disabled={saving}
+        />
+        <div className={`w-5 h-5 rounded border-2 flex items-center justify-center flex-shrink-0 transition-colors ${checked ? "border-amber-400 bg-amber-400" : "border-zinc-600 bg-transparent"}`}>
+          {checked && (
+            <svg className="w-3 h-3 text-black" fill="currentColor" viewBox="0 0 12 12" aria-hidden="true">
+              <path d="M10 3L5 8.5 2 5.5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+            </svg>
+          )}
+        </div>
+        {provider.icon_url && (
+          <img src={provider.icon_url} alt="" className="w-6 h-6 rounded flex-shrink-0" loading="lazy" />
+        )}
+        <span className="text-sm text-zinc-200">{provider.name}</span>
+      </label>
+    );
+  }
+
+  return (
+    <div>
+      <SCard
+        title={t("settings.subscriptions.title")}
+        subtitle={t("settings.subscriptions.subtitle")}
+      >
+        {allProviders.length === 0 ? (
+          <p className="text-sm text-zinc-500">{t("settings.subscriptions.empty")}</p>
+        ) : (
+          <div className="space-y-6">
+            {regionProviders.length > 0 && (
+              <div>
+                <div className="text-xs font-mono font-semibold uppercase tracking-widest text-amber-400 mb-2">
+                  {t("settings.subscriptions.regionProviders")}
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-0.5">
+                  {regionProviders.map((p) => <ProviderRow key={p.id} provider={p} />)}
+                </div>
+              </div>
+            )}
+            {otherProviders.length > 0 && (
+              <div>
+                <div className="text-xs font-mono font-semibold uppercase tracking-widest text-zinc-500 mb-2">
+                  {t("settings.subscriptions.otherProviders")}
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-0.5">
+                  {otherProviders.map((p) => <ProviderRow key={p.id} provider={p} />)}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </SCard>
+
+      <SCard>
+        <SSwitch
+          label={t("settings.subscriptions.onlyMine.label")}
+          sub={t("settings.subscriptions.onlyMine.description")}
+          on={onlyMine}
+          onChange={toggleOnlyMine}
+        />
+      </SCard>
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -125,6 +125,11 @@ export interface Provider {
   icon_url: string;
 }
 
+export interface UserSubscriptions {
+  providerIds: number[];
+  onlyMine: boolean;
+}
+
 export interface WatchHistoryEntry {
   id: string;
   watchedAt: string;

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -133,6 +133,6 @@ describe("fixSkippedMigrations", () => {
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(44);
+    expect(migrations.cnt).toBe(45);
   });
 });

--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -263,3 +263,11 @@ export {
   pruneOldRows,
 } from "./notification-log";
 export type { NotificationLogRow } from "./notification-log";
+
+export {
+  getSubscribedProviderIds,
+  setSubscribedProviderIds,
+  getOnlyMineFilter,
+  setOnlyMineFilter,
+  filterValidProviderIds,
+} from "./user-subscribed-providers";

--- a/server/db/repository/user-subscribed-providers.test.ts
+++ b/server/db/repository/user-subscribed-providers.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
+import { createUser, upsertTitles } from "../repository";
+import { makeParsedTitle, makeParsedOffer } from "../../test-utils/fixtures";
+import {
+  getSubscribedProviderIds,
+  setSubscribedProviderIds,
+  getOnlyMineFilter,
+  setOnlyMineFilter,
+  filterValidProviderIds,
+} from "./user-subscribed-providers";
+
+let userId: string;
+
+beforeEach(async () => {
+  setupTestDb();
+  userId = await createUser("subuser", "hash");
+  // Seed providers 8 (Netflix) and 337 (Disney+) via a title with offers
+  await upsertTitles([
+    makeParsedTitle({
+      id: "movie-sub-1",
+      offers: [
+        makeParsedOffer({ titleId: "movie-sub-1", providerId: 8, providerName: "Netflix", providerTechnicalName: "netflix" }),
+        makeParsedOffer({ titleId: "movie-sub-1", providerId: 337, providerName: "Disney+", providerTechnicalName: "disneyplus" }),
+      ],
+    }),
+  ]);
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+describe("getSubscribedProviderIds / setSubscribedProviderIds", () => {
+  it("returns empty array for a new user", async () => {
+    const ids = await getSubscribedProviderIds(userId);
+    expect(ids).toEqual([]);
+  });
+
+  it("round-trips set and get", async () => {
+    await setSubscribedProviderIds(userId, [8, 337]);
+    const ids = await getSubscribedProviderIds(userId);
+    expect(ids.sort((a, b) => a - b)).toEqual([8, 337]);
+  });
+
+  it("replaces the full list on each set (no duplicates)", async () => {
+    await setSubscribedProviderIds(userId, [8]);
+    await setSubscribedProviderIds(userId, [337]);
+    const ids = await getSubscribedProviderIds(userId);
+    expect(ids).toEqual([337]);
+  });
+
+  it("clearing to empty array removes all subscriptions", async () => {
+    await setSubscribedProviderIds(userId, [8, 337]);
+    await setSubscribedProviderIds(userId, []);
+    const ids = await getSubscribedProviderIds(userId);
+    expect(ids).toEqual([]);
+  });
+
+  it("is scoped per user — another user's subscriptions don't interfere", async () => {
+    const other = await createUser("subuser2", "hash");
+    await setSubscribedProviderIds(userId, [8]);
+    await setSubscribedProviderIds(other, [337]);
+    expect(await getSubscribedProviderIds(userId)).toEqual([8]);
+    expect(await getSubscribedProviderIds(other)).toEqual([337]);
+  });
+});
+
+describe("getOnlyMineFilter / setOnlyMineFilter", () => {
+  it("defaults to false for a new user", async () => {
+    const value = await getOnlyMineFilter(userId);
+    expect(value).toBe(false);
+  });
+
+  it("round-trips true", async () => {
+    await setOnlyMineFilter(userId, true);
+    expect(await getOnlyMineFilter(userId)).toBe(true);
+  });
+
+  it("round-trips false", async () => {
+    await setOnlyMineFilter(userId, true);
+    await setOnlyMineFilter(userId, false);
+    expect(await getOnlyMineFilter(userId)).toBe(false);
+  });
+});
+
+describe("filterValidProviderIds", () => {
+  it("returns empty for empty input", async () => {
+    expect(await filterValidProviderIds([])).toEqual([]);
+  });
+
+  it("returns only IDs that exist in the providers table", async () => {
+    const result = await filterValidProviderIds([8, 337, 9999]);
+    expect(result.sort((a, b) => a - b)).toEqual([8, 337]);
+  });
+
+  it("returns empty when none of the IDs exist", async () => {
+    const result = await filterValidProviderIds([9998, 9999]);
+    expect(result).toEqual([]);
+  });
+});

--- a/server/db/repository/user-subscribed-providers.ts
+++ b/server/db/repository/user-subscribed-providers.ts
@@ -1,0 +1,63 @@
+import { eq, inArray } from "drizzle-orm";
+import { getDb } from "../schema";
+import { userSubscribedProviders, users, providers } from "../schema";
+import { traceDbQuery } from "../../tracing";
+
+export async function getSubscribedProviderIds(userId: string): Promise<number[]> {
+  return traceDbQuery("getSubscribedProviderIds", async () => {
+    const db = getDb();
+    const rows = await db
+      .select({ providerId: userSubscribedProviders.providerId })
+      .from(userSubscribedProviders)
+      .where(eq(userSubscribedProviders.userId, userId))
+      .all();
+    return rows.map((r) => r.providerId);
+  });
+}
+
+export async function setSubscribedProviderIds(userId: string, providerIds: number[]): Promise<void> {
+  return traceDbQuery("setSubscribedProviderIds", async () => {
+    const db = getDb();
+    await db.transaction(async (tx) => {
+      await tx.delete(userSubscribedProviders).where(eq(userSubscribedProviders.userId, userId)).run();
+      if (providerIds.length > 0) {
+        await tx.insert(userSubscribedProviders)
+          .values(providerIds.map((providerId) => ({ userId, providerId })))
+          .run();
+      }
+    });
+  });
+}
+
+export async function getOnlyMineFilter(userId: string): Promise<boolean> {
+  return traceDbQuery("getOnlyMineFilter", async () => {
+    const db = getDb();
+    const row = await db
+      .select({ onlyMineFilter: users.onlyMineFilter })
+      .from(users)
+      .where(eq(users.id, userId))
+      .get();
+    return (row?.onlyMineFilter ?? 0) !== 0;
+  });
+}
+
+export async function setOnlyMineFilter(userId: string, value: boolean): Promise<void> {
+  return traceDbQuery("setOnlyMineFilter", async () => {
+    const db = getDb();
+    await db.update(users).set({ onlyMineFilter: value ? 1 : 0 }).where(eq(users.id, userId)).run();
+  });
+}
+
+/** Returns the subset of providerIds that actually exist in the providers table. */
+export async function filterValidProviderIds(providerIds: number[]): Promise<number[]> {
+  if (providerIds.length === 0) return [];
+  return traceDbQuery("filterValidProviderIds", async () => {
+    const db = getDb();
+    const rows = await db
+      .select({ id: providers.id })
+      .from(providers)
+      .where(inArray(providers.id, providerIds))
+      .all();
+    return rows.map((r) => r.id);
+  });
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -179,6 +179,7 @@ export const users = sqliteTable(
     highContrast: integer("high_contrast").notNull().default(0),
     hideEpisodeSpoilers: integer("hide_episode_spoilers").notNull().default(0),
     autoplayTrailers: integer("autoplay_trailers").notNull().default(0),
+    onlyMineFilter: integer("only_mine_filter").notNull().default(0),
   },
   (table) => [
     uniqueIndex("users_auth_provider_subject").on(
@@ -244,6 +245,23 @@ export const settings = sqliteTable("settings", {
   key: text("key").primaryKey(),
   value: text("value").notNull(),
 });
+
+export const userSubscribedProviders = sqliteTable(
+  "user_subscribed_providers",
+  {
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    providerId: integer("provider_id")
+      .notNull()
+      .references(() => providers.id, { onDelete: "restrict" }),
+    createdAt: text("created_at").default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.providerId] }),
+    index("idx_user_subscribed_providers_user_id").on(table.userId),
+  ]
+);
 
 export const tracked = sqliteTable(
   "tracked",
@@ -750,7 +768,7 @@ export const passkeyRelations = relations(passkey, ({ one }) => ({
 }));
 
 export const schemaExports = {
-  titles, providers, offers, scores, titleGenres, episodes, users, sessions, account, verification, passkey, settings, tracked, watchedEpisodes, watchedTitles, notifiers, oidcStates, jobs, cronJobs,
+  titles, providers, offers, scores, titleGenres, episodes, users, sessions, account, verification, passkey, settings, tracked, watchedEpisodes, watchedTitles, notifiers, oidcStates, jobs, cronJobs, userSubscribedProviders,
   follows, ratings, episodeRatings, recommendations, recommendationReads, invitations, integrations, plexLibraryItems, titleTags,
   watchHistory, streamingAlerts, activityKindVisibility, hiddenActivityEvents, notificationLog,
   titlesRelations, providersRelations, offersRelations, scoresRelations, titleGenresRelations, episodesRelations,

--- a/server/routes/browse.ts
+++ b/server/routes/browse.ts
@@ -19,7 +19,7 @@ import {
   parseTvDetails,
   type ParsedTitle,
 } from "../tmdb/parser";
-import { getTrackedTitleIds, upsertTitles } from "../db/repository";
+import { getTrackedTitleIds, upsertTitles, getSubscribedProviderIds } from "../db/repository";
 import type { AppEnv } from "../types";
 import { logger } from "../logger";
 import { syncFailureTotal } from "../metrics";
@@ -99,13 +99,29 @@ app.get("/", async (c) => {
   const yearMinParam = c.req.query("year_min");
   const yearMaxParam = c.req.query("year_max");
   const minRatingParam = c.req.query("min_rating");
+  const onlyMine = c.req.query("onlyMine") === "true";
   const genreNames = genreParam ? genreParam.split(",").filter(Boolean) : [];
-  const providerValues = providerParam ? providerParam.split(",").filter(Boolean) : [];
+  let providerValues = providerParam ? providerParam.split(",").filter(Boolean) : [];
   const languageValues = languageParam ? languageParam.split(",").filter(Boolean) : [];
   const typeValues = type ? type.split(",").filter(Boolean) : [];
   const yearMin = yearMinParam ? parseInt(yearMinParam, 10) : undefined;
   const yearMax = yearMaxParam ? parseInt(yearMaxParam, 10) : undefined;
   const minRating = minRatingParam ? parseFloat(minRatingParam) : undefined;
+
+  const user = c.get("user");
+  if (onlyMine && user) {
+    const subscribedIds = await getSubscribedProviderIds(user.id);
+    if (subscribedIds.length === 0) {
+      return ok(c, { titles: [], page, totalPages: 0, totalResults: 0, availableGenres: [], availableProviders: [], availableLanguages: [], regionProviderIds: [], priorityLanguageCodes: [] });
+    }
+    const subscribedStrings = subscribedIds.map(String);
+    providerValues = providerValues.length > 0
+      ? providerValues.filter((p) => subscribedStrings.includes(p))
+      : subscribedStrings;
+    if (providerValues.length === 0) {
+      return ok(c, { titles: [], page, totalPages: 0, totalResults: 0, availableGenres: [], availableProviders: [], availableLanguages: [], regionProviderIds: [], priorityLanguageCodes: [] });
+    }
+  }
 
   if (!category || !VALID_CATEGORIES.includes(category as Category)) {
     return err(c, "Invalid category. Must be one of: popular, upcoming, top_rated");
@@ -196,7 +212,6 @@ app.get("/", async (c) => {
       });
     }
 
-    const user = c.get("user");
     const trackedIds = user ? await getTrackedTitleIds(user.id) : new Set<string>();
     const titlesWithTracked = titles.map((t) => ({
       ...t,

--- a/server/routes/titles.test.ts
+++ b/server/routes/titles.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, afterAll, spyOn } from "bu
 import { Hono } from "hono";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
 import { makeParsedTitle, makeParsedOffer } from "../test-utils/fixtures";
-import { upsertTitles, trackTitle, createUser } from "../db/repository";
+import { upsertTitles, trackTitle, createUser, setSubscribedProviderIds } from "../db/repository";
 import titlesApp from "./titles";
 import type { AppEnv } from "../types";
 import * as tmdbClient from "../tmdb/client";
@@ -284,5 +284,112 @@ describe("GET /titles/providers", () => {
     const res = await app.request("/titles/providers");
     expect(res.status).toBe(200);
     expect(res.headers.get("cache-control")).toContain("max-age=86400");
+  });
+});
+
+describe("GET /titles?onlyMine", () => {
+  function makeAuthedApp(userId: string) {
+    const a = new Hono<AppEnv>();
+    a.use("*", async (c, next) => {
+      c.set("user", { id: userId, username: "u", name: null, role: null, is_admin: false });
+      await next();
+    });
+    a.route("/titles", titlesApp);
+    return a;
+  }
+
+  it("returns only titles matching subscribed providers", async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    await upsertTitles([
+      makeParsedTitle({
+        id: "netflix-title",
+        title: "Netflix Movie",
+        releaseDate: today,
+        offers: [makeParsedOffer({ titleId: "netflix-title", providerId: 8, providerName: "Netflix", providerTechnicalName: "netflix" })],
+      }),
+      makeParsedTitle({
+        id: "disney-title",
+        title: "Disney Movie",
+        releaseDate: today,
+        offers: [makeParsedOffer({ titleId: "disney-title", providerId: 337, providerName: "Disney+", providerTechnicalName: "disneyplus" })],
+      }),
+    ]);
+    const userId = await createUser("onlymineuser", "hash");
+    await setSubscribedProviderIds(userId, [8]);
+
+    const authedApp = makeAuthedApp(userId);
+    const res = await authedApp.request("/titles?daysBack=9999&onlyMine=true");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.titles).toHaveLength(1);
+    expect(body.titles[0].title).toBe("Netflix Movie");
+  });
+
+  it("returns empty when user has no subscribed providers", async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    await upsertTitles([
+      makeParsedTitle({
+        id: "some-title",
+        title: "Some Movie",
+        releaseDate: today,
+        offers: [makeParsedOffer({ titleId: "some-title", providerId: 8 })],
+      }),
+    ]);
+    const userId = await createUser("onlymineempty", "hash");
+    // no subscriptions set
+
+    const authedApp = makeAuthedApp(userId);
+    const res = await authedApp.request("/titles?daysBack=9999&onlyMine=true");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.titles).toHaveLength(0);
+    expect(body.count).toBe(0);
+  });
+
+  it("intersects subscribed providers with explicit provider param", async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    await upsertTitles([
+      makeParsedTitle({
+        id: "netflix-title2",
+        title: "Netflix Movie",
+        releaseDate: today,
+        offers: [makeParsedOffer({ titleId: "netflix-title2", providerId: 8, providerName: "Netflix", providerTechnicalName: "netflix" })],
+      }),
+      makeParsedTitle({
+        id: "disney-title2",
+        title: "Disney Movie",
+        releaseDate: today,
+        offers: [makeParsedOffer({ titleId: "disney-title2", providerId: 337, providerName: "Disney+", providerTechnicalName: "disneyplus" })],
+      }),
+    ]);
+    const userId = await createUser("onlymineint", "hash");
+    await setSubscribedProviderIds(userId, [8, 337]);
+
+    // Explicit provider=8 + onlyMine=true (subscribed to both) → intersection = [8]
+    const authedApp = makeAuthedApp(userId);
+    const res = await authedApp.request("/titles?daysBack=9999&onlyMine=true&provider=8");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.titles).toHaveLength(1);
+    expect(body.titles[0].title).toBe("Netflix Movie");
+  });
+
+  it("ignores onlyMine when user is not authenticated", async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    await upsertTitles([
+      makeParsedTitle({
+        id: "anon-title",
+        title: "Anon Movie",
+        releaseDate: today,
+        offers: [makeParsedOffer({ titleId: "anon-title", providerId: 8 })],
+      }),
+    ]);
+
+    // No user context — use the plain unauthenticated app
+    const res = await app.request("/titles?daysBack=9999&onlyMine=true");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Without auth, onlyMine is ignored and all titles are returned
+    expect(body.titles.length).toBeGreaterThan(0);
   });
 });

--- a/server/routes/titles.ts
+++ b/server/routes/titles.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { getRecentTitles, getProviders, getGenres, getLanguages } from "../db/repository";
+import { getRecentTitles, getProviders, getGenres, getLanguages, getSubscribedProviderIds } from "../db/repository";
 import { getMovieWatchProviders, getTvWatchProviders } from "../tmdb/client";
 import { expandGenreGroup } from "../genres";
 import { CONFIG } from "../config";
@@ -19,13 +19,28 @@ app.get("/", async (c) => {
   const genreParam = c.req.query("genre") || "";
   const languageParam = c.req.query("language") || "";
   const excludeTracked = c.req.query("excludeTracked") === "1";
+  const onlyMine = c.req.query("onlyMine") === "true";
   const limit = Math.max(1, Math.min(Number(c.req.query("limit")) || 100, 1000));
   const offset = Math.max(0, Number(c.req.query("offset")) || 0);
 
   const objectTypes = typeParam ? typeParam.split(",").filter(Boolean) : [];
-  const providers = providerParam ? providerParam.split(",").filter(Boolean) : [];
+  let providers = providerParam ? providerParam.split(",").filter(Boolean) : [];
   const genres = genreParam ? genreParam.split(",").filter(Boolean).flatMap(expandGenreGroup) : [];
   const languages = languageParam ? languageParam.split(",").filter(Boolean) : [];
+
+  if (onlyMine && user) {
+    const subscribedIds = await getSubscribedProviderIds(user.id);
+    if (subscribedIds.length === 0) {
+      return ok(c, { titles: [], count: 0 });
+    }
+    const subscribedStrings = subscribedIds.map(String);
+    providers = providers.length > 0
+      ? providers.filter((p) => subscribedStrings.includes(p))
+      : subscribedStrings;
+    if (providers.length === 0) {
+      return ok(c, { titles: [], count: 0 });
+    }
+  }
 
   const titles = await getRecentTitles({ daysBack, objectTypes, providers, genres, languages, excludeTracked, limit, offset }, user?.id);
   setPublicCacheIfAnon(c, 600);

--- a/server/routes/user-settings.test.ts
+++ b/server/routes/user-settings.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterAll } from "bun:test";
 import { Hono } from "hono";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
-import { createUser } from "../db/repository";
+import { createUser, upsertTitles } from "../db/repository";
+import { makeParsedTitle, makeParsedOffer } from "../test-utils/fixtures";
 import userSettingsApp, { DEFAULT_HOMEPAGE_LAYOUT } from "./user-settings";
 import type { AppEnv } from "../types";
 
@@ -284,6 +285,103 @@ describe("PUT /user/settings/departure-alerts", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.streamingDeparturesEnabled).toBe(true);
+  });
+});
+
+// ─── Subscriptions ────────────────────────────────────────────────────────────
+
+describe("GET /user/settings/subscriptions", () => {
+  it("returns empty providerIds and onlyMine=false for new user", async () => {
+    const app = makeAuthedApp();
+    const res = await app.request("/user/settings/subscriptions");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.providerIds).toEqual([]);
+    expect(body.onlyMine).toBe(false);
+  });
+});
+
+describe("PUT /user/settings/subscriptions", () => {
+  beforeEach(async () => {
+    // Seed provider 8 (Netflix) so FK is satisfied
+    await upsertTitles([
+      makeParsedTitle({
+        id: "movie-settings-sub-1",
+        offers: [makeParsedOffer({ titleId: "movie-settings-sub-1", providerId: 8, providerName: "Netflix", providerTechnicalName: "netflix" })],
+      }),
+    ]);
+  });
+
+  it("saves and returns subscribed provider IDs", async () => {
+    const app = makeAuthedApp();
+    const res = await app.request("/user/settings/subscriptions", {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ providerIds: [8] }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.providerIds).toEqual([8]);
+  });
+
+  it("returns 400 for invalid (non-existent) providerId", async () => {
+    const app = makeAuthedApp();
+    const res = await app.request("/user/settings/subscriptions", {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ providerIds: [9999] }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for missing providerIds field (zod validation)", async () => {
+    const app = makeAuthedApp();
+    const res = await app.request("/user/settings/subscriptions", {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.issues).toBeDefined();
+  });
+
+  it("allows saving an empty list", async () => {
+    const app = makeAuthedApp();
+    const res = await app.request("/user/settings/subscriptions", {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ providerIds: [] }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.providerIds).toEqual([]);
+  });
+});
+
+describe("PUT /user/settings/subscriptions/only-mine", () => {
+  it("saves and returns onlyMine=true", async () => {
+    const app = makeAuthedApp();
+    const res = await app.request("/user/settings/subscriptions/only-mine", {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ onlyMine: true }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.onlyMine).toBe(true);
+  });
+
+  it("returns 400 for invalid body (zod validation)", async () => {
+    const app = makeAuthedApp();
+    const res = await app.request("/user/settings/subscriptions/only-mine", {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ onlyMine: "yes" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.issues).toBeDefined();
   });
 });
 

--- a/server/routes/user-settings.ts
+++ b/server/routes/user-settings.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { getHomepageLayout, setHomepageLayout, getUserDepartureSettings, updateUserDepartureSettings, getCrowdedWeekSettings, updateCrowdedWeekSettings, getAppearanceSettings, updateAppearanceSettings } from "../db/repository";
+import { getHomepageLayout, setHomepageLayout, getUserDepartureSettings, updateUserDepartureSettings, getCrowdedWeekSettings, updateCrowdedWeekSettings, getAppearanceSettings, updateAppearanceSettings, getSubscribedProviderIds, setSubscribedProviderIds, getOnlyMineFilter, setOnlyMineFilter, filterValidProviderIds } from "../db/repository";
 import type { AppEnv } from "../types";
 import { ok } from "./response";
 import { zValidator } from "../lib/validator";
@@ -216,6 +216,56 @@ app.put(
     const settings = await getAppearanceSettings(user.id);
     return ok(c, settings ?? DEFAULT_APPEARANCE);
   },
+);
+
+// ─── Subscribed streaming providers ──────────────────────────────────────────
+
+const updateSubscriptionsSchema = z.object({
+  providerIds: z.array(z.number().int().positive()).max(100),
+});
+
+const updateOnlyMineSchema = z.object({
+  onlyMine: z.boolean(),
+});
+
+app.get("/subscriptions", async (c) => {
+  const user = c.get("user")!;
+  const [providerIds, onlyMine] = await Promise.all([
+    getSubscribedProviderIds(user.id),
+    getOnlyMineFilter(user.id),
+  ]);
+  return ok(c, { providerIds, onlyMine });
+});
+
+app.put(
+  "/subscriptions",
+  zValidator("json", updateSubscriptionsSchema),
+  async (c) => {
+    const user = c.get("user")!;
+    const { providerIds } = c.req.valid("json");
+
+    if (providerIds.length > 0) {
+      const valid = await filterValidProviderIds(providerIds);
+      if (valid.length !== providerIds.length) {
+        return c.json({ error: "One or more provider IDs are invalid" }, 400);
+      }
+    }
+
+    await setSubscribedProviderIds(user.id, providerIds);
+    const updated = await getSubscribedProviderIds(user.id);
+    return ok(c, { providerIds: updated });
+  }
+);
+
+app.put(
+  "/subscriptions/only-mine",
+  zValidator("json", updateOnlyMineSchema),
+  async (c) => {
+    const user = c.get("user")!;
+    const { onlyMine } = c.req.valid("json");
+    await setOnlyMineFilter(user.id, onlyMine);
+    return ok(c, { onlyMine });
+  }
 );
 
 export default app;


### PR DESCRIPTION
## Summary

- Adds a **Subscriptions** settings tab where users pick which streaming services they pay for — checkbox grid grouped by region providers vs "Other", saves inline on each toggle
- **Browse page** preselects subscribed providers on first visit (skipped if `?provider` already in URL); "On my services" chip visible when subscriptions are configured, passes `?onlyMine=true` to the API
- **WatchButtonGroup** sorts subscribed providers to the front of the dropdown/inline list; non-subscribed offers render at 50 % opacity with an accessible `aria-label` suffix

## Backend

- New `user_subscribed_providers` join table + `only_mine_filter` column on `users` (migration 0042, additive-only — safe on D1)
- Repository: `getSubscribedProviderIds`, `setSubscribedProviderIds`, `getOnlyMineFilter`, `setOnlyMineFilter`, `filterValidProviderIds`
- `GET/PUT /api/user-settings/subscriptions`, `PUT /api/user-settings/subscriptions/only-mine`
- `?onlyMine=true` on `/api/titles` and `/api/browse` — intersects subscribed IDs with any explicit `?provider=` param; returns empty when user has zero subscriptions

## Test plan

- [ ] `bun run check` — 2561 pass, 0 fail ✓
- [ ] Log in, go to Settings → Subscriptions, check Netflix + Disney+
- [ ] Browse page reloads with `?provider=8,337` preselected automatically
- [ ] Toggle "On my services" chip → `&onlyMine=true` appended; untoggle preserves provider selection
- [ ] Open a title card with offers on a non-subscribed service — that row is visibly dimmed; subscribed service renders first and at full opacity
- [ ] Log in as a user with no subscriptions configured — browse and cards must look exactly as before (no dimming, no preselect)
- [ ] `bun run db:migrate:cf` against a CF preview — migration 0042 applies cleanly

Closes #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)