### PR TITLE
fix: collapse duplicate providers and fix D1 save crash in subscriptions

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -439,7 +439,8 @@
       },
       "empty": "No providers found.",
       "regionProviders": "My Region",
-      "otherProviders": "Other"
+      "otherProviders": "Other",
+      "saveError": "Failed to save. Please try again."
     },
     "theme": {
       "title": "Theme",

--- a/frontend/src/pages/settings/SubscriptionsTab.test.tsx
+++ b/frontend/src/pages/settings/SubscriptionsTab.test.tsx
@@ -88,6 +88,23 @@ describe("SubscriptionsTab", () => {
     });
   });
 
+  it("shows an error message and skips refreshSubscriptions when updateSubscriptions rejects", async () => {
+    (api.updateSubscriptions as ReturnType<typeof spyOn>).mockRejectedValue(new Error("500"));
+
+    render(<SubscriptionsTab />);
+    await waitFor(() => screen.getByText("Netflix"));
+
+    const netflixLabel = screen.getByText("Netflix").closest("label")!;
+    await act(async () => {
+      fireEvent.click(netflixLabel);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to save. Please try again.")).toBeDefined();
+      expect(mockRefreshSubscriptions).not.toHaveBeenCalled();
+    });
+  });
+
   it("calls updateOnlyMine when the Apply Automatically switch is toggled", async () => {
     render(<SubscriptionsTab />);
 

--- a/frontend/src/pages/settings/SubscriptionsTab.tsx
+++ b/frontend/src/pages/settings/SubscriptionsTab.tsx
@@ -14,6 +14,7 @@ export default function SubscriptionsTab() {
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [onlyMine, setOnlyMine] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState(false);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -32,7 +33,8 @@ export default function SubscriptionsTab() {
   }, [subscriptions]);
 
   async function toggleProvider(id: number) {
-    const next = new Set(selectedIds);
+    const prev = selectedIds;
+    const next = new Set(prev);
     if (next.has(id)) {
       next.delete(id);
     } else {
@@ -40,9 +42,13 @@ export default function SubscriptionsTab() {
     }
     setSelectedIds(next);
     setSaving(true);
+    setSaveError(false);
     try {
       await api.updateSubscriptions(Array.from(next));
       await refreshSubscriptions();
+    } catch {
+      setSelectedIds(prev);
+      setSaveError(true);
     } finally {
       setSaving(false);
     }
@@ -90,6 +96,9 @@ export default function SubscriptionsTab() {
 
   return (
     <div>
+      {saveError && (
+        <p className="text-sm text-red-400 mb-3">{t("settings.subscriptions.saveError")}</p>
+      )}
       <SCard
         title={t("settings.subscriptions.title")}
         subtitle={t("settings.subscriptions.subtitle")}

--- a/server/db/repository.test.ts
+++ b/server/db/repository.test.ts
@@ -854,6 +854,31 @@ describe("getProviders", () => {
     expect(providers[0].name).toBe("Disney Plus");
     expect(providers[1].name).toBe("Netflix");
   });
+
+  it("collapses duplicate provider IDs into their canonical ID", async () => {
+    await upsertTitles([
+      makeParsedTitle({
+        id: "movie-dedup-1",
+        offers: [
+          makeParsedOffer({ titleId: "movie-dedup-1", providerId: 9, providerName: "Amazon Prime Video", providerTechnicalName: "amazon_prime_video" }),
+          makeParsedOffer({ titleId: "movie-dedup-1", providerId: 384, providerName: "HBO Max", providerTechnicalName: "hbo_max" }),
+        ],
+      }),
+    ]);
+    // Insert the historical duplicate rows (119 = legacy Amazon Prime Video, 1899 = legacy HBO Max)
+    const db = getRawDb();
+    db.run("INSERT OR IGNORE INTO providers (id, name, technical_name, icon_url) VALUES (119, 'Amazon Prime Video', 'amazon_prime_video', NULL)");
+    db.run("INSERT OR IGNORE INTO providers (id, name, technical_name, icon_url) VALUES (1899, 'HBO Max', 'hbo_max', NULL)");
+
+    const results = await getProviders();
+    const ids = results.map((p) => p.id);
+    expect(ids).not.toContain(119);
+    expect(ids).not.toContain(1899);
+    expect(ids).toContain(9);
+    expect(ids).toContain(384);
+    expect(ids.filter((id) => id === 9)).toHaveLength(1);
+    expect(ids.filter((id) => id === 384)).toHaveLength(1);
+  });
 });
 
 // ─── Notifier JSON.parse error handling ─────────────────────────────────────

--- a/server/db/repository/titles.ts
+++ b/server/db/repository/titles.ts
@@ -662,7 +662,7 @@ export async function getTitlesByMonth(filters: MonthFilters, userId?: string) {
 export async function getProviders() {
   return traceDbQuery("getProviders", async () => {
     const db = getDb();
-    return await db
+    const rows = await db
       .select({
         id: providers.id,
         name: providers.name,
@@ -672,6 +672,14 @@ export async function getProviders() {
       .from(providers)
       .orderBy(asc(providers.name))
       .all();
+    const seen = new Map<number, typeof rows[number]>();
+    for (const row of rows) {
+      const cid = canonicalProviderId(row.id);
+      if (!seen.has(cid)) {
+        seen.set(cid, cid === row.id ? row : { ...row, id: cid });
+      }
+    }
+    return Array.from(seen.values()).sort((a, b) => a.name.localeCompare(b.name));
   });
 }
 

--- a/server/db/repository/user-subscribed-providers.test.ts
+++ b/server/db/repository/user-subscribed-providers.test.ts
@@ -37,6 +37,19 @@ describe("getSubscribedProviderIds / setSubscribedProviderIds", () => {
     expect(ids).toEqual([]);
   });
 
+  it("normalises non-canonical provider IDs (119→9) on save", async () => {
+    // Seed canonical provider 9 (Amazon Prime Video)
+    await upsertTitles([
+      makeParsedTitle({
+        id: "movie-sub-canonical",
+        offers: [makeParsedOffer({ titleId: "movie-sub-canonical", providerId: 9, providerName: "Amazon Prime Video", providerTechnicalName: "amazon_prime_video" })],
+      }),
+    ]);
+    await setSubscribedProviderIds(userId, [119]);
+    const ids = await getSubscribedProviderIds(userId);
+    expect(ids).toEqual([9]);
+  });
+
   it("round-trips set and get", async () => {
     await setSubscribedProviderIds(userId, [8, 337]);
     const ids = await getSubscribedProviderIds(userId);

--- a/server/db/repository/user-subscribed-providers.ts
+++ b/server/db/repository/user-subscribed-providers.ts
@@ -2,6 +2,7 @@ import { eq, inArray } from "drizzle-orm";
 import { getDb } from "../schema";
 import { userSubscribedProviders, users, providers } from "../schema";
 import { traceDbQuery } from "../../tracing";
+import { canonicalProviderId } from "../../streaming-availability/provider-map";
 
 export async function getSubscribedProviderIds(userId: string): Promise<number[]> {
   return traceDbQuery("getSubscribedProviderIds", async () => {
@@ -18,14 +19,13 @@ export async function getSubscribedProviderIds(userId: string): Promise<number[]
 export async function setSubscribedProviderIds(userId: string, providerIds: number[]): Promise<void> {
   return traceDbQuery("setSubscribedProviderIds", async () => {
     const db = getDb();
-    await db.transaction(async (tx) => {
-      await tx.delete(userSubscribedProviders).where(eq(userSubscribedProviders.userId, userId)).run();
-      if (providerIds.length > 0) {
-        await tx.insert(userSubscribedProviders)
-          .values(providerIds.map((providerId) => ({ userId, providerId })))
-          .run();
-      }
-    });
+    const canonical = Array.from(new Set(providerIds.map(canonicalProviderId)));
+    await db.delete(userSubscribedProviders).where(eq(userSubscribedProviders.userId, userId)).run();
+    if (canonical.length > 0) {
+      await db.insert(userSubscribedProviders)
+        .values(canonical.map((providerId) => ({ userId, providerId })))
+        .run();
+    }
   });
 }
 

--- a/server/routes/titles.ts
+++ b/server/routes/titles.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { getRecentTitles, getProviders, getGenres, getLanguages, getSubscribedProviderIds } from "../db/repository";
 import { getMovieWatchProviders, getTvWatchProviders } from "../tmdb/client";
+import { canonicalProviderId } from "../streaming-availability/provider-map";
 import { expandGenreGroup } from "../genres";
 import { CONFIG } from "../config";
 import type { AppEnv } from "../types";
@@ -53,10 +54,9 @@ app.get("/providers", async (c) => {
     getMovieWatchProviders(),
     getTvWatchProviders(),
   ]);
-  const regionIds = new Set([
-    ...movieProviders.map((p) => p.id),
-    ...tvProviders.map((p) => p.id),
-  ]);
+  const regionIds = new Set(
+    [...movieProviders, ...tvProviders].map((p) => canonicalProviderId(p.id))
+  );
   c.header("Cache-Control", "public, max-age=86400, stale-while-revalidate=604800");
   return ok(c, { providers: dbProviders, regionProviderIds: Array.from(regionIds) });
 });


### PR DESCRIPTION
## Summary

- **Duplicate providers** — Amazon Prime Video and HBO Max appeared 2–3× in the subscriptions picker because TMDB assigns multiple `provider_id`s to the same service (9/119 for Amazon Prime, 384/1899 for HBO Max). The existing `canonicalProviderId()` map was only applied at offer-parse time; now it's also applied in `getProviders()`, the `regionProviderIds` union, and `setSubscribedProviderIds()`. "Amazon Video" (id 10, the TVOD rent/buy service) is a distinct service and is intentionally kept.
- **Selections don't save (prod 500)** — Every `PUT /api/user/settings/subscriptions` was returning 500 in production. Root cause: `setSubscribedProviderIds()` was the only place in the repo calling `db.transaction()`, which Drizzle's D1 driver doesn't support (works fine on Bun SQLite locally). Fixed by using two sequential statements, matching the pattern everywhere else in the repo.
- **Silent failure UX** — `toggleProvider()` had no error handling, so a failed save left the checkbox appearing checked until page reload. Now reverts optimistic state on failure and shows an inline error message.

## Test plan

- [ ] `bun run check` passes (2564 tests, 0 failures)
- [ ] `/settings?tab=subscriptions` on production shows Amazon Prime Video once, Amazon Video once, HBO Max once
- [ ] Toggle a provider on production → reload → checkbox persists
- [ ] Cloudflare logs show 200s for `PUT /api/user/settings/subscriptions` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)