### PR TITLE
feat(home): sort unwatched / hero / reels by most recently watched

### DIFF
--- a/frontend/src/pages/HomePage.test.ts
+++ b/frontend/src/pages/HomePage.test.ts
@@ -64,30 +64,16 @@ describe("buildUnwatchedCards", () => {
     expect(cards[0].allEpisodeIds).toEqual([10, 20, 30]);
   });
 
-  it("orders shows by most recent air_date descending", () => {
+  it("preserves the order of first occurrence in the input (backend-provided sort)", () => {
     const episodes: Episode[] = [
-      makeEpisode({ id: 1, title_id: "show-old", season_number: 1, episode_number: 1, air_date: "2025-01-01", show_title: "Old Show" }),
+      makeEpisode({ id: 1, title_id: "show-mid", season_number: 1, episode_number: 1, air_date: "2025-03-10", show_title: "Mid Show" }),
       makeEpisode({ id: 2, title_id: "show-new", season_number: 1, episode_number: 1, air_date: "2025-06-15", show_title: "New Show" }),
-      makeEpisode({ id: 3, title_id: "show-mid", season_number: 1, episode_number: 1, air_date: "2025-03-10", show_title: "Mid Show" }),
+      makeEpisode({ id: 3, title_id: "show-mid", season_number: 1, episode_number: 2, air_date: "2025-03-17", show_title: "Mid Show" }),
+      makeEpisode({ id: 4, title_id: "show-old", season_number: 1, episode_number: 1, air_date: "2025-01-01", show_title: "Old Show" }),
     ];
     const cards = buildUnwatchedCards(episodes);
 
-    expect(cards[0].titleId).toBe("show-new");
-    expect(cards[1].titleId).toBe("show-mid");
-    expect(cards[2].titleId).toBe("show-old");
-  });
-
-  it("uses most recent episode air_date for ordering when show has multiple episodes", () => {
-    const episodes: Episode[] = [
-      makeEpisode({ id: 1, title_id: "show-a", season_number: 1, episode_number: 1, air_date: "2025-01-01" }),
-      makeEpisode({ id: 2, title_id: "show-a", season_number: 1, episode_number: 2, air_date: "2025-01-08" }),
-      makeEpisode({ id: 3, title_id: "show-b", season_number: 1, episode_number: 1, air_date: "2025-01-05" }),
-    ];
-    const cards = buildUnwatchedCards(episodes);
-
-    // show-a has most recent ep on 2025-01-08, show-b on 2025-01-05
-    expect(cards[0].titleId).toBe("show-a");
-    expect(cards[1].titleId).toBe("show-b");
+    expect(cards.map((c) => c.titleId)).toEqual(["show-mid", "show-new", "show-old"]);
   });
 
   it("returns empty array for empty input", () => {

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -39,7 +39,6 @@ export function buildUnwatchedCards(episodes: Episode[]): UnwatchedCardEntry[] {
 
   const entries: UnwatchedCardEntry[] = [];
   for (const [titleId, eps] of showMap) {
-    // Sort episodes: lowest season first, then lowest episode number
     const sorted = [...eps].sort((a, b) =>
       a.season_number !== b.season_number
         ? a.season_number - b.season_number
@@ -47,12 +46,6 @@ export function buildUnwatchedCards(episodes: Episode[]): UnwatchedCardEntry[] {
     );
     const firstEpisode = sorted[0];
     const allIds = sorted.map((e) => e.id);
-
-    // Find most recent air_date across all episodes for ordering
-    let mostRecentDate = "";
-    for (const ep of eps) {
-      if (ep.air_date && ep.air_date > mostRecentDate) mostRecentDate = ep.air_date;
-    }
 
     entries.push({
       episode: firstEpisode,
@@ -62,19 +55,6 @@ export function buildUnwatchedCards(episodes: Episode[]): UnwatchedCardEntry[] {
       titleId,
     });
   }
-
-  // Sort by most recent air_date descending
-  entries.sort((a, b) => {
-    const aDate = a.allEpisodeIds.reduce((best, id) => {
-      const ep = episodes.find((e) => e.id === id);
-      return ep?.air_date && ep.air_date > best ? ep.air_date : best;
-    }, "");
-    const bDate = b.allEpisodeIds.reduce((best, id) => {
-      const ep = episodes.find((e) => e.id === id);
-      return ep?.air_date && ep.air_date > best ? ep.air_date : best;
-    }, "");
-    return bDate.localeCompare(aDate);
-  });
 
   return entries;
 }

--- a/server/db/repository/episodes.test.ts
+++ b/server/db/repository/episodes.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterAll } from "bun:test";
 import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
 import { makeParsedTitle } from "../../test-utils/fixtures";
-import { upsertTitles, createUser, trackTitle, upsertEpisodes, watchEpisode } from "../repository";
+import { upsertTitles, createUser, trackTitle, upsertEpisodes, watchEpisode, watchEpisodesBulk } from "../repository";
 import { getUnwatchedEpisodes } from "./episodes";
 
 let userId: string;
@@ -73,5 +73,62 @@ describe("getUnwatchedEpisodes", () => {
 
     const after = await getUnwatchedEpisodes(userId);
     expect(after.some((e) => e.id === episode.id)).toBe(false);
+  });
+
+  it("orders title-groups by most recent watched_at descending, with never-watched titles last (alphabetical fallback)", async () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+    const twoDaysAgo = new Date(Date.now() - 2 * 86400000).toISOString().slice(0, 10);
+
+    await upsertTitles([
+      makeParsedTitle({ id: "show-2", objectType: "SHOW", title: "B Show" }),
+      makeParsedTitle({ id: "show-3", objectType: "SHOW", title: "A Never Watched Show" }),
+    ]);
+    await trackTitle("show-2", userId);
+    await trackTitle("show-3", userId);
+
+    await upsertEpisodes([
+      // show-1 (Test Show): two unwatched + one we'll mark watched at the EARLIER time
+      { title_id: "show-1", season_number: 1, episode_number: 1, name: "S1 E1", overview: null, air_date: twoDaysAgo, still_path: null },
+      { title_id: "show-1", season_number: 1, episode_number: 2, name: "S1 E2", overview: null, air_date: yesterday, still_path: null },
+      { title_id: "show-1", season_number: 1, episode_number: 3, name: "S1 E3 (will be watched)", overview: null, air_date: yesterday, still_path: null },
+      // show-2 (B Show): two unwatched + one we'll mark watched at the LATER time
+      { title_id: "show-2", season_number: 1, episode_number: 1, name: "B S1 E1", overview: null, air_date: twoDaysAgo, still_path: null },
+      { title_id: "show-2", season_number: 1, episode_number: 2, name: "B S1 E2", overview: null, air_date: yesterday, still_path: null },
+      { title_id: "show-2", season_number: 1, episode_number: 3, name: "B S1 E3 (will be watched)", overview: null, air_date: yesterday, still_path: null },
+      // show-3 (never watched): two unwatched
+      { title_id: "show-3", season_number: 1, episode_number: 1, name: "A S1 E1", overview: null, air_date: twoDaysAgo, still_path: null },
+      { title_id: "show-3", season_number: 1, episode_number: 2, name: "A S1 E2", overview: null, air_date: yesterday, still_path: null },
+    ]);
+
+    const all = await getUnwatchedEpisodes(userId);
+    const show1Watched = all.find((e) => e.title_id === "show-1" && e.episode_number === 3)!;
+    const show2Watched = all.find((e) => e.title_id === "show-2" && e.episode_number === 3)!;
+
+    // show-2 watched 1 hour after show-1 → show-2 should sort first by recency.
+    await watchEpisodesBulk(
+      [show1Watched.id, show2Watched.id],
+      userId,
+      new Map([
+        [show1Watched.id, "2024-01-01 12:00:00"],
+        [show2Watched.id, "2024-01-01 13:00:00"],
+      ]),
+    );
+
+    const results = await getUnwatchedEpisodes(userId);
+    const titleOrder: string[] = [];
+    for (const ep of results) {
+      if (titleOrder[titleOrder.length - 1] !== ep.title_id) titleOrder.push(ep.title_id);
+    }
+
+    // show-2 first (most recently watched), then show-1, then show-3 (never watched, alphabetical fallback by title)
+    expect(titleOrder).toEqual(["show-2", "show-1", "show-3"]);
+
+    // Within each group, episodes preserve season/episode ascending order
+    const show1Episodes = results.filter((e) => e.title_id === "show-1");
+    expect(show1Episodes.map((e) => e.episode_number)).toEqual([1, 2]);
+    const show2Episodes = results.filter((e) => e.title_id === "show-2");
+    expect(show2Episodes.map((e) => e.episode_number)).toEqual([1, 2]);
+    const show3Episodes = results.filter((e) => e.title_id === "show-3");
+    expect(show3Episodes.map((e) => e.episode_number)).toEqual([1, 2]);
   });
 });

--- a/server/db/repository/episodes.ts
+++ b/server/db/repository/episodes.ts
@@ -205,8 +205,32 @@ export async function getUnwatchedEpisodes(userId: string, timezone = "UTC") {
       .orderBy(asc(titles.title), asc(episodes.seasonNumber), asc(episodes.episodeNumber))
       .all();
 
-    const offersByTitle = await getOffersWithPlex([...new Set(rows.map((r) => r.title_id))], userId);
-    return rows.map((row) => ({
+    const lastWatchedByTitle = await getLastWatchedAtPerShow(userId);
+
+    const titleOrder = new Map<string, number>();
+    for (const row of rows) {
+      if (!titleOrder.has(row.title_id)) {
+        titleOrder.set(row.title_id, titleOrder.size);
+      }
+    }
+
+    const sortedRows = [...rows].sort((a, b) => {
+      const aWatched = lastWatchedByTitle.get(a.title_id)?.getTime() ?? null;
+      const bWatched = lastWatchedByTitle.get(b.title_id)?.getTime() ?? null;
+      if (aWatched !== bWatched) {
+        if (aWatched === null) return 1;
+        if (bWatched === null) return -1;
+        return bWatched - aWatched;
+      }
+      const aIdx = titleOrder.get(a.title_id)!;
+      const bIdx = titleOrder.get(b.title_id)!;
+      if (aIdx !== bIdx) return aIdx - bIdx;
+      if (a.season_number !== b.season_number) return a.season_number - b.season_number;
+      return a.episode_number - b.episode_number;
+    });
+
+    const offersByTitle = await getOffersWithPlex([...new Set(sortedRows.map((r) => r.title_id))], userId);
+    return sortedRows.map((row) => ({
       ...row,
       is_watched: false,
       offers: offersByTitle.get(row.title_id) ?? [],


### PR DESCRIPTION
Sort unwatched episode title-groups on the backend by MAX(watched_at)
DESC so the show whose last watched episode is most recent appears
first. Never-watched titles fall back to alphabetical order at the end.

The sort is applied once per fetch and the frontend no longer re-sorts,
so marking an episode watched mid-session does not cause its show to
jump to the top — reordering happens only on a fresh page load.

This flows through to all three surfaces that consume the unwatched
array: the desktop hero banner, the unwatched carousel, and the reels
"coming-soon" source.

https://claude.ai/code/session_019qyc8kPLhCpmgTGxTLpNaE