### PR TITLE
Add collapsible mobile filter UI with active filter counter

### DIFF
--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -234,6 +234,16 @@ export default function BrowsePage() {
     [setOnlyMineStr]
   );
 
+  const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
+  const activeFilterCount =
+    type.length +
+    genre.length +
+    provider.length +
+    language.length +
+    (browseYearMin !== "" || browseYearMax !== "" ? 1 : 0) +
+    (browseMinRating !== "" ? 1 : 0) +
+    (onlyMine ? 1 : 0);
+
   // Preselect provider filter with subscribed providers on first load (when no provider param is set)
   const preselectedRef = useRef(false);
   useEffect(() => {
@@ -407,49 +417,95 @@ export default function BrowsePage() {
 
       <CategoryBar category={category} onCategoryChange={setCategory} />
 
-      {/* Persistent browse filter — desktop 4-field card / mobile chip strip */}
+      {/* Persistent browse filter — desktop 4-field card / mobile collapsible chip strip */}
       {searchResults === null && (
         isMobile ? (
-          <div className="flex gap-2 overflow-x-auto scrollbar-none pb-0.5">
-            {/* Type chips */}
-            {[
-              { label: "All", value: "" },
-              { label: "Shows", value: "SHOW" },
-              { label: "Movies", value: "MOVIE" },
-            ].map(({ label, value }) => {
-              const isActive = value === "" ? type.length === 0 : type.includes(value);
-              return (
-                <button
-                  key={label}
-                  onClick={() => value === "" ? setType([]) : setType(isActive ? [] : [value])}
-                  className={`shrink-0 inline-flex items-center text-[11px] font-semibold font-mono px-3 py-2 rounded-full border transition-colors ${
-                    isActive
-                      ? "bg-amber-400 text-black border-amber-400"
-                      : "bg-white/[0.06] text-zinc-300 border-white/[0.08]"
-                  }`}
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setMobileFiltersOpen((v) => !v)}
+                aria-expanded={mobileFiltersOpen}
+                aria-controls="mobile-filter-strip"
+                className="inline-flex items-center gap-2 px-3 py-2 rounded-full text-[11px] font-semibold font-mono border bg-white/[0.06] text-zinc-300 border-white/[0.08] hover:border-zinc-500 transition-colors"
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <path d="M3 6h18M6 12h12M10 18h4" />
+                </svg>
+                Filters
+                {activeFilterCount > 0 && (
+                  <span className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-amber-400 text-black text-[10px] font-bold leading-none">
+                    {activeFilterCount}
+                  </span>
+                )}
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="3"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                  className={`transition-transform ${mobileFiltersOpen ? "rotate-180" : ""}`}
                 >
-                  {label}
-                </button>
-              );
-            })}
-            {/* Provider chips */}
-            {filterProviders.filter((_, i) => i < 6).map((p) => {
-              const isActive = provider.includes(String(p.id));
-              return (
+                  <polyline points="6 9 12 15 18 9" />
+                </svg>
+              </button>
+              {activeFilterCount > 0 && (
                 <button
-                  key={p.id}
-                  onClick={() => setProvider(isActive ? provider.filter((v) => v !== String(p.id)) : [...provider, String(p.id)])}
-                  className={`shrink-0 inline-flex items-center gap-1.5 text-[11px] font-semibold font-mono px-3 py-2 rounded-full border transition-colors ${
-                    isActive
-                      ? "bg-amber-400/[0.12] text-amber-400 border-amber-400/[0.25]"
-                      : "bg-white/[0.06] text-zinc-300 border-white/[0.08]"
-                  }`}
+                  type="button"
+                  onClick={clearFilters}
+                  className="text-[11px] font-semibold font-mono text-zinc-400 hover:text-white transition-colors"
                 >
-                  {p.icon_url && <img src={p.icon_url} alt="" className="w-3.5 h-3.5 rounded-sm" />}
-                  {p.name}
+                  Clear all
                 </button>
-              );
-            })}
+              )}
+            </div>
+            {mobileFiltersOpen && (
+              <div id="mobile-filter-strip" className="flex gap-2 overflow-x-auto scrollbar-none pb-0.5">
+                {/* Type chips */}
+                {[
+                  { label: "All", value: "" },
+                  { label: "Shows", value: "SHOW" },
+                  { label: "Movies", value: "MOVIE" },
+                ].map(({ label, value }) => {
+                  const isActive = value === "" ? type.length === 0 : type.includes(value);
+                  return (
+                    <button
+                      key={label}
+                      onClick={() => value === "" ? setType([]) : setType(isActive ? [] : [value])}
+                      className={`shrink-0 inline-flex items-center text-[11px] font-semibold font-mono px-3 py-2 rounded-full border transition-colors ${
+                        isActive
+                          ? "bg-amber-400 text-black border-amber-400"
+                          : "bg-white/[0.06] text-zinc-300 border-white/[0.08]"
+                      }`}
+                    >
+                      {label}
+                    </button>
+                  );
+                })}
+                {/* Provider chips */}
+                {filterProviders.filter((_, i) => i < 6).map((p) => {
+                  const isActive = provider.includes(String(p.id));
+                  return (
+                    <button
+                      key={p.id}
+                      onClick={() => setProvider(isActive ? provider.filter((v) => v !== String(p.id)) : [...provider, String(p.id)])}
+                      className={`shrink-0 inline-flex items-center gap-1.5 text-[11px] font-semibold font-mono px-3 py-2 rounded-full border transition-colors ${
+                        isActive
+                          ? "bg-amber-400/[0.12] text-amber-400 border-amber-400/[0.25]"
+                          : "bg-white/[0.06] text-zinc-300 border-white/[0.08]"
+                      }`}
+                    >
+                      {p.icon_url && <img src={p.icon_url} alt="" className="w-3.5 h-3.5 rounded-sm" />}
+                      {p.name}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
           </div>
         ) : category === "new_releases" ? (
           // new_releases keeps the legacy FilterBar so the daysBack toggle stays available.
@@ -504,7 +560,7 @@ export default function BrowsePage() {
       )}
 
       {/* On my services toggle chip — shown when user has subscribed providers */}
-      {searchResults === null && subscriptions && subscriptions.providerIds.length > 0 && (
+      {searchResults === null && subscriptions && subscriptions.providerIds.length > 0 && (!isMobile || mobileFiltersOpen) && (
         <div className="flex items-center gap-2">
           <button
             type="button"

--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -427,39 +427,28 @@ export default function BrowsePage() {
                 onClick={() => setMobileFiltersOpen((v) => !v)}
                 aria-expanded={mobileFiltersOpen}
                 aria-controls="mobile-filter-strip"
-                className="inline-flex items-center gap-2 px-3 py-2 rounded-full text-[11px] font-semibold font-mono border bg-white/[0.06] text-zinc-300 border-white/[0.08] hover:border-zinc-500 transition-colors"
+                aria-label={mobileFiltersOpen ? "Hide filters" : "Show filters"}
+                className="relative inline-flex items-center justify-center w-9 h-9 rounded-full border bg-white/[0.06] text-zinc-300 border-white/[0.08] hover:border-zinc-500 transition-colors"
               >
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                   <path d="M3 6h18M6 12h12M10 18h4" />
                 </svg>
-                Filters
                 {activeFilterCount > 0 && (
-                  <span className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-amber-400 text-black text-[10px] font-bold leading-none">
+                  <span className="absolute -top-1 -right-1 inline-flex items-center justify-center min-w-[16px] h-[16px] px-1 rounded-full bg-amber-400 text-black text-[10px] font-bold leading-none">
                     {activeFilterCount}
                   </span>
                 )}
-                <svg
-                  width="10"
-                  height="10"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="3"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  aria-hidden="true"
-                  className={`transition-transform ${mobileFiltersOpen ? "rotate-180" : ""}`}
-                >
-                  <polyline points="6 9 12 15 18 9" />
-                </svg>
               </button>
               {activeFilterCount > 0 && (
                 <button
                   type="button"
                   onClick={clearFilters}
-                  className="text-[11px] font-semibold font-mono text-zinc-400 hover:text-white transition-colors"
+                  aria-label="Clear all filters"
+                  className="inline-flex items-center justify-center w-9 h-9 rounded-full border bg-white/[0.06] text-zinc-300 border-white/[0.08] hover:border-zinc-500 hover:text-white transition-colors"
                 >
-                  Clear all
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <path d="M18 6 6 18M6 6l12 12" />
+                  </svg>
                 </button>
               )}
             </div>


### PR DESCRIPTION
## Summary
Refactored the mobile browse filter interface to use a collapsible design with a dedicated toggle button, improving space efficiency and UX on smaller screens.

## Key Changes
- Added `mobileFiltersOpen` state to control filter visibility on mobile
- Implemented `activeFilterCount` calculation that tracks all active filters (type, genre, provider, language, year range, rating, and "only mine" toggle)
- Replaced always-visible mobile filter chip strip with a collapsible design:
  - Added a filter toggle button with an icon that shows the count of active filters as a badge
  - Added a clear filters button that appears when filters are active
  - Filter chips now only display when the toggle is expanded
- Updated the "On my services" toggle to only show on mobile when filters are open, reducing clutter
- Added proper accessibility attributes (`aria-expanded`, `aria-controls`, `aria-label`) to the toggle button

## Implementation Details
- The active filter counter includes all filter types: type selections, genres, providers, languages, year range, minimum rating, and the "only mine" toggle
- The filter UI uses a `space-y-2` container to organize the toggle button row and the collapsible filter strip
- SVG icons are used for the filter toggle (three horizontal lines) and clear button (X icon)
- The badge styling matches the existing amber accent color scheme

https://claude.ai/code/session_01H42hapybXyDnA9kuYTjoxT