### PR TITLE
Extract hasTrailer utility function for trailer availability checks

### DIFF
--- a/frontend/src/components/title-detail/MovieHero.tsx
+++ b/frontend/src/components/title-detail/MovieHero.tsx
@@ -8,7 +8,7 @@ import { Chip, Kicker } from "../design";
 import { RatingBadge } from "./RatingBadge";
 import { backdropUrl as mkBackdropUrl, posterUrl as mkPosterUrl } from "../../lib/tmdb-images";
 import { formatRuntime } from "./utils";
-import TrailerEmbed from "./TrailerEmbed";
+import TrailerEmbed, { hasTrailer } from "./TrailerEmbed";
 
 export interface MovieHeroProps {
   title: Title;
@@ -22,6 +22,7 @@ export interface MovieHeroProps {
 export default function MovieHero({ title, tmdb, watchedActions, watchHistoryPanel }: MovieHeroProps) {
   const [showTrailer, setShowTrailer] = useState(false);
   const videos = tmdb?.videos?.results ?? [];
+  const trailerAvailable = hasTrailer(videos);
   const genres = tmdb?.genres?.map((g) => g.name) || title.genres;
   const certification = title.age_certification;
   const backdropUrl = mkBackdropUrl(tmdb?.backdrop_path, "w1280") ?? null;
@@ -42,7 +43,7 @@ export default function MovieHero({ title, tmdb, watchedActions, watchHistoryPan
           : undefined
       }
     >
-      {showTrailer && videos.length > 0 && (
+      {showTrailer && trailerAvailable && (
         <div className="mb-6 sm:mb-8 lg:mb-10 max-w-[1100px] mx-auto">
           <TrailerEmbed videos={videos} />
         </div>
@@ -131,7 +132,7 @@ export default function MovieHero({ title, tmdb, watchedActions, watchHistoryPan
             />
             {watchedActions}
             <WatchButtonGroup offers={title.offers} variant="inline" maxVisible={3} />
-            {videos.length > 0 && (
+            {trailerAvailable && (
               <button
                 type="button"
                 onClick={() => setShowTrailer((prev) => !prev)}

--- a/frontend/src/components/title-detail/ShowHero.tsx
+++ b/frontend/src/components/title-detail/ShowHero.tsx
@@ -12,7 +12,7 @@ import { RatingBadge } from "./RatingBadge";
 import { backdropUrl as mkBackdropUrl, posterUrl as mkPosterUrl } from "../../lib/tmdb-images";
 import { getCertification } from "./utils";
 import { formatEta } from "../../pages/StatsPage";
-import TrailerEmbed from "./TrailerEmbed";
+import TrailerEmbed, { hasTrailer } from "./TrailerEmbed";
 
 export interface ShowHeroProps {
   title: Title;
@@ -24,6 +24,7 @@ export default function ShowHero({ title, tmdb, country }: ShowHeroProps) {
   const [showTrailer, setShowTrailer] = useState(false);
   const isMobile = useIsMobile();
   const videos = tmdb?.videos?.results ?? [];
+  const trailerAvailable = hasTrailer(videos);
   const genres = tmdb?.genres?.map((g) => g.name) || title.genres;
   const certification =
     getCertification(tmdb?.content_ratings?.results, country) || title.age_certification;
@@ -137,7 +138,7 @@ export default function ShowHero({ title, tmdb, country }: ShowHeroProps) {
           : undefined
       }
     >
-      {showTrailer && videos.length > 0 && (
+      {showTrailer && trailerAvailable && (
         <div className="mb-6 sm:mb-8 lg:mb-10 max-w-[1100px] mx-auto">
           <TrailerEmbed videos={videos} />
         </div>
@@ -240,7 +241,7 @@ export default function ShowHero({ title, tmdb, country }: ShowHeroProps) {
               isTracked={title.is_tracked}
             />
             <WatchButtonGroup offers={title.offers} variant="inline" maxVisible={3} />
-            {videos.length > 0 && (
+            {trailerAvailable && (
               <button
                 type="button"
                 onClick={() => setShowTrailer((prev) => !prev)}

--- a/frontend/src/components/title-detail/TrailerEmbed.test.tsx
+++ b/frontend/src/components/title-detail/TrailerEmbed.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, mock, afterEach } from "bun:test";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
-import TrailerEmbed from "./TrailerEmbed";
+import TrailerEmbed, { hasTrailer } from "./TrailerEmbed";
 import type { TmdbVideo } from "../../types";
 
 // happy-dom does not implement window.matchMedia; provide a stub that survives
@@ -99,5 +99,21 @@ describe("TrailerEmbed", () => {
     const videos = [makeVideo({ site: "Vimeo", key: "vimeo-key" })];
     const { container } = render(<TrailerEmbed videos={videos} />);
     expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("hasTrailer", () => {
+  it("returns false for empty array", () => {
+    expect(hasTrailer([])).toBe(false);
+  });
+
+  it("returns false when no YouTube Trailer is present", () => {
+    expect(hasTrailer([makeVideo({ type: "Featurette" })])).toBe(false);
+    expect(hasTrailer([makeVideo({ site: "Vimeo" })])).toBe(false);
+  });
+
+  it("returns true when at least one YouTube Trailer is present", () => {
+    expect(hasTrailer([makeVideo()])).toBe(true);
+    expect(hasTrailer([makeVideo({ type: "Teaser" }), makeVideo()])).toBe(true);
   });
 });

--- a/frontend/src/components/title-detail/TrailerEmbed.tsx
+++ b/frontend/src/components/title-detail/TrailerEmbed.tsx
@@ -5,6 +5,10 @@ export type TrailerEmbedProps = {
   videos: TmdbVideo[];
 };
 
+export function hasTrailer(videos: TmdbVideo[]): boolean {
+  return videos.some((v) => v.site === "YouTube" && v.type === "Trailer");
+}
+
 function pickBestTrailer(videos: TmdbVideo[]): TmdbVideo | null {
   const trailers = videos.filter((v) => v.site === "YouTube" && v.type === "Trailer");
   if (trailers.length === 0) return null;


### PR DESCRIPTION
## Summary
Refactored trailer availability logic by extracting a reusable `hasTrailer` utility function from `TrailerEmbed.tsx`. This function is now used consistently across `MovieHero` and `ShowHero` components to determine whether a YouTube Trailer video is available, replacing inline array length checks.

## Key Changes
- **New utility function**: Exported `hasTrailer(videos)` from `TrailerEmbed.tsx` that checks if any video is a YouTube Trailer
- **Updated MovieHero**: Replaced `videos.length > 0` checks with `trailerAvailable` computed value using `hasTrailer()`
- **Updated ShowHero**: Replaced `videos.length > 0` checks with `trailerAvailable` computed value using `hasTrailer()`
- **Added test coverage**: Comprehensive test suite for `hasTrailer()` covering empty arrays, non-trailer videos, and valid trailers

## Implementation Details
The `hasTrailer()` function uses the same filtering logic as the existing `pickBestTrailer()` function, ensuring consistency. This change improves code clarity by making the intent explicit (checking for YouTube Trailers specifically) rather than relying on array length as a proxy for trailer availability.

https://claude.ai/code/session_015JUjJ9kiCfkW6yNVBPfrub