### PR TITLE
fix: per-handler timeout for Bun job worker — prevents queue freeze on stalled handler

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -19,6 +19,9 @@ export const CONFIG = {
   TMDB_BASE_URL: "https://api.themoviedb.org/3",
   TMDB_IMAGE_BASE_URL: "https://image.tmdb.org/t/p",
   TMDB_API_TIMEOUT_MS: Number(process.env.TMDB_API_TIMEOUT_MS) || 15000,
+  // Job worker per-handler deadline (Bun queue only). Must be < 30 min stale-job
+  // recovery window so the in-process timeout fires before recoverStaleJobs could.
+  JOB_HANDLER_TIMEOUT_MS: Number(process.env.JOB_HANDLER_TIMEOUT_MS) || 300000,
   EPISODE_SYNC_DELAY_MS: 500,
   SYNC_TITLES_CRON: process.env.SYNC_TITLES_CRON || "0 3 * * *",
   SYNC_EPISODES_CRON: process.env.SYNC_EPISODES_CRON || "30 3 * * *",

--- a/server/jobs/worker.test.ts
+++ b/server/jobs/worker.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterAll, mock, spyOn } from "bun:test";
 import Sentry from "../sentry";
+import { CONFIG } from "../config";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
-import { enqueueJob, registerCron, getCronExpression } from "./queue";
+import { enqueueJob, registerCron, getCronExpression, getJobStats } from "./queue";
 import { registerHandler, processJobs, stopWorker } from "./worker";
 
 const withMonitorSpy = spyOn(Sentry, "withMonitor").mockImplementation(
@@ -80,6 +81,27 @@ describe("worker Sentry monitoring", () => {
     await processJobs();
 
     expect(captureExceptionSpy).toHaveBeenCalledWith(jobError);
+  });
+});
+
+describe("worker handler timeout", () => {
+  it("fails a job whose handler never resolves within JOB_HANDLER_TIMEOUT_MS", async () => {
+    const original = CONFIG.JOB_HANDLER_TIMEOUT_MS;
+    CONFIG.JOB_HANDLER_TIMEOUT_MS = 50;
+    try {
+      registerHandler("hung-job", () => new Promise(() => {})); // never resolves
+      enqueueJob("hung-job", undefined, { maxAttempts: 1 });
+      await processJobs();
+
+      expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+      const err = captureExceptionSpy.mock.calls[0][0] as Error;
+      expect(err.message).toContain("exceeded handler timeout");
+
+      const stats = getJobStats();
+      expect(stats["hung-job"].failed).toBe(1);
+    } finally {
+      CONFIG.JOB_HANDLER_TIMEOUT_MS = original;
+    }
   });
 });
 

--- a/server/jobs/worker.ts
+++ b/server/jobs/worker.ts
@@ -1,6 +1,7 @@
 import Sentry from "../sentry";
 import { logger } from "../logger";
 import { jobsTotal, jobDurationSeconds } from "../metrics";
+import { CONFIG } from "../config";
 
 const log = logger.child({ module: "jobs" });
 
@@ -28,6 +29,23 @@ export function registerHandler(name: string, handler: JobHandler) {
   handlers.set(name, handler);
 }
 
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, jobName: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Job "${jobName}" exceeded handler timeout of ${timeoutMs}ms`)),
+          timeoutMs
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
 export async function processJobs() {
   for (const [name, handler] of handlers) {
     const job = claimNextJob(name);
@@ -43,16 +61,11 @@ export async function processJobs() {
 
     const jobStart = performance.now();
     try {
+      const exec = () => withTimeout(handler(job), CONFIG.JOB_HANDLER_TIMEOUT_MS, name);
       if (cronExpr) {
-        await Sentry.withMonitor(
-          name,
-          async () => {
-            await handler(job);
-          },
-          monitorConfig
-        );
+        await Sentry.withMonitor(name, exec, monitorConfig);
       } else {
-        await handler(job);
+        await exec();
       }
       completeJob(job.id);
       const duration = (performance.now() - jobStart) / 1000;


### PR DESCRIPTION
## Summary

- Wraps each job handler invocation in a `Promise.race` against a configurable deadline (`JOB_HANDLER_TIMEOUT_MS`, default 5 min) so a stalled upstream (slow TMDB response, unresponsive Discord webhook, locked SQLite WAL) can no longer freeze the entire job queue
- On timeout the existing failure path fires: `failJob` → `Sentry.captureException` → metrics → `log.error("Failed job")` → exponential-backoff retry
- New `JOB_HANDLER_TIMEOUT_MS` config value reads from `process.env`, defaulting to 300 000 ms — well below the 30-min `recoverStaleJobs` threshold so the in-process timeout always fires first
- The handler keeps running as an orphan after timeout (same semantics as a process crash mid-run); `AbortController` threading through every handler signature is a larger blast radius and is out of scope

## What changed

| File | Change |
|---|---|
| `server/config.ts` | Added `JOB_HANDLER_TIMEOUT_MS` alongside the other numeric timeouts |
| `server/jobs/worker.ts` | Added `withTimeout` helper; refactored handler call sites (both cron and non-cron paths) to route through it |
| `server/jobs/worker.test.ts` | Added regression test: registers a never-resolving handler, asserts job transitions to `failed` and `Sentry.captureException` fires |

## Out of scope

- Per-handler timeout overrides (would change `JobHandler` signature) — open a follow-up if needed
- CF Workers / Durable Object equivalent — different code path, different lifecycle

## Test plan

- [x] New unit test: `worker handler timeout — fails a job whose handler never resolves within JOB_HANDLER_TIMEOUT_MS`
- [x] `bun run check` passes (2631 tests, 0 failures)

Closes #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)