### PR TITLE
fix(a11y): BottomTabBar More link — add descriptive aria-label

### DIFF
--- a/frontend/src/components/BottomTabBar.test.tsx
+++ b/frontend/src/components/BottomTabBar.test.tsx
@@ -117,4 +117,11 @@ describe("BottomTabBar", () => {
     render(<BottomTabBar />, { wrapper: Wrapper });
     expect(screen.getByRole("navigation", { name: "Mobile navigation" })).toBeDefined();
   });
+
+  it("More link has descriptive aria-label", () => {
+    render(<BottomTabBar />, { wrapper: Wrapper });
+    const moreLink = screen.getByRole("link", { name: "More navigation options" });
+    expect(moreLink).toBeDefined();
+    expect(moreLink.getAttribute("href")).toBe("/more");
+  });
 });

--- a/frontend/src/components/BottomTabBar.tsx
+++ b/frontend/src/components/BottomTabBar.tsx
@@ -55,7 +55,7 @@ export default function BottomTabBar() {
               <span className="text-[10px] font-semibold tracking-[0.02em]">{t("bottomNav.tracked")}</span>
             </NavLink>
 
-            <NavLink to="/more" className={({ isActive }) => tabClass(isActive)}>
+            <NavLink to="/more" aria-label={t("bottomNav.moreOptions")} className={({ isActive }) => tabClass(isActive)}>
               <div className="relative">
                 <MoreHorizontal size={ICON_SIZE} aria-hidden="true" />
                 {unreadCount > 0 && (

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -60,6 +60,7 @@
     "tracked": "Tracked",
     "discovery": "Discovery",
     "more": "More",
+    "moreOptions": "More navigation options",
     "profile": "Profile",
     "signIn": "Sign In",
     "unreadRecommendations_one": "{{count}} unread recommendation",


### PR DESCRIPTION
## Summary
- Added `aria-label="More navigation options"` to the More NavLink in `BottomTabBar.tsx` via the existing i18n system (`t("bottomNav.moreOptions")`)
- Added the `bottomNav.moreOptions` key (`"More navigation options"`) to `frontend/src/locales/en.json`
- Added a regression test in `BottomTabBar.test.tsx` asserting `aria-label="More navigation options"` on the More link

## Test plan
- [x] `bun test frontend/src/components/BottomTabBar.test.tsx` — all 8 tests pass
- [x] ESLint passes with zero errors and zero warnings (`bun run lint` from frontend/)
- [ ] Inspect DOM: `<a aria-label="More navigation options">` on the More nav item
- [ ] Lighthouse `link-text` audit passes for BottomTabBar

Closes #687