### PR TITLE
Refactor reels header layout to edge-to-edge with horizontal scroll

### DIFF
--- a/frontend/src/components/ReelsCard.tsx
+++ b/frontend/src/components/ReelsCard.tsx
@@ -110,7 +110,13 @@ export default function ReelsCard({ episode, caughtUp, onMarkWatched, index, tot
 
       {/* Top-left chips: Live/Countdown + Provider */}
       {!caughtUp && (
-        <div className="absolute z-10 flex items-center gap-1.5" style={{ top: 104, left: 20 }}>
+        <div
+          className="absolute z-10 flex items-center gap-1.5"
+          style={{
+            top: "calc(var(--reels-chrome-h, 56px) + 8px + env(safe-area-inset-top, 0px))",
+            left: 20,
+          }}
+        >
           {isLive ? (
             <span className="inline-flex items-center gap-1.5 bg-amber-400 text-black text-[10px] font-extrabold font-mono px-2.5 py-1.5 rounded-full tracking-[0.12em]">
               <span className="w-1.5 h-1.5 rounded-full bg-black animate-pulse" />

--- a/frontend/src/pages/ReelsPage.tsx
+++ b/frontend/src/pages/ReelsPage.tsx
@@ -548,21 +548,32 @@ export default function ReelsPage() {
 
   return (
     <>
-      {/* Feed / Reels mode switcher + source picker — fixed overlay, top-left */}
-      <div className="fixed z-40" style={{ top: "calc(8px + env(safe-area-inset-top, 0px))", left: 20, right: 20 }}>
-        {/* Feed / Reels toggle row */}
-        <div className="flex items-center gap-2 mb-2">
-          <Link to="/" className="px-3 py-1.5 rounded-full text-[12px] font-bold text-white/55 border border-transparent">Feed</Link>
-          <span className="px-3 py-1.5 rounded-full bg-white/[0.15] backdrop-blur border border-white/[0.2] text-[12px] font-bold text-white">Reels</span>
-        </div>
-        {/* Source picker chips */}
-        <div className="flex items-center gap-1.5 flex-wrap">
+      {/* Feed / Reels mode switcher + source picker — fixed overlay, edge-to-edge with scrim */}
+      <div
+        className="fixed z-40 left-0 right-0 bg-gradient-to-b from-black/55 to-transparent"
+        style={{ top: 0, paddingTop: "calc(8px + env(safe-area-inset-top, 0px))", paddingBottom: 12 }}
+      >
+        {/* Single horizontally-scrolling row: Feed/Reels toggle + source chips */}
+        <div
+          className="flex items-center gap-1.5 overflow-x-auto whitespace-nowrap [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
+          style={{ paddingLeft: 20, paddingRight: 20 }}
+        >
+          <Link
+            to="/"
+            className="flex-shrink-0 px-3 py-1.5 rounded-full text-[11px] font-bold text-white/60 border border-transparent"
+          >
+            Feed
+          </Link>
+          <span className="flex-shrink-0 px-3 py-1.5 rounded-full bg-white/[0.15] backdrop-blur border border-white/[0.2] text-[11px] font-bold text-white">
+            Reels
+          </span>
+          <span className="flex-shrink-0 w-px h-4 bg-white/15 mx-1" aria-hidden="true" />
           {ALL_SOURCES.map((s) => (
             <button
               key={s}
               onClick={() => handleSourceChange(s)}
               className={[
-                "px-3 py-1.5 rounded-full text-[11px] font-bold transition-colors cursor-pointer",
+                "flex-shrink-0 px-3 py-1.5 rounded-full text-[11px] font-bold transition-colors cursor-pointer",
                 s === source
                   ? "bg-amber-400 text-zinc-950 border border-amber-400"
                   : "bg-white/[0.15] backdrop-blur-sm border border-white/[0.2] text-white/80 hover:bg-white/[0.25]",


### PR DESCRIPTION
## Summary
Restructured the ReelsPage header to use an edge-to-edge layout with a gradient scrim background and horizontal scrolling for navigation controls. Updated ReelsCard positioning to dynamically reference the header height via CSS variable.

## Key Changes
- **ReelsPage header redesign**: Converted from fixed-width centered layout to full-width edge-to-edge design with `bg-gradient-to-b from-black/55 to-transparent` scrim
- **Horizontal scrolling navigation**: Combined Feed/Reels toggle and source chips into a single horizontally-scrollable row with hidden scrollbars across all browsers
- **Visual refinements**: 
  - Added visual separator divider between toggle and source chips
  - Adjusted text sizes (12px → 11px) and opacity values for consistency
  - Applied `flex-shrink-0` to all navigation items to prevent compression
- **Dynamic positioning**: Updated ReelsCard top-left chips to use CSS variable `--reels-chrome-h` for responsive positioning relative to header height, replacing hardcoded pixel value (104px)

## Implementation Details
- Header uses `paddingTop` and `paddingBottom` with safe area insets for proper mobile viewport handling
- Horizontal scroll implemented with webkit, Firefox, and standard scrollbar-width hiding techniques
- ReelsCard positioning now scales with header height, improving layout robustness across different screen configurations

https://claude.ai/code/session_01AxSzm72r3pECJtJ9RUxoVc