### PR TITLE
feat(discovery): V1 Signal redesign — algo hero, dismiss persistence, friend signal

### DIFF
--- a/drizzle/0045_dismissed_suggestions.sql
+++ b/drizzle/0045_dismissed_suggestions.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `dismissed_suggestions` (
+	`user_id` text NOT NULL REFERENCES `users`(`id`) ON DELETE CASCADE,
+	`title_id` text NOT NULL REFERENCES `titles`(`id`) ON DELETE CASCADE,
+	`dismissed_at` text NOT NULL DEFAULT (datetime('now')),
+	PRIMARY KEY(`user_id`, `title_id`)
+);
+--> statement-breakpoint
+CREATE INDEX `idx_dismissed_suggestions_user_id` ON `dismissed_suggestions` (`user_id`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1746576000000,
       "tag": "0044_reconcile_movie_watched_completed",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "6",
+      "when": 1746662400000,
+      "tag": "0045_dismissed_suggestions",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1225,3 +1225,11 @@ export async function getSuggestionsAggregate(
   const query = qs.toString();
   return fetchJson(`/suggestions${query ? `?${query}` : ""}`, { signal });
 }
+
+export async function dismissSuggestion(titleId: string, signal?: AbortSignal): Promise<void> {
+  await fetchJson(`/suggestions/dismiss/${encodeURIComponent(titleId)}`, { method: "POST", signal });
+}
+
+export async function undismissSuggestion(titleId: string, signal?: AbortSignal): Promise<void> {
+  await fetchJson(`/suggestions/dismiss/${encodeURIComponent(titleId)}`, { method: "DELETE", signal });
+}

--- a/frontend/src/pages/DiscoveryPage.test.tsx
+++ b/frontend/src/pages/DiscoveryPage.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, mock, afterEach } from "bun:test";
 import { render, screen, waitFor, cleanup, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import type { ReactNode } from "react";
+import type { SearchTitle, SuggestionsAggregateResponse, SuggestionSeedReason } from "../types";
 
 // Initialize i18n before anything else
 import "../i18n";
@@ -47,6 +48,11 @@ const mockGetUnreadCount = mock(() =>
 const mockTrackTitle = mock(() => Promise.resolve());
 const mockMarkRecommendationRead = mock(() => Promise.resolve());
 const mockDeleteRecommendation = mock(() => Promise.resolve());
+const mockGetSuggestionsAggregate = mock<() => Promise<SuggestionsAggregateResponse>>(() =>
+  Promise.resolve({ flat: [], groups: [] })
+);
+const mockDismissSuggestion = mock(() => Promise.resolve());
+const mockUndismissSuggestion = mock(() => Promise.resolve());
 
 mock.module("../api", () => ({
   getRecommendations: mockGetRecommendations,
@@ -54,6 +60,9 @@ mock.module("../api", () => ({
   trackTitle: mockTrackTitle,
   markRecommendationRead: mockMarkRecommendationRead,
   deleteRecommendation: mockDeleteRecommendation,
+  getSuggestionsAggregate: mockGetSuggestionsAggregate,
+  dismissSuggestion: mockDismissSuggestion,
+  undismissSuggestion: mockUndismissSuggestion,
 }));
 
 const { default: DiscoveryPage } = await import("./DiscoveryPage");
@@ -85,6 +94,33 @@ function makeRecommendation(id: string, overrides: Record<string, unknown> = {})
   };
 }
 
+function makeSearchTitle(id: string, overrides: Partial<SearchTitle> = {}): SearchTitle {
+  return {
+    id,
+    objectType: "MOVIE",
+    title: `Title ${id}`,
+    originalTitle: null,
+    releaseYear: 2024,
+    releaseDate: null,
+    runtimeMinutes: null,
+    shortDescription: null,
+    genres: [],
+    imdbId: null,
+    tmdbId: "1",
+    posterUrl: null,
+    ageCertification: null,
+    originalLanguage: "en",
+    tmdbUrl: null,
+    offers: [],
+    scores: { imdbScore: null, imdbVotes: null, tmdbScore: 7.5 },
+    ...overrides,
+  };
+}
+
+function makeAggregate(overrides?: Partial<SuggestionsAggregateResponse>): SuggestionsAggregateResponse {
+  return { flat: [], groups: [], ...overrides };
+}
+
 afterEach(() => {
   cleanup();
   mockGetRecommendations.mockReset();
@@ -92,6 +128,9 @@ afterEach(() => {
   mockTrackTitle.mockReset();
   mockMarkRecommendationRead.mockReset();
   mockDeleteRecommendation.mockReset();
+  mockGetSuggestionsAggregate.mockReset();
+  mockDismissSuggestion.mockReset();
+  mockUndismissSuggestion.mockReset();
 
   // Reset defaults
   mockGetRecommendations.mockImplementation(() =>
@@ -100,6 +139,11 @@ afterEach(() => {
   mockGetUnreadCount.mockImplementation(() =>
     Promise.resolve({ count: 0 })
   );
+  mockGetSuggestionsAggregate.mockImplementation(() =>
+    Promise.resolve({ flat: [], groups: [] })
+  );
+  mockDismissSuggestion.mockImplementation(() => Promise.resolve());
+  mockUndismissSuggestion.mockImplementation(() => Promise.resolve());
 });
 
 describe("DiscoveryPage", () => {
@@ -164,7 +208,7 @@ describe("DiscoveryPage", () => {
     });
   });
 
-  it("track button calls trackTitle and removes the card", async () => {
+  it("track button on Activity tab calls trackTitle and removes the card", async () => {
     const rec = makeRecommendation("r1");
     mockGetRecommendations.mockImplementation(() =>
       Promise.resolve({ recommendations: [rec], count: 1 })
@@ -176,6 +220,12 @@ describe("DiscoveryPage", () => {
     mockMarkRecommendationRead.mockImplementation(() => Promise.resolve());
 
     render(<DiscoveryPage />, { wrapper: Wrapper });
+
+    // Switch to Activity tab where removing-on-track behaviour lives
+    await waitFor(() => {
+      expect(screen.getByText("Activity")).toBeDefined();
+    });
+    fireEvent.click(screen.getByText("Activity"));
 
     await waitFor(() => {
       expect(screen.getByText("Movie r1")).toBeDefined();
@@ -227,7 +277,7 @@ describe("DiscoveryPage", () => {
     });
   });
 
-  it("shows sender name and optional message", async () => {
+  it("shows sender name and optional message on Activity tab", async () => {
     const rec = makeRecommendation("r1", {
       from_user: { id: "s1", username: "charlie", name: "Charlie D", display_name: "Charlie D", image: null },
       message: "Great film!",
@@ -240,6 +290,12 @@ describe("DiscoveryPage", () => {
     );
 
     render(<DiscoveryPage />, { wrapper: Wrapper });
+
+    // Sender details are shown on the Activity tab RecommendationCard
+    await waitFor(() => {
+      expect(screen.getByText("Activity")).toBeDefined();
+    });
+    fireEvent.click(screen.getByText("Activity"));
 
     await waitFor(() => {
       expect(screen.getByText("Charlie D")).toBeDefined();
@@ -281,5 +337,190 @@ describe("DiscoveryPage", () => {
     const tvBadges = screen.getAllByText("TV Show");
     expect(movieBadges.length).toBeGreaterThanOrEqual(1);
     expect(tvBadges.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("For you tab — suggestions", () => {
+  it("hero renders the top untracked/undismissed suggestion from aggregate", async () => {
+    const title1 = makeSearchTitle("movie-1");
+    mockGetSuggestionsAggregate.mockImplementation(() =>
+      Promise.resolve(makeAggregate({ flat: [title1], groups: [] }))
+    );
+
+    render(<DiscoveryPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Title movie-1")).toBeDefined();
+    });
+    expect(screen.getByText("Top pick for you")).toBeDefined();
+  });
+
+  it("hero shows 'None of your friends have recommended this yet' when no recs match the hero", async () => {
+    const title1 = makeSearchTitle("movie-1");
+    mockGetSuggestionsAggregate.mockImplementation(() =>
+      Promise.resolve(makeAggregate({ flat: [title1], groups: [] }))
+    );
+    // default: no recommendations
+
+    render(<DiscoveryPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText(/None of your friends have recommended this yet/)).toBeDefined();
+    });
+  });
+
+  it("hero shows friend recommendation signal when a rec matches the hero title", async () => {
+    const heroTitle = makeSearchTitle("movie-1");
+    mockGetSuggestionsAggregate.mockImplementation(() =>
+      Promise.resolve(makeAggregate({ flat: [heroTitle], groups: [] }))
+    );
+    const rec = makeRecommendation("r1", {
+      title: { id: "movie-1", title: "Title movie-1", object_type: "MOVIE", poster_url: null },
+      from_user: { id: "u2", username: "bob", name: "Bob", display_name: "Bob", image: null },
+      message: "You should watch this",
+    });
+    mockGetRecommendations.mockImplementation(() =>
+      Promise.resolve({ recommendations: [rec], count: 1 })
+    );
+
+    render(<DiscoveryPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      // Friend rec count label in hero signal grid
+      expect(screen.getByText("1 rec")).toBeDefined();
+    });
+    // Message quote shown in hero friends panel
+    expect(screen.getByText(/You should watch this/)).toBeDefined();
+  });
+
+  it("session counter reflects tracked and dismissed counts after actions", async () => {
+    const title1 = makeSearchTitle("movie-1");
+    mockGetSuggestionsAggregate.mockImplementation(() =>
+      Promise.resolve(makeAggregate({ flat: [title1], groups: [] }))
+    );
+    mockTrackTitle.mockImplementation(() => Promise.resolve());
+
+    render(<DiscoveryPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Top pick for you")).toBeDefined();
+    });
+
+    // Track the hero — counter should appear
+    const trackButtons = screen.getAllByText("Track");
+    fireEvent.click(trackButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 tracked · 0 dismissed/)).toBeDefined();
+    });
+  });
+
+  it("clicking 'Not interested' on hero calls dismissSuggestion and shifts to next suggestion", async () => {
+    const title1 = makeSearchTitle("movie-1");
+    const title2 = makeSearchTitle("movie-2");
+    mockGetSuggestionsAggregate.mockImplementation(() =>
+      Promise.resolve(makeAggregate({ flat: [title1, title2], groups: [] }))
+    );
+
+    render(<DiscoveryPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Title movie-1")).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByText("Not interested"));
+
+    await waitFor(() => {
+      expect(mockDismissSuggestion).toHaveBeenCalledWith("movie-1");
+    });
+
+    // Hero shifts to the second title
+    await waitFor(() => {
+      expect(screen.getByText("Title movie-2")).toBeDefined();
+    });
+  });
+
+  it("clicking Undo on a dismissed friend rec calls undismissSuggestion", async () => {
+    const rec = makeRecommendation("r1");
+    mockGetRecommendations.mockImplementation(() =>
+      Promise.resolve({ recommendations: [rec], count: 1 })
+    );
+
+    render(<DiscoveryPage />, { wrapper: Wrapper });
+
+    // Wait for "Friends are recommending" section to render
+    await waitFor(() => {
+      expect(screen.getByText("Friends are recommending")).toBeDefined();
+    });
+
+    // Dismiss the friend rec card
+    fireEvent.click(screen.getByText("Dismiss"));
+
+    await waitFor(() => {
+      expect(mockDismissSuggestion).toHaveBeenCalledWith("title-r1");
+      // Dismiss swaps to Undo
+      expect(screen.getByText("Undo")).toBeDefined();
+    });
+
+    // Click Undo
+    fireEvent.click(screen.getByText("Undo"));
+
+    await waitFor(() => {
+      expect(mockUndismissSuggestion).toHaveBeenCalledWith("title-r1");
+    });
+  });
+
+  it("renders the hiddenCount subnote in a Because you group", async () => {
+    const suggestion = makeSearchTitle("movie-s1");
+    const group = {
+      source: {
+        id: "movie-seed",
+        title: "Seed Movie",
+        posterUrl: null,
+        reason: "watched" as SuggestionSeedReason,
+      },
+      suggestions: [suggestion],
+      hiddenCount: 2,
+    };
+    mockGetSuggestionsAggregate.mockImplementation(() =>
+      Promise.resolve({
+        flat: [suggestion],
+        groups: [group],
+      })
+    );
+
+    render(<DiscoveryPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText(/2 hidden — already tracked or dismissed/)).toBeDefined();
+    });
+  });
+
+  it("Track button in More for you rail calls trackTitle with the suggestion id", async () => {
+    const title1 = makeSearchTitle("movie-1");
+    const title2 = makeSearchTitle("movie-2");
+    mockGetSuggestionsAggregate.mockImplementation(() =>
+      Promise.resolve(makeAggregate({ flat: [title1, title2], groups: [] }))
+    );
+    mockTrackTitle.mockImplementation(() => Promise.resolve());
+
+    render(<DiscoveryPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Top pick for you")).toBeDefined();
+    });
+
+    // title2 is in the More for you rail; hero shows title1
+    // There are two Track buttons: one for hero, one for moreForYou item
+    const trackButtons = screen.getAllByText("Track");
+    expect(trackButtons.length).toBeGreaterThanOrEqual(2);
+
+    // Click the second Track button (moreForYou item = title2)
+    fireEvent.click(trackButtons[1]);
+
+    await waitFor(() => {
+      // First argument should be the title id
+      expect(mockTrackTitle.mock.calls[0]?.[0]).toBe("movie-2");
+    });
   });
 });

--- a/frontend/src/pages/DiscoveryPage.tsx
+++ b/frontend/src/pages/DiscoveryPage.tsx
@@ -1,32 +1,396 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { Link } from "react-router";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import * as api from "../api";
-import type { Recommendation, SuggestionsAggregateResponse, SuggestionSeedReason, SearchTitle } from "../types";
+import type {
+  Recommendation,
+  SuggestionsAggregateResponse,
+  SuggestionsGroup,
+  SuggestionSeedReason,
+  SearchTitle,
+} from "../types";
+import { normalizeSearchTitle } from "../types";
 import { useApiCall } from "../hooks/useApiCall";
 import { Skeleton } from "../components/ui/skeleton";
 import { Card } from "../components/ui/card";
 import { PageHeader, Kicker, Pill, Chip } from "../components/design";
-import { posterUrl } from "../lib/tmdb-images";
-import FullBleedCarousel from "../components/FullBleedCarousel";
 import ScrollableRow from "../components/ScrollableRow";
+import { posterUrl } from "../lib/tmdb-images";
+
+// ─── Utilities ────────────────────────────────────────────────────────────────
 
 function formatRelativeTime(dateStr: string): string {
-  const now = Date.now();
-  const then = new Date(dateStr).getTime();
-  const diffMs = now - then;
-  const diffSec = Math.floor(diffMs / 1000);
-  const diffMin = Math.floor(diffSec / 60);
+  const diffMs = Date.now() - new Date(dateStr).getTime();
+  const diffMin = Math.floor(diffMs / 60_000);
   const diffHr = Math.floor(diffMin / 60);
   const diffDay = Math.floor(diffHr / 24);
-
-  if (diffSec < 60) return "just now";
+  if (diffMin < 1) return "just now";
   if (diffMin < 60) return `${diffMin}m ago`;
   if (diffHr < 24) return `${diffHr}h ago`;
   if (diffDay < 30) return `${diffDay}d ago`;
   return new Date(dateStr).toLocaleDateString();
 }
+
+function becauseLabel(reason: SuggestionSeedReason, title: string): string {
+  if (reason === "loved") return `Because you loved ${title}`;
+  if (reason === "liked") return `Because you liked ${title}`;
+  if (reason === "watched") return `Because you watched ${title}`;
+  return `Because you tracked ${title}`;
+}
+
+// ─── Small primitives ─────────────────────────────────────────────────────────
+
+type FriendInfo = { username: string; displayName: string | null; image: string | null };
+
+function FriendDot({ friend, size = 20 }: { friend: FriendInfo; size?: number }) {
+  const name = friend.displayName ?? friend.username;
+  const initial = (name || "?")[0].toUpperCase();
+  if (friend.image) {
+    return (
+      <img
+        src={friend.image}
+        alt={name}
+        title={name}
+        className="rounded-full object-cover ring-[1.5px] ring-zinc-900 flex-shrink-0"
+        style={{ width: size, height: size }}
+      />
+    );
+  }
+  const bgColor = `hsl(${(name.charCodeAt(0) * 47) % 360}, 50%, 40%)`;
+  return (
+    <div
+      title={name}
+      className="rounded-full ring-[1.5px] ring-zinc-900 flex items-center justify-center flex-shrink-0 font-bold text-zinc-950"
+      style={{ width: size, height: size, background: bgColor, fontSize: Math.round(size * 0.5) }}
+    >
+      {initial}
+    </div>
+  );
+}
+
+function FriendStack({ friends, max = 4 }: { friends: FriendInfo[]; max?: number }) {
+  const shown = friends.slice(0, max);
+  const extra = friends.length - shown.length;
+  return (
+    <div className="flex items-center">
+      {shown.map((f, i) => (
+        <div key={f.username} style={{ marginLeft: i === 0 ? 0 : -7 }}>
+          <FriendDot friend={f} size={18} />
+        </div>
+      ))}
+      {extra > 0 && (
+        <div
+          className="ring-[1.5px] ring-zinc-900 rounded-full bg-zinc-700 text-zinc-300 flex items-center justify-center"
+          style={{ marginLeft: -7, height: 18, minWidth: 18, padding: "0 5px", fontSize: 9, fontWeight: 700 }}
+        >
+          +{extra}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StateBadge({ state }: { state: "tracked" | "dismissed" | null }) {
+  if (!state) return null;
+  if (state === "tracked") {
+    return (
+      <div className="absolute top-2 right-2 px-2 py-0.5 rounded bg-amber-400/90 text-zinc-950 text-[9px] font-black font-mono uppercase tracking-wider">
+        ✓ Tracked
+      </div>
+    );
+  }
+  return (
+    <div className="absolute top-2 right-2 px-2 py-0.5 rounded bg-zinc-950/85 text-zinc-400 border border-white/[0.12] text-[9px] font-bold font-mono uppercase tracking-wider">
+      Dismissed
+    </div>
+  );
+}
+
+// ─── Suggestion card ──────────────────────────────────────────────────────────
+
+interface CardItem { id: string; title: string; posterUrl: string | null }
+
+function SuggestionCard({
+  item,
+  friends = [],
+  isTracked,
+  isDismissed,
+  onTrack,
+  onDismiss,
+  onUndismiss,
+}: {
+  item: CardItem;
+  friends?: FriendInfo[];
+  isTracked: boolean;
+  isDismissed: boolean;
+  onTrack: () => void;
+  onDismiss: () => void;
+  onUndismiss: () => void;
+}) {
+  const src = item.posterUrl ? posterUrl(item.posterUrl, "w185") : null;
+  const state = isTracked ? "tracked" : isDismissed ? "dismissed" : null;
+
+  return (
+    <div className="w-[118px] sm:w-[140px] shrink-0 flex flex-col gap-2" style={{ opacity: isDismissed ? 0.55 : 1 }}>
+      <div className="aspect-[2/3] rounded-lg overflow-hidden bg-zinc-800 relative">
+        <Link to={`/title/${item.id}`} className="block w-full h-full">
+          {src ? (
+            <img src={src} alt={item.title} className="w-full h-full object-cover" loading="lazy" width={185} height={278} />
+          ) : (
+            <div className="w-full h-full bg-zinc-800" />
+          )}
+        </Link>
+        {/* Friend stack overlay bottom-left */}
+        {friends.length > 0 && !state && (
+          <div className="absolute bottom-2 left-2 bg-zinc-950/80 backdrop-blur-sm rounded-full px-1.5 py-0.5 flex items-center">
+            <FriendStack friends={friends} max={3} />
+          </div>
+        )}
+        <StateBadge state={state} />
+      </div>
+      <p className={`text-[11px] sm:text-xs text-zinc-200 font-medium leading-snug line-clamp-2 ${isDismissed ? "line-through" : ""}`}>
+        {item.title}
+      </p>
+      <div className="flex gap-1">
+        {isTracked ? (
+          <button
+            onClick={onTrack}
+            className="flex-1 py-1 rounded text-[10px] font-bold bg-amber-400/[0.16] text-amber-400 border border-amber-400/[0.35] cursor-pointer"
+          >
+            ✓ Tracked
+          </button>
+        ) : (
+          <button
+            onClick={onTrack}
+            className="flex-1 py-1 rounded text-[10px] font-bold bg-amber-400 text-zinc-950 hover:bg-amber-300 transition-colors cursor-pointer"
+          >
+            Track
+          </button>
+        )}
+        {isDismissed ? (
+          <button
+            onClick={onUndismiss}
+            className="flex-1 py-1 rounded text-[10px] font-medium bg-white/[0.04] text-zinc-500 border border-white/[0.08] cursor-pointer"
+          >
+            Undo
+          </button>
+        ) : (
+          <button
+            onClick={onDismiss}
+            className="flex-1 py-1 rounded text-[10px] font-medium bg-zinc-800 text-zinc-400 hover:bg-zinc-700 transition-colors cursor-pointer"
+          >
+            Dismiss
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Hero card ────────────────────────────────────────────────────────────────
+
+function DiscoveryHero({
+  hero,
+  algoGroup,
+  friendRecs,
+  isTracked,
+  isDismissed,
+  onTrack,
+  onDismiss,
+  onUndismiss,
+}: {
+  hero: SearchTitle;
+  algoGroup: SuggestionsGroup | null;
+  friendRecs: Recommendation[];
+  isTracked: boolean;
+  isDismissed: boolean;
+  onTrack: () => void;
+  onDismiss: () => void;
+  onUndismiss: () => void;
+}) {
+  const src = hero.posterUrl ? posterUrl(hero.posterUrl, "w342") : null;
+  const sourceSrc = algoGroup?.source.posterUrl ? posterUrl(algoGroup.source.posterUrl, "w92") : null;
+  const state = isTracked ? "tracked" : isDismissed ? "dismissed" : null;
+
+  const topFriend = friendRecs[0] ?? null;
+
+  return (
+    <Card radius="2xl" padding="lg" className="mb-8 grid grid-cols-1 sm:grid-cols-[280px_1fr] lg:grid-cols-[320px_1fr] gap-6 sm:gap-8 items-stretch">
+      {/* Poster */}
+      <div className="relative aspect-[2/3] rounded-[10px] overflow-hidden max-w-[200px] sm:max-w-none mx-auto sm:mx-0 shadow-2xl">
+        <Link to={`/title/${hero.id}`} className="block w-full h-full">
+          {src ? (
+            <img src={src} alt={hero.title} className="w-full h-full object-cover" loading="lazy" width={342} height={513} />
+          ) : (
+            <div className="w-full h-full bg-zinc-800" />
+          )}
+        </Link>
+        <StateBadge state={state} />
+      </div>
+
+      {/* Info */}
+      <div className="flex flex-col min-w-0 py-1">
+        <div className="flex flex-wrap items-center gap-2 mb-3">
+          <Kicker>Top pick for you</Kicker>
+        </div>
+
+        <h2 className="text-[26px] sm:text-[36px] lg:text-[40px] font-extrabold tracking-[-0.03em] leading-[1.02] text-zinc-100 mb-3">
+          {hero.title}
+        </h2>
+
+        <div className="flex flex-wrap gap-2 mb-5">
+          <Chip variant="default">{hero.objectType === "SHOW" ? "TV Series" : "Movie"}</Chip>
+          {hero.genres?.slice(0, 3).map((g) => <Chip key={g} variant="default">{g}</Chip>)}
+          {hero.releaseYear && <Chip variant="default">{hero.releaseYear}</Chip>}
+          {/* TODO(scoring): no match score from /api/suggestions yet */}
+        </div>
+
+        {/* Two-source signal grid */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-5">
+          {/* Algo source */}
+          <div className="bg-white/[0.03] border border-white/[0.06] rounded-xl p-3.5 flex flex-col gap-2.5">
+            <div className="flex items-center gap-2">
+              <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-black font-mono uppercase tracking-wider bg-amber-400/[0.14] text-amber-400 border border-amber-400/[0.3]">
+                Remindarr
+              </span>
+              <span className="text-[11px] text-zinc-500 font-mono">algo</span>
+            </div>
+            {algoGroup ? (
+              <div className="flex gap-2.5 items-center">
+                {sourceSrc && (
+                  <div className="w-8 h-12 rounded overflow-hidden flex-shrink-0 bg-zinc-800">
+                    <img src={sourceSrc} alt={algoGroup.source.title} className="w-full h-full object-cover" loading="lazy" width={32} height={48} />
+                  </div>
+                )}
+                <div className="min-w-0">
+                  <p className="font-mono text-[9px] uppercase tracking-wider text-zinc-500 mb-0.5">
+                    {algoGroup.source.reason === "loved" ? "Because you loved" :
+                     algoGroup.source.reason === "liked" ? "Because you liked" :
+                     algoGroup.source.reason === "watched" ? "Because you watched" :
+                     "Because you tracked"}
+                  </p>
+                  <p className="text-[13px] text-zinc-200 font-semibold truncate">{algoGroup.source.title}</p>
+                </div>
+              </div>
+            ) : (
+              <p className="text-xs text-zinc-400 leading-snug">Top pick from your taste profile.</p>
+            )}
+          </div>
+
+          {/* Friends source */}
+          <div className="bg-white/[0.03] border border-white/[0.06] rounded-xl p-3.5 flex flex-col gap-2.5">
+            <div className="flex items-center gap-2">
+              <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-black font-mono uppercase tracking-wider bg-blue-400/[0.10] text-blue-300 border border-blue-400/[0.2]">
+                Friends
+              </span>
+              <span className="text-[11px] text-zinc-500 font-mono">
+                {friendRecs.length} {friendRecs.length === 1 ? "rec" : "recs"}
+              </span>
+            </div>
+            {friendRecs.length > 0 ? (
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center gap-2">
+                  <FriendStack friends={friendRecs.map((r) => ({ username: r.from_user.username, displayName: r.from_user.display_name ?? null, image: r.from_user.image ?? null }))} max={4} />
+                  <span className="text-xs text-zinc-300 truncate">
+                    {friendRecs.slice(0, 2).map((r) => (r.from_user.display_name ?? r.from_user.username).split(" ")[0]).join(", ")}
+                    {friendRecs.length > 2 ? ` +${friendRecs.length - 2}` : ""}
+                  </span>
+                </div>
+                {topFriend?.message && (
+                  <p className="text-xs text-zinc-400 italic leading-snug line-clamp-2 select-text">
+                    &ldquo;{topFriend.message}&rdquo;
+                    <span className="not-italic text-zinc-500"> — @{topFriend.from_user.username}</span>
+                  </p>
+                )}
+                {friendRecs.some((r) => r.is_targeted) && (
+                  <span className="inline-flex items-center self-start px-1.5 py-0.5 rounded text-[9px] font-bold font-mono uppercase tracking-wider bg-amber-400/[0.15] text-amber-400 border border-amber-400/[0.3]">
+                    Direct
+                  </span>
+                )}
+              </div>
+            ) : (
+              <p className="text-xs text-zinc-500 leading-snug">None of your friends have recommended this yet.</p>
+            )}
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex flex-wrap gap-2.5 mt-auto">
+          {isTracked ? (
+            <button
+              onClick={onTrack}
+              className="inline-flex items-center justify-center px-5 py-2.5 rounded-lg text-sm font-bold bg-amber-400/[0.16] text-amber-400 border border-amber-400/[0.35] cursor-pointer"
+            >
+              ✓ Tracked
+            </button>
+          ) : (
+            <button
+              onClick={onTrack}
+              className="inline-flex items-center justify-center px-5 py-2.5 rounded-lg text-sm font-bold bg-amber-400 text-black hover:bg-amber-300 transition-colors cursor-pointer"
+            >
+              Track
+            </button>
+          )}
+          <Link
+            to={`/title/${hero.id}`}
+            className="inline-flex items-center justify-center px-[18px] py-2.5 rounded-lg text-sm font-semibold bg-white/[0.08] border border-white/[0.14] text-zinc-100 hover:bg-white/[0.14] transition-colors"
+          >
+            View details
+          </Link>
+          {isDismissed ? (
+            <button
+              onClick={onUndismiss}
+              className="inline-flex items-center justify-center px-[14px] py-2.5 rounded-lg text-sm font-medium bg-white/[0.04] text-zinc-500 border border-white/[0.08] cursor-pointer"
+            >
+              Undo dismiss
+            </button>
+          ) : (
+            <button
+              onClick={onDismiss}
+              className="inline-flex items-center justify-center px-[14px] py-2.5 rounded-lg text-sm font-semibold text-zinc-500 border border-white/[0.08] hover:text-zinc-300 hover:border-white/[0.16] transition-colors cursor-pointer"
+            >
+              Not interested
+            </button>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+// ─── Section header ───────────────────────────────────────────────────────────
+
+function SectionHead({
+  kicker,
+  title,
+  sub,
+  sourcePosterUrl,
+  sourceId,
+}: {
+  kicker?: string;
+  title: string;
+  sub?: string;
+  sourcePosterUrl?: string | null;
+  sourceId?: string;
+}) {
+  return (
+    <div className="flex items-center gap-3 mb-4">
+      {sourcePosterUrl && sourceId && (
+        <Link to={`/title/${sourceId}`} className="flex-shrink-0">
+          <img src={sourcePosterUrl} alt="" className="w-8 h-12 rounded object-cover" loading="lazy" width={32} height={48} />
+        </Link>
+      )}
+      <div>
+        {kicker && <Kicker>{kicker}</Kicker>}
+        <h2 className="text-base font-bold tracking-[-0.01em] text-zinc-100 leading-snug">{title}</h2>
+        {sub && <p className="text-xs text-zinc-500 mt-0.5">{sub}</p>}
+      </div>
+    </div>
+  );
+}
+
+// ─── Skeleton ─────────────────────────────────────────────────────────────────
 
 function DiscoverySkeleton() {
   return (
@@ -38,7 +402,7 @@ function DiscoverySkeleton() {
             <div className="flex-1 space-y-2">
               <Skeleton className="h-4 w-32" />
               <div className="flex gap-3">
-                <Skeleton className="w-12 h-18 rounded flex-shrink-0" />
+                <Skeleton className="w-12 h-[72px] rounded flex-shrink-0" />
                 <div className="flex-1 space-y-1.5">
                   <Skeleton className="h-4 w-48" />
                   <Skeleton className="h-3 w-20" />
@@ -51,6 +415,8 @@ function DiscoverySkeleton() {
     </div>
   );
 }
+
+// ─── Activity-tab recommendation card ────────────────────────────────────────
 
 function RecommendationCard({
   rec,
@@ -69,10 +435,8 @@ function RecommendationCard({
 
   useEffect(() => {
     if (rec.read_at || markedRef.current) return;
-
     const el = cardRef.current;
     if (!el) return;
-
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries[0].isIntersecting && !markedRef.current) {
@@ -83,30 +447,20 @@ function RecommendationCard({
       },
       { threshold: 0.5 },
     );
-
     observer.observe(el);
     return () => observer.disconnect();
   }, [rec, onMarkRead]);
 
   const isUnread = !rec.read_at;
-  const posterSrc = posterUrl(rec.title.poster_url, "w92");
-
+  const src = posterUrl(rec.title.poster_url, "w92");
   const senderName = rec.from_user.display_name ?? rec.from_user.username;
   const senderInitial = (senderName || "?")[0].toUpperCase();
 
   return (
-    <div
-      ref={cardRef}
-      className={`bg-zinc-900 rounded-lg p-4 transition-colors ${isUnread ? "border-l-2 border-l-amber-500" : ""}`}
-    >
-      {/* Sender row */}
+    <div ref={cardRef} className={`bg-zinc-900 rounded-lg p-4 ${isUnread ? "border-l-2 border-l-amber-500" : ""}`}>
       <div className="flex items-center gap-2 mb-3">
         {rec.from_user.image ? (
-          <img
-            src={rec.from_user.image}
-            alt=""
-            className="w-7 h-7 rounded-full object-cover flex-shrink-0"
-          />
+          <img src={rec.from_user.image} alt="" className="w-7 h-7 rounded-full object-cover flex-shrink-0" />
         ) : (
           <div className="w-7 h-7 rounded-full bg-zinc-700 flex items-center justify-center text-xs font-medium text-zinc-300 flex-shrink-0">
             {senderInitial}
@@ -121,29 +475,16 @@ function RecommendationCard({
         <span className="text-xs text-zinc-500 ml-auto">{formatRelativeTime(rec.created_at)}</span>
       </div>
 
-      {/* Title info */}
       <div className="flex gap-3 mb-3">
         <Link to={`/title/${rec.title.id}`} className="flex-shrink-0">
-          {posterSrc ? (
-            <img
-              src={posterSrc}
-              alt={rec.title.title}
-              className="w-12 h-18 rounded object-cover"
-              loading="lazy"
-              width={92}
-              height={138}
-            />
+          {src ? (
+            <img src={src} alt={rec.title.title} className="w-12 h-[72px] rounded object-cover" loading="lazy" width={92} height={138} />
           ) : (
-            <div className="w-12 h-18 rounded bg-zinc-800 flex items-center justify-center text-zinc-600 text-xs">
-              N/A
-            </div>
+            <div className="w-12 h-[72px] rounded bg-zinc-800 flex items-center justify-center text-zinc-600 text-xs">N/A</div>
           )}
         </Link>
         <div className="flex-1 min-w-0">
-          <Link
-            to={`/title/${rec.title.id}`}
-            className="text-sm font-medium text-white hover:text-amber-400 transition-colors line-clamp-2"
-          >
+          <Link to={`/title/${rec.title.id}`} className="text-sm font-medium text-white hover:text-amber-400 transition-colors line-clamp-2">
             {rec.title.title}
           </Link>
           <p className="text-xs text-zinc-500 mt-0.5">
@@ -152,12 +493,10 @@ function RecommendationCard({
         </div>
       </div>
 
-      {/* Optional message */}
       {rec.message && (
         <p className="text-sm text-zinc-400 mb-3 italic select-text">&ldquo;{rec.message}&rdquo;</p>
       )}
 
-      {/* Actions */}
       <div className="flex gap-2">
         <button
           onClick={() => onTrack(rec)}
@@ -176,191 +515,26 @@ function RecommendationCard({
   );
 }
 
-function HeroCard({
-  rec,
-  onTrack,
-  onDismiss,
-}: {
-  rec: Recommendation;
-  onTrack: (rec: Recommendation) => void;
-  onDismiss: (rec: Recommendation) => void;
-}) {
-  const { t } = useTranslation();
-  const posterSrc = posterUrl(rec.title.poster_url, "w342");
-
-  const senderName = rec.from_user.display_name ?? rec.from_user.username;
-  const typeLabel = rec.title.object_type === "SHOW" ? "TV Series" : "Movie";
-
-  return (
-    <Card radius="2xl" padding="lg" className="mb-8 grid grid-cols-1 sm:grid-cols-[280px_1fr] lg:grid-cols-[360px_1fr] gap-6 sm:gap-8 items-stretch">
-      {/* Poster */}
-      <div className="aspect-[2/3] rounded-[10px] overflow-hidden max-w-[220px] sm:max-w-none mx-auto sm:mx-0 shadow-2xl">
-        {posterSrc ? (
-          <img
-            src={posterSrc}
-            alt={rec.title.title}
-            className="w-full h-full object-cover"
-            loading="lazy"
-            width={342}
-            height={513}
-          />
-        ) : (
-          <div className="w-full h-full bg-zinc-800" />
-        )}
-      </div>
-
-      {/* Info */}
-      <div className="flex flex-col min-w-0 py-2">
-        <Kicker>{rec.is_targeted ? "Just for you" : "Pick of the week"}{senderName ? ` · from @${rec.from_user.username}` : ""}</Kicker>
-
-        <h2 className="text-[30px] sm:text-[36px] lg:text-[44px] font-extrabold tracking-[-0.03em] leading-[1.02] text-zinc-100 mb-3.5">
-          {rec.title.title}
-        </h2>
-
-        <div className="flex flex-wrap gap-2 mb-4">
-          <Chip variant="default">{typeLabel}</Chip>
-        </div>
-
-        {/* "Why you'll like it" — featuring sender message */}
-        {(rec.message || senderName) && (
-          <div className="bg-white/[0.04] border border-white/[0.06] rounded-lg p-3.5 mb-5">
-            <div className="font-mono text-[10px] uppercase tracking-[0.15em] text-zinc-500 font-semibold mb-2">
-              Why you'll like it
-            </div>
-            {rec.message ? (
-              <p className="text-sm text-zinc-300 italic leading-relaxed mb-2 select-text">&ldquo;{rec.message}&rdquo;</p>
-            ) : null}
-            {senderName && (
-              <div className="flex flex-wrap gap-1.5 items-center">
-                <span className="text-[11px] px-2.5 py-1 rounded-full bg-amber-400/[0.08] text-amber-400 border border-amber-400/[0.18] font-medium">
-                  Recommended by
-                </span>
-                <span className="text-xs text-zinc-200 font-medium select-text">{senderName}</span>
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* Actions */}
-        <div className="flex flex-wrap gap-2.5 mt-auto">
-          <button
-            onClick={() => onTrack(rec)}
-            className="inline-flex items-center justify-center px-5 py-2.5 rounded-lg text-sm font-bold bg-amber-400 text-black hover:bg-amber-300 transition-colors cursor-pointer"
-          >
-            {t("discovery.track")}
-          </button>
-          <Link
-            to={`/title/${rec.title.id}`}
-            className="inline-flex items-center justify-center px-[18px] py-2.5 rounded-lg text-sm font-semibold bg-white/[0.08] border border-white/[0.14] text-zinc-100 hover:bg-white/[0.14] transition-colors"
-          >
-            View details
-          </Link>
-          <button
-            onClick={() => onDismiss(rec)}
-            className="inline-flex items-center justify-center px-[14px] py-2.5 rounded-lg text-sm font-semibold text-zinc-500 border border-white/[0.08] hover:text-zinc-300 hover:border-white/[0.16] transition-colors cursor-pointer"
-          >
-            Not interested
-          </button>
-        </div>
-      </div>
-    </Card>
-  );
-}
-
-function RailCard({
-  rec,
-  onTrack,
-  onDismiss,
-}: {
-  rec: Recommendation;
-  onTrack: (rec: Recommendation) => void;
-  onDismiss: (rec: Recommendation) => void;
-}) {
-  const { t } = useTranslation();
-  const posterSrc = posterUrl(rec.title.poster_url, "w185");
-
-  return (
-    <div className="w-[118px] sm:w-[140px] shrink-0 flex flex-col gap-2">
-      <Link to={`/title/${rec.title.id}`} className="block aspect-[2/3] rounded-lg overflow-hidden bg-zinc-800">
-        {posterSrc ? (
-          <img
-            src={posterSrc}
-            alt={rec.title.title}
-            className="w-full h-full object-cover hover:scale-105 transition-transform duration-200"
-            loading="lazy"
-            width={185}
-            height={278}
-          />
-        ) : (
-          <div className="w-full h-full bg-zinc-800" />
-        )}
-      </Link>
-      <p className="text-xs text-zinc-300 font-medium line-clamp-2 leading-snug">
-        {rec.title.title}
-      </p>
-      <div className="flex gap-1">
-        <button
-          onClick={() => onTrack(rec)}
-          className="flex-1 py-1 rounded text-[10px] font-semibold bg-amber-500 text-zinc-950 hover:bg-amber-400 transition-colors cursor-pointer"
-        >
-          {t("discovery.track")}
-        </button>
-        <button
-          onClick={() => onDismiss(rec)}
-          className="flex-1 py-1 rounded text-[10px] font-semibold bg-zinc-700 text-zinc-400 hover:bg-zinc-600 transition-colors cursor-pointer"
-        >
-          {t("discovery.dismiss")}
-        </button>
-      </div>
-    </div>
-  );
-}
-
-function becauseLabel(reason: SuggestionSeedReason, title: string, t: ReturnType<typeof useTranslation>["t"]): string {
-  switch (reason) {
-    case "loved": return t("suggestions.becauseLoved", { title });
-    case "liked": return t("suggestions.becauseLiked", { title });
-    case "watched": return t("suggestions.becauseWatched", { title });
-    default: return t("suggestions.becauseTracked", { title });
-  }
-}
-
-function PosterCard({ title }: { title: SearchTitle }) {
-  return (
-    <Link to={`/title/${title.id}`} className="w-32 flex-shrink-0 group" style={{ scrollSnapAlign: "start" }}>
-      <div className="relative aspect-[2/3] rounded-lg overflow-hidden bg-zinc-800">
-        {title.posterUrl ? (
-          <img src={title.posterUrl} alt={title.title} className="w-full h-full object-cover group-hover:scale-105 transition-transform" loading="lazy" width={128} height={192} />
-        ) : (
-          <div className="w-full h-full flex items-center justify-center text-zinc-600 text-xs">N/A</div>
-        )}
-      </div>
-      <p className="text-sm text-white mt-1.5 line-clamp-2 group-hover:text-amber-400 transition-colors">{title.title}</p>
-    </Link>
-  );
-}
+// ─── Main page ────────────────────────────────────────────────────────────────
 
 export default function DiscoveryPage() {
   const { t } = useTranslation();
   const [recommendations, setRecommendations] = useState<Recommendation[]>([]);
-  const [tab, setTab] = useState<"foryou" | "activity">("foryou");
   const [aggregate, setAggregate] = useState<SuggestionsAggregateResponse | null>(null);
+  const [tab, setTab] = useState<"foryou" | "activity">("foryou");
+  const [trackedSet, setTrackedSet] = useState<Set<string>>(() => new Set());
+  const [dismissedSet, setDismissedSet] = useState<Set<string>>(() => new Set());
 
   const { loading, error } = useApiCall(
     (signal) => api.getRecommendations(undefined, undefined, signal),
     [],
-    {
-      onSuccess: (data) => {
-        setRecommendations(data.recommendations);
-      },
-    },
+    { onSuccess: (data) => setRecommendations(data.recommendations) },
   );
 
   const { data: countData } = useApiCall(
     (signal) => api.getUnreadRecommendationCount(signal),
     [],
   );
-
   const unreadCount = countData?.count ?? 0;
 
   useEffect(() => {
@@ -371,25 +545,86 @@ export default function DiscoveryPage() {
     return () => controller.abort();
   }, []);
 
+  // Group received recommendations by title ID for hero + friend overlays
+  const recsByTitle = useMemo(() => {
+    const m: Record<string, Recommendation[]> = {};
+    for (const r of recommendations) {
+      if (!m[r.title.id]) m[r.title.id] = [];
+      m[r.title.id].push(r);
+    }
+    return m;
+  }, [recommendations]);
+
+  // Hero: first algo suggestion that's not tracked or dismissed this session
+  const hero = useMemo(
+    () => aggregate?.flat.find((s) => !trackedSet.has(s.id) && !dismissedSet.has(s.id)) ?? null,
+    [aggregate, trackedSet, dismissedSet],
+  );
+
+  const heroFriendRecs = hero ? (recsByTitle[hero.id] ?? []) : [];
+  const heroAlgoGroup = hero
+    ? (aggregate?.groups.find((g) => g.suggestions.some((s) => s.id === hero.id)) ?? null)
+    : null;
+
+  // More for you: flat list minus hero, minus session-tracked/dismissed
+  const moreForYou = useMemo(
+    () =>
+      aggregate?.flat
+        .filter((s) => s.id !== hero?.id && !trackedSet.has(s.id) && !dismissedSet.has(s.id))
+        .slice(0, 12) ?? [],
+    [aggregate, hero, trackedSet, dismissedSet],
+  );
+
+  // ─── Suggestion (algo) handlers ───────────────────────────────────────────
+
+  const handleTrackSuggestion = useCallback(async (titleId: string, titleData?: SearchTitle) => {
+    setTrackedSet((prev) => new Set([...prev, titleId]));
+    setDismissedSet((prev) => { const s = new Set(prev); s.delete(titleId); return s; });
+    try {
+      await api.trackTitle(titleId, undefined, titleData ? normalizeSearchTitle(titleData) : undefined);
+    } catch {
+      setTrackedSet((prev) => { const s = new Set(prev); s.delete(titleId); return s; });
+      toast.error(t("discovery.trackFailed"));
+    }
+  }, [t]);
+
+  const handleDismissSuggestion = useCallback(async (titleId: string) => {
+    setDismissedSet((prev) => new Set([...prev, titleId]));
+    setTrackedSet((prev) => { const s = new Set(prev); s.delete(titleId); return s; });
+    try {
+      await api.dismissSuggestion(titleId);
+    } catch {
+      setDismissedSet((prev) => { const s = new Set(prev); s.delete(titleId); return s; });
+      toast.error(t("discovery.dismissFailed"));
+    }
+  }, [t]);
+
+  const handleUndismiss = useCallback(async (titleId: string) => {
+    setDismissedSet((prev) => { const s = new Set(prev); s.delete(titleId); return s; });
+    try {
+      await api.undismissSuggestion(titleId);
+    } catch {
+      setDismissedSet((prev) => new Set([...prev, titleId]));
+    }
+  }, []);
+
+  // ─── Activity-tab handlers ────────────────────────────────────────────────
+
   const handleMarkRead = useCallback(async (rec: Recommendation) => {
     try {
       await api.markRecommendationRead(rec.id);
       setRecommendations((prev) =>
-        prev.map((r) =>
-          r.id === rec.id ? { ...r, read_at: new Date().toISOString() } : r,
-        ),
+        prev.map((r) => r.id === rec.id ? { ...r, read_at: new Date().toISOString() } : r),
       );
     } catch {
       // Silent failure for mark-read
     }
   }, []);
 
-  const handleTrack = useCallback(async (rec: Recommendation) => {
+  const handleTrackRec = useCallback(async (rec: Recommendation) => {
     try {
       await api.trackTitle(rec.title.id);
-      if (!rec.read_at) {
-        await api.markRecommendationRead(rec.id);
-      }
+      if (!rec.read_at) await api.markRecommendationRead(rec.id);
       setRecommendations((prev) => prev.filter((r) => r.id !== rec.id));
       toast.success(t("discovery.tracked", { title: rec.title.title }));
     } catch {
@@ -397,7 +632,7 @@ export default function DiscoveryPage() {
     }
   }, [t]);
 
-  const handleDismiss = useCallback(async (rec: Recommendation) => {
+  const handleDismissRec = useCallback(async (rec: Recommendation) => {
     try {
       await api.deleteRecommendation(rec.id);
       setRecommendations((prev) => prev.filter((r) => r.id !== rec.id));
@@ -406,12 +641,27 @@ export default function DiscoveryPage() {
     }
   }, [t]);
 
-  const heroRec = recommendations[0];
-  const railRecs = recommendations.slice(1);
+  // ─── Derived counts ───────────────────────────────────────────────────────
+
+  const isEmpty =
+    !hero &&
+    moreForYou.length === 0 &&
+    Object.keys(recsByTitle).length === 0 &&
+    (!aggregate || aggregate.groups.length === 0);
 
   return (
     <div className="space-y-0">
-      <PageHeader kicker="Based on what you watch" title="For you" />
+      <PageHeader
+        kicker="Based on what you watch & who you follow"
+        title="For you"
+        right={
+          (trackedSet.size > 0 || dismissedSet.size > 0) ? (
+            <span className="font-mono text-[11px] uppercase tracking-[0.15em] text-zinc-500">
+              {trackedSet.size} tracked · {dismissedSet.size} dismissed
+            </span>
+          ) : undefined
+        }
+      />
 
       {/* Tab toggle */}
       <div className="flex gap-2 mb-6">
@@ -428,87 +678,135 @@ export default function DiscoveryPage() {
         </Pill>
       </div>
 
-      {loading ? (
-        <DiscoverySkeleton />
-      ) : error ? (
-        <div className="bg-red-900/50 border border-red-800 text-red-200 px-4 py-2 rounded-lg text-sm">
-          {error}
-        </div>
-      ) : tab === "foryou" ? (
-        recommendations.length === 0 && (!aggregate || (aggregate.flat.length === 0 && aggregate.groups.length === 0)) ? (
-          <p className="text-zinc-500 text-sm py-8 text-center">
-            {t("discovery.empty")}
-          </p>
+      {/* ── For you tab ─────────────────────────────────────────────────── */}
+      {tab === "foryou" && (
+        loading ? (
+          <DiscoverySkeleton />
+        ) : error ? (
+          <div className="bg-red-900/50 border border-red-800 text-red-200 px-4 py-2 rounded-lg text-sm">{error}</div>
+        ) : isEmpty ? (
+          <p className="text-zinc-500 text-sm py-8 text-center">{t("discovery.empty")}</p>
         ) : (
           <div className="space-y-8">
-            {/* Social recommendations */}
-            {recommendations.length > 0 && (
-              <div>
-                <HeroCard rec={heroRec} onTrack={handleTrack} onDismiss={handleDismiss} />
-                {railRecs.length > 0 && (
-                  <div>
-                    <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-3">More recommendations</p>
-                    <div className="flex gap-4 overflow-x-auto pb-2 -mx-1 px-1">
-                      {railRecs.map((rec) => (
-                        <RailCard key={rec.id} rec={rec} onTrack={handleTrack} onDismiss={handleDismiss} />
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
+            {/* Hero — combined algo + friends */}
+            {hero && (
+              <DiscoveryHero
+                hero={hero}
+                algoGroup={heroAlgoGroup}
+                friendRecs={heroFriendRecs}
+                isTracked={trackedSet.has(hero.id)}
+                isDismissed={dismissedSet.has(hero.id)}
+                onTrack={() => handleTrackSuggestion(hero.id, hero)}
+                onDismiss={() => handleDismissSuggestion(hero.id)}
+                onUndismiss={() => handleUndismiss(hero.id)}
+              />
             )}
 
-            {/* TMDB hero rail */}
-            {aggregate && aggregate.flat.length > 0 && (
+            {/* More for you rail */}
+            {moreForYou.length > 0 && (
               <section>
-                <div className="mb-4">
-                  <Kicker>For you</Kicker>
-                  <h2 className="text-xl font-bold tracking-[-0.01em]">{t("suggestions.forYou")}</h2>
-                </div>
-                <FullBleedCarousel>
-                  {aggregate.flat.slice(0, 12).map((title) => (
-                    <PosterCard key={title.id} title={title} />
-                  ))}
-                </FullBleedCarousel>
-              </section>
-            )}
-
-            {/* "Because you …" groups */}
-            {aggregate && aggregate.groups.map((group) => (
-              <section key={group.source.id}>
-                <div className="flex items-center gap-3 mb-4">
-                  {group.source.posterUrl && (
-                    <Link to={`/title/${group.source.id}`} className="flex-shrink-0">
-                      <img src={group.source.posterUrl} alt={group.source.title} className="w-8 h-12 rounded object-cover" width={32} height={48} loading="lazy" />
-                    </Link>
-                  )}
-                  <h2 className="text-base font-semibold text-zinc-100 leading-snug">
-                    {becauseLabel(group.source.reason, group.source.title, t)}
-                  </h2>
-                </div>
+                <SectionHead kicker="More for you" title="Suggested next" sub="Ranked by score — tracked and dismissed titles are filtered out." />
                 <ScrollableRow>
-                  {group.suggestions.map((title) => (
-                    <PosterCard key={title.id} title={title} />
+                  {moreForYou.map((title) => (
+                    <SuggestionCard
+                      key={title.id}
+                      item={{ id: title.id, title: title.title, posterUrl: title.posterUrl }}
+                      friends={(recsByTitle[title.id] ?? []).map((r) => ({ username: r.from_user.username, displayName: r.from_user.display_name ?? null, image: r.from_user.image ?? null }))}
+                      isTracked={trackedSet.has(title.id)}
+                      isDismissed={dismissedSet.has(title.id)}
+                      onTrack={() => handleTrackSuggestion(title.id, title)}
+                      onDismiss={() => handleDismissSuggestion(title.id)}
+                      onUndismiss={() => handleUndismiss(title.id)}
+                    />
                   ))}
                 </ScrollableRow>
               </section>
-            ))}
+            )}
+
+            {/* Friends are recommending */}
+            {Object.keys(recsByTitle).length > 0 && (
+              <section>
+                <SectionHead kicker="From people you follow" title="Friends are recommending" />
+                <ScrollableRow>
+                  {Object.entries(recsByTitle).map(([titleId, recs]) => {
+                    const first = recs[0];
+                    return (
+                      <SuggestionCard
+                        key={titleId}
+                        item={{ id: titleId, title: first.title.title, posterUrl: first.title.poster_url }}
+                        friends={recs.map((r) => ({ username: r.from_user.username, displayName: r.from_user.display_name ?? null, image: r.from_user.image ?? null }))}
+                        isTracked={trackedSet.has(titleId)}
+                        isDismissed={dismissedSet.has(titleId)}
+                        onTrack={() => handleTrackSuggestion(titleId)}
+                        onDismiss={() => handleDismissSuggestion(titleId)}
+                        onUndismiss={() => handleUndismiss(titleId)}
+                      />
+                    );
+                  })}
+                </ScrollableRow>
+              </section>
+            )}
+
+            {/* Because you … rails */}
+            {aggregate?.groups.map((group) => {
+              const visibleSuggestions = group.suggestions.filter(
+                (s) => !trackedSet.has(s.id) && !dismissedSet.has(s.id),
+              );
+              const sessionHidden = group.suggestions.filter(
+                (s) => trackedSet.has(s.id) || dismissedSet.has(s.id),
+              ).length;
+              const totalHidden = group.hiddenCount + sessionHidden;
+              const sourceSrc = group.source.posterUrl ? posterUrl(group.source.posterUrl, "w92") : null;
+
+              if (visibleSuggestions.length === 0 && totalHidden === 0) return null;
+
+              return (
+                <section key={group.source.id}>
+                  <SectionHead
+                    title={becauseLabel(group.source.reason, group.source.title)}
+                    sub={totalHidden > 0 ? `${totalHidden} hidden — already tracked or dismissed` : undefined}
+                    sourcePosterUrl={sourceSrc}
+                    sourceId={group.source.id}
+                  />
+                  {visibleSuggestions.length > 0 ? (
+                    <ScrollableRow>
+                      {visibleSuggestions.map((title) => (
+                        <SuggestionCard
+                          key={title.id}
+                          item={{ id: title.id, title: title.title, posterUrl: title.posterUrl }}
+                          friends={(recsByTitle[title.id] ?? []).map((r) => ({ username: r.from_user.username, displayName: r.from_user.display_name ?? null, image: r.from_user.image ?? null }))}
+                          isTracked={trackedSet.has(title.id)}
+                          isDismissed={dismissedSet.has(title.id)}
+                          onTrack={() => handleTrackSuggestion(title.id, title)}
+                          onDismiss={() => handleDismissSuggestion(title.id)}
+                          onUndismiss={() => handleUndismiss(title.id)}
+                        />
+                      ))}
+                    </ScrollableRow>
+                  ) : (
+                    <p className="text-xs text-zinc-500 py-2">All suggestions tracked or dismissed.</p>
+                  )}
+                </section>
+              );
+            })}
           </div>
         )
-      ) : (
-        /* Activity tab — original feed */
-        recommendations.length === 0 ? (
-          <p className="text-zinc-500 text-sm py-8 text-center">
-            {t("discovery.empty")}
-          </p>
+      )}
+
+      {/* ── Activity tab ─────────────────────────────────────────────────── */}
+      {tab === "activity" && (
+        loading ? (
+          <DiscoverySkeleton />
+        ) : recommendations.length === 0 ? (
+          <p className="text-zinc-500 text-sm py-8 text-center">{t("discovery.empty")}</p>
         ) : (
           <div className="space-y-3">
             {recommendations.map((rec) => (
               <RecommendationCard
                 key={rec.id}
                 rec={rec}
-                onTrack={handleTrack}
-                onDismiss={handleDismiss}
+                onTrack={handleTrackRec}
+                onDismiss={handleDismissRec}
                 onMarkRead={handleMarkRead}
               />
             ))}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -845,6 +845,7 @@ export type SuggestionSeedReason = "loved" | "liked" | "watched" | "tracked";
 export interface SuggestionsGroup {
   source: { id: string; title: string; posterUrl: string | null; reason: SuggestionSeedReason };
   suggestions: SearchTitle[];
+  hiddenCount: number;
 }
 
 export interface SuggestionsAggregateResponse {

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -133,6 +133,6 @@ describe("fixSkippedMigrations", () => {
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(47);
+    expect(migrations.cnt).toBe(48);
   });
 });

--- a/server/db/repository/dismissed.test.ts
+++ b/server/db/repository/dismissed.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
+import { createUser } from "../repository";
+import { dismissTitle, undismissTitle, getDismissedTitleIds, getDismissedCount } from "./dismissed";
+import { upsertTitles } from "./titles";
+
+let userId: string;
+const titleId = "tt-1";
+const titleId2 = "tt-2";
+
+beforeEach(async () => {
+  setupTestDb();
+  userId = await createUser("alice", "hash");
+  await upsertTitles([
+    { id: titleId, objectType: "SHOW", title: "Test Show", originalTitle: null, releaseYear: 2024, releaseDate: null, runtimeMinutes: null, shortDescription: null, genres: [], originalLanguage: "en", imdbId: null, tmdbId: null, posterUrl: null, backdropUrl: null, ageCertification: null, tmdbUrl: null, offers: [], scores: { imdbScore: null, imdbVotes: null, tmdbScore: null } },
+    { id: titleId2, objectType: "MOVIE", title: "Test Movie", originalTitle: null, releaseYear: 2024, releaseDate: null, runtimeMinutes: null, shortDescription: null, genres: [], originalLanguage: "en", imdbId: null, tmdbId: null, posterUrl: null, backdropUrl: null, ageCertification: null, tmdbUrl: null, offers: [], scores: { imdbScore: null, imdbVotes: null, tmdbScore: null } },
+  ]);
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+describe("dismissTitle", () => {
+  it("adds a title to the dismissed set", async () => {
+    await dismissTitle(userId, titleId);
+    const ids = await getDismissedTitleIds(userId);
+    expect(ids.has(titleId)).toBe(true);
+  });
+
+  it("is idempotent — dismissing twice does not error", async () => {
+    await dismissTitle(userId, titleId);
+    await dismissTitle(userId, titleId);
+    const ids = await getDismissedTitleIds(userId);
+    expect(ids.size).toBe(1);
+  });
+
+  it("dismissed titles are isolated per user", async () => {
+    const userId2 = await createUser("bob", "hash");
+    await dismissTitle(userId, titleId);
+    const ids = await getDismissedTitleIds(userId2);
+    expect(ids.has(titleId)).toBe(false);
+  });
+});
+
+describe("undismissTitle", () => {
+  it("removes a title from the dismissed set", async () => {
+    await dismissTitle(userId, titleId);
+    await undismissTitle(userId, titleId);
+    const ids = await getDismissedTitleIds(userId);
+    expect(ids.has(titleId)).toBe(false);
+  });
+
+  it("is a no-op when title was not dismissed", async () => {
+    await undismissTitle(userId, titleId);
+    const ids = await getDismissedTitleIds(userId);
+    expect(ids.size).toBe(0);
+  });
+});
+
+describe("getDismissedTitleIds", () => {
+  it("returns all dismissed titles for a user", async () => {
+    await dismissTitle(userId, titleId);
+    await dismissTitle(userId, titleId2);
+    const ids = await getDismissedTitleIds(userId);
+    expect(ids.size).toBe(2);
+    expect(ids.has(titleId)).toBe(true);
+    expect(ids.has(titleId2)).toBe(true);
+  });
+
+  it("returns an empty set when nothing is dismissed", async () => {
+    const ids = await getDismissedTitleIds(userId);
+    expect(ids.size).toBe(0);
+  });
+});
+
+describe("getDismissedCount", () => {
+  it("returns the number of dismissed titles", async () => {
+    await dismissTitle(userId, titleId);
+    await dismissTitle(userId, titleId2);
+    expect(await getDismissedCount(userId)).toBe(2);
+  });
+
+  it("returns 0 when nothing is dismissed", async () => {
+    expect(await getDismissedCount(userId)).toBe(0);
+  });
+});

--- a/server/db/repository/dismissed.ts
+++ b/server/db/repository/dismissed.ts
@@ -1,0 +1,53 @@
+import { and, eq } from "drizzle-orm";
+import { getDb, dismissedSuggestions } from "../schema";
+import { traceDbQuery } from "../../tracing";
+
+export async function dismissTitle(userId: string, titleId: string): Promise<void> {
+  return traceDbQuery("dismissTitle", async () => {
+    const db = getDb();
+    await db
+      .insert(dismissedSuggestions)
+      .values({ userId, titleId })
+      .onConflictDoNothing()
+      .run();
+  });
+}
+
+export async function undismissTitle(userId: string, titleId: string): Promise<void> {
+  return traceDbQuery("undismissTitle", async () => {
+    const db = getDb();
+    await db
+      .delete(dismissedSuggestions)
+      .where(
+        and(
+          eq(dismissedSuggestions.userId, userId),
+          eq(dismissedSuggestions.titleId, titleId),
+        ),
+      )
+      .run();
+  });
+}
+
+export async function getDismissedTitleIds(userId: string): Promise<Set<string>> {
+  return traceDbQuery("getDismissedTitleIds", async () => {
+    const db = getDb();
+    const rows = await db
+      .select({ titleId: dismissedSuggestions.titleId })
+      .from(dismissedSuggestions)
+      .where(eq(dismissedSuggestions.userId, userId))
+      .all();
+    return new Set(rows.map((r) => r.titleId));
+  });
+}
+
+export async function getDismissedCount(userId: string): Promise<number> {
+  return traceDbQuery("getDismissedCount", async () => {
+    const db = getDb();
+    const rows = await db
+      .select({ titleId: dismissedSuggestions.titleId })
+      .from(dismissedSuggestions)
+      .where(eq(dismissedSuggestions.userId, userId))
+      .all();
+    return rows.length;
+  });
+}

--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -272,3 +272,10 @@ export {
   setOnlyMineFilter,
   filterValidProviderIds,
 } from "./user-subscribed-providers";
+
+export {
+  dismissTitle,
+  undismissTitle,
+  getDismissedTitleIds,
+  getDismissedCount,
+} from "./dismissed";

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -767,10 +767,23 @@ export const passkeyRelations = relations(passkey, ({ one }) => ({
   user: one(users, { fields: [passkey.userId], references: [users.id] }),
 }));
 
+export const dismissedSuggestions = sqliteTable(
+  "dismissed_suggestions",
+  {
+    userId: text("user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
+    titleId: text("title_id").notNull().references(() => titles.id, { onDelete: "cascade" }),
+    dismissedAt: text("dismissed_at").notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.titleId] }),
+    index("idx_dismissed_suggestions_user_id").on(table.userId),
+  ]
+);
+
 export const schemaExports = {
   titles, providers, offers, scores, titleGenres, episodes, users, sessions, account, verification, passkey, settings, tracked, watchedEpisodes, watchedTitles, notifiers, oidcStates, jobs, cronJobs, userSubscribedProviders,
   follows, ratings, episodeRatings, recommendations, recommendationReads, invitations, integrations, plexLibraryItems, titleTags,
-  watchHistory, streamingAlerts, activityKindVisibility, hiddenActivityEvents, notificationLog,
+  watchHistory, streamingAlerts, activityKindVisibility, hiddenActivityEvents, notificationLog, dismissedSuggestions,
   titlesRelations, providersRelations, offersRelations, scoresRelations, titleGenresRelations, episodesRelations,
   passkeyRelations,
   usersRelations, sessionsRelations, accountRelations, trackedRelations, watchedEpisodesRelations, watchedTitlesRelations, notifiersRelations,

--- a/server/routes/suggestions.test.ts
+++ b/server/routes/suggestions.test.ts
@@ -5,6 +5,7 @@ import { CONFIG } from "../config";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
 import { trackTitle, upsertTitles, createUser, rateTitle } from "../db/repository";
 import { watchTitle } from "../db/repository/watched-titles";
+import { getDismissedTitleIds } from "../db/repository/dismissed";
 import { makeParsedTitle, makeTmdbDiscoverMovie, makeTmdbDiscoverTv } from "../test-utils/fixtures";
 import * as tmdbClient from "../tmdb/client";
 
@@ -261,5 +262,105 @@ describe("GET /suggestions", () => {
     const body = await res.json();
     expect(tmdbClient.fetchTvSuggestions).toHaveBeenCalledWith(500, 1);
     expect(body.flat[0].id).toBe("tv-600");
+  });
+
+  it("filters out dismissed titles", async () => {
+    await upsertTitles([
+      makeParsedTitle({ id: "movie-100", tmdbId: "100", objectType: "MOVIE" }),
+      makeParsedTitle({ id: "movie-200", tmdbId: "200", objectType: "MOVIE" }),
+    ]);
+    await trackTitle("movie-100", mockUserId);
+
+    (tmdbClient.fetchMovieSuggestions as any).mockResolvedValueOnce({
+      results: [makeTmdbDiscoverMovie({ id: 200, title: "Dismissed Movie" })],
+      page: 1, total_pages: 1, total_results: 1,
+    });
+
+    // Dismiss via the route
+    const dismissRes = await app.request("/suggestions/dismiss/movie-200", { method: "POST" });
+    expect(dismissRes.status).toBe(200);
+
+    const res = await app.request("/suggestions");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.flat.every((t: any) => t.id !== "movie-200")).toBe(true);
+  });
+
+  it("includes hiddenCount per group reflecting filtered titles", async () => {
+    await upsertTitles([
+      makeParsedTitle({ id: "movie-100", tmdbId: "100", objectType: "MOVIE" }),
+      makeParsedTitle({ id: "movie-200", tmdbId: "200", objectType: "MOVIE" }),
+      makeParsedTitle({ id: "movie-300", tmdbId: "300", objectType: "MOVIE" }),
+    ]);
+    await trackTitle("movie-100", mockUserId);
+    await trackTitle("movie-200", mockUserId); // will be filtered
+
+    (tmdbClient.fetchMovieSuggestions as any).mockResolvedValueOnce({
+      results: [
+        makeTmdbDiscoverMovie({ id: 200, title: "Already Tracked" }),
+        makeTmdbDiscoverMovie({ id: 300, title: "Suggestion" }),
+      ],
+      page: 1, total_pages: 1, total_results: 2,
+    });
+
+    const res = await app.request("/suggestions");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.groups[0].hiddenCount).toBe(1);
+  });
+});
+
+describe("POST /suggestions/dismiss/:titleId", () => {
+  it("dismisses a title and returns ok", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-500", tmdbId: "500", objectType: "MOVIE" })]);
+    const res = await app.request("/suggestions/dismiss/movie-500", { method: "POST" });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    const ids = await getDismissedTitleIds(mockUserId);
+    expect(ids.has("movie-500")).toBe(true);
+  });
+
+  it("is idempotent — dismissing twice returns ok", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-500", tmdbId: "500", objectType: "MOVIE" })]);
+    await app.request("/suggestions/dismiss/movie-500", { method: "POST" });
+    const res = await app.request("/suggestions/dismiss/movie-500", { method: "POST" });
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const anonApp = makeAnonApp();
+    const res = await anonApp.request("/suggestions/dismiss/movie-500", { method: "POST" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for an empty titleId", async () => {
+    const res = await app.request("/suggestions/dismiss/", { method: "POST" });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("DELETE /suggestions/dismiss/:titleId", () => {
+  it("undismisses a title and returns ok", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-600", tmdbId: "600", objectType: "MOVIE" })]);
+    await app.request("/suggestions/dismiss/movie-600", { method: "POST" });
+
+    const res = await app.request("/suggestions/dismiss/movie-600", { method: "DELETE" });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    const ids = await getDismissedTitleIds(mockUserId);
+    expect(ids.has("movie-600")).toBe(false);
+  });
+
+  it("is a no-op when title was not dismissed", async () => {
+    const res = await app.request("/suggestions/dismiss/movie-999", { method: "DELETE" });
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const anonApp = makeAnonApp();
+    const res = await anonApp.request("/suggestions/dismiss/movie-600", { method: "DELETE" });
+    expect(res.status).toBe(401);
   });
 });

--- a/server/routes/suggestions.ts
+++ b/server/routes/suggestions.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { z } from "zod";
 import { pLimit } from "../lib/p-limit";
 import {
   fetchMovieSuggestions,
@@ -11,14 +12,34 @@ import type { ParsedTitle } from "../tmdb/parser";
 import { getSuggestionSeedTitles, type SuggestionSourceTitle } from "../db/repository/tracked";
 import { getTrackedTitleIds } from "../db/repository/tracked";
 import { getWatchedTitleIds } from "../db/repository/watched-titles";
+import { dismissTitle, undismissTitle, getDismissedTitleIds } from "../db/repository/dismissed";
 import { CONFIG } from "../config";
 import type { AppEnv } from "../types";
 import { logger } from "../logger";
 import { ok, err } from "./response";
+import { zValidator } from "../lib/validator";
 
 const log = logger.child({ module: "suggestions" });
 
 const app = new Hono<AppEnv>();
+
+const dismissParamSchema = z.object({ titleId: z.string().min(1) });
+
+app.post("/dismiss/:titleId", zValidator("param", dismissParamSchema), async (c) => {
+  const user = c.get("user");
+  if (!user) return err(c, "Authentication required", 401);
+  const { titleId } = c.req.valid("param");
+  await dismissTitle(user.id, titleId);
+  return ok(c, { ok: true });
+});
+
+app.delete("/dismiss/:titleId", zValidator("param", dismissParamSchema), async (c) => {
+  const user = c.get("user");
+  if (!user) return err(c, "Authentication required", 401);
+  const { titleId } = c.req.valid("param");
+  await undismissTitle(user.id, titleId);
+  return ok(c, { ok: true });
+});
 
 app.get("/", async (c) => {
   const user = c.get("user");
@@ -29,10 +50,11 @@ app.get("/", async (c) => {
   const limit = isNaN(rawLimit) || rawLimit < 1 ? 40 : Math.min(rawLimit, 100);
 
   try {
-    const [sourceTitles, trackedIds, watchedIds] = await Promise.all([
+    const [sourceTitles, trackedIds, watchedIds, dismissedIds] = await Promise.all([
       getSuggestionSeedTitles(user.id, 5),
       getTrackedTitleIds(user.id),
       getWatchedTitleIds(user.id),
+      getDismissedTitleIds(user.id),
     ]);
 
     if (sourceTitles.length === 0) {
@@ -68,16 +90,20 @@ app.get("/", async (c) => {
       )
     );
 
-    // Dedupe by id, filter out tracked and watched titles
+    // Dedupe by id, filter out tracked, watched, and dismissed titles
     const seen = new Set<string>();
     const flat: ParsedTitle[] = [];
 
     const groups = groupResults
       .map(({ source, suggestions }) => {
-        const filtered = suggestions.filter((t) => !trackedIds.has(t.id) && !watchedIds.has(t.id));
+        const unfiltered = suggestions.length;
+        const filtered = suggestions.filter(
+          (t) => !trackedIds.has(t.id) && !watchedIds.has(t.id) && !dismissedIds.has(t.id),
+        );
         return {
           source: { id: source.id, title: source.title, posterUrl: source.posterUrl, reason: source.reason },
           suggestions: filtered,
+          hiddenCount: unfiltered - filtered.length,
         };
       })
       .filter((g) => g.suggestions.length > 0);


### PR DESCRIPTION
## Summary

- **Backend dismiss store**: new `dismissed_suggestions` table (migration 0045) with `POST/DELETE /api/suggestions/dismiss/:titleId` endpoints; the GET aggregate now filters dismissed titles server-side and exposes `hiddenCount` per group
- **Hero card**: top algo suggestion is the hero; shows both an Remindarr algo signal panel (seed title + reason) and a Friends panel (friend stack, quote, Direct tag) side-by-side; "None of your friends have recommended this yet" placeholder when no recs match
- **Ubiquitous track/dismiss**: every suggestion card (hero, More for you, Friends are recommending, Because you… rails) has inline Track / Dismiss / Undo buttons with optimistic session state; dismissed friend-rec cards stay visible with ghost styling and an Undo button
- **Session counter + hiddenCount subnote**: PageHeader right-slot shows `N tracked · N dismissed` after any action; "Because you…" groups show `N hidden — already tracked or dismissed` from server `hiddenCount` + session state

## Test plan

- [ ] `bun run check` passes (server tsc + frontend tsc + lint + all tests) ✅
- [ ] New `server/db/repository/dismissed.test.ts` — insert idempotency, delete, list, count
- [ ] `server/routes/suggestions.test.ts` extended — dismiss/undismiss happy-path + 401 unauthed
- [ ] `frontend/src/pages/DiscoveryPage.test.tsx` extended — hero render, friend placeholder, friend signal, session counter, dismiss/shift, undo, hiddenCount subnote, rail track
- [ ] Run `bun run dev` and open `/discovery`: track a card → badge flips, counter ticks; dismiss → poster ghosts; reload → card stays gone (server persisted); undo → card un-ghosts
- [ ] Activity tab: existing recommendation feed and unread badge still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)