### PR TITLE
Add consistent spacing to ScrollableRow components on Discovery page

### DIFF
--- a/frontend/src/pages/DiscoveryPage.tsx
+++ b/frontend/src/pages/DiscoveryPage.tsx
@@ -706,7 +706,7 @@ export default function DiscoveryPage() {
             {moreForYou.length > 0 && (
               <section>
                 <SectionHead kicker="More for you" title="Suggested next" sub="Ranked by score — tracked and dismissed titles are filtered out." />
-                <ScrollableRow>
+                <ScrollableRow className="gap-3 pb-2">
                   {moreForYou.map((title) => (
                     <SuggestionCard
                       key={title.id}
@@ -727,7 +727,7 @@ export default function DiscoveryPage() {
             {Object.keys(recsByTitle).length > 0 && (
               <section>
                 <SectionHead kicker="From people you follow" title="Friends are recommending" />
-                <ScrollableRow>
+                <ScrollableRow className="gap-3 pb-2">
                   {Object.entries(recsByTitle).map(([titleId, recs]) => {
                     const first = recs[0];
                     return (
@@ -769,7 +769,7 @@ export default function DiscoveryPage() {
                     sourceId={group.source.id}
                   />
                   {visibleSuggestions.length > 0 ? (
-                    <ScrollableRow>
+                    <ScrollableRow className="gap-3 pb-2">
                       {visibleSuggestions.map((title) => (
                         <SuggestionCard
                           key={title.id}


### PR DESCRIPTION
## Summary
Updated three `ScrollableRow` components on the Discovery page to include consistent gap and padding styling for improved visual consistency and spacing.

## Changes
- Added `className="gap-3 pb-2"` to the "Suggested next" section's ScrollableRow
- Added `className="gap-3 pb-2"` to the "Friends are recommending" section's ScrollableRow
- Added `className="gap-3 pb-2"` to the source-based suggestions section's ScrollableRow

## Details
These changes apply consistent Tailwind CSS classes across all ScrollableRow instances in the Discovery page:
- `gap-3`: Adds consistent spacing between child elements (12px gap)
- `pb-2`: Adds bottom padding (8px) for proper spacing below the scrollable rows

This ensures a uniform visual appearance and spacing throughout the discovery feed sections.

https://claude.ai/code/session_01WL2eFgGoHm2iRnT9tSDFPV