### PR TITLE
Replace inline styles with Tailwind classes in WatchButtonGroup

### DIFF
--- a/frontend/src/components/WatchButtonGroup.tsx
+++ b/frontend/src/components/WatchButtonGroup.tsx
@@ -122,7 +122,7 @@ function SplitWatchButton({ providers, subscribedSet, size, fullWidth }: { provi
   const primaryUrl = useMobileDeepLink ? plexDeepLink(primary.url, platform) : primary.url;
 
   return (
-    <div ref={containerRef} className={`flex${fullWidth || isLg ? " w-full" : ""}`} style={{ minHeight: isLg ? "52px" : "32px" }}>
+    <div ref={containerRef} className={`flex${fullWidth || isLg ? " w-full" : ""} ${isLg ? "min-h-[3.25rem]" : "min-h-8"}`}>
       {/* Primary provider link */}
       <a
         href={primaryUrl}


### PR DESCRIPTION
## Summary
Refactored the `SplitWatchButton` component to use Tailwind CSS classes instead of inline styles for minimum height styling, improving consistency with the codebase's styling approach.

## Key Changes
- Replaced inline `style={{ minHeight: isLg ? "52px" : "32px" }}` with Tailwind utility classes `${isLg ? "min-h-[3.25rem]" : "min-h-8"}`
- Maintains the same responsive behavior: 52px (3.25rem) on large screens and 32px (2rem) on smaller screens
- Consolidates all styling into the className attribute for better maintainability

## Implementation Details
- `min-h-[3.25rem]` is equivalent to the previous 52px minimum height for large screens
- `min-h-8` is equivalent to the previous 32px minimum height for smaller screens
- This change aligns with Tailwind-first styling practices used throughout the component

https://claude.ai/code/session_01JcFed2nbM3KXbJGL5jXn8w