### PR TITLE
perf: bump Vite build.target to es2020 to drop legacy JS polyfills

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,6 +13,7 @@ export const pwaOptions: Partial<VitePWAOptions> = {
   injectRegister: "script-defer",
   injectManifest: {
     globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
+    target: "es2020",
   },
   manifest: {
     name: "Remindarr",
@@ -68,6 +69,7 @@ export default defineConfig({
     },
   },
   build: {
+    target: "es2020",
     sourcemap: true,
     rollupOptions: {
       output: {


### PR DESCRIPTION
## Summary

- Sets `build.target: "es2020"` in `frontend/vite.config.ts` to eliminate legacy JS polyfills (~11 KB)
- Sets `target: "es2020"` in the `injectManifest` block for the PWA service worker

Lighthouse `legacy-javascript-insight` was reporting an `Array.from` polyfill wasted because the esbuild target was lower than necessary. Modern evergreen browsers all support ES2020.

## Test plan

- [x] `bun run check` passes (2629 tests, 0 failures, no lint errors, no type errors)
- [ ] Bundle still works in supported browsers (modern evergreen browsers)

Closes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)