### PR TITLE
fix(a11y): nav search button label-content-name-mismatch

### DIFF
--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
 import { navLinkClass } from "./nav-utils";
 
 describe("navLinkClass", () => {
@@ -38,5 +40,35 @@ describe("navLinkClass", () => {
       expect(result).toContain("transition-colors");
       expect(result).toContain("border-b-2");
     }
+  });
+});
+
+describe("nav search button a11y (WCAG 2.5.3)", () => {
+  const src = readFileSync(join(import.meta.dir, "App.tsx"), "utf-8");
+
+  it("search trigger button has no aria-label (accessible name derives from visible text)", () => {
+    // Extract the <button> JSX block for the ⌘K search trigger so we only
+    // inspect the right button and not unrelated aria-labels in the file.
+    // Slice from the <button after the comment marker.
+    const commentMarker = "{/* ⌘K search trigger */}";
+    const commentPos = src.indexOf(commentMarker);
+    const buttonStart = src.indexOf("<button", commentPos);
+    const buttonEnd = src.indexOf("</button>", buttonStart) + "</button>".length;
+    const buttonSrc = src.slice(buttonStart, buttonEnd);
+    expect(buttonSrc).not.toContain("aria-label");
+  });
+
+  it("⌘K keyboard hint span is aria-hidden to exclude it from the accessible name", () => {
+    const commentMarker = "{/* ⌘K search trigger */}";
+    const commentPos = src.indexOf(commentMarker);
+    const buttonStart = src.indexOf("<button", commentPos);
+    const buttonEnd = src.indexOf("</button>", buttonStart) + "</button>".length;
+    const buttonSrc = src.slice(buttonStart, buttonEnd);
+    // The aria-hidden span must appear before the ⌘K glyph
+    const ariaHiddenIdx = buttonSrc.indexOf('aria-hidden="true"');
+    const cmdKIdx = buttonSrc.indexOf("⌘K");
+    expect(ariaHiddenIdx).toBeGreaterThan(-1);
+    expect(cmdKIdx).toBeGreaterThan(-1);
+    expect(ariaHiddenIdx).toBeLessThan(cmdKIdx);
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -134,13 +134,12 @@ export default function App() {
           {/* ⌘K search trigger */}
           <button
             type="button"
-            aria-label={t("nav.search")}
             onClick={() => focusOrNavigateSearch(navigate, location.pathname)}
             className="hidden sm:flex items-center gap-2 w-[260px] bg-white/[0.06] border border-white/[0.08] rounded-lg px-3 py-1.5 text-sm text-zinc-400 hover:bg-white/[0.1] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900"
           >
             <span className="opacity-60 text-base leading-none">⌕</span>
             <span className="flex-1 text-left text-[13px]">Search titles, people…</span>
-            <span className="font-mono text-[11px] opacity-60">⌘K</span>
+            <span aria-hidden="true" className="font-mono text-[11px] opacity-60">⌘K</span>
           </button>
           {/* Desktop user section */}
           <div className="hidden sm:flex items-center gap-3">


### PR DESCRIPTION
## Summary
- Removed `aria-label="Search"` from the nav search trigger button; accessible name now derives from visible text "Search titles, people…"
- Wrapped `⌘K` hint in `<span aria-hidden="true">` so it is excluded from the accessible name

## Test plan
- [ ] `bun run check` passes
- [ ] Inspect element: search button has no `aria-label` attribute
- [ ] Screen reader announces button as "Search titles, people…" without "Command K"

Closes #683