### PR TITLE
fix: shorten Cache-Control TTL on providers/genres/languages endpoints

### DIFF
--- a/server/routes/titles.test.ts
+++ b/server/routes/titles.test.ts
@@ -238,7 +238,7 @@ describe("GET /titles/genres", () => {
   it("sets Cache-Control header", async () => {
     const res = await app.request("/titles/genres");
     expect(res.status).toBe(200);
-    expect(res.headers.get("cache-control")).toContain("max-age=86400");
+    expect(res.headers.get("cache-control")).toContain("max-age=60");
   });
 });
 
@@ -258,7 +258,7 @@ describe("GET /titles/languages", () => {
   it("sets Cache-Control header", async () => {
     const res = await app.request("/titles/languages");
     expect(res.status).toBe(200);
-    expect(res.headers.get("cache-control")).toContain("max-age=86400");
+    expect(res.headers.get("cache-control")).toContain("max-age=60");
   });
 });
 
@@ -283,7 +283,7 @@ describe("GET /titles/providers", () => {
   it("sets Cache-Control header", async () => {
     const res = await app.request("/titles/providers");
     expect(res.status).toBe(200);
-    expect(res.headers.get("cache-control")).toContain("max-age=86400");
+    expect(res.headers.get("cache-control")).toContain("max-age=60");
   });
 });
 

--- a/server/routes/titles.ts
+++ b/server/routes/titles.ts
@@ -57,13 +57,13 @@ app.get("/providers", async (c) => {
   const regionIds = new Set(
     [...movieProviders, ...tvProviders].map((p) => canonicalProviderId(p.id))
   );
-  c.header("Cache-Control", "public, max-age=86400, stale-while-revalidate=604800");
+  c.header("Cache-Control", "public, max-age=60, stale-while-revalidate=300");
   return ok(c, { providers: dbProviders, regionProviderIds: Array.from(regionIds) });
 });
 
 app.get("/genres", async (c) => {
   const genres = await getGenres();
-  c.header("Cache-Control", "public, max-age=86400, stale-while-revalidate=604800");
+  c.header("Cache-Control", "public, max-age=60, stale-while-revalidate=300");
   return ok(c, { genres });
 });
 
@@ -72,7 +72,7 @@ app.get("/languages", async (c) => {
   const localLang = CONFIG.LANGUAGE.split("-")[0];
   const prioritySet = new Set([localLang, ...PRIORITY_LANGUAGES]);
   const priorityLanguageCodes = languages.filter((l) => prioritySet.has(l));
-  c.header("Cache-Control", "public, max-age=86400, stale-while-revalidate=604800");
+  c.header("Cache-Control", "public, max-age=60, stale-while-revalidate=300");
   return ok(c, { languages, priorityLanguageCodes });
 });
 


### PR DESCRIPTION
## Summary

- Reduces `max-age` from 86400s (24h) to 60s and `stale-while-revalidate` from 604800s (7d) to 300s on `/api/titles/providers`, `/api/titles/genres`, and `/api/titles/languages`

## Why

The 24h TTL caused the subscription picker to serve stale provider lists for up to a day after the 0043 migration cleaned duplicate IDs from D1. Users saw duplicate "Amazon Prime Video" and "HBO Max" entries in the picker because the edge/browser cache still had the pre-migration response with legacy IDs 119 and 1899.

These endpoints are only hit on the Settings page (low traffic), so aggressive caching bought nothing. A 60s TTL self-heals within a minute after any data change.

## After merging

Purge the existing stale edge cache entry manually: **Cloudflare Dashboard → remindarr.app → Caching → Configuration → Purge Custom URLs**:
- `https://remindarr.app/api/titles/providers`

Then do a hard refresh (Ctrl+Shift+R) on the settings page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)