### PR TITLE
fix(a11y): SettingsSidebar — WAI-ARIA tablist/tab/aria-selected pattern

### DIFF
--- a/frontend/src/components/settings/SettingsSidebar.test.tsx
+++ b/frontend/src/components/settings/SettingsSidebar.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, afterEach } from "bun:test";
+import { SettingsSidebar, type SettingsTabDef } from "./SettingsSidebar";
+
+const tabs: SettingsTabDef[] = [
+  { value: "notifications", label: "Notifications" },
+  { value: "integrations", label: "Integrations" },
+  { value: "account", label: "Account" },
+];
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SettingsSidebar", () => {
+  it("marks the active tab buttons with aria-selected=true and inactive tabs with aria-selected=false", () => {
+    render(
+      <SettingsSidebar
+        tabs={tabs}
+        active="integrations"
+        onSelect={vi.fn()}
+      />,
+    );
+
+    // Both mobile and desktop render in JSDOM (CSS visibility not applied).
+    // Expect 2 buttons per tab label (one per nav).
+    const activeButtons = screen.getAllByRole("tab", { name: "Integrations" });
+    for (const btn of activeButtons) {
+      expect(btn.getAttribute("aria-selected")).toBe("true");
+    }
+
+    const inactiveButtons = screen.getAllByRole("tab", { name: "Notifications" });
+    for (const btn of inactiveButtons) {
+      expect(btn.getAttribute("aria-selected")).toBe("false");
+    }
+  });
+
+  it("renders tablist roles on nav elements with the expected accessible label", () => {
+    render(
+      <SettingsSidebar
+        tabs={tabs}
+        active="notifications"
+        onSelect={vi.fn()}
+      />,
+    );
+
+    // Both mobile and desktop navs have role=tablist.
+    // In JSDOM both render regardless of Tailwind sm:hidden,
+    // so we expect 2 tablists (mobile + desktop).
+    const tablists = screen.getAllByRole("tablist", { name: "Settings sections" });
+    expect(tablists.length).toBe(2);
+  });
+
+  it("calls onSelect with the tab value when a tab button is clicked", () => {
+    const onSelect = vi.fn();
+    render(
+      <SettingsSidebar
+        tabs={tabs}
+        active="notifications"
+        onSelect={onSelect}
+      />,
+    );
+
+    // Click the first rendered "Account" tab (mobile nav).
+    const accountTabs = screen.getAllByRole("tab", { name: "Account" });
+    fireEvent.click(accountTabs[0]);
+    expect(onSelect).toHaveBeenCalledWith("account");
+  });
+});

--- a/frontend/src/components/settings/SettingsSidebar.tsx
+++ b/frontend/src/components/settings/SettingsSidebar.tsx
@@ -21,6 +21,7 @@ export function SettingsSidebar({
     <>
       {/* Mobile: horizontal pill row */}
       <nav
+        role="tablist"
         aria-label="Settings sections"
         className="flex sm:hidden gap-1.5 overflow-x-auto scrollbar-none pb-1"
       >
@@ -29,6 +30,8 @@ export function SettingsSidebar({
           return (
             <button
               key={tab.value}
+              role="tab"
+              aria-selected={isActive}
               onClick={() => onSelect(tab.value)}
               className={cn(
                 "shrink-0 px-3.5 py-2 text-sm font-semibold rounded-full whitespace-nowrap transition-colors cursor-pointer",
@@ -49,6 +52,7 @@ export function SettingsSidebar({
           Sections
         </div>
         <nav
+          role="tablist"
           aria-label="Settings sections"
           className="flex flex-col gap-0.5"
         >
@@ -57,8 +61,9 @@ export function SettingsSidebar({
             return (
               <button
                 key={tab.value}
+                role="tab"
+                aria-selected={isActive}
                 onClick={() => onSelect(tab.value)}
-                aria-current={isActive ? "page" : undefined}
                 className={cn(
                   "flex items-center justify-between px-3.5 py-2.5 rounded-r-md text-left text-[14px] font-medium transition-colors cursor-pointer border-l-2",
                   isActive

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -222,18 +222,18 @@ describe("Settings tabs", () => {
   it("renders tab list with expected tabs for non-admin user", async () => {
     render(<SettingsPage />, { wrapper: Wrapper });
 
-    // Wait for the sidebar nav to be rendered — all tabs appear as <button> elements in the sidebar
+    // Wait for the sidebar nav to be rendered — all tabs appear as role="tab" elements in the sidebar
     await waitFor(() => {
-      const navButtons = screen.getAllByRole("button", { name: "Account" });
-      expect(navButtons.length).toBeGreaterThanOrEqual(1);
+      const navTabs = screen.getAllByRole("tab", { name: "Account" });
+      expect(navTabs.length).toBeGreaterThanOrEqual(1);
     });
 
-    // Sidebar nav buttons for each tab should exist
-    expect(screen.getAllByRole("button", { name: "Appearance" }).length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByRole("button", { name: "Notifications" }).length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByRole("button", { name: "Integrations" }).length).toBeGreaterThanOrEqual(1);
+    // Sidebar nav tabs for each tab should exist
+    expect(screen.getAllByRole("tab", { name: "Appearance" }).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByRole("tab", { name: "Notifications" }).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByRole("tab", { name: "Integrations" }).length).toBeGreaterThanOrEqual(1);
     // Admin tab should not appear for non-admin users
-    expect(screen.queryByRole("button", { name: "Admin" })).toBeNull();
+    expect(screen.queryByRole("tab", { name: "Admin" })).toBeNull();
   });
 
   it("shows account tab content by default", async () => {


### PR DESCRIPTION
## Summary
- Added `role="tablist"` to both mobile and desktop `<nav>` wrappers in SettingsSidebar
- Added `role="tab"` and `aria-selected={isActive}` to each navigation button
- Removed `aria-current="page"` (incorrect for tab navigation)
- Created `SettingsSidebar.test.tsx` (no test file existed before) asserting the active tab has `aria-selected="true"` and inactive tabs have `aria-selected="false"`
- Updated existing `SettingsPage.test.tsx` to query tabs by `role="tab"` instead of `role="button"` to stay in sync with the ARIA changes

## Test plan
- [ ] `bun run check` passes
- [ ] Open Settings; screen reader announces active tab as "selected, tab"
- [ ] DOM inspector confirms `aria-selected="true"` on active tab and `aria-selected="false"` on inactive tabs

Closes #686