### PR TITLE
feat: disable text selection on UI chrome

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -85,7 +85,7 @@ export default class ErrorBoundary extends Component<Props, State> {
             <h1 className="text-xl font-bold text-red-400 mb-2">
               Something went wrong
             </h1>
-            <p className="text-zinc-400 text-sm mb-4">
+            <p className="text-zinc-400 text-sm mb-4 select-text">
               {this.state.error?.message || "An unexpected error occurred."}
             </p>
             <button

--- a/frontend/src/components/HeroBanner.tsx
+++ b/frontend/src/components/HeroBanner.tsx
@@ -186,13 +186,13 @@ export default function HeroBanner({
 
           {/* Title */}
           <Link to={`/title/${current.featured.title_id}`} className="group">
-            <h2 className="text-5xl sm:text-[56px] font-extrabold tracking-[-0.03em] leading-none text-white group-hover:text-amber-300 transition-colors mb-4">
+            <h2 className="text-5xl sm:text-[56px] font-extrabold tracking-[-0.03em] leading-none text-white group-hover:text-amber-300 transition-colors mb-4 select-text">
               {current.featured.show_title}
             </h2>
           </Link>
 
           {/* Episode info */}
-          <p className="text-base text-zinc-300 leading-relaxed mb-6 line-clamp-2">
+          <p className="text-base text-zinc-300 leading-relaxed mb-6 line-clamp-2 select-text">
             {formatEpisodeCode(current.featured)}
             {current.featured.name && ` · ${current.featured.name}`}
             {current.featured.overview && ` — ${current.featured.overview}`}

--- a/frontend/src/components/ReelsCard.tsx
+++ b/frontend/src/components/ReelsCard.tsx
@@ -201,7 +201,7 @@ export default function ReelsCard({ episode, caughtUp, onMarkWatched, index, tot
 
             {/* Episode name — large */}
             <Link to={`/title/${episode.title_id}/season/${episode.season_number}/episode/${episode.episode_number}`}>
-              <h2 className="text-[30px] font-extrabold tracking-[-0.02em] leading-[1.02] text-white mb-2.5 drop-shadow-lg hover:text-amber-300 transition-colors">
+              <h2 className="text-[30px] font-extrabold tracking-[-0.02em] leading-[1.02] text-white mb-2.5 drop-shadow-lg hover:text-amber-300 transition-colors select-text">
                 {episode.name ?? formatEpisodeCode(episode)}
               </h2>
             </Link>
@@ -215,7 +215,7 @@ export default function ReelsCard({ episode, caughtUp, onMarkWatched, index, tot
 
             {/* Overview */}
             {episode.overview && (
-              <p className="text-sm text-white/70 line-clamp-3 mb-4 drop-shadow">
+              <p className="text-sm text-white/70 line-clamp-3 mb-4 drop-shadow select-text">
                 {episode.overview}
               </p>
             )}

--- a/frontend/src/components/TitleCard.tsx
+++ b/frontend/src/components/TitleCard.tsx
@@ -169,7 +169,7 @@ const TitleCard = memo(function TitleCard({ title, onTrackToggle, showVisibility
 
       {/* Info */}
       <div className="p-3 flex-1 flex flex-col gap-2">
-        <div>
+        <div className="select-text">
           <Link to={`/title/${title.id}`} className="hover:text-amber-400 transition-colors">
             <h3 className="font-semibold text-sm leading-tight line-clamp-2">{title.title}</h3>
           </Link>

--- a/frontend/src/components/profile/BioCard.tsx
+++ b/frontend/src/components/profile/BioCard.tsx
@@ -37,7 +37,7 @@ export default function BioCard({ bio, isOwnProfile, onBioUpdated }: BioCardProp
         )}
       </div>
       <div
-        className={empty ? "text-sm text-zinc-500 italic leading-relaxed" : "text-sm text-zinc-200 leading-relaxed"}
+        className={empty ? "text-sm text-zinc-500 italic leading-relaxed select-text" : "text-sm text-zinc-200 leading-relaxed select-text"}
         data-testid="bio-text"
       >
         {empty ? placeholder : bio}

--- a/frontend/src/components/profile/ProfileHero.tsx
+++ b/frontend/src/components/profile/ProfileHero.tsx
@@ -155,7 +155,7 @@ export default function ProfileHero({
             <div className="min-w-0">
               <MemberSinceKicker memberSince={user.member_since} />
               <h1
-                className="text-white font-extrabold leading-none truncate"
+                className="text-white font-extrabold leading-none truncate select-text"
                 style={{
                   fontSize: "clamp(32px, 5vw, 56px)",
                   letterSpacing: "-0.032em",
@@ -164,7 +164,7 @@ export default function ProfileHero({
               >
                 {displayName}
               </h1>
-              <div className="mt-2 font-mono text-[13px] text-zinc-300 flex items-center gap-2">
+              <div className="mt-2 font-mono text-[13px] text-zinc-300 flex items-center gap-2 select-text">
                 @{user.username}
                 {user.country_code && (
                   <span title={user.country_code} aria-label={user.country_code}>

--- a/frontend/src/components/title-detail/MovieHero.tsx
+++ b/frontend/src/components/title-detail/MovieHero.tsx
@@ -69,16 +69,16 @@ export default function MovieHero({ title, tmdb, watchedActions, watchHistoryPan
         {/* Title info */}
         <div className="flex-1 space-y-3 max-w-[820px]">
           <div>
-            {tmdb?.tagline && <p className="text-sm text-amber-400 italic mb-1">{tmdb.tagline}</p>}
+            {tmdb?.tagline && <p className="text-sm text-amber-400 italic mb-1 select-text">{tmdb.tagline}</p>}
             <Kicker className="mb-2">
               Movie{title.release_year ? ` · ${title.release_year}` : ""}
               {title.offers[0]?.provider_name ? ` · ${title.offers[0].provider_name}` : ""}
             </Kicker>
-            <h1 className="text-[30px] sm:text-[56px] lg:text-[64px] leading-none tracking-[-0.035em] font-extrabold text-white">
+            <h1 className="text-[30px] sm:text-[56px] lg:text-[64px] leading-none tracking-[-0.035em] font-extrabold text-white select-text">
               {displayTitle}
             </h1>
             {originalTitle && originalTitle !== displayTitle && (
-              <p className="text-sm text-zinc-400 mt-1">{originalTitle}</p>
+              <p className="text-sm text-zinc-400 mt-1 select-text">{originalTitle}</p>
             )}
           </div>
 

--- a/frontend/src/components/title-detail/ShowHero.tsx
+++ b/frontend/src/components/title-detail/ShowHero.tsx
@@ -162,16 +162,16 @@ export default function ShowHero({ title, tmdb, country }: ShowHeroProps) {
 
         <div className="flex-1 space-y-3 max-w-[820px]">
           <div>
-            {tmdb?.tagline && <p className="text-sm text-amber-400 italic mb-1">{tmdb.tagline}</p>}
+            {tmdb?.tagline && <p className="text-sm text-amber-400 italic mb-1 select-text">{tmdb.tagline}</p>}
             <Kicker className="mb-2">
               TV Show{title.release_year ? ` · ${title.release_year}` : ""}
               {title.offers[0]?.provider_name ? ` · ${title.offers[0].provider_name}` : ""}
             </Kicker>
-            <h1 className="text-[30px] sm:text-[56px] lg:text-[64px] leading-none tracking-[-0.035em] font-extrabold text-white">
+            <h1 className="text-[30px] sm:text-[56px] lg:text-[64px] leading-none tracking-[-0.035em] font-extrabold text-white select-text">
               {displayTitle}
             </h1>
             {originalTitle && originalTitle !== displayTitle && (
-              <p className="text-sm text-zinc-400 mt-1">{originalTitle}</p>
+              <p className="text-sm text-zinc-400 mt-1 select-text">{originalTitle}</p>
             )}
           </div>
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -324,9 +324,15 @@
     }
   body {
     @apply bg-background text-foreground;
+    -webkit-user-select: none;
+    user-select: none;
     }
   html {
     @apply font-sans overflow-x-hidden;
+    }
+  input, textarea, [contenteditable="true"] {
+    -webkit-user-select: text;
+    user-select: text;
     }
 }
 

--- a/frontend/src/pages/AdminUsersPage.tsx
+++ b/frontend/src/pages/AdminUsersPage.tsx
@@ -153,7 +153,7 @@ export default function AdminUsersPage() {
       </div>
 
       {actionError && (
-        <div className="bg-red-900/30 border border-red-800 text-red-300 px-4 py-2 rounded-lg text-sm">
+        <div className="bg-red-900/30 border border-red-800 text-red-300 px-4 py-2 rounded-lg text-sm select-text">
           {actionError}
         </div>
       )}

--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -603,7 +603,7 @@ export default function BrowsePage() {
       )}
 
       {searchError && (
-        <div className="bg-red-900/50 border border-red-800 text-red-200 px-4 py-2 rounded-lg text-sm">
+        <div className="bg-red-900/50 border border-red-800 text-red-200 px-4 py-2 rounded-lg text-sm select-text">
           {searchError}
         </div>
       )}

--- a/frontend/src/pages/DiscoveryPage.tsx
+++ b/frontend/src/pages/DiscoveryPage.tsx
@@ -110,7 +110,7 @@ function RecommendationCard({
             {senderInitial}
           </div>
         )}
-        <span className="text-sm text-zinc-300 font-medium">{senderName}</span>
+        <span className="text-sm text-zinc-300 font-medium select-text">{senderName}</span>
         {rec.is_targeted && (
           <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-500/15 text-amber-400 border border-amber-500/30">
             Direct
@@ -152,7 +152,7 @@ function RecommendationCard({
 
       {/* Optional message */}
       {rec.message && (
-        <p className="text-sm text-zinc-400 mb-3 italic">&ldquo;{rec.message}&rdquo;</p>
+        <p className="text-sm text-zinc-400 mb-3 italic select-text">&ldquo;{rec.message}&rdquo;</p>
       )}
 
       {/* Actions */}
@@ -226,14 +226,14 @@ function HeroCard({
               Why you'll like it
             </div>
             {rec.message ? (
-              <p className="text-sm text-zinc-300 italic leading-relaxed mb-2">&ldquo;{rec.message}&rdquo;</p>
+              <p className="text-sm text-zinc-300 italic leading-relaxed mb-2 select-text">&ldquo;{rec.message}&rdquo;</p>
             ) : null}
             {senderName && (
               <div className="flex flex-wrap gap-1.5 items-center">
                 <span className="text-[11px] px-2.5 py-1 rounded-full bg-amber-400/[0.08] text-amber-400 border border-amber-400/[0.18] font-medium">
                   Recommended by
                 </span>
-                <span className="text-xs text-zinc-200 font-medium">{senderName}</span>
+                <span className="text-xs text-zinc-200 font-medium select-text">{senderName}</span>
               </div>
             )}
           </div>

--- a/frontend/src/pages/EpisodeDetailPage.tsx
+++ b/frontend/src/pages/EpisodeDetailPage.tsx
@@ -78,7 +78,7 @@ export default function EpisodeDetailPage() {
   if (error || !data) {
     return (
       <div className="flex items-center justify-center py-20">
-        <div className="text-red-400">{error || "Episode not found"}</div>
+        <div className="text-red-400 select-text">{error || "Episode not found"}</div>
       </div>
     );
   }
@@ -131,7 +131,7 @@ export default function EpisodeDetailPage() {
       {/* Episode header */}
       <div className="space-y-3">
         <div className="flex items-center gap-3">
-          <h1 className="text-2xl font-bold text-white">
+          <h1 className="text-2xl font-bold text-white select-text">
             <span className="text-zinc-500">S{String(seasonNumber).padStart(2, "0")}E{String(episodeNumber).padStart(2, "0")}</span>
             {" "}
             {tmdb?.name || `Episode ${episodeNumber}`}
@@ -181,7 +181,7 @@ export default function EpisodeDetailPage() {
       {tmdb?.overview && (
         <section className="space-y-2">
           <h2 className="text-lg font-semibold text-white">Overview</h2>
-          <p className="text-zinc-300 leading-relaxed">{tmdb.overview}</p>
+          <p className="text-zinc-300 leading-relaxed select-text">{tmdb.overview}</p>
         </section>
       )}
 

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -656,10 +656,10 @@ export default function HomePage() {
                         <div className="absolute top-1.5 right-1.5 w-2 h-2 rounded-full bg-amber-500" />
                       )}
                     </div>
-                    <p className="text-sm text-white mt-1.5 line-clamp-2 group-hover:text-amber-400 transition-colors">
+                    <p className="text-sm text-white mt-1.5 line-clamp-2 group-hover:text-amber-400 transition-colors select-text">
                       {rec.title.title}
                     </p>
-                    <p className="text-xs text-zinc-400 truncate">
+                    <p className="text-xs text-zinc-400 truncate select-text">
                       from @{rec.from_user.username}
                     </p>
                   </Link>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -123,7 +123,7 @@ export default function LoginPage() {
         <h2 className="text-2xl font-bold text-white text-center mb-8">{t("login.title")}</h2>
 
         {error && (
-          <div className="mb-4 p-3 rounded-lg bg-red-900/50 border border-red-700 text-red-200 text-sm">
+          <div className="mb-4 p-3 rounded-lg bg-red-900/50 border border-red-700 text-red-200 text-sm select-text">
             {error}
           </div>
         )}

--- a/frontend/src/pages/PersonPage.tsx
+++ b/frontend/src/pages/PersonPage.tsx
@@ -138,7 +138,7 @@ export default function PersonPage() {
           </div>
         </div>
         <div className="flex-1 space-y-3">
-          <h1 className="text-2xl sm:text-3xl font-bold text-white">{person.name}</h1>
+          <h1 className="text-2xl sm:text-3xl font-bold text-white select-text">{person.name}</h1>
           <div className="flex flex-wrap gap-2 text-sm">
             {person.known_for_department && (
               <span className="bg-amber-500/15 text-amber-400 px-2 py-0.5 rounded">
@@ -178,7 +178,7 @@ export default function PersonPage() {
       {biography && (
         <section className="space-y-2">
           <h2 className="text-lg font-semibold text-white">Biography</h2>
-          <p className="text-zinc-300 leading-relaxed whitespace-pre-line">{displayBio}</p>
+          <p className="text-zinc-300 leading-relaxed whitespace-pre-line select-text">{displayBio}</p>
           {showBioToggle && (
             <button
               onClick={() => setBioExpanded(!bioExpanded)}

--- a/frontend/src/pages/SeasonDetailPage.tsx
+++ b/frontend/src/pages/SeasonDetailPage.tsx
@@ -224,7 +224,7 @@ export default function SeasonDetailPage() {
           </div>
 
           {tmdb?.overview && (
-            <p className="text-zinc-300 leading-relaxed">{tmdb.overview}</p>
+            <p className="text-zinc-300 leading-relaxed select-text">{tmdb.overview}</p>
           )}
 
           <div className="pt-2">
@@ -350,7 +350,7 @@ export default function SeasonDetailPage() {
                           )}
                         </div>
                         {ep.overview && (
-                          <p className="hidden sm:block text-xs text-zinc-500 mt-1 line-clamp-2 leading-snug">
+                          <p className="hidden sm:block text-xs text-zinc-500 mt-1 line-clamp-2 leading-snug select-text">
                             {ep.overview}
                           </p>
                         )}

--- a/frontend/src/pages/TitleDetailPage.tsx
+++ b/frontend/src/pages/TitleDetailPage.tsx
@@ -54,7 +54,7 @@ export default function TitleDetailPage() {
   if (error) {
     return (
       <div className="flex items-center justify-center py-20">
-        <div className="text-red-400">{error}</div>
+        <div className="text-red-400 select-text">{error}</div>
       </div>
     );
   }

--- a/frontend/src/pages/title/MovieDetail.tsx
+++ b/frontend/src/pages/title/MovieDetail.tsx
@@ -158,7 +158,7 @@ export default function MovieDetail({ data }: { data: MovieDetailsResponse }) {
       {/* Overview */}
       {overview && (
         <Section title="Overview">
-          <p className="text-zinc-300 leading-relaxed">{overview}</p>
+          <p className="text-zinc-300 leading-relaxed select-text">{overview}</p>
         </Section>
       )}
 

--- a/frontend/src/pages/title/ShowDetail.tsx
+++ b/frontend/src/pages/title/ShowDetail.tsx
@@ -57,7 +57,7 @@ export default function ShowDetail({ data }: { data: ShowDetailsResponse }) {
       {/* Overview */}
       {overview && (
         <Section title="Overview">
-          <p className="text-zinc-300 leading-relaxed">{overview}</p>
+          <p className="text-zinc-300 leading-relaxed select-text">{overview}</p>
         </Section>
       )}
 


### PR DESCRIPTION
## Summary

- Adds `user-select: none` globally on `body` in `index.css` — navigation labels, buttons, filter chips, badges, kickers, tab triggers, and all other chrome are non-selectable by default
- Form fields (`input`, `textarea`, `[contenteditable]`) are explicitly re-enabled so typing/selection inside forms is unaffected
- Opts content text back in with `select-text` on: title/episode/season overviews, taglines, show/movie/episode H1s, person bios, profile display name + `@username`, bio card, incoming recommendation messages + sender names, and all error message blocks

## Test plan

- [ ] Navigate to a title detail page — drag-select the tagline, H1, and Overview paragraph; confirm text copies correctly
- [ ] Episode detail page — select episode title and overview
- [ ] Season page — select season overview and a per-episode synopsis
- [ ] Person page — select name and biography paragraph
- [ ] Profile page (own + another user) — select display name, `@username`, bio
- [ ] DiscoveryPage — select incoming recommendation `"message"` (both list and hero variants) and sender name
- [ ] HomePage recommendation carousel — select title text and `from @username`
- [ ] Trigger an error (e.g. invalid search) — confirm error text is selectable
- [ ] Negative: try drag-selecting bottom tab bar labels, nav links, Track/Watch/Follow button labels, filter chips, badges — confirm nothing selects
- [ ] Forms still work: type and select text inside search bar, recommendation textarea, bio editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)