### PR TITLE
fix(a11y): associate Settings form inputs with labels (incl. country select)

### DIFF
--- a/frontend/src/components/settings/kit.test.tsx
+++ b/frontend/src/components/settings/kit.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "bun:test";
+import { render, screen } from "@testing-library/react";
+import { SFormRow, SInput, SLabel } from "./kit";
+
+describe("SFormRow a11y", () => {
+  it("renders a <label> with htmlFor matching the child SInput id", () => {
+    render(
+      <SFormRow label="Username">
+        <SInput value="alice" />
+      </SFormRow>,
+    );
+
+    // The label element must exist and have a non-empty htmlFor
+    const label = screen.getByText("Username").closest("label");
+    expect(label).not.toBeNull();
+    const htmlFor = label?.getAttribute("for");
+    expect(htmlFor).toBeTruthy();
+
+    // The input associated with the label must exist in the DOM
+    const input = document.getElementById(htmlFor!);
+    expect(input).not.toBeNull();
+    expect(input?.tagName.toLowerCase()).toBe("input");
+  });
+
+  it("renders a <label> with htmlFor matching a native <select> id", () => {
+    render(
+      <SFormRow label="Country">
+        <select>
+          <option value="">None</option>
+          <option value="US">United States</option>
+        </select>
+      </SFormRow>,
+    );
+
+    const label = screen.getByText("Country").closest("label");
+    expect(label).not.toBeNull();
+    const htmlFor = label?.getAttribute("for");
+    expect(htmlFor).toBeTruthy();
+
+    const select = document.getElementById(htmlFor!);
+    expect(select).not.toBeNull();
+    expect(select?.tagName.toLowerCase()).toBe("select");
+  });
+
+  it("renders a <label> with htmlFor matching a native <textarea> id", () => {
+    render(
+      <SFormRow label="Bio">
+        <textarea />
+      </SFormRow>,
+    );
+
+    const label = screen.getByText("Bio").closest("label");
+    expect(label).not.toBeNull();
+    const htmlFor = label?.getAttribute("for");
+    expect(htmlFor).toBeTruthy();
+
+    const textarea = document.getElementById(htmlFor!);
+    expect(textarea).not.toBeNull();
+    expect(textarea?.tagName.toLowerCase()).toBe("textarea");
+  });
+
+  it("still renders when SFormRow has multiple children (control + hint)", () => {
+    render(
+      <SFormRow label="Schedule">
+        <select>
+          <option value="daily">Daily</option>
+        </select>
+        <div>Covers the next 7 days</div>
+      </SFormRow>,
+    );
+
+    // Label should still point to the select (first child)
+    const label = screen.getByText("Schedule").closest("label");
+    expect(label).not.toBeNull();
+    const htmlFor = label?.getAttribute("for");
+    expect(htmlFor).toBeTruthy();
+
+    const select = document.getElementById(htmlFor!);
+    expect(select?.tagName.toLowerCase()).toBe("select");
+
+    // Hint text must still be rendered
+    expect(screen.getByText("Covers the next 7 days")).not.toBeNull();
+  });
+});
+
+describe("SLabel a11y", () => {
+  it("renders a <div> when no htmlFor is given", () => {
+    const { container } = render(<SLabel>Standalone label text</SLabel>);
+    // The outer wrapper should be a div, not a label
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.tagName.toLowerCase()).toBe("div");
+  });
+
+  it("renders a <label> element when htmlFor is provided", () => {
+    const { container } = render(<SLabel htmlFor="my-test-input">Field name here</SLabel>);
+    // The outer wrapper should be a label element
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.tagName.toLowerCase()).toBe("label");
+    expect(wrapper.getAttribute("for")).toBe("my-test-input");
+  });
+});

--- a/frontend/src/components/settings/kit.tsx
+++ b/frontend/src/components/settings/kit.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { type ReactNode, useId, isValidElement, cloneElement, Children } from "react";
 import { cn } from "@/lib/utils";
 import { Card } from "@/components/ui/card";
 
@@ -78,18 +78,33 @@ export function SHead({
 export function SLabel({
   children,
   hint,
+  htmlFor,
   className,
 }: {
   children: ReactNode;
   hint?: ReactNode;
+  /** When provided, renders a `<label>` element with this `htmlFor` value. */
+  htmlFor?: string;
   className?: string;
 }) {
-  return (
-    <div className={cn("flex justify-between items-baseline mb-1.5", className)}>
+  const inner = (
+    <>
       <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-500">
         {children}
       </div>
       {hint && <div className="text-[11px] text-zinc-500">{hint}</div>}
+    </>
+  );
+  if (htmlFor) {
+    return (
+      <label htmlFor={htmlFor} className={cn("flex justify-between items-baseline mb-1.5", className)}>
+        {inner}
+      </label>
+    );
+  }
+  return (
+    <div className={cn("flex justify-between items-baseline mb-1.5", className)}>
+      {inner}
     </div>
   );
 }
@@ -105,10 +120,23 @@ export function SFormRow({
   children: ReactNode;
   className?: string;
 }) {
+  const generatedId = useId();
+  // Inject `id` into the first React element child so the label's `htmlFor`
+  // points to it. Works for single-child rows (SInput, select, textarea) and
+  // also for multi-child rows where the first child is the control and the
+  // rest are hint elements.
+  const childArray = Children.toArray(children);
+  const [firstChild, ...restChildren] = childArray;
+  const patchedFirst =
+    firstChild && isValidElement(firstChild)
+      ? cloneElement(firstChild as React.ReactElement<{ id?: string }>, { id: generatedId })
+      : firstChild;
+
   return (
     <div className={cn("mb-3.5", className)}>
-      <SLabel hint={hint}>{label}</SLabel>
-      {children}
+      <SLabel hint={hint} htmlFor={generatedId}>{label}</SLabel>
+      {patchedFirst}
+      {restChildren}
     </div>
   );
 }
@@ -403,6 +431,7 @@ export function SButton({
 }
 
 export function SInput({
+  id,
   value,
   onChange,
   type = "text",
@@ -419,6 +448,7 @@ export function SInput({
   list,
   autoComplete,
 }: {
+  id?: string;
   value: string;
   onChange?: (v: string) => void;
   type?: string;
@@ -437,6 +467,7 @@ export function SInput({
 }) {
   return (
     <input
+      id={id}
       type={type}
       value={value}
       onChange={(e) => onChange?.(e.target.value)}

--- a/frontend/src/pages/settings/AccountTab.tsx
+++ b/frontend/src/pages/settings/AccountTab.tsx
@@ -502,10 +502,11 @@ function PasskeySection() {
 
             <div className="flex flex-col sm:flex-row gap-2 sm:items-end pt-1 bg-zinc-800 rounded-[10px] p-3.5">
               <div className="flex-1">
-                <SLabel hint={<span>optional</span>}>
+                <SLabel htmlFor="passkey-name-input" hint={<span>optional</span>}>
                   {t("profile.passkeyName")}
                 </SLabel>
                 <SInput
+                  id="passkey-name-input"
                   value={passkeyName}
                   onChange={setPasskeyName}
                   placeholder={t("profile.passkeyNamePlaceholder")}


### PR DESCRIPTION
## Summary
- Converted `SLabel` in `kit.tsx` to render a `<label>` element with `htmlFor` when the prop is provided (falls back to `<div>` for standalone use)
- `SFormRow` now calls `useId()` and injects the generated id into its first React element child via `React.cloneElement`, automatically associating every settings input (`SInput`, `<select>`, `<textarea>`) with its visible label
- Added `id` prop to `SInput` so it can receive the injected id
- Updated the standalone `SLabel` + `SInput` combo in `PasskeySection` (`AccountTab.tsx`) with an explicit `id`/`htmlFor` pair
- Added `kit.test.tsx` with 6 tests asserting `htmlFor`/`id` association for `SInput`, `<select>`, `<textarea>`, multi-child rows, and standalone `SLabel`

All 877 frontend tests pass. No new TypeScript errors introduced (3 pre-existing worktree environment errors unrelated to this change).

## Test plan
- [ ] `bun run check` passes (pre-existing env issues in worktree do not affect CI)
- [ ] Open Settings; focus any input in the Account tab — screen reader announces the visible label
- [ ] DOM inspector: each `<input>`, `<select>`, and `<textarea>` has a matching `<label for="...">` pointing to it
- [ ] Country select in Profile Edit section is properly labelled
- [ ] Bio textarea in Profile Edit section is properly labelled
- [ ] Read-only inputs (Username, Auth provider, Display name, Role) each have associated labels

Closes #684