### PR TITLE
fix(a11y): color-contrast sweep — text-zinc-500/opacity-60 on dark surfaces

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -139,7 +139,7 @@ export default function App() {
           >
             <span className="opacity-60 text-base leading-none">⌕</span>
             <span className="flex-1 text-left text-[13px]">Search titles, people…</span>
-            <span aria-hidden="true" className="font-mono text-[11px] opacity-60">⌘K</span>
+            <span aria-hidden="true" className="font-mono text-[11px] opacity-75">⌘K</span>
           </button>
           {/* Desktop user section */}
           <div className="hidden sm:flex items-center gap-3">
@@ -163,7 +163,7 @@ export default function App() {
                 </Link>
                 <button
                   onClick={logout}
-                  className="text-sm text-zinc-500 hover:text-white transition-colors cursor-pointer"
+                  className="text-sm text-zinc-400 hover:text-white transition-colors cursor-pointer"
                 >
                   {t("nav.logout")}
                 </button>

--- a/frontend/src/components/settings/SettingsSidebar.tsx
+++ b/frontend/src/components/settings/SettingsSidebar.tsx
@@ -48,7 +48,7 @@ export function SettingsSidebar({
 
       {/* Desktop: sidebar */}
       <aside className="hidden sm:block">
-        <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-zinc-500 px-3.5 pb-2.5">
+        <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-zinc-400 px-3.5 pb-2.5">
           Sections
         </div>
         <nav
@@ -86,7 +86,7 @@ export function SettingsSidebar({
         </nav>
         {buildInfo && (
           <Card padding="none" className="mt-6 p-3.5 rounded-[10px]">
-            <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-zinc-500 mb-2">
+            <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-zinc-400 mb-2">
               Build
             </div>
             <div className="font-mono text-xs text-zinc-300 leading-relaxed">

--- a/frontend/src/components/settings/kit.tsx
+++ b/frontend/src/components/settings/kit.tsx
@@ -31,7 +31,7 @@ export function SCard({
               </div>
             )}
             {subtitle && (
-              <div className="text-sm text-zinc-500 leading-relaxed max-w-[640px]">
+              <div className="text-sm text-zinc-400 leading-relaxed max-w-[640px]">
                 {subtitle}
               </div>
             )}
@@ -89,10 +89,10 @@ export function SLabel({
 }) {
   const inner = (
     <>
-      <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-500">
+      <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-400">
         {children}
       </div>
-      {hint && <div className="text-[11px] text-zinc-500">{hint}</div>}
+      {hint && <div className="text-[11px] text-zinc-400">{hint}</div>}
     </>
   );
   if (htmlFor) {
@@ -165,7 +165,7 @@ export function SSwitch({
           <div
             className={cn(
               "text-xs font-mono leading-relaxed",
-              warning ? "text-red-400" : "text-zinc-500",
+              warning ? "text-red-400" : "text-zinc-400",
             )}
           >
             {sub}
@@ -343,7 +343,7 @@ export function SDivider({
     <div className={cn("flex items-center gap-3 my-5 mb-3.5", className)}>
       <div className="flex-1 h-px bg-white/[0.06]" />
       {label && (
-        <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.15em] text-zinc-500">
+        <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.15em] text-zinc-400">
           {label}
         </div>
       )}
@@ -363,7 +363,7 @@ export function SKeyValue({
 }) {
   return (
     <div className="flex justify-between gap-3 py-2 border-b border-white/[0.04] text-xs">
-      <div className="font-mono tracking-[0.04em] text-zinc-500 shrink-0">{k}</div>
+      <div className="font-mono tracking-[0.04em] text-zinc-400 shrink-0">{k}</div>
       <div
         className={cn(
           "text-right text-zinc-200 min-w-0 truncate",

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -159,7 +159,7 @@ function MobileFeedHome({
       {/* Header */}
       <div className="flex items-center justify-between px-5 pt-3 pb-0">
         <div>
-          <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-500 mb-1">{dateLabel}</div>
+          <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 mb-1">{dateLabel}</div>
           <div className="text-[22px] font-bold tracking-[-0.6px]">
             {getGreeting()}, <span className="text-amber-400">{user.display_name?.split(" ")[0] ?? user.username}</span>
           </div>
@@ -178,7 +178,7 @@ function MobileFeedHome({
       {/* Tonight hero card */}
       {tonightEp && (
         <div className="px-5 pt-4 pb-2">
-          <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-500 mb-2">
+          <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 mb-2">
             Tonight · {today.length} airing
           </div>
           <Link to={`/title/${tonightEp.title_id}`}>
@@ -225,7 +225,7 @@ function MobileFeedHome({
         <>
           <div className="flex items-baseline justify-between px-5 pt-5 pb-3">
             <div>
-              <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-500 mb-1">{alsoAiring.length} more today</div>
+              <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 mb-1">{alsoAiring.length} more today</div>
               <div className="text-[22px] font-bold tracking-[-0.6px]">Also airing</div>
             </div>
           </div>
@@ -238,14 +238,14 @@ function MobileFeedHome({
                   </div>
                   <div className="flex-1 min-w-0">
                     <div className="text-[14px] font-semibold truncate mb-0.5">{ep.show_title}</div>
-                    <div className="font-mono text-[11px] text-zinc-500 mb-1">
+                    <div className="font-mono text-[11px] text-zinc-400 mb-1">
                       S{String(ep.season_number).padStart(2,"0")}·E{String(ep.episode_number).padStart(2,"0")}{ep.name ? ` · ${ep.name}` : ""}
                     </div>
                     <div className="font-mono text-[11px] text-amber-400">
                       {ep.air_date ?? ""}{ep.offers?.[0] ? ` · ${ep.offers[0].provider_name}` : ""}
                     </div>
                   </div>
-                  <span className="text-zinc-500 text-base">›</span>
+                  <span className="text-zinc-400 text-base">›</span>
                 </Card>
               </Link>
             ))}
@@ -258,7 +258,7 @@ function MobileFeedHome({
         <>
           <div className="flex items-baseline justify-between px-5 pt-5 pb-3">
             <div>
-              <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-500 mb-1">
+              <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 mb-1">
                 {cwByShow.size} show{cwByShow.size !== 1 ? "s" : ""} · {unwatched.length} unwatched
               </div>
               <div className="text-[22px] font-bold tracking-[-0.6px]">Continue watching</div>
@@ -283,7 +283,7 @@ function MobileFeedHome({
                     </div>
                   </div>
                   <div className="text-[12px] font-medium leading-[1.2] truncate mb-0.5">{ep.show_title}</div>
-                  <div className="font-mono text-[10px] text-zinc-500">
+                  <div className="font-mono text-[10px] text-zinc-400">
                     E{ep.episode_number}
                   </div>
                 </Link>
@@ -298,7 +298,7 @@ function MobileFeedHome({
         <>
           <div className="flex items-baseline justify-between px-5 pt-5 pb-3">
             <div>
-              <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-500 mb-1">
+              <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 mb-1">
                 {today7.length} episodes
               </div>
               <div className="text-[22px] font-bold tracking-[-0.6px]">This week</div>
@@ -312,7 +312,7 @@ function MobileFeedHome({
                   {ep.poster_url && <img src={ep.poster_url} alt="" className="w-full h-full object-cover" loading="lazy" />}
                 </div>
                 <div className="text-[11px] font-medium leading-[1.15] truncate">{ep.show_title}</div>
-                <div className="font-mono text-[9px] text-zinc-500 uppercase tracking-[0.3px]">
+                <div className="font-mono text-[9px] text-zinc-400 uppercase tracking-[0.3px]">
                   {ep.air_date ? ep.air_date.slice(5) : ""}
                 </div>
               </Link>
@@ -661,7 +661,7 @@ export default function HomePage() {
               <Link to="/calendar" className="font-mono text-xs text-amber-400 hover:text-amber-300 transition-colors">{t("home.seeAll")} →</Link>
             </div>
             {today.length === 0 ? (
-              <p className="text-zinc-500 text-sm">
+              <p className="text-zinc-400 text-sm">
                 {noEpisodes ? t("home.noEpisodes") : t("home.noEpisodesToday")}
               </p>
             ) : (
@@ -694,7 +694,7 @@ export default function HomePage() {
             <div className="space-y-4">
               {upcomingByDateEntries.map(({ date, dateLabel, byShow }) => (
                 <div key={date}>
-                  <h3 className="font-mono text-[11px] uppercase tracking-[0.12em] text-zinc-500 mb-2">{dateLabel === "__TOMORROW__" ? t("episodes.tomorrow") : dateLabel}</h3>
+                  <h3 className="font-mono text-[11px] uppercase tracking-[0.12em] text-zinc-400 mb-2">{dateLabel === "__TOMORROW__" ? t("episodes.tomorrow") : dateLabel}</h3>
                   <FullBleedCarousel>
                     {byShow.map(([titleId, showEps]) => (
                       <div key={titleId} className="w-80 flex-shrink-0" style={{ scrollSnapAlign: "start" }}>
@@ -741,7 +741,7 @@ export default function HomePage() {
                 <h2 className="text-xl font-bold tracking-[-0.01em]">{t("home.airingSoon.title")}</h2>
               </div>
             </div>
-            <p className="text-zinc-500 text-sm">{t("home.airingSoon.empty")}</p>
+            <p className="text-zinc-400 text-sm">{t("home.airingSoon.empty")}</p>
           </section>
         );
 

--- a/frontend/src/pages/title/MovieDetail.tsx
+++ b/frontend/src/pages/title/MovieDetail.tsx
@@ -148,7 +148,7 @@ export default function MovieDetail({ data }: { data: MovieDetailsResponse }) {
           .filter(Boolean)
           .map((cell) => (
             <div key={cell!.label}>
-              <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-500 mb-1">
+              <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 mb-1">
                 {cell!.label}
               </div>
               <div className="font-mono text-[13px] font-semibold text-zinc-100">{cell!.value}</div>
@@ -206,13 +206,13 @@ export default function MovieDetail({ data }: { data: MovieDetailsResponse }) {
           <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 text-sm">
             {tmdb.original_language && (
               <div>
-                <span className="text-zinc-500 block">Original Language</span>
+                <span className="text-zinc-400 block">Original Language</span>
                 <span className="text-zinc-300">{tmdb.original_language.toUpperCase()}</span>
               </div>
             )}
             {tmdb.production_countries?.length > 0 && (
               <div>
-                <span className="text-zinc-500 block">Country</span>
+                <span className="text-zinc-400 block">Country</span>
                 <span className="text-zinc-300">
                   {tmdb.production_countries.map((c) => c.name).join(", ")}
                 </span>
@@ -220,7 +220,7 @@ export default function MovieDetail({ data }: { data: MovieDetailsResponse }) {
             )}
             {tmdb.spoken_languages?.length > 0 && (
               <div>
-                <span className="text-zinc-500 block">Languages</span>
+                <span className="text-zinc-400 block">Languages</span>
                 <span className="text-zinc-300">
                   {tmdb.spoken_languages.map((l) => l.english_name).join(", ")}
                 </span>
@@ -228,19 +228,19 @@ export default function MovieDetail({ data }: { data: MovieDetailsResponse }) {
             )}
             {tmdb.budget > 0 && (
               <div>
-                <span className="text-zinc-500 block">Budget</span>
+                <span className="text-zinc-400 block">Budget</span>
                 <span className="text-zinc-300">{formatCurrency(tmdb.budget)}</span>
               </div>
             )}
             {tmdb.revenue > 0 && (
               <div>
-                <span className="text-zinc-500 block">Revenue</span>
+                <span className="text-zinc-400 block">Revenue</span>
                 <span className="text-zinc-300">{formatCurrency(tmdb.revenue)}</span>
               </div>
             )}
             {tmdb.production_companies?.length > 0 && (
               <div className="col-span-2 sm:col-span-3">
-                <span className="text-zinc-500 block">Production</span>
+                <span className="text-zinc-400 block">Production</span>
                 <span className="text-zinc-300">
                   {tmdb.production_companies.map((c) => c.name).join(", ")}
                 </span>

--- a/frontend/src/pages/title/ShowDetail.tsx
+++ b/frontend/src/pages/title/ShowDetail.tsx
@@ -47,7 +47,7 @@ export default function ShowDetail({ data }: { data: ShowDetailsResponse }) {
           .filter(Boolean)
           .map((cell) => (
             <div key={cell!.label}>
-              <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-500 mb-1">
+              <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-zinc-400 mb-1">
                 {cell!.label}
               </div>
               <div className="font-mono text-[13px] font-semibold text-zinc-100">{cell!.value}</div>
@@ -131,7 +131,7 @@ export default function ShowDetail({ data }: { data: ShowDetailsResponse }) {
                         </span>
                       )}
                     </div>
-                    <p className="text-xs text-zinc-500 mt-0.5">
+                    <p className="text-xs text-zinc-400 mt-0.5">
                       {s.episode_count} episode{s.episode_count !== 1 ? "s" : ""}
                       {s.air_date && ` · ${s.air_date.slice(0, 4)}`}
                     </p>
@@ -164,19 +164,19 @@ export default function ShowDetail({ data }: { data: ShowDetailsResponse }) {
           <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 text-sm">
             {tmdb.type && (
               <div>
-                <span className="text-zinc-500 block">Type</span>
+                <span className="text-zinc-400 block">Type</span>
                 <span className="text-zinc-300">{tmdb.type}</span>
               </div>
             )}
             {tmdb.original_language && (
               <div>
-                <span className="text-zinc-500 block">Original Language</span>
+                <span className="text-zinc-400 block">Original Language</span>
                 <span className="text-zinc-300">{tmdb.original_language.toUpperCase()}</span>
               </div>
             )}
             {tmdb.production_countries?.length > 0 && (
               <div>
-                <span className="text-zinc-500 block">Country</span>
+                <span className="text-zinc-400 block">Country</span>
                 <span className="text-zinc-300">
                   {tmdb.production_countries.map((c) => c.name).join(", ")}
                 </span>
@@ -184,7 +184,7 @@ export default function ShowDetail({ data }: { data: ShowDetailsResponse }) {
             )}
             {tmdb.spoken_languages?.length > 0 && (
               <div>
-                <span className="text-zinc-500 block">Languages</span>
+                <span className="text-zinc-400 block">Languages</span>
                 <span className="text-zinc-300">
                   {tmdb.spoken_languages.map((l) => l.english_name).join(", ")}
                 </span>
@@ -192,7 +192,7 @@ export default function ShowDetail({ data }: { data: ShowDetailsResponse }) {
             )}
             {tmdb.production_companies?.length > 0 && (
               <div className="col-span-2 sm:col-span-3">
-                <span className="text-zinc-500 block">Production</span>
+                <span className="text-zinc-400 block">Production</span>
                 <span className="text-zinc-300">
                   {tmdb.production_companies.map((c) => c.name).join(", ")}
                 </span>


### PR DESCRIPTION
## Summary
- Replaced `text-zinc-500` with `text-zinc-400` on `bg-zinc-900`/`bg-zinc-950`/dark-overlay surfaces in App.tsx, SettingsSidebar.tsx, HomePage.tsx, ShowDetail.tsx, MovieDetail.tsx, and kit.tsx
- Raised `opacity-60` to `opacity-75` on the `⌘K` hint span in App.tsx (already `aria-hidden` from #683)
- Targeted fix only — occurrences on lighter backgrounds are unchanged

## Test plan
- [ ] `bun run check` passes
- [ ] Run Lighthouse on Home page: `color-contrast` audit passes
- [ ] Run Lighthouse on Settings page: `color-contrast` audit passes
- [ ] Run Lighthouse on a Title detail page: `color-contrast` audit passes
- [ ] Visual check: muted text is still clearly muted, not jarring

Closes #688