### PR TITLE
fix(ux): add md: breakpoint to StatsPage overview grid

### DIFF
--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -126,7 +126,7 @@ export function StatsView() {
   if (loading || !data) {
     return (
       <div className="space-y-6">
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4">
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
           {Array.from({ length: 6 }).map((_, i) => (
             <div key={i} className="bg-zinc-900 rounded-xl p-4 h-20 animate-pulse" />
           ))}
@@ -142,7 +142,7 @@ export function StatsView() {
   return (
     <div className="space-y-8 pb-8">
       {/* Overview */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4">
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
         <OverviewCard label="Movies Watched" value={overview.watched_movies} />
         <OverviewCard label="Episodes Watched" value={overview.watched_episodes} />
         <OverviewCard label="Shows Tracked" value={overview.tracked_shows} />


### PR DESCRIPTION
## Summary

- Adds `md:grid-cols-4` to the 6-tile stats overview grid, filling the missing 768–1023 px breakpoint
- Updated both the loaded state and the loading skeleton so they stay in sync
- Previously the grid jumped directly from 3 cols (sm) to 6 cols (lg), causing a jarring layout shift on tablet portrait

## Test plan

- [x] `bun run check` passes (tsc + ESLint + tests)
- [x] Visually verified at 768 px → 4 columns
- [x] Visually verified at 1024 px → 6 columns

Closes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)