### PR TITLE
fix(a11y): HeroBanner pagination dots — accessible name + tap target

### DIFF
--- a/frontend/src/components/HeroBanner.render.test.tsx
+++ b/frontend/src/components/HeroBanner.render.test.tsx
@@ -67,4 +67,42 @@ describe("HeroBanner", () => {
     expect(img).not.toBeNull();
     expect(img?.getAttribute("crossorigin")).toBe("anonymous");
   });
+
+  it("renders pagination dots with aria-label and aria-current when multiple slides exist (#682)", () => {
+    const episodes = [
+      makeEpisode({ id: 1, title_id: "tv-1", show_title: "Show A" }),
+      makeEpisode({ id: 2, title_id: "tv-2", show_title: "Show B" }),
+      makeEpisode({ id: 3, title_id: "tv-3", show_title: "Show C" }),
+    ];
+
+    const { container } = render(
+      <Wrapper>
+        <HeroBanner episodes={episodes} />
+      </Wrapper>
+    );
+
+    const dots = container.querySelectorAll(
+      'button[aria-label^="Slide"]'
+    );
+    expect(dots.length).toBe(3);
+    expect(dots[0].getAttribute("aria-label")).toBe("Slide 1 of 3");
+    expect(dots[1].getAttribute("aria-label")).toBe("Slide 2 of 3");
+    expect(dots[2].getAttribute("aria-label")).toBe("Slide 3 of 3");
+
+    // First dot is active by default
+    expect(dots[0].getAttribute("aria-current")).toBe("true");
+    expect(dots[1].getAttribute("aria-current")).toBeNull();
+    expect(dots[2].getAttribute("aria-current")).toBeNull();
+  });
+
+  it("does not render pagination dots when only one slide exists", () => {
+    const { container } = render(
+      <Wrapper>
+        <HeroBanner episodes={[makeEpisode()]} />
+      </Wrapper>
+    );
+
+    const dots = container.querySelectorAll('button[aria-label^="Slide"]');
+    expect(dots.length).toBe(0);
+  });
 });

--- a/frontend/src/components/HeroBanner.tsx
+++ b/frontend/src/components/HeroBanner.tsx
@@ -228,15 +228,21 @@ export default function HeroBanner({
 
           {/* Slide dots */}
           {slides.length > 1 && (
-            <div className="flex gap-2 mt-6">
+            <div className="flex gap-1 mt-6">
               {slides.map((_, i) => (
                 <button
                   key={i}
                   onClick={() => goTo(i)}
-                  className={`h-1 rounded-full transition-all cursor-pointer ${
-                    i === safeIndex ? "w-6 bg-amber-400" : "w-2 bg-white/30 hover:bg-white/50"
-                  }`}
-                />
+                  aria-label={`Slide ${i + 1} of ${slides.length}`}
+                  aria-current={i === safeIndex ? "true" : undefined}
+                  className="p-2 cursor-pointer"
+                >
+                  <span
+                    className={`block h-1 rounded-full transition-all ${
+                      i === safeIndex ? "w-6 bg-amber-400" : "w-2 bg-white/30 hover:bg-white/50"
+                    }`}
+                  />
+                </button>
               ))}
             </div>
           )}


### PR DESCRIPTION
## Summary
- Added `aria-label="Slide N of M"` to each pagination dot button
- Added `aria-current="true"` to the active dot
- Wrapped visual dot in inner `<span>` so outer `<button>` can carry `p-2` for ≥24×24 px hit area

## Test plan
- [ ] `bun run check` passes
- [ ] Tab to a dot button in browser; accessible name is announced
- [ ] Active dot has `aria-current="true"` in DOM inspector
- [ ] Tests in `HeroBanner.render.test.tsx` all pass (3/3)

Closes #682