### PR TITLE
perf: remove Sentry Replay from prod bundle (~85 KB wasted JS)

### DIFF
--- a/frontend/src/instrument.ts
+++ b/frontend/src/instrument.ts
@@ -11,7 +11,6 @@ if (dsn) {
       release: import.meta.env.VITE_SENTRY_RELEASE,
       integrations: [
         Sentry.browserTracingIntegration(),
-        Sentry.replayIntegration(),
         Sentry.reactRouterV7BrowserTracingIntegration({
           useEffect,
           useLocation,
@@ -21,8 +20,6 @@ if (dsn) {
         }),
       ],
       tracesSampleRate: 1.0,
-      replaysSessionSampleRate: 0.1,
-      replaysOnErrorSampleRate: 1.0,
     });
   });
 }


### PR DESCRIPTION
## Summary

- Removes `Sentry.replayIntegration()` from the integrations array in `frontend/src/instrument.ts`
- Removes `replaysSessionSampleRate: 0.1` and `replaysOnErrorSampleRate: 1.0` config options
- Keeps `browserTracingIntegration`, `reactRouterV7BrowserTracingIntegration`, and `tracesSampleRate` intact

The Replay SDK adds ~85 KB of JavaScript to the production bundle. It was included by default Sentry scaffolding but was never intentionally enabled for this project.

## Test plan

- [x] `bun run check` passes (2629 tests, 0 failures, no lint errors, no type errors)
- [x] Sentry error capture and tracing remain functional — only replay code removed

Closes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)