### PR TITLE
fix(perf): bound watched_titles fetch in profile load and add (user_id, title_id) index

### DIFF
--- a/drizzle/0046_idx_watched_titles_user_title.sql
+++ b/drizzle/0046_idx_watched_titles_user_title.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `idx_watched_titles_user_title` ON `watched_titles` (`user_id`,`title_id`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1746662400000,
       "tag": "0045_dismissed_suggestions",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "6",
+      "when": 1746748800000,
+      "tag": "0046_idx_watched_titles_user_title",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -133,6 +133,6 @@ describe("fixSkippedMigrations", () => {
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(48);
+    expect(migrations.cnt).toBe(49);
   });
 });

--- a/server/db/repository/profile.test.ts
+++ b/server/db/repository/profile.test.ts
@@ -97,6 +97,40 @@ describe("getUserPublicProfile movie sort order", () => {
     expect(result!.movies).toHaveLength(2);
     // Both unwatched, so order is stable (original order preserved)
   });
+
+  it("returns all movies without truncation for large watchlists (regression for #677)", async () => {
+    const TOTAL = 200;
+    const WATCHED = 50;
+    const movies = Array.from({ length: TOTAL }, (_, i) =>
+      makeParsedTitle({ id: `bulk-movie-${i}`, objectType: "MOVIE", title: `Bulk Movie ${i}` })
+    );
+    await upsertTitles(movies);
+    for (const m of movies) {
+      await trackTitle(m.id, userId);
+    }
+
+    const db = getDb();
+    // Watch the first WATCHED movies at distinct timestamps
+    for (let i = 0; i < WATCHED; i++) {
+      await db.insert(watchedTitles).values({ titleId: `bulk-movie-${i}`, userId }).run();
+      const ts = `2024-01-${String(i + 1).padStart(2, "0")} 10:00:00`;
+      await db.update(watchedTitles).set({ watchedAt: ts })
+        .where(sql`${watchedTitles.titleId} = ${"bulk-movie-" + i} AND ${watchedTitles.userId} = ${userId}`).run();
+    }
+
+    const result = await getUserPublicProfile("testuser");
+    expect(result).not.toBeNull();
+    // All 200 movies must be present — LIMIT must not truncate the list
+    expect(result!.movies).toHaveLength(TOTAL);
+    // The 50 watched movies must all sort before the 150 unwatched ones
+    const watchedInResult = result!.movies.slice(0, WATCHED);
+    const unwatchedInResult = result!.movies.slice(WATCHED);
+    expect(watchedInResult.every(m => m.id.startsWith("bulk-movie-"))).toBe(true);
+    expect(unwatchedInResult).toHaveLength(TOTAL - WATCHED);
+    // Most recently watched first: bulk-movie-49 (Jan 49) > bulk-movie-48 > ... > bulk-movie-0
+    expect(watchedInResult[0].id).toBe(`bulk-movie-${WATCHED - 1}`);
+    expect(watchedInResult[WATCHED - 1].id).toBe("bulk-movie-0");
+  });
 });
 
 describe("getUserPublicProfile progress metrics", () => {

--- a/server/db/repository/profile.ts
+++ b/server/db/repository/profile.ts
@@ -146,6 +146,7 @@ export async function getUserPublicProfile(username: string, isOwnProfile = fals
         .select({ titleId: watchedTitles.titleId, watchedAt: watchedTitles.watchedAt })
         .from(watchedTitles)
         .where(sql`${watchedTitles.titleId} IN (${sql.join(movieIds.map(id => sql`${id}`), sql`, `)}) AND ${watchedTitles.userId} = ${user.id}`)
+        .limit(movieIds.length)
         .all();
       for (const row of watchedRows) {
         watchedAtMap.set(row.titleId, row.watchedAt);

--- a/server/db/repository/watch-history.ts
+++ b/server/db/repository/watch-history.ts
@@ -52,6 +52,7 @@ export async function getTitleWatchHistory(
       .from(watchHistory)
       .where(and(eq(watchHistory.userId, userId), eq(watchHistory.titleId, titleId)))
       .orderBy(desc(watchHistory.watchedAt))
+      .limit(1000)
       .all();
     return rows;
   });

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -317,6 +317,7 @@ export const watchedTitles = sqliteTable(
   (table) => [
     primaryKey({ columns: [table.titleId, table.userId] }),
     index("idx_watched_titles_user_id").on(table.userId),
+    index("idx_watched_titles_user_title").on(table.userId, table.titleId),
   ]
 );
 


### PR DESCRIPTION
## Summary

- Adds composite index `idx_watched_titles_user_title (user_id, title_id)` to `watched_titles` so the IN-list query in `getUserPublicProfile` and `EXISTS` subqueries across `titles.ts`/`tracked.ts`/`ratings.ts` use a covering index instead of a full table scan
- Adds `.limit(movieIds.length)` to the unbounded watched-movies query in `profile.ts` — PK guarantees at most one row per `(titleId, userId)` pair today, so this is a safety guard against future per-rewatch rows
- Adds `.limit(1000)` safety cap to `getTitleWatchHistory` in `watch-history.ts`
- Regression test inserts 200 tracked movies with 50 watched entries and asserts all 200 are returned in the correct sort order

## Test plan

- [x] `bun test server/db/repository/profile.test.ts` — all 19 tests pass including new 200-movie regression
- [x] `bun test server/db/migrations.test.ts` — new migration replays cleanly with `PRAGMA foreign_keys=ON`
- [x] `bun run check` — full CI pipeline passes (2702 tests, 0 failures)

Closes #677

🤖 Generated with [Claude Code](https://claude.ai/code)