### PR TITLE
fix: chunk plex stale-item delete to stay under D1's 100-param limit

### DIFF
--- a/server/db/repository/plex-library.test.ts
+++ b/server/db/repository/plex-library.test.ts
@@ -115,10 +115,57 @@ describe("deleteStaleLibraryItems", () => {
     getRawDb().prepare(`INSERT INTO plex_library_items (integration_id, user_id, title_id, rating_key, media_type) VALUES (?, ?, ?, ?, ?)`)
       .run("int-1", userId, "movie-1", "rk-1", "movie");
 
-    await deleteStaleLibraryItems("int-1", []);
+    const removed = await deleteStaleLibraryItems("int-1", []);
+    expect(removed).toBe(1);
 
     const count = (getRawDb().prepare(`SELECT COUNT(*) as cnt FROM plex_library_items WHERE integration_id = ?`).get("int-1") as any).cnt;
     expect(count).toBe(0);
+  });
+
+  it("returns 0 when nothing is stale", async () => {
+    insertTitle("movie-1");
+    insertIntegration("int-1", userId, "srv-1");
+
+    getRawDb().prepare(`INSERT INTO plex_library_items (integration_id, user_id, title_id, rating_key, media_type) VALUES (?, ?, ?, ?, ?)`)
+      .run("int-1", userId, "movie-1", "rk-1", "movie");
+
+    const removed = await deleteStaleLibraryItems("int-1", ["movie-1"]);
+    expect(removed).toBe(0);
+  });
+
+  it("handles >99 titles without D1 param-limit errors (chunked delete)", async () => {
+    const user2 = await createUser("user2", "hash2");
+    insertIntegration("int-1", userId, "srv-1");
+    insertIntegration("int-2", user2, "srv-2");
+
+    // Seed 200 titles across two integrations; keep only the first 50 for int-1
+    const keepIds: string[] = [];
+    for (let i = 1; i <= 200; i++) {
+      const id = `bulk-movie-${i}`;
+      insertTitle(id);
+      getRawDb()
+        .prepare(`INSERT INTO plex_library_items (integration_id, user_id, title_id, rating_key, media_type) VALUES (?, ?, ?, ?, ?)`)
+        .run("int-1", userId, id, `rk-${i}`, "movie");
+      if (i <= 50) keepIds.push(id);
+    }
+    // Also seed a row for int-2 to confirm cross-integration isolation
+    insertTitle("other-movie");
+    getRawDb()
+      .prepare(`INSERT INTO plex_library_items (integration_id, user_id, title_id, rating_key, media_type) VALUES (?, ?, ?, ?, ?)`)
+      .run("int-2", user2, "other-movie", "rk-other", "movie");
+
+    const removed = await deleteStaleLibraryItems("int-1", keepIds);
+    expect(removed).toBe(150);
+
+    const remaining = getRawDb()
+      .prepare(`SELECT title_id FROM plex_library_items WHERE integration_id = ?`)
+      .all("int-1") as Array<{ title_id: string }>;
+    expect(remaining).toHaveLength(50);
+    expect(remaining.map((r) => r.title_id).sort()).toEqual(keepIds.sort());
+
+    // int-2 row must be untouched
+    const int2Count = (getRawDb().prepare(`SELECT COUNT(*) as cnt FROM plex_library_items WHERE integration_id = ?`).get("int-2") as any).cnt;
+    expect(int2Count).toBe(1);
   });
 });
 

--- a/server/db/repository/plex-library.ts
+++ b/server/db/repository/plex-library.ts
@@ -1,4 +1,4 @@
-import { eq, and, inArray, notInArray, sql } from "drizzle-orm";
+import { eq, and, inArray, sql } from "drizzle-orm";
 import { getDb } from "../schema";
 import { plexLibraryItems, integrations } from "../schema";
 import { traceDbQuery } from "../../tracing";
@@ -54,24 +54,36 @@ export async function upsertPlexLibraryItems(items: PlexLibraryItem[]) {
 export async function deleteStaleLibraryItems(
   integrationId: string,
   currentTitleIds: string[]
-) {
+): Promise<number> {
   return traceDbQuery("deleteStaleLibraryItems", async () => {
     const db = getDb();
-    if (currentTitleIds.length === 0) {
-      // All items for this integration are stale
+
+    // Fetch all rows for this integration (single param — D1-safe)
+    const existing = await db
+      .select({ id: plexLibraryItems.id, titleId: plexLibraryItems.titleId })
+      .from(plexLibraryItems)
+      .where(eq(plexLibraryItems.integrationId, integrationId))
+      .all();
+
+    if (existing.length === 0) return 0;
+
+    // Compute stale set in app code (handles empty currentTitleIds naturally)
+    const currentSet = new Set(currentTitleIds);
+    const staleIds = existing
+      .filter((r) => !currentSet.has(r.titleId))
+      .map((r) => r.id);
+
+    if (staleIds.length === 0) return 0;
+
+    // Delete by PK in chunks to stay under D1's 100-param limit
+    for (let i = 0; i < staleIds.length; i += PLEX_TITLEIDS_CHUNK_SIZE) {
+      const chunk = staleIds.slice(i, i + PLEX_TITLEIDS_CHUNK_SIZE);
       await db.delete(plexLibraryItems)
-        .where(eq(plexLibraryItems.integrationId, integrationId))
+        .where(inArray(plexLibraryItems.id, chunk))
         .run();
-      return;
     }
-    await db.delete(plexLibraryItems)
-      .where(
-        and(
-          eq(plexLibraryItems.integrationId, integrationId),
-          notInArray(plexLibraryItems.titleId, currentTitleIds)
-        )
-      )
-      .run();
+
+    return staleIds.length;
   });
 }
 

--- a/server/jobs/sync.ts
+++ b/server/jobs/sync.ts
@@ -196,6 +196,7 @@ export function registerSyncJobs() {
           integrationId: integration.id,
           moviesAdded: result.moviesAdded,
           showsAdded: result.showsAdded,
+          itemsRemoved: result.itemsRemoved,
         });
         synced++;
       } catch (err) {

--- a/server/plex/library-sync.test.ts
+++ b/server/plex/library-sync.test.ts
@@ -151,7 +151,8 @@ describe("syncPlexLibrary — stale cleanup", () => {
     mockGetAllMovies.mockResolvedValue([
       { ratingKey: "rk-1", title: "Movie A", viewCount: 0, Guid: [{ id: "tmdb://100" }] },
     ]);
-    await syncPlexLibrary(integration());
+    const result = await syncPlexLibrary(integration());
+    expect(result.itemsRemoved).toBe(1);
     expect(countLibraryItems(integrationId)).toBe(1);
     expect(getLibraryItem(userId, "movie-100")).not.toBeNull();
     expect(getLibraryItem(userId, "movie-200")).toBeNull();
@@ -167,7 +168,8 @@ describe("syncPlexLibrary — stale cleanup", () => {
     mockGetAllMovies.mockResolvedValue([]);
     mockGetShows.mockResolvedValue([]);
 
-    await syncPlexLibrary(integration());
+    const result = await syncPlexLibrary(integration());
+    expect(result.itemsRemoved).toBe(1);
     expect(countLibraryItems(integrationId)).toBe(0);
   });
 });

--- a/server/plex/library-sync.ts
+++ b/server/plex/library-sync.ts
@@ -10,6 +10,7 @@ const log = logger.child({ module: "plex-library-sync" });
 export type LibrarySyncResult = {
   moviesAdded: number;
   showsAdded: number;
+  itemsRemoved: number;
 };
 
 type IntegrationRow = {
@@ -96,10 +97,10 @@ export async function syncPlexLibrary(integration: IntegrationRow): Promise<Libr
 
     // Upsert all items, then remove stale ones in a single pass
     await upsertPlexLibraryItems(itemsToUpsert);
-    await deleteStaleLibraryItems(integrationId, currentTitleIds);
+    const itemsRemoved = await deleteStaleLibraryItems(integrationId, currentTitleIds);
 
-    log.info("Plex library sync complete", { integrationId, moviesAdded, showsAdded });
-    return { moviesAdded, showsAdded };
+    log.info("Plex library sync complete", { integrationId, moviesAdded, showsAdded, itemsRemoved });
+    return { moviesAdded, showsAdded, itemsRemoved };
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : String(err);
 


### PR DESCRIPTION
## Summary

- `deleteStaleLibraryItems` was calling `notInArray(titleId, currentTitleIds)` — a single SQL statement with one bound param per title id
- On Cloudflare D1 (hard cap: 100 params per statement), any Plex library with ≥100 titles caused the delete to throw **after** the upsert had already succeeded
- Net effect: items were added on every sync, but stale items were never removed
- The exact same bug was fixed on the read path in efc40e8 (`getPlexOffersForUser`); the write path was missed

**Fix:** replace `notInArray` with read-then-diff-then-delete-by-PK-in-chunks:
1. `SELECT id, title_id WHERE integration_id = ?` (single param — D1-safe)
2. Diff `currentTitleIds` against DB rows in app code
3. `DELETE WHERE id IN (chunk)` in batches of 99, same pattern as `getPlexOffersForUser`

Also returns removed count from `deleteStaleLibraryItems`, threaded into `LibrarySyncResult.itemsRemoved` and the per-integration log line.

## Test plan

- [ ] New unit test: seed 200 rows for one integration, keep 50 — asserts 150 removed, correct rows kept, second integration untouched
- [ ] Existing stale-cleanup tests updated to assert `itemsRemoved` on `LibrarySyncResult`
- [ ] `bun run check` passes (2568/2569 — the one failure is the pre-existing flaky timing test in `sync-utils.test.ts`)

Closes #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)