### PR TITLE
perf: fix Cumulative Layout Shift on Home and Settings pages

### DIFF
--- a/frontend/src/components/SkeletonComponents.tsx
+++ b/frontend/src/components/SkeletonComponents.tsx
@@ -169,6 +169,90 @@ export function GridCalendarSkeleton() {
   );
 }
 
+/** Hero banner skeleton — matches the 520px hero container on desktop */
+export function HeroBannerSkeleton() {
+  return (
+    <div className="hidden lg:block w-[100vw] relative left-[50%] ml-[-50vw] h-[520px] bg-zinc-900 overflow-hidden">
+      <Skeleton className="absolute inset-0 rounded-none" />
+    </div>
+  );
+}
+
+/** Scrollable row of card skeletons matching FullBleedCarousel content */
+export function ScrollableRowSkeleton({ count = 4 }: { count?: number }) {
+  return (
+    <div className="flex gap-3 overflow-hidden">
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="w-80 flex-shrink-0">
+          <div className="bg-zinc-900 rounded-xl overflow-hidden">
+            <Skeleton className="w-full aspect-video rounded-none" />
+            <div className="p-3 space-y-2">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-3 w-1/2" />
+              <Skeleton className="h-3 w-2/3" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Home page skeleton for authenticated users — reserves space for hero + content rows */
+export function HomeAuthSkeleton() {
+  return (
+    <div className="space-y-8">
+      <div className="-mt-6">
+        <HeroBannerSkeleton />
+      </div>
+      <section className="space-y-3">
+        <div className="flex items-baseline justify-between mb-4">
+          <div className="space-y-1.5">
+            <Skeleton className="h-3 w-12" />
+            <Skeleton className="h-6 w-40" />
+          </div>
+        </div>
+        <ScrollableRowSkeleton count={4} />
+      </section>
+      <section className="space-y-3">
+        <div className="flex items-baseline justify-between mb-4">
+          <div className="space-y-1.5">
+            <Skeleton className="h-3 w-16" />
+            <Skeleton className="h-6 w-32" />
+          </div>
+        </div>
+        <ScrollableRowSkeleton count={4} />
+      </section>
+    </div>
+  );
+}
+
+/** Settings tab content skeleton — reserves height to prevent layout shift when lazy tab loads */
+export function SettingsTabSkeleton() {
+  return (
+    <div className="min-h-[480px] space-y-4">
+      <div className="bg-zinc-900 rounded-xl p-5 space-y-3.5">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-3 w-64" />
+        <div className="space-y-3 pt-1">
+          <Skeleton className="h-10 w-full max-w-sm" />
+          <Skeleton className="h-10 w-full max-w-sm" />
+          <Skeleton className="h-10 w-full max-w-sm" />
+        </div>
+      </div>
+      <div className="bg-zinc-900 rounded-xl p-5 space-y-3.5">
+        <Skeleton className="h-5 w-36" />
+        <Skeleton className="h-3 w-56" />
+        <div className="space-y-2 pt-1">
+          <Skeleton className="h-14 w-full rounded-lg" />
+          <Skeleton className="h-14 w-full rounded-lg" />
+          <Skeleton className="h-14 w-full rounded-lg" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 /** Reels page skeleton (full-height card) */
 export function ReelsSkeleton() {
   return (

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -10,7 +10,7 @@ import * as api from "../api";
 import type { Episode, Title, Recommendation, HomepageSection, FriendsLovedItem } from "../types";
 import { normalizeSearchTitle, DEFAULT_HOMEPAGE_LAYOUT } from "../types";
 import TitleList from "../components/TitleList";
-import { EpisodeListSkeleton } from "../components/SkeletonComponents";
+import { HomeAuthSkeleton } from "../components/SkeletonComponents";
 import { groupByShow, formatUpcomingDate } from "../components/EpisodeComponents";
 import { EpisodeShowCard, DeckCardWrapper } from "../components/EpisodeShowCard";
 import HeroBanner from "../components/HeroBanner";
@@ -491,7 +491,7 @@ export default function HomePage() {
   }, [upcoming]);
 
   if (authLoading || state.status === "loading") {
-    return <EpisodeListSkeleton />;
+    return <HomeAuthSkeleton />;
   }
 
   if (!user) {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "../context/AuthContext";
 import { Kicker } from "../components/design";
 import { SettingsSidebar } from "../components/settings/SettingsSidebar";
 import { lazyWithRetry } from "../lib/lazyWithRetry";
+import { SettingsTabSkeleton } from "../components/SkeletonComponents";
 
 const AccountTab = lazyWithRetry(() => import("./settings/AccountTab"));
 const AppearanceTab = lazyWithRetry(() => import("./settings/AppearanceTab"));
@@ -89,7 +90,7 @@ export default function SettingsPage() {
         />
 
         <div className="min-w-0">
-          <Suspense fallback={<div className="p-8 text-zinc-400">Loading…</div>}>
+          <Suspense fallback={<SettingsTabSkeleton />}>
             {activeTab === "account" && <AccountTab />}
             {activeTab === "appearance" && <AppearanceTab />}
             {activeTab === "subscriptions" && <SubscriptionsTab />}


### PR DESCRIPTION
## Summary
- Add `HeroBannerSkeleton` (520px full-bleed placeholder matching the desktop hero height) to `SkeletonComponents.tsx`
- Add `ScrollableRowSkeleton` and `HomeAuthSkeleton` (hero + two carousel rows) to replace the bare `EpisodeListSkeleton` on the authenticated home loading state — eliminates the massive layout shift as the 520px hero and carousel rows pop in after data loads
- Add `SettingsTabSkeleton` (`min-h-[480px]` with card-shaped placeholders) as the `Suspense` fallback for lazy-loaded settings tabs — eliminates the reflow when tab content replaces the small "Loading…" text node

## Test plan
- [ ] Load Home page while logged in: loading state should show the 520px grey hero placeholder + two rows of card skeletons before data arrives — no layout shift when content appears
- [ ] Load Home page while logged out: brief skeleton appears, then the landing hero text + popular grid render — no shift
- [ ] Navigate to `/settings`: the tab content area should show card-shaped placeholders (not a small "Loading…" span) while the lazy chunk loads — no shift when the form fields appear
- [ ] Switch between settings tabs (e.g. Account → Notifications): transition should not cause a layout jump
- [ ] `bun run check` passes (2629 tests, 0 failures, no lint errors)

Closes #694