### PR TITLE
feat(validation): add zValidator to 6 high-traffic public query-param routes

### DIFF
--- a/server/routes/browse.test.ts
+++ b/server/routes/browse.test.ts
@@ -57,7 +57,8 @@ describe("GET /browse", () => {
     const res = await app.request("/browse");
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toContain("Invalid category");
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
   });
 
   it("returns 400 for invalid category", async () => {
@@ -169,32 +170,20 @@ describe("GET /browse", () => {
     expect(callArgs.voteCountGte).toBe("200");
   });
 
-  it("clamps negative page to 1", async () => {
-    (tmdbClient.discoverMovies as any).mockResolvedValueOnce({
-      results: [], total_pages: 10, total_results: 200, page: 1,
-    });
-
+  it("rejects negative page", async () => {
     const res = await app.request("/browse?category=popular&type=MOVIE&page=-5");
-    expect(res.status).toBe(200);
-
+    expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.page).toBe(1);
-    const callArgs = ((tmdbClient.discoverMovies as any).mock.calls[0] as unknown[])[0] as Record<string, unknown>;
-    expect(callArgs.page).toBe(1);
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
   });
 
-  it("clamps NaN page to 1", async () => {
-    (tmdbClient.discoverMovies as any).mockResolvedValueOnce({
-      results: [], total_pages: 10, total_results: 200, page: 1,
-    });
-
+  it("rejects non-numeric page", async () => {
     const res = await app.request("/browse?category=popular&type=MOVIE&page=abc");
-    expect(res.status).toBe(200);
-
+    expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.page).toBe(1);
-    const callArgs = ((tmdbClient.discoverMovies as any).mock.calls[0] as unknown[])[0] as Record<string, unknown>;
-    expect(callArgs.page).toBe(1);
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
   });
 
   it("passes page parameter correctly", async () => {
@@ -482,18 +471,12 @@ describe("GET /browse", () => {
       expect(filters.voteAverageGte).toBe(7.5);
     });
 
-    it("ignores non-numeric year/rating values", async () => {
-      (tmdbClient.discoverMovies as any).mockResolvedValueOnce({
-        results: [], total_pages: 1, total_results: 0, page: 1,
-      });
-
+    it("rejects non-numeric year/rating values", async () => {
       const res = await app.request("/browse?category=popular&type=MOVIE&year_min=abc&min_rating=xyz");
-      expect(res.status).toBe(200);
-
-      const callArgs = ((tmdbClient.discoverMovies as any).mock.calls[0] as unknown[])[0] as Record<string, unknown>;
-      const filters = callArgs.filters as Record<string, unknown>;
-      expect(filters.yearMin).toBeUndefined();
-      expect(filters.voteAverageGte).toBeUndefined();
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("Validation failed");
+      expect(Array.isArray(body.issues)).toBe(true);
     });
   });
 
@@ -524,6 +507,74 @@ describe("GET /browse", () => {
       expect(body.priorityLanguageCodes).toContain("en");
       expect(body.priorityLanguageCodes).toContain("fr");
       expect(body.priorityLanguageCodes).toContain("ja");
+    });
+  });
+
+  describe("validation", () => {
+    it("rejects missing category", async () => {
+      const res = await app.request("/browse");
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("Validation failed");
+      expect(Array.isArray(body.issues)).toBe(true);
+    });
+
+    it("rejects unknown category value", async () => {
+      const res = await app.request("/browse?category=trending");
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("Validation failed");
+      expect(Array.isArray(body.issues)).toBe(true);
+    });
+
+    it("rejects page=0", async () => {
+      const res = await app.request("/browse?category=popular&page=0");
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("Validation failed");
+      expect(Array.isArray(body.issues)).toBe(true);
+    });
+
+    it("rejects min_rating above 10", async () => {
+      const res = await app.request("/browse?category=popular&min_rating=11");
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("Validation failed");
+      expect(Array.isArray(body.issues)).toBe(true);
+    });
+
+    it("rejects min_rating below 0", async () => {
+      const res = await app.request("/browse?category=popular&min_rating=-1");
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("Validation failed");
+      expect(Array.isArray(body.issues)).toBe(true);
+    });
+
+    it("rejects non-numeric year_min", async () => {
+      const res = await app.request("/browse?category=popular&year_min=notanumber");
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("Validation failed");
+      expect(Array.isArray(body.issues)).toBe(true);
+    });
+
+    it("rejects onlyMine=false (only literal 'true' is accepted)", async () => {
+      const res = await app.request("/browse?category=popular&onlyMine=false");
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("Validation failed");
+      expect(Array.isArray(body.issues)).toBe(true);
+    });
+
+    it("happy-path: minimal request with category only", async () => {
+      const res = await app.request("/browse?category=popular");
+      expect(res.status).toBe(200);
+    });
+
+    it("happy-path: category + year filters + min_rating", async () => {
+      const res = await app.request("/browse?category=popular&year_min=2000&min_rating=7.5");
+      expect(res.status).toBe(200);
     });
   });
 });

--- a/server/routes/browse.ts
+++ b/server/routes/browse.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { z } from "zod";
 import { pLimit } from "../lib/p-limit";
 import {
   discoverMovies,
@@ -25,6 +26,7 @@ import { logger } from "../logger";
 import { syncFailureTotal } from "../metrics";
 import { ok, err } from "./response";
 import { setPublicCacheIfAnon } from "./cache-headers";
+import { zValidator } from "../lib/validator";
 import { toCanonicalGenre, expandGenreIds } from "../genres";
 import { CONFIG } from "../config";
 
@@ -32,6 +34,19 @@ const log = logger.child({ module: "browse" });
 
 const VALID_CATEGORIES = ["popular", "upcoming", "top_rated"] as const;
 type Category = (typeof VALID_CATEGORIES)[number];
+
+const browseQuerySchema = z.object({
+  category: z.enum(["popular", "upcoming", "top_rated"]),
+  type: z.string().optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  genre: z.string().optional(),
+  provider: z.string().optional(),
+  language: z.string().optional(),
+  year_min: z.coerce.number().int().optional(),
+  year_max: z.coerce.number().int().optional(),
+  min_rating: z.coerce.number().min(0).max(10).optional(),
+  onlyMine: z.literal("true").optional().transform((v) => v === "true"),
+});
 
 function formatDate(date: Date): string {
   return date.toISOString().split("T")[0];
@@ -89,24 +104,12 @@ function fetchTvByCategory(category: Category, opts: CategoryDiscoverOptions) {
 
 const app = new Hono<AppEnv>();
 
-app.get("/", async (c) => {
-  const category = c.req.query("category");
-  const type = c.req.query("type") || "";
-  const page = Math.max(1, parseInt(c.req.query("page") || "1", 10) || 1);
-  const genreParam = c.req.query("genre") || "";
-  const providerParam = c.req.query("provider") || "";
-  const languageParam = c.req.query("language") || "";
-  const yearMinParam = c.req.query("year_min");
-  const yearMaxParam = c.req.query("year_max");
-  const minRatingParam = c.req.query("min_rating");
-  const onlyMine = c.req.query("onlyMine") === "true";
+app.get("/", zValidator("query", browseQuerySchema), async (c) => {
+  const { category, type, page, genre: genreParam, provider: providerParam, language: languageParam, year_min: yearMin, year_max: yearMax, min_rating: minRating, onlyMine } = c.req.valid("query");
   const genreNames = genreParam ? genreParam.split(",").filter(Boolean) : [];
   let providerValues = providerParam ? providerParam.split(",").filter(Boolean) : [];
   const languageValues = languageParam ? languageParam.split(",").filter(Boolean) : [];
   const typeValues = type ? type.split(",").filter(Boolean) : [];
-  const yearMin = yearMinParam ? parseInt(yearMinParam, 10) : undefined;
-  const yearMax = yearMaxParam ? parseInt(yearMaxParam, 10) : undefined;
-  const minRating = minRatingParam ? parseFloat(minRatingParam) : undefined;
 
   const user = c.get("user");
   if (onlyMine && user) {
@@ -121,10 +124,6 @@ app.get("/", async (c) => {
     if (providerValues.length === 0) {
       return ok(c, { titles: [], page, totalPages: 0, totalResults: 0, availableGenres: [], availableProviders: [], availableLanguages: [], regionProviderIds: [], priorityLanguageCodes: [] });
     }
-  }
-
-  if (!category || !VALID_CATEGORIES.includes(category as Category)) {
-    return err(c, "Invalid category. Must be one of: popular, upcoming, top_rated");
   }
 
   try {

--- a/server/routes/calendar.test.ts
+++ b/server/routes/calendar.test.ts
@@ -36,7 +36,8 @@ describe("GET /calendar", () => {
     const res = await app.request("/calendar");
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toContain("month parameter required");
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
   });
 
   it("returns 400 for invalid month format", async () => {
@@ -53,7 +54,8 @@ describe("GET /calendar", () => {
     const res = await app.request("/calendar?month=2026-03&type=INVALID");
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toContain("Invalid type");
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
   });
 
   it("accepts valid objectType MOVIE", async () => {
@@ -106,6 +108,57 @@ describe("GET /calendar", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.titles.length).toBeGreaterThanOrEqual(0);
+  });
+
+  describe("validation", () => {
+    it("rejects missing month", async () => {
+      const res = await app.request("/calendar");
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("Validation failed");
+      expect(Array.isArray(body.issues)).toBe(true);
+    });
+
+    it("rejects single-digit month (2026-3)", async () => {
+      const res = await app.request("/calendar?month=2026-3");
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("Validation failed");
+      expect(Array.isArray(body.issues)).toBe(true);
+    });
+
+    it("rejects non-date month", async () => {
+      const res = await app.request("/calendar?month=foo");
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("Validation failed");
+    });
+
+    it("rejects lowercase type", async () => {
+      const res = await app.request("/calendar?month=2026-05&type=movie");
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("Validation failed");
+      expect(Array.isArray(body.issues)).toBe(true);
+    });
+
+    it("rejects unknown type value", async () => {
+      const res = await app.request("/calendar?month=2026-05&type=BOOK");
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("Validation failed");
+      expect(Array.isArray(body.issues)).toBe(true);
+    });
+
+    it("happy-path: minimal request with month only", async () => {
+      const res = await app.request("/calendar?month=2026-05");
+      expect(res.status).toBe(200);
+    });
+
+    it("happy-path: month + type + provider", async () => {
+      const res = await app.request("/calendar?month=2026-05&type=MOVIE&provider=8");
+      expect(res.status).toBe(200);
+    });
   });
 
   it("works with authenticated user context", async () => {

--- a/server/routes/calendar.ts
+++ b/server/routes/calendar.ts
@@ -1,24 +1,22 @@
 import { Hono } from "hono";
+import { z } from "zod";
 import { getTitlesByMonth, getEpisodesByMonth } from "../db/repository";
 import type { AppEnv } from "../types";
-import { ok, err } from "./response";
+import { ok } from "./response";
 import { setPublicCacheIfAnon } from "./cache-headers";
+import { zValidator } from "../lib/validator";
+
+const calendarQuerySchema = z.object({
+  month: z.string().regex(/^\d{4}-\d{2}$/, "month must be YYYY-MM"),
+  type: z.enum(["MOVIE", "SHOW"]).optional(),
+  provider: z.string().optional(),
+});
 
 const app = new Hono<AppEnv>();
 
-app.get("/", async (c) => {
+app.get("/", zValidator("query", calendarQuerySchema), async (c) => {
   const user = c.get("user");
-  const month = c.req.query("month"); // format: 2026-03
-  if (!month || !/^\d{4}-\d{2}$/.test(month)) {
-    return err(c, "month parameter required (format: YYYY-MM)");
-  }
-
-  const objectType = c.req.query("type");
-  const provider = c.req.query("provider");
-
-  if (objectType && !["MOVIE", "SHOW"].includes(objectType)) {
-    return err(c, "Invalid type. Must be one of: MOVIE, SHOW");
-  }
+  const { month, type: objectType, provider } = c.req.valid("query");
 
   const titles = await getTitlesByMonth({ month, objectType, provider }, user?.id);
   const episodes = await getEpisodesByMonth({ month, objectType, provider }, user?.id);

--- a/server/routes/details.test.ts
+++ b/server/routes/details.test.ts
@@ -84,9 +84,12 @@ describe("GET /details/movie/:id", () => {
     expect(res.status).toBe(404);
   });
 
-  it("returns 404 for invalid title ID format", async () => {
+  it("returns 400 for invalid title ID format", async () => {
     const res = await app.request("/details/movie/invalid-id");
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
   });
 });
 
@@ -190,12 +193,11 @@ describe("GET /details/show/:id/season/:season", () => {
   });
 
   it("returns 400 for non-numeric season param", async () => {
-    await upsertTitles([makeParsedTitle({ id: "tv-555", objectType: "SHOW", title: "Season Show", tmdbId: "555" })]);
-
     const res = await app.request("/details/show/tv-555/season/abc");
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toBe("Invalid season number");
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
   });
 
   it("includes seasons array from show details", async () => {
@@ -235,21 +237,19 @@ describe("GET /details/show/:id/season/:season", () => {
 
 describe("GET /details/show/:id/season/:season/episode/:episode", () => {
   it("returns 400 for non-numeric season param", async () => {
-    await upsertTitles([makeParsedTitle({ id: "tv-555", objectType: "SHOW", title: "Season Show", tmdbId: "555" })]);
-
     const res = await app.request("/details/show/tv-555/season/abc/episode/1");
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toBe("Invalid season or episode number");
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
   });
 
   it("returns 400 for non-numeric episode param", async () => {
-    await upsertTitles([makeParsedTitle({ id: "tv-555", objectType: "SHOW", title: "Season Show", tmdbId: "555" })]);
-
     const res = await app.request("/details/show/tv-555/season/1/episode/abc");
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toBe("Invalid season or episode number");
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
   });
 });
 
@@ -321,6 +321,97 @@ describe("GET /details/show/:id/suggestions", () => {
     (tmdbClient.fetchTvSuggestions as any).mockRejectedValueOnce(new Error("TMDB error"));
     const res = await app.request("/details/show/tv-456/suggestions");
     expect(res.status).toBe(503);
+  });
+});
+
+describe("GET /details — validation", () => {
+  it("rejects invalid title ID format on /movie/:id", async () => {
+    const res = await app.request("/details/movie/abc");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects non-prefixed numeric ID on /movie/:id", async () => {
+    const res = await app.request("/details/movie/123");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects non-numeric season param", async () => {
+    const res = await app.request("/details/show/tv-1/season/abc");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects episode=0 (min is 1)", async () => {
+    const res = await app.request("/details/show/tv-1/season/1/episode/0");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects non-numeric episode param", async () => {
+    const res = await app.request("/details/show/tv-1/season/1/episode/abc");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects non-numeric personId", async () => {
+    const res = await app.request("/details/person/abc");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects personId=0 (min is 1)", async () => {
+    const res = await app.request("/details/person/0");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects page=0 on suggestions", async () => {
+    const res = await app.request("/details/movie/movie-1/suggestions?page=0");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects non-numeric page on suggestions", async () => {
+    const res = await app.request("/details/movie/movie-1/suggestions?page=foo");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("happy-path: GET /movie/:id with valid movie id", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-550", title: "Valid Movie", tmdbId: "550" })]);
+    const res = await app.request("/details/movie/movie-550");
+    expect(res.status).toBe(200);
+  });
+
+  it("happy-path: GET /movie/:id/suggestions?page=1", async () => {
+    const res = await app.request("/details/movie/movie-123/suggestions?page=1");
+    expect(res.status).toBe(200);
+  });
+
+  it("happy-path: GET /show/:id/season/:season/episode/:episode with valid params", async () => {
+    await upsertTitles([makeParsedTitle({ id: "tv-555", objectType: "SHOW", title: "Season Show", tmdbId: "555" })]);
+    const res = await app.request("/details/show/tv-555/season/1/episode/2");
+    expect(res.status).toBe(200);
   });
 });
 

--- a/server/routes/details.ts
+++ b/server/routes/details.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { z } from "zod";
 import { getTitleById, upsertTitles } from "../db/repository";
 import { CONFIG } from "../config";
 import {
@@ -19,11 +20,28 @@ import type { AppEnv } from "../types";
 import { logger } from "../logger";
 import { ok, err } from "./response";
 import { setPublicCacheIfAnon } from "./cache-headers";
+import { zValidator } from "../lib/validator";
 import { getUserPace, computeEta } from "../db/repository/stats";
 import { getDb } from "../db/schema";
 import { sql } from "drizzle-orm";
 
 const log = logger.child({ module: "details" });
+
+const titleIdParam = z.object({
+  id: z.string().regex(/^(movie|tv)-\d+$/, "id must match movie-N or tv-N"),
+});
+const seasonParam = titleIdParam.extend({
+  season: z.coerce.number().int().min(0),
+});
+const episodeParam = seasonParam.extend({
+  episode: z.coerce.number().int().min(1),
+});
+const personIdParam = z.object({
+  personId: z.coerce.number().int().min(1),
+});
+const suggestionsQuery = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+});
 
 const app = new Hono<AppEnv>();
 
@@ -62,7 +80,7 @@ async function getOrFetchTitle(titleId: string, userId?: string) {
   return await getTitleById(titleId, userId);
 }
 
-app.get("/movie/:id", async (c) => {
+app.get("/movie/:id", zValidator("param", titleIdParam), async (c) => {
   const user = c.get("user");
   const title = await getOrFetchTitle(c.req.param("id"), user?.id);
   if (!title) return err(c, "Title not found", 404);
@@ -80,7 +98,7 @@ app.get("/movie/:id", async (c) => {
   return ok(c, { title, tmdb, country });
 });
 
-app.get("/show/:id", async (c) => {
+app.get("/show/:id", zValidator("param", titleIdParam), async (c) => {
   const user = c.get("user");
   const titleId = c.req.param("id");
   const title = await getOrFetchTitle(titleId, user?.id);
@@ -126,13 +144,12 @@ app.get("/show/:id", async (c) => {
   return ok(c, { title: { ...title, eta_days: etaDays }, tmdb, country });
 });
 
-app.get("/show/:id/season/:season", async (c) => {
+app.get("/show/:id/season/:season", zValidator("param", seasonParam), async (c) => {
   const user = c.get("user");
   const title = await getOrFetchTitle(c.req.param("id"), user?.id);
   if (!title) return err(c, "Title not found", 404);
 
-  const seasonNumber = Number(c.req.param("season"));
-  if (isNaN(seasonNumber)) return c.json({ error: "Invalid season number" }, 400);
+  const seasonNumber = c.req.valid("param").season;
 
   let tmdb = null;
   let seasons: { season_number: number; name: string; episode_count: number; air_date: string | null; poster_path: string | null }[] = [];
@@ -167,14 +184,12 @@ app.get("/show/:id/season/:season", async (c) => {
   return ok(c, { title, tmdb, seasonNumber, country, seasons });
 });
 
-app.get("/show/:id/season/:season/episode/:episode", async (c) => {
+app.get("/show/:id/season/:season/episode/:episode", zValidator("param", episodeParam), async (c) => {
   const user = c.get("user");
   const title = await getOrFetchTitle(c.req.param("id"), user?.id);
   if (!title) return err(c, "Title not found", 404);
 
-  const seasonNumber = Number(c.req.param("season"));
-  const episodeNumber = Number(c.req.param("episode"));
-  if (isNaN(seasonNumber) || isNaN(episodeNumber)) return c.json({ error: "Invalid season or episode number" }, 400);
+  const { season: seasonNumber, episode: episodeNumber } = c.req.valid("param");
 
   let tmdb = null;
   if (title.tmdb_id && CONFIG.TMDB_API_KEY) {
@@ -188,11 +203,8 @@ app.get("/show/:id/season/:season/episode/:episode", async (c) => {
   return ok(c, { title, tmdb, seasonNumber, episodeNumber, country });
 });
 
-app.get("/person/:personId", async (c) => {
-  const personId = Number(c.req.param("personId"));
-  if (!personId || isNaN(personId)) {
-    return err(c, "Invalid person ID");
-  }
+app.get("/person/:personId", zValidator("param", personIdParam), async (c) => {
+  const personId = c.req.valid("param").personId;
 
   if (!CONFIG.TMDB_API_KEY) {
     return err(c, "TMDB not configured", 503);
@@ -207,12 +219,12 @@ app.get("/person/:personId", async (c) => {
   }
 });
 
-app.get("/movie/:id/suggestions", async (c) => {
+app.get("/movie/:id/suggestions", zValidator("param", titleIdParam), zValidator("query", suggestionsQuery), async (c) => {
   const parsed = parseTitleId(c.req.param("id"));
   if (!parsed || parsed.type !== "MOVIE") return err(c, "Invalid title ID", 400);
   if (!CONFIG.TMDB_API_KEY) return err(c, "TMDB not configured", 503);
 
-  const page = Math.max(1, Number(c.req.query("page") ?? "1") || 1);
+  const page = c.req.valid("query").page;
 
   try {
     const [data, genreMap] = await Promise.all([
@@ -228,12 +240,12 @@ app.get("/movie/:id/suggestions", async (c) => {
   }
 });
 
-app.get("/show/:id/suggestions", async (c) => {
+app.get("/show/:id/suggestions", zValidator("param", titleIdParam), zValidator("query", suggestionsQuery), async (c) => {
   const parsed = parseTitleId(c.req.param("id"));
   if (!parsed || parsed.type !== "SHOW") return err(c, "Invalid title ID", 400);
   if (!CONFIG.TMDB_API_KEY) return err(c, "TMDB not configured", 503);
 
-  const page = Math.max(1, Number(c.req.query("page") ?? "1") || 1);
+  const page = c.req.valid("query").page;
 
   try {
     const [data, genreMap] = await Promise.all([

--- a/server/routes/episodes.test.ts
+++ b/server/routes/episodes.test.ts
@@ -298,3 +298,41 @@ describe("POST /episodes/sync", () => {
     CONFIG.TMDB_API_KEY = origKey;
   });
 });
+
+describe("GET /episodes — validation", () => {
+  it("rejects invalid titleId format on /status/:titleId/:season", async () => {
+    const res = await app.request("/episodes/status/abc/1");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects non-numeric season on /status/:titleId/:season", async () => {
+    const res = await app.request("/episodes/status/movie-1/abc");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects negative season number", async () => {
+    const res = await app.request("/episodes/status/movie-1/-1");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("happy-path: GET /upcoming returns 200 with no user", async () => {
+    const res = await app.request("/episodes/upcoming");
+    expect(res.status).toBe(200);
+  });
+
+  it("happy-path: GET /status/:titleId/:season returns 200 for valid params (no user = empty episodes)", async () => {
+    const res = await app.request("/episodes/status/movie-1/1");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.episodes)).toBe(true);
+  });
+});

--- a/server/routes/episodes.ts
+++ b/server/routes/episodes.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { z } from "zod";
 import * as sync from "../tmdb/sync";
 import { getEpisodesByDateRange, getUnwatchedEpisodes, getSeasonEpisodeStatus } from "../db/repository";
 import { localDateForTimezone, addDays } from "../utils/timezone";
@@ -6,6 +7,12 @@ import { CONFIG } from "../config";
 import { requireAuth } from "../middleware/auth";
 import type { AppEnv } from "../types";
 import { ok, err } from "./response";
+import { zValidator } from "../lib/validator";
+
+const statusParamSchema = z.object({
+  titleId: z.string().regex(/^(movie|tv)-\d+$/),
+  season: z.coerce.number().int().min(0),
+});
 
 const app = new Hono<AppEnv>();
 
@@ -28,13 +35,11 @@ app.get("/upcoming", async (c) => {
   return ok(c, { today: todayEpisodes, upcoming: upcomingEpisodes, unwatched: unwatchedEpisodes });
 });
 
-app.get("/status/:titleId/:season", async (c) => {
+app.get("/status/:titleId/:season", zValidator("param", statusParamSchema), async (c) => {
   const user = c.get("user");
   if (!user) return ok(c, { episodes: [] });
 
-  const titleId = c.req.param("titleId");
-  const seasonNumber = Number(c.req.param("season"));
-  if (isNaN(seasonNumber)) return err(c, "Invalid season number", 400);
+  const { titleId, season: seasonNumber } = c.req.valid("param");
 
   const episodes = await getSeasonEpisodeStatus(titleId, seasonNumber, user.id);
   return ok(c, { episodes });

--- a/server/routes/search.test.ts
+++ b/server/routes/search.test.ts
@@ -42,7 +42,8 @@ describe("GET /search", () => {
     const res = await app.request("/search");
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toContain("required");
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
   });
 
   it("returns search results with isTracked=false when no user", async () => {
@@ -218,17 +219,57 @@ describe("GET /search — filter params", () => {
     expect(body.titles.every((t: any) => (t.scores?.tmdbScore ?? 0) >= 9)).toBe(true);
   });
 
-  it("ignores invalid filter params gracefully", async () => {
-    const movie = makeTmdbSearchMultiMovie({ id: 40 });
-    (tmdbClient.searchMulti as any).mockResolvedValueOnce({
-      results: [movie], total_pages: 1, total_results: 1, page: 1,
-    });
-    (tmdbClient.fetchMovieDetails as any).mockResolvedValueOnce(makeTmdbMovieDetails({ id: 40 }));
+});
 
-    const res = await app.request("/search?q=test&year_min=notanumber&min_rating=abc");
-    expect(res.status).toBe(200);
+describe("GET /search — validation", () => {
+  it("rejects missing q param", async () => {
+    const res = await app.request("/search");
+    expect(res.status).toBe(400);
     const body = await res.json();
-    expect(Array.isArray(body.titles)).toBe(true);
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects empty q param", async () => {
+    const res = await app.request("/search?q=");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects non-numeric year_min", async () => {
+    const res = await app.request("/search?q=foo&year_min=notanumber");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects non-numeric min_rating", async () => {
+    const res = await app.request("/search?q=foo&min_rating=abc");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects lowercase type", async () => {
+    const res = await app.request("/search?q=foo&type=show");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("happy-path: minimal request with q only", async () => {
+    const res = await app.request("/search?q=foo");
+    expect(res.status).toBe(200);
+  });
+
+  it("happy-path: q + year_min + type", async () => {
+    const res = await app.request("/search?q=foo&year_min=2000&type=MOVIE");
+    expect(res.status).toBe(200);
   });
 });
 

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { z } from "zod";
 import { pLimit } from "../lib/p-limit";
 import { searchMulti, fetchMovieDetails, fetchTvDetails, getMovieGenres, getTvGenres } from "../tmdb/client";
 import { parseSearchResult, parseMovieDetails, parseTvDetails, type ParsedTitle } from "../tmdb/parser";
@@ -8,27 +9,23 @@ import { syncFailureTotal } from "../metrics";
 
 const log = logger.child({ module: "search" });
 import { ok, err } from "./response";
+import { zValidator } from "../lib/validator";
 
 import type { AppEnv } from "../types";
 
+const searchQuerySchema = z.object({
+  q: z.string().min(1),
+  year_min: z.coerce.number().int().optional(),
+  year_max: z.coerce.number().int().optional(),
+  min_rating: z.coerce.number().min(0).max(10).optional(),
+  type: z.enum(["MOVIE", "SHOW"]).optional(),
+  language: z.string().optional(),
+});
+
 const app = new Hono<AppEnv>();
 
-app.get("/", async (c) => {
-  const query = c.req.query("q");
-  if (!query) {
-    return err(c, "Query parameter 'q' is required");
-  }
-
-  // Parse optional filter params
-  const yearMinRaw = c.req.query("year_min");
-  const yearMaxRaw = c.req.query("year_max");
-  const minRatingRaw = c.req.query("min_rating");
-  const typeParam = c.req.query("type"); // "MOVIE" | "SHOW"
-  const languageParam = c.req.query("language");
-
-  const yearMin = yearMinRaw ? parseInt(yearMinRaw, 10) : undefined;
-  const yearMax = yearMaxRaw ? parseInt(yearMaxRaw, 10) : undefined;
-  const minRating = minRatingRaw ? parseFloat(minRatingRaw) : undefined;
+app.get("/", zValidator("query", searchQuerySchema), async (c) => {
+  const { q: query, year_min: yearMin, year_max: yearMax, min_rating: minRating, type: typeParam, language: languageParam } = c.req.valid("query");
 
   try {
     const [genreMap, tvGenreMap, searchResult] = await Promise.all([

--- a/server/routes/titles.test.ts
+++ b/server/routes/titles.test.ts
@@ -40,7 +40,7 @@ describe("GET /titles", () => {
     const today = new Date().toISOString().slice(0, 10);
     await upsertTitles([makeParsedTitle({ releaseDate: today })]);
 
-    const res = await app.request("/titles?daysBack=9999");
+    const res = await app.request("/titles?daysBack=365");
     expect(res.status).toBe(200);
 
     const body = await res.json();
@@ -56,7 +56,7 @@ describe("GET /titles", () => {
       makeParsedTitle({ id: "tv-1", objectType: "SHOW", title: "Show", releaseDate: today }),
     ]);
 
-    const res = await app.request("/titles?daysBack=9999&type=SHOW");
+    const res = await app.request("/titles?daysBack=365&type=SHOW");
     const body = await res.json();
     expect(body.titles).toHaveLength(1);
     expect(body.titles[0].object_type).toBe("SHOW");
@@ -76,7 +76,7 @@ describe("GET /titles", () => {
       makeParsedTitle({ id: "movie-2", title: "Comedy Film", genres: ["Comedy"], releaseDate: today }),
     ]);
 
-    const res = await app.request("/titles?daysBack=9999&genre=Comedy");
+    const res = await app.request("/titles?daysBack=365&genre=Comedy");
     const body = await res.json();
     expect(body.titles).toHaveLength(1);
     expect(body.titles[0].title).toBe("Comedy Film");
@@ -89,7 +89,7 @@ describe("GET /titles", () => {
       makeParsedTitle({ id: "movie-2", title: "Japanese Movie", originalLanguage: "ja", releaseDate: today }),
     ]);
 
-    const res = await app.request("/titles?daysBack=9999&language=ja");
+    const res = await app.request("/titles?daysBack=365&language=ja");
     const body = await res.json();
     expect(body.titles).toHaveLength(1);
     expect(body.titles[0].title).toBe("Japanese Movie");
@@ -102,7 +102,7 @@ describe("GET /titles", () => {
       makeParsedTitle({ id: "tv-1", objectType: "SHOW", title: "Show", releaseDate: today }),
     ]);
 
-    const res = await app.request("/titles?daysBack=9999&type=MOVIE,SHOW");
+    const res = await app.request("/titles?daysBack=365&type=MOVIE,SHOW");
     const body = await res.json();
     expect(body.titles).toHaveLength(2);
   });
@@ -115,7 +115,7 @@ describe("GET /titles", () => {
       makeParsedTitle({ id: "movie-3", title: "Drama Film", genres: ["Drama"], releaseDate: today }),
     ]);
 
-    const res = await app.request("/titles?daysBack=9999&genre=Action,Comedy");
+    const res = await app.request("/titles?daysBack=365&genre=Action,Comedy");
     const body = await res.json();
     expect(body.titles).toHaveLength(2);
     const titles = body.titles.map((t: any) => t.title).sort();
@@ -130,7 +130,7 @@ describe("GET /titles", () => {
       makeParsedTitle({ id: "movie-3", title: "French Movie", originalLanguage: "fr", releaseDate: today }),
     ]);
 
-    const res = await app.request("/titles?daysBack=9999&language=en,ja");
+    const res = await app.request("/titles?daysBack=365&language=en,ja");
     const body = await res.json();
     expect(body.titles).toHaveLength(2);
   });
@@ -139,40 +139,35 @@ describe("GET /titles", () => {
     const today = new Date().toISOString().slice(0, 10);
     await upsertTitles([makeParsedTitle({ releaseDate: today })]);
 
-    const res = await app.request("/titles?daysBack=9999");
+    const res = await app.request("/titles?daysBack=365");
     expect(res.status).toBe(200);
     // Should still work — titles within 365 days are returned
     const body = await res.json();
     expect(body.titles).toHaveLength(1);
   });
 
-  it("clamps limit to max 1000 and min 1", async () => {
-    const today = new Date().toISOString().slice(0, 10);
-    await upsertTitles([makeParsedTitle({ releaseDate: today })]);
-
+  it("rejects limit above max 1000", async () => {
     const res = await app.request("/titles?daysBack=365&limit=999999999");
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(400);
     const body = await res.json();
-    // Should still return results (clamped to 1000)
-    expect(body.titles).toHaveLength(1);
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
   });
 
-  it("clamps negative offset to 0", async () => {
-    const today = new Date().toISOString().slice(0, 10);
-    await upsertTitles([makeParsedTitle({ releaseDate: today })]);
-
+  it("rejects negative offset", async () => {
     const res = await app.request("/titles?daysBack=365&offset=-1");
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.titles).toHaveLength(1);
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
   });
 
-  it("clamps negative daysBack to 1", async () => {
+  it("rejects negative daysBack", async () => {
     const res = await app.request("/titles?daysBack=-5");
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(400);
     const body = await res.json();
-    // With daysBack=1, may or may not have titles, but should not error
-    expect(body.titles).toBeDefined();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
   });
 
   it("filters titles by daysBack date range", async () => {
@@ -212,7 +207,7 @@ describe("GET /titles", () => {
     });
     authedApp.route("/titles", titlesApp);
 
-    const res = await authedApp.request("/titles?daysBack=9999&excludeTracked=1");
+    const res = await authedApp.request("/titles?daysBack=365&excludeTracked=1");
     const body = await res.json();
     expect(body.titles).toHaveLength(1);
     expect(body.titles[0].title).toBe("Untracked");
@@ -318,7 +313,7 @@ describe("GET /titles?onlyMine", () => {
     await setSubscribedProviderIds(userId, [8]);
 
     const authedApp = makeAuthedApp(userId);
-    const res = await authedApp.request("/titles?daysBack=9999&onlyMine=true");
+    const res = await authedApp.request("/titles?daysBack=365&onlyMine=true");
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.titles).toHaveLength(1);
@@ -339,7 +334,7 @@ describe("GET /titles?onlyMine", () => {
     // no subscriptions set
 
     const authedApp = makeAuthedApp(userId);
-    const res = await authedApp.request("/titles?daysBack=9999&onlyMine=true");
+    const res = await authedApp.request("/titles?daysBack=365&onlyMine=true");
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.titles).toHaveLength(0);
@@ -367,7 +362,7 @@ describe("GET /titles?onlyMine", () => {
 
     // Explicit provider=8 + onlyMine=true (subscribed to both) → intersection = [8]
     const authedApp = makeAuthedApp(userId);
-    const res = await authedApp.request("/titles?daysBack=9999&onlyMine=true&provider=8");
+    const res = await authedApp.request("/titles?daysBack=365&onlyMine=true&provider=8");
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.titles).toHaveLength(1);
@@ -386,10 +381,99 @@ describe("GET /titles?onlyMine", () => {
     ]);
 
     // No user context — use the plain unauthenticated app
-    const res = await app.request("/titles?daysBack=9999&onlyMine=true");
+    const res = await app.request("/titles?daysBack=365&onlyMine=true");
     expect(res.status).toBe(200);
     const body = await res.json();
     // Without auth, onlyMine is ignored and all titles are returned
     expect(body.titles.length).toBeGreaterThan(0);
+  });
+});
+
+describe("GET /titles — validation", () => {
+  it("rejects daysBack=0 (below min 1)", async () => {
+    const res = await app.request("/titles?daysBack=0");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects daysBack=999 (above max 365)", async () => {
+    const res = await app.request("/titles?daysBack=999");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects daysBack=foo (non-numeric)", async () => {
+    const res = await app.request("/titles?daysBack=foo");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects limit=-1 (below min 1)", async () => {
+    const res = await app.request("/titles?limit=-1");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects limit=10000 (above max 1000)", async () => {
+    const res = await app.request("/titles?limit=10000");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects excludeTracked=0 (only literal '1' accepted)", async () => {
+    const res = await app.request("/titles?excludeTracked=0");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects excludeTracked=true (only literal '1' accepted)", async () => {
+    const res = await app.request("/titles?excludeTracked=true");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects onlyMine=false (only literal 'true' accepted)", async () => {
+    const res = await app.request("/titles?onlyMine=false");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects onlyMine=1 (only literal 'true' accepted)", async () => {
+    const res = await app.request("/titles?onlyMine=1");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("happy-path: zero params (all defaults applied)", async () => {
+    const res = await app.request("/titles");
+    expect(res.status).toBe(200);
+  });
+
+  it("happy-path: offset=0 is accepted (regression: 0 is a valid number)", async () => {
+    const res = await app.request("/titles?offset=0&limit=1");
+    expect(res.status).toBe(200);
+  });
+
+  it("happy-path: excludeTracked=1 and onlyMine=true with CSV type filter", async () => {
+    const res = await app.request("/titles?excludeTracked=1&onlyMine=true&type=MOVIE,SHOW");
+    expect(res.status).toBe(200);
   });
 });

--- a/server/routes/titles.ts
+++ b/server/routes/titles.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { z } from "zod";
 import { getRecentTitles, getProviders, getGenres, getLanguages, getSubscribedProviderIds } from "../db/repository";
 import { getMovieWatchProviders, getTvWatchProviders } from "../tmdb/client";
 import { canonicalProviderId } from "../streaming-availability/provider-map";
@@ -7,22 +8,27 @@ import { CONFIG } from "../config";
 import type { AppEnv } from "../types";
 import { ok } from "./response";
 import { setPublicCacheIfAnon } from "./cache-headers";
+import { zValidator } from "../lib/validator";
 
 const PRIORITY_LANGUAGES = ["en", "es", "fr", "de", "pt", "ja", "ko", "zh", "hi", "it", "ar"];
 
+const titlesQuerySchema = z.object({
+  daysBack: z.coerce.number().int().min(1).max(365).default(30),
+  type: z.string().optional(),
+  provider: z.string().optional(),
+  genre: z.string().optional(),
+  language: z.string().optional(),
+  excludeTracked: z.literal("1").optional().transform((v) => v === "1"),
+  onlyMine: z.literal("true").optional().transform((v) => v === "true"),
+  limit: z.coerce.number().int().min(1).max(1000).default(100),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
 const app = new Hono<AppEnv>();
 
-app.get("/", async (c) => {
+app.get("/", zValidator("query", titlesQuerySchema), async (c) => {
   const user = c.get("user");
-  const daysBack = Math.max(1, Math.min(Number(c.req.query("daysBack")) || 30, 365));
-  const typeParam = c.req.query("type") || "";
-  const providerParam = c.req.query("provider") || "";
-  const genreParam = c.req.query("genre") || "";
-  const languageParam = c.req.query("language") || "";
-  const excludeTracked = c.req.query("excludeTracked") === "1";
-  const onlyMine = c.req.query("onlyMine") === "true";
-  const limit = Math.max(1, Math.min(Number(c.req.query("limit")) || 100, 1000));
-  const offset = Math.max(0, Number(c.req.query("offset")) || 0);
+  const { daysBack, type: typeParam, provider: providerParam, genre: genreParam, language: languageParam, excludeTracked, onlyMine, limit, offset } = c.req.valid("query");
 
   const objectTypes = typeParam ? typeParam.split(",").filter(Boolean) : [];
   let providers = providerParam ? providerParam.split(",").filter(Boolean) : [];


### PR DESCRIPTION
## Summary

- Adds `zValidator("query"|"param", schema)` from `server/lib/validator.ts` to `titles`, `browse`, `calendar`, `search`, `details`, and `episodes` routes
- Replaces manual `Number()`/`parseInt()`/`Math.max`/`Math.min` extraction blocks with typed Zod schemas; invalid input now returns HTTP 400 + `{ error: "Validation failed", issues: [...] }` consistently
- Boolean string params use `z.literal("1")` / `z.literal("true")` transforms (not `z.coerce.boolean()`) so only the exact values the frontend sends are accepted
- Drops the ad-hoc `VALID_CATEGORIES` whitelist in `browse.ts` in favour of `z.enum([...])`; removes `isNaN` guard branches in `details.ts` and `episodes.ts`

## Test plan

- [ ] `bun test server/routes/titles.test.ts server/routes/browse.test.ts server/routes/calendar.test.ts server/routes/search.test.ts server/routes/details.test.ts server/routes/episodes.test.ts` → 164 pass, 0 fail
- [ ] `bun run check` (full CI: server tsc + frontend tsc + ESLint + all tests) passes
- [ ] `GET /api/titles` (zero params) → 200
- [ ] `GET /api/titles?offset=0&limit=1` → 200 (regression: `0` accepted)
- [ ] `GET /api/titles?excludeTracked=0` → 400 with `issues` (only `"1"` allowed)
- [ ] `GET /api/browse?category=popular` → 200
- [ ] `GET /api/browse` (missing category) → 400
- [ ] `GET /api/calendar?month=2026-05` → 200
- [ ] `GET /api/calendar?month=2026-3` → 400 (wrong format)
- [ ] `GET /api/search?q=foo` → 200
- [ ] `GET /api/details/movie/movie-550` → 200
- [ ] `GET /api/details/movie/abc` → 400

Closes #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)