### PR TITLE
feat(gamification): foundation — schema, registry, evaluators, repos

### DIFF
--- a/drizzle/0047_achievements.sql
+++ b/drizzle/0047_achievements.sql
@@ -1,0 +1,35 @@
+CREATE TABLE `achievements` (
+  `key` text PRIMARY KEY NOT NULL,
+  `kind` text NOT NULL,
+  `threshold` integer NOT NULL,
+  `points` integer NOT NULL,
+  `title` text NOT NULL,
+  `description` text NOT NULL,
+  `icon` text NOT NULL,
+  `metadata` text
+);
+--> statement-breakpoint
+CREATE TABLE `user_achievements` (
+  `user_id` text NOT NULL,
+  `achievement_key` text NOT NULL,
+  `progress` integer NOT NULL DEFAULT 0,
+  `earned_at` text,
+  `earned_notified` integer NOT NULL DEFAULT 0,
+  `updated_at` text DEFAULT (datetime('now')),
+  PRIMARY KEY (`user_id`, `achievement_key`),
+  FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE,
+  FOREIGN KEY (`achievement_key`) REFERENCES `achievements`(`key`) ON DELETE CASCADE
+);
+--> statement-breakpoint
+CREATE INDEX `idx_user_achievements_earned` ON `user_achievements` (`user_id`, `earned_at`);
+--> statement-breakpoint
+CREATE TABLE `user_streaks` (
+  `user_id` text PRIMARY KEY NOT NULL,
+  `current_streak` integer NOT NULL DEFAULT 0,
+  `longest_streak` integer NOT NULL DEFAULT 0,
+  `last_watch_date` text,
+  `updated_at` text DEFAULT (datetime('now')),
+  FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE
+);
+--> statement-breakpoint
+ALTER TABLE `notifiers` ADD COLUMN `achievements_enabled` integer NOT NULL DEFAULT 0;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -344,6 +344,13 @@
       "when": 1746748800000,
       "tag": "0046_idx_watched_titles_user_title",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "6",
+      "when": 1746835200000,
+      "tag": "0047_achievements",
+      "breakpoints": true
     }
   ]
 }

--- a/server/achievements/definitions.test.ts
+++ b/server/achievements/definitions.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "bun:test";
+import { ACHIEVEMENTS } from "./definitions";
+
+describe("ACHIEVEMENTS registry", () => {
+  it("has no duplicate keys", () => {
+    const keys = ACHIEVEMENTS.map((a) => a.key);
+    const unique = new Set(keys);
+    expect(unique.size).toBe(keys.length);
+  });
+
+  it("every entry has non-empty title, description, and icon", () => {
+    for (const a of ACHIEVEMENTS) {
+      expect(a.title.length).toBeGreaterThan(0);
+      expect(a.description.length).toBeGreaterThan(0);
+      expect(a.icon.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every genre_count entry (except genre_explorer) has a genre defined", () => {
+    for (const a of ACHIEVEMENTS) {
+      if (a.kind === "genre_count" && a.key !== "genre_explorer") {
+        expect(a.genre).toBeDefined();
+        expect(typeof a.genre).toBe("string");
+        expect((a.genre as string).length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("genre_explorer uses the __any__ convention", () => {
+    const explorer = ACHIEVEMENTS.find((a) => a.key === "genre_explorer");
+    expect(explorer).toBeDefined();
+    expect(explorer?.genre).toBe("__any__");
+  });
+
+  it("every speed_binge_season entry has windowHours defined", () => {
+    for (const a of ACHIEVEMENTS) {
+      if (a.kind === "speed_binge_season") {
+        expect(a.windowHours).toBeDefined();
+        expect(typeof a.windowHours).toBe("number");
+        expect(a.windowHours as number).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("all points and threshold values are positive integers", () => {
+    for (const a of ACHIEVEMENTS) {
+      expect(Number.isInteger(a.points)).toBe(true);
+      expect(a.points).toBeGreaterThan(0);
+      expect(Number.isInteger(a.threshold)).toBe(true);
+      expect(a.threshold).toBeGreaterThan(0);
+    }
+  });
+
+  it("all kinds are valid AchievementKind values", () => {
+    const validKinds = new Set([
+      "count_movies",
+      "count_episodes",
+      "streak_days",
+      "genre_count",
+      "completionist",
+      "social_first_recommendation",
+      "social_first_follow",
+      "speed_binge_season",
+    ]);
+    for (const a of ACHIEVEMENTS) {
+      expect(validKinds.has(a.kind)).toBe(true);
+    }
+  });
+});

--- a/server/achievements/definitions.ts
+++ b/server/achievements/definitions.ts
@@ -1,0 +1,52 @@
+export type AchievementKind =
+  | "count_movies"
+  | "count_episodes"
+  | "streak_days"
+  | "genre_count"
+  | "completionist"
+  | "social_first_recommendation"
+  | "social_first_follow"
+  | "speed_binge_season";
+
+export interface Achievement {
+  key: string;           // immutable PK — NEVER reused (orphan rows in user_achievements if renamed)
+  kind: AchievementKind;
+  threshold: number;     // movies/episodes/days/genre-count/episodes-per-season
+  points: number;        // XP awarded on earn
+  title: string;
+  description: string;
+  icon: string;          // lucide-react icon name
+  genre?: string;        // required for kind === "genre_count"
+  seasons?: number;      // completionist scope (optional)
+  windowHours?: number;  // required for kind === "speed_binge_season"
+}
+
+export const ACHIEVEMENTS: readonly Achievement[] = [
+  // Milestone — movies
+  { key: "movies_10",   kind: "count_movies",   threshold: 10,  points: 10,  title: "Cinephile I",    description: "Watch 10 movies",           icon: "Film" },
+  { key: "movies_50",   kind: "count_movies",   threshold: 50,  points: 40,  title: "Cinephile II",   description: "Watch 50 movies",           icon: "Film" },
+  { key: "movies_100",  kind: "count_movies",   threshold: 100, points: 100, title: "Cinephile III",  description: "Watch 100 movies",          icon: "Film" },
+  { key: "movies_500",  kind: "count_movies",   threshold: 500, points: 400, title: "Film Fanatic",   description: "Watch 500 movies",          icon: "Film" },
+  // Milestone — episodes
+  { key: "episodes_100",  kind: "count_episodes", threshold: 100,  points: 20,  title: "Binge Starter",  description: "Watch 100 episodes",   icon: "Tv" },
+  { key: "episodes_500",  kind: "count_episodes", threshold: 500,  points: 75,  title: "Couch Captain",  description: "Watch 500 episodes",   icon: "Tv" },
+  { key: "episodes_1000", kind: "count_episodes", threshold: 1000, points: 200, title: "Marathon Mind",  description: "Watch 1000 episodes",  icon: "Tv" },
+  // Streaks
+  { key: "streak_3",   kind: "streak_days", threshold: 3,  points: 10,  title: "3-Day Streak",  description: "Watch 3 days in a row",   icon: "Flame" },
+  { key: "streak_7",   kind: "streak_days", threshold: 7,  points: 25,  title: "Week Warrior",   description: "Watch 7 days in a row",   icon: "Flame" },
+  { key: "streak_14",  kind: "streak_days", threshold: 14, points: 60,  title: "Fortnight Fan",  description: "Watch 14 days in a row",  icon: "Flame" },
+  { key: "streak_30",  kind: "streak_days", threshold: 30, points: 150, title: "Month Master",   description: "Watch 30 days in a row",  icon: "Flame" },
+  // Genre
+  { key: "genre_action_25",  kind: "genre_count", threshold: 25, points: 40, title: "Action Hero",   description: "Watch 25 action titles",  icon: "Swords",  genre: "Action" },
+  { key: "genre_comedy_25",  kind: "genre_count", threshold: 25, points: 40, title: "Laugh Track",   description: "Watch 25 comedy titles",  icon: "Laugh",   genre: "Comedy" },
+  { key: "genre_horror_25",  kind: "genre_count", threshold: 25, points: 40, title: "Final Girl",    description: "Watch 25 horror titles",  icon: "Skull",   genre: "Horror" },
+  { key: "genre_drama_25",   kind: "genre_count", threshold: 25, points: 40, title: "Drama Queen",   description: "Watch 25 drama titles",   icon: "Sparkles",genre: "Drama" },
+  { key: "genre_explorer",   kind: "genre_count", threshold: 10, points: 50, title: "Genre Explorer", description: "Watch titles from 10 different genres", icon: "Compass", genre: "__any__" },
+  // Completionist
+  { key: "completionist_first", kind: "completionist", threshold: 1, points: 30, title: "Completionist", description: "Finish every released episode of a show", icon: "CheckCircle2" },
+  // Social
+  { key: "first_recommendation", kind: "social_first_recommendation", threshold: 1, points: 5,  title: "Word of Mouth", description: "Send your first recommendation", icon: "MessageCircle" },
+  { key: "first_follow",         kind: "social_first_follow",         threshold: 1, points: 5,  title: "Friend Indeed",  description: "Follow your first user",        icon: "UserPlus" },
+  // Speed
+  { key: "binge_season_24h", kind: "speed_binge_season", threshold: 8, windowHours: 24, points: 50, title: "Speedrun", description: "Watch 8 episodes of one season in 24 hours", icon: "Zap" },
+];

--- a/server/achievements/evaluate.test.ts
+++ b/server/achievements/evaluate.test.ts
@@ -1,0 +1,442 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { makeParsedTitle } from "../test-utils/fixtures";
+import {
+  createUser,
+  upsertTitles,
+  watchTitle,
+  upsertEpisodes,
+  watchEpisode,
+} from "../db/repository";
+import { createRecommendation } from "../db/repository/recommendations";
+import { follow } from "../db/repository/follows";
+import { logWatch } from "../db/repository/watch-history";
+import { bumpStreak } from "../db/repository/streaks";
+import { getDb } from "../db/schema";
+import {
+  watchedEpisodes,
+  titleGenres,
+  episodes,
+  watchHistory,
+} from "../db/schema";
+import {
+  evaluateCountMovies,
+  evaluateCountEpisodes,
+  evaluateStreak,
+  evaluateGenreCount,
+  evaluateCompletionist,
+  evaluateSocialFirstRecommendation,
+  evaluateSocialFirstFollow,
+  evaluateSpeedBingeSeason,
+} from "./evaluate";
+
+let userId: string;
+
+beforeEach(async () => {
+  setupTestDb();
+  userId = await createUser("testuser", "hash");
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+// ─── count_movies ─────────────────────────────────────────────────────────────
+
+describe("evaluateCountMovies", () => {
+  it("returns zero progress with no watched movies", async () => {
+    const result = await evaluateCountMovies(userId, 10);
+    expect(result.progress).toBe(0);
+    expect(result.earned).toBe(false);
+  });
+
+  it("returns partial progress below threshold", async () => {
+    await upsertTitles([makeParsedTitle({ id: "m1", objectType: "MOVIE" })]);
+    await upsertTitles([makeParsedTitle({ id: "m2", objectType: "MOVIE" })]);
+    await watchTitle("m1", userId);
+    await watchTitle("m2", userId);
+
+    const result = await evaluateCountMovies(userId, 10);
+    expect(result.progress).toBe(2);
+    expect(result.earned).toBe(false);
+  });
+
+  it("earned = true exactly at threshold", async () => {
+    for (let i = 0; i < 3; i++) {
+      const id = `movie-${i}`;
+      await upsertTitles([makeParsedTitle({ id, objectType: "MOVIE" })]);
+      await watchTitle(id, userId);
+    }
+    const result = await evaluateCountMovies(userId, 3);
+    expect(result.progress).toBe(3);
+    expect(result.earned).toBe(true);
+  });
+
+  it("earned = true past threshold", async () => {
+    for (let i = 0; i < 5; i++) {
+      const id = `moviet-${i}`;
+      await upsertTitles([makeParsedTitle({ id, objectType: "MOVIE" })]);
+      await watchTitle(id, userId);
+    }
+    const result = await evaluateCountMovies(userId, 3);
+    expect(result.progress).toBe(5);
+    expect(result.earned).toBe(true);
+  });
+
+  it("does not count SHOW titles", async () => {
+    await upsertTitles([makeParsedTitle({ id: "show-1", objectType: "SHOW", title: "Test Show" })]);
+    await watchTitle("show-1", userId);
+
+    const result = await evaluateCountMovies(userId, 1);
+    expect(result.progress).toBe(0);
+    expect(result.earned).toBe(false);
+  });
+});
+
+// ─── count_episodes ───────────────────────────────────────────────────────────
+
+describe("evaluateCountEpisodes", () => {
+  const showId = "show-eps-test";
+
+  beforeEach(async () => {
+    await upsertTitles([makeParsedTitle({ id: showId, objectType: "SHOW", title: "Episode Test Show" })]);
+  });
+
+  it("returns zero progress with no watched episodes", async () => {
+    const result = await evaluateCountEpisodes(userId, 100);
+    expect(result.progress).toBe(0);
+    expect(result.earned).toBe(false);
+  });
+
+  it("returns partial progress below threshold", async () => {
+    await upsertEpisodes([
+      { title_id: showId, season_number: 1, episode_number: 1, name: "E1", overview: null, air_date: "2024-01-01", still_path: null },
+      { title_id: showId, season_number: 1, episode_number: 2, name: "E2", overview: null, air_date: "2024-01-08", still_path: null },
+    ]);
+    const db = getDb();
+    const epRows = await db.select().from(episodes).all();
+    for (const ep of epRows) {
+      await watchEpisode(ep.id, userId);
+    }
+
+    const result = await evaluateCountEpisodes(userId, 100);
+    expect(result.progress).toBe(2);
+    expect(result.earned).toBe(false);
+  });
+
+  it("earned = true at threshold", async () => {
+    await upsertEpisodes([
+      { title_id: showId, season_number: 1, episode_number: 1, name: "E1", overview: null, air_date: "2024-01-01", still_path: null },
+    ]);
+    const db = getDb();
+    const ep = await db.select().from(episodes).all();
+    await watchEpisode(ep[0].id, userId);
+
+    const result = await evaluateCountEpisodes(userId, 1);
+    expect(result.progress).toBe(1);
+    expect(result.earned).toBe(true);
+  });
+});
+
+// ─── streak_days ──────────────────────────────────────────────────────────────
+
+describe("evaluateStreak", () => {
+  it("returns zero when no streak row exists", async () => {
+    const result = await evaluateStreak(userId, 3);
+    expect(result.progress).toBe(0);
+    expect(result.earned).toBe(false);
+  });
+
+  it("reflects current streak from user_streaks", async () => {
+    // Bump streak to 3 days by simulating consecutive days
+    const day1 = "2024-01-01T10:00:00.000Z";
+    const day2 = "2024-01-02T10:00:00.000Z";
+    const day3 = "2024-01-03T10:00:00.000Z";
+    await bumpStreak(userId, day1);
+    await bumpStreak(userId, day2);
+    await bumpStreak(userId, day3);
+
+    const result = await evaluateStreak(userId, 3);
+    expect(result.progress).toBe(3);
+    expect(result.earned).toBe(true);
+  });
+
+  it("returns false when streak is below threshold", async () => {
+    await bumpStreak(userId, "2024-01-01T10:00:00.000Z");
+    await bumpStreak(userId, "2024-01-02T10:00:00.000Z");
+
+    const result = await evaluateStreak(userId, 7);
+    expect(result.progress).toBe(2);
+    expect(result.earned).toBe(false);
+  });
+});
+
+// ─── genre_count ──────────────────────────────────────────────────────────────
+
+describe("evaluateGenreCount", () => {
+  it("returns zero with no watched titles", async () => {
+    const result = await evaluateGenreCount(userId, 5, "Action");
+    expect(result.progress).toBe(0);
+    expect(result.earned).toBe(false);
+  });
+
+  it("counts distinct Action titles watched", async () => {
+    const db = getDb();
+    for (let i = 0; i < 3; i++) {
+      const id = `action-${i}`;
+      await upsertTitles([makeParsedTitle({ id, objectType: "MOVIE", genres: ["Action"] })]);
+      await db.insert(titleGenres).values({ titleId: id, genre: "Action" }).onConflictDoNothing().run();
+      await watchTitle(id, userId);
+    }
+
+    const result = await evaluateGenreCount(userId, 3, "Action");
+    expect(result.progress).toBe(3);
+    expect(result.earned).toBe(true);
+  });
+
+  it("__any__ counts distinct genres, not titles", async () => {
+    const db = getDb();
+    const m1 = "genre-any-1";
+    const m2 = "genre-any-2";
+    await upsertTitles([makeParsedTitle({ id: m1, objectType: "MOVIE" })]);
+    await upsertTitles([makeParsedTitle({ id: m2, objectType: "MOVIE" })]);
+    await db.insert(titleGenres).values({ titleId: m1, genre: "Action" }).onConflictDoNothing().run();
+    await db.insert(titleGenres).values({ titleId: m1, genre: "Drama" }).onConflictDoNothing().run();
+    await db.insert(titleGenres).values({ titleId: m2, genre: "Comedy" }).onConflictDoNothing().run();
+    await watchTitle(m1, userId);
+    await watchTitle(m2, userId);
+
+    // 3 distinct genres watched
+    const result = await evaluateGenreCount(userId, 3, "__any__");
+    expect(result.progress).toBe(3);
+    expect(result.earned).toBe(true);
+  });
+
+  it("__any__ returns false when below threshold", async () => {
+    const m1 = "genre-any-few";
+    // Use genres: [] to avoid the default ["Action", "Drama"] from the fixture
+    await upsertTitles([makeParsedTitle({ id: m1, objectType: "MOVIE", genres: ["Thriller"] })]);
+    await watchTitle(m1, userId);
+
+    // Only 1 distinct genre watched — below threshold of 5
+    const result = await evaluateGenreCount(userId, 5, "__any__");
+    expect(result.progress).toBe(1);
+    expect(result.earned).toBe(false);
+  });
+});
+
+// ─── completionist ────────────────────────────────────────────────────────────
+
+describe("evaluateCompletionist", () => {
+  const showId = "show-completionist";
+  const pastDate = "2024-01-01";
+
+  beforeEach(async () => {
+    await upsertTitles([makeParsedTitle({ id: showId, objectType: "SHOW", title: "Completionist Show" })]);
+  });
+
+  it("returns zero when no episodes watched", async () => {
+    await upsertEpisodes([
+      { title_id: showId, season_number: 1, episode_number: 1, name: "E1", overview: null, air_date: pastDate, still_path: null },
+    ]);
+    const result = await evaluateCompletionist(userId, 1);
+    expect(result.progress).toBe(0);
+    expect(result.earned).toBe(false);
+  });
+
+  it("earned when all released episodes of a show are watched (titleId mode)", async () => {
+    await upsertEpisodes([
+      { title_id: showId, season_number: 1, episode_number: 1, name: "E1", overview: null, air_date: pastDate, still_path: null },
+      { title_id: showId, season_number: 1, episode_number: 2, name: "E2", overview: null, air_date: pastDate, still_path: null },
+    ]);
+    const db = getDb();
+    const eps = await db.select().from(episodes).all();
+    for (const ep of eps) {
+      await watchEpisode(ep.id, userId);
+    }
+
+    const result = await evaluateCompletionist(userId, 1, showId);
+    expect(result.earned).toBe(true);
+  });
+
+  it("not earned with only partial episodes watched (titleId mode)", async () => {
+    await upsertEpisodes([
+      { title_id: showId, season_number: 1, episode_number: 1, name: "E1", overview: null, air_date: pastDate, still_path: null },
+      { title_id: showId, season_number: 1, episode_number: 2, name: "E2", overview: null, air_date: pastDate, still_path: null },
+    ]);
+    const db = getDb();
+    const eps = await db.select().from(episodes).all();
+    await watchEpisode(eps[0].id, userId); // only first
+
+    const result = await evaluateCompletionist(userId, 1, showId);
+    expect(result.earned).toBe(false);
+  });
+
+  it("counts completed shows in null titleId mode", async () => {
+    await upsertEpisodes([
+      { title_id: showId, season_number: 1, episode_number: 1, name: "E1", overview: null, air_date: pastDate, still_path: null },
+    ]);
+    const db = getDb();
+    const eps = await db.select().from(episodes).all();
+    await watchEpisode(eps[0].id, userId);
+
+    const result = await evaluateCompletionist(userId, 1);
+    expect(result.progress).toBe(1);
+    expect(result.earned).toBe(true);
+  });
+});
+
+// ─── social_first_recommendation ─────────────────────────────────────────────
+
+describe("evaluateSocialFirstRecommendation", () => {
+  it("returns zero progress with no recommendations sent", async () => {
+    const result = await evaluateSocialFirstRecommendation(userId);
+    expect(result.progress).toBe(0);
+    expect(result.earned).toBe(false);
+  });
+
+  it("earned after sending first recommendation", async () => {
+    await upsertTitles([makeParsedTitle({ id: "rec-movie", objectType: "MOVIE" })]);
+    const userId2 = await createUser("receiver", "hash");
+    await createRecommendation(userId, "rec-movie", undefined, userId2);
+
+    const result = await evaluateSocialFirstRecommendation(userId);
+    expect(result.progress).toBe(1);
+    expect(result.earned).toBe(true);
+  });
+
+  it("progress capped at 1 even with multiple recommendations", async () => {
+    await upsertTitles([makeParsedTitle({ id: "rec-movie2", objectType: "MOVIE" })]);
+    const userId2 = await createUser("receiver2", "hash");
+    await createRecommendation(userId, "rec-movie2", undefined, userId2);
+    await createRecommendation(userId, "rec-movie2", undefined, userId2);
+
+    const result = await evaluateSocialFirstRecommendation(userId);
+    expect(result.progress).toBe(1);
+  });
+});
+
+// ─── social_first_follow ──────────────────────────────────────────────────────
+
+describe("evaluateSocialFirstFollow", () => {
+  it("returns zero progress with no follows", async () => {
+    const result = await evaluateSocialFirstFollow(userId);
+    expect(result.progress).toBe(0);
+    expect(result.earned).toBe(false);
+  });
+
+  it("earned after following first user", async () => {
+    const userId2 = await createUser("followee", "hash");
+    await follow(userId, userId2);
+
+    const result = await evaluateSocialFirstFollow(userId);
+    expect(result.progress).toBe(1);
+    expect(result.earned).toBe(true);
+  });
+});
+
+// ─── speed_binge_season ───────────────────────────────────────────────────────
+
+describe("evaluateSpeedBingeSeason", () => {
+  const showId = "show-speed-binge";
+
+  beforeEach(async () => {
+    await upsertTitles([makeParsedTitle({ id: showId, objectType: "SHOW", title: "Speed Binge Show" })]);
+  });
+
+  it("returns zero progress with no watched episodes", async () => {
+    const result = await evaluateSpeedBingeSeason(userId, 8, 24, showId);
+    expect(result.progress).toBe(0);
+    expect(result.earned).toBe(false);
+  });
+
+  it("earned when 8 episodes watched in a 24h window", async () => {
+    await upsertEpisodes(
+      Array.from({ length: 8 }, (_, i) => ({
+        title_id: showId,
+        season_number: 1,
+        episode_number: i + 1,
+        name: `E${i + 1}`,
+        overview: null,
+        air_date: "2024-01-01",
+        still_path: null,
+      }))
+    );
+    const db = getDb();
+    const eps = await db.select().from(episodes).all();
+
+    // Watch all 8 within the same hour
+    const baseTime = new Date("2024-06-01T10:00:00.000Z");
+    for (let i = 0; i < eps.length; i++) {
+      const watchedAt = new Date(baseTime.getTime() + i * 5 * 60 * 1000).toISOString();
+      await db
+        .insert(watchedEpisodes)
+        .values({ episodeId: eps[i].id, userId, watchedAt })
+        .onConflictDoNothing()
+        .run();
+    }
+
+    const result = await evaluateSpeedBingeSeason(userId, 8, 24, showId);
+    expect(result.progress).toBe(8);
+    expect(result.earned).toBe(true);
+  });
+
+  it("not earned when episodes span more than 24h", async () => {
+    await upsertEpisodes(
+      Array.from({ length: 8 }, (_, i) => ({
+        title_id: showId,
+        season_number: 1,
+        episode_number: i + 1,
+        name: `E${i + 1}`,
+        overview: null,
+        air_date: "2024-01-01",
+        still_path: null,
+      }))
+    );
+    const db = getDb();
+    const eps = await db.select().from(episodes).all();
+
+    // Spread 8 episodes over 3 days (way more than 24h)
+    for (let i = 0; i < eps.length; i++) {
+      const watchedAt = new Date("2024-06-01T10:00:00.000Z");
+      watchedAt.setDate(watchedAt.getDate() + i);
+      await db
+        .insert(watchedEpisodes)
+        .values({ episodeId: eps[i].id, userId, watchedAt: watchedAt.toISOString() })
+        .onConflictDoNothing()
+        .run();
+    }
+
+    const result = await evaluateSpeedBingeSeason(userId, 8, 24, showId);
+    expect(result.earned).toBe(false);
+  });
+
+  it("partial progress below threshold", async () => {
+    await upsertEpisodes(
+      Array.from({ length: 4 }, (_, i) => ({
+        title_id: showId,
+        season_number: 1,
+        episode_number: i + 1,
+        name: `E${i + 1}`,
+        overview: null,
+        air_date: "2024-01-01",
+        still_path: null,
+      }))
+    );
+    const db = getDb();
+    const eps = await db.select().from(episodes).all();
+    const baseTime = new Date("2024-06-01T10:00:00.000Z");
+    for (let i = 0; i < eps.length; i++) {
+      const watchedAt = new Date(baseTime.getTime() + i * 10 * 60 * 1000).toISOString();
+      await db
+        .insert(watchedEpisodes)
+        .values({ episodeId: eps[i].id, userId, watchedAt })
+        .onConflictDoNothing()
+        .run();
+    }
+
+    const result = await evaluateSpeedBingeSeason(userId, 8, 24, showId);
+    expect(result.progress).toBe(4);
+    expect(result.earned).toBe(false);
+  });
+});

--- a/server/achievements/evaluate.ts
+++ b/server/achievements/evaluate.ts
@@ -1,0 +1,264 @@
+import { sql, eq, and, count } from "drizzle-orm";
+import { getDb } from "../db/schema";
+import {
+  watchedTitles,
+  watchedEpisodes,
+  titles,
+  titleGenres,
+  episodes,
+  follows,
+  recommendations,
+  userStreaks,
+} from "../db/schema";
+import { traceDbQuery } from "../tracing";
+
+export type EvalResult = { progress: number; earned: boolean };
+
+/**
+ * count_movies: COUNT watched_titles WHERE title.object_type = 'MOVIE'
+ */
+export async function evaluateCountMovies(userId: string, threshold: number): Promise<EvalResult> {
+  return traceDbQuery("evaluateCountMovies", async () => {
+    const db = getDb();
+    const row = await db
+      .select({ cnt: count() })
+      .from(watchedTitles)
+      .innerJoin(titles, eq(titles.id, watchedTitles.titleId))
+      .where(and(eq(watchedTitles.userId, userId), eq(titles.objectType, "MOVIE")))
+      .get();
+    const progress = row?.cnt ?? 0;
+    return { progress, earned: progress >= threshold };
+  });
+}
+
+/**
+ * count_episodes: COUNT watched_episodes for the user
+ */
+export async function evaluateCountEpisodes(userId: string, threshold: number): Promise<EvalResult> {
+  return traceDbQuery("evaluateCountEpisodes", async () => {
+    const db = getDb();
+    const row = await db
+      .select({ cnt: count() })
+      .from(watchedEpisodes)
+      .where(eq(watchedEpisodes.userId, userId))
+      .get();
+    const progress = row?.cnt ?? 0;
+    return { progress, earned: progress >= threshold };
+  });
+}
+
+/**
+ * streak_days: read user_streaks.current_streak
+ */
+export async function evaluateStreak(userId: string, threshold: number): Promise<EvalResult> {
+  return traceDbQuery("evaluateStreak", async () => {
+    const db = getDb();
+    const row = await db
+      .select({ currentStreak: userStreaks.currentStreak })
+      .from(userStreaks)
+      .where(eq(userStreaks.userId, userId))
+      .get();
+    const progress = row?.currentStreak ?? 0;
+    return { progress, earned: progress >= threshold };
+  });
+}
+
+/**
+ * genre_count:
+ * - genre === "__any__": count DISTINCT genres the user has watched
+ * - specific genre: count DISTINCT watched_titles joined to title_genres WHERE genre = ?
+ */
+export async function evaluateGenreCount(userId: string, threshold: number, genre: string): Promise<EvalResult> {
+  return traceDbQuery("evaluateGenreCount", async () => {
+    const db = getDb();
+    let progress: number;
+
+    if (genre === "__any__") {
+      // Count distinct genres across all watched titles
+      const row = await db
+        .select({ cnt: sql<number>`COUNT(DISTINCT ${titleGenres.genre})` })
+        .from(watchedTitles)
+        .innerJoin(titleGenres, eq(titleGenres.titleId, watchedTitles.titleId))
+        .where(eq(watchedTitles.userId, userId))
+        .get();
+      progress = row?.cnt ?? 0;
+    } else {
+      // Count distinct titles of a specific genre
+      const row = await db
+        .select({ cnt: sql<number>`COUNT(DISTINCT ${watchedTitles.titleId})` })
+        .from(watchedTitles)
+        .innerJoin(titleGenres, eq(titleGenres.titleId, watchedTitles.titleId))
+        .where(and(eq(watchedTitles.userId, userId), eq(titleGenres.genre, genre)))
+        .get();
+      progress = row?.cnt ?? 0;
+    }
+
+    return { progress, earned: progress >= threshold };
+  });
+}
+
+/**
+ * completionist:
+ * - titleId provided: compare watched episodes vs released episodes for that show
+ * - titleId null/undefined: count shows where user has completed all released episodes
+ */
+export async function evaluateCompletionist(userId: string, threshold: number, titleId?: string): Promise<EvalResult> {
+  return traceDbQuery("evaluateCompletionist", async () => {
+    const db = getDb();
+
+    if (titleId) {
+      // Count watched episodes for this show
+      const watchedRow = await db
+        .select({ cnt: count() })
+        .from(watchedEpisodes)
+        .innerJoin(episodes, eq(episodes.id, watchedEpisodes.episodeId))
+        .where(and(eq(watchedEpisodes.userId, userId), eq(episodes.titleId, titleId)))
+        .get();
+
+      // Count released episodes for this show
+      const releasedRow = await db
+        .select({ cnt: count() })
+        .from(episodes)
+        .where(and(
+          eq(episodes.titleId, titleId),
+          sql`${episodes.airDate} <= date('now')`
+        ))
+        .get();
+
+      const watched = watchedRow?.cnt ?? 0;
+      const released = releasedRow?.cnt ?? 0;
+
+      // Earned if all released episodes are watched (and there are released episodes)
+      const earned = released > 0 && watched >= released;
+      return { progress: earned ? 1 : 0, earned };
+    }
+
+    // Find all shows where the user has watched count = released episode count
+    // Use a subquery approach: get all titleIds the user has watched episodes from,
+    // then count those where their watched count equals the released count
+    const completedShows = await db.all<{ title_id: string }>(sql`
+      SELECT e.title_id
+      FROM watched_episodes we
+      JOIN episodes e ON e.id = we.episode_id
+      WHERE we.user_id = ${userId}
+      GROUP BY e.title_id
+      HAVING COUNT(*) = (
+        SELECT COUNT(*)
+        FROM episodes e2
+        WHERE e2.title_id = e.title_id
+          AND e2.air_date <= date('now')
+      )
+        AND (
+        SELECT COUNT(*)
+        FROM episodes e2
+        WHERE e2.title_id = e.title_id
+          AND e2.air_date <= date('now')
+      ) > 0
+    `);
+
+    const progress = completedShows.length;
+    return { progress, earned: progress >= threshold };
+  });
+}
+
+/**
+ * social_first_recommendation: COUNT recommendations WHERE from_user_id = userId
+ */
+export async function evaluateSocialFirstRecommendation(userId: string): Promise<EvalResult> {
+  return traceDbQuery("evaluateSocialFirstRecommendation", async () => {
+    const db = getDb();
+    const row = await db
+      .select({ cnt: count() })
+      .from(recommendations)
+      .where(eq(recommendations.fromUserId, userId))
+      .get();
+    const progress = Math.min(row?.cnt ?? 0, 1);
+    return { progress, earned: progress >= 1 };
+  });
+}
+
+/**
+ * social_first_follow: COUNT follows WHERE follower_id = userId
+ */
+export async function evaluateSocialFirstFollow(userId: string): Promise<EvalResult> {
+  return traceDbQuery("evaluateSocialFirstFollow", async () => {
+    const db = getDb();
+    const row = await db
+      .select({ cnt: count() })
+      .from(follows)
+      .where(eq(follows.followerId, userId))
+      .get();
+    const progress = Math.min(row?.cnt ?? 0, 1);
+    return { progress, earned: progress >= 1 };
+  });
+}
+
+/**
+ * speed_binge_season:
+ * Scan watched_episodes joined to episodes for user+title.
+ * Group by season_number, apply sliding window of windowHours.
+ * Returns { progress: max episodes in any window, earned: max >= threshold }
+ */
+export async function evaluateSpeedBingeSeason(
+  userId: string,
+  threshold: number,
+  windowHours: number,
+  titleId: string
+): Promise<EvalResult> {
+  return traceDbQuery("evaluateSpeedBingeSeason", async () => {
+    const db = getDb();
+
+    // Get all watched episodes for this user+title with their season and watched_at
+    const rows = await db.all<{ season_number: number; watched_at: string }>(sql`
+      SELECT e.season_number, we.watched_at
+      FROM watched_episodes we
+      JOIN episodes e ON e.id = we.episode_id
+      WHERE we.user_id = ${userId}
+        AND e.title_id = ${titleId}
+        AND we.watched_at IS NOT NULL
+      ORDER BY e.season_number, we.watched_at
+    `);
+
+    if (rows.length === 0) {
+      return { progress: 0, earned: false };
+    }
+
+    // Group by season
+    const bySeason = new Map<number, string[]>();
+    for (const row of rows) {
+      const bucket = bySeason.get(row.season_number);
+      if (bucket) {
+        bucket.push(row.watched_at);
+      } else {
+        bySeason.set(row.season_number, [row.watched_at]);
+      }
+    }
+
+    const windowMs = windowHours * 60 * 60 * 1000;
+    let maxInWindow = 0;
+
+    // Sliding window per season
+    for (const timestamps of bySeason.values()) {
+      timestamps.sort();
+      let left = 0;
+      for (let right = 0; right < timestamps.length; right++) {
+        const rightMs = new Date(timestamps[right]).getTime();
+        // Advance left pointer until window fits
+        while (left < right) {
+          const leftMs = new Date(timestamps[left]).getTime();
+          if (rightMs - leftMs > windowMs) {
+            left++;
+          } else {
+            break;
+          }
+        }
+        const inWindow = right - left + 1;
+        if (inWindow > maxInWindow) {
+          maxInWindow = inWindow;
+        }
+      }
+    }
+
+    return { progress: maxInWindow, earned: maxInWindow >= threshold };
+  });
+}

--- a/server/achievements/index.ts
+++ b/server/achievements/index.ts
@@ -1,0 +1,14 @@
+export { ACHIEVEMENTS } from "./definitions";
+export type { Achievement, AchievementKind } from "./definitions";
+export { syncAchievementRegistry } from "./sync";
+export {
+  evaluateCountMovies,
+  evaluateCountEpisodes,
+  evaluateStreak,
+  evaluateGenreCount,
+  evaluateCompletionist,
+  evaluateSocialFirstRecommendation,
+  evaluateSocialFirstFollow,
+  evaluateSpeedBingeSeason,
+} from "./evaluate";
+export type { EvalResult } from "./evaluate";

--- a/server/achievements/sync.test.ts
+++ b/server/achievements/sync.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { eq } from "drizzle-orm";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { ACHIEVEMENTS } from "./definitions";
+import { syncAchievementRegistry } from "./sync";
+import { listAchievementDefs } from "../db/repository/achievements";
+import { getDb } from "../db/schema";
+import { achievements } from "../db/schema";
+
+beforeEach(() => setupTestDb());
+afterEach(() => teardownTestDb());
+
+describe("syncAchievementRegistry", () => {
+  it("inserts all ACHIEVEMENTS entries into the DB", async () => {
+    await syncAchievementRegistry();
+    const defs = await listAchievementDefs();
+    expect(defs.length).toBe(ACHIEVEMENTS.length);
+
+    const keys = new Set(defs.map((d) => d.key));
+    for (const a of ACHIEVEMENTS) {
+      expect(keys.has(a.key)).toBe(true);
+    }
+  });
+
+  it("is idempotent — calling twice does not throw or duplicate", async () => {
+    await syncAchievementRegistry();
+    await syncAchievementRegistry(); // should not throw
+    const defs = await listAchievementDefs();
+    expect(defs.length).toBe(ACHIEVEMENTS.length);
+  });
+
+  it("does NOT delete an orphan row (key not in registry)", async () => {
+    // Insert a row with a key that doesn't exist in ACHIEVEMENTS
+    const db = getDb();
+    await db.insert(achievements).values({
+      key: "orphan_achievement",
+      kind: "count_movies",
+      threshold: 1,
+      points: 1,
+      title: "Orphan",
+      description: "Old achievement",
+      icon: "Star",
+      metadata: null,
+    }).run();
+
+    await syncAchievementRegistry();
+
+    // Orphan row should still exist
+    const all = await listAchievementDefs();
+    const orphan = all.find((d) => d.key === "orphan_achievement");
+    expect(orphan).toBeDefined();
+    // Plus all registry entries
+    expect(all.length).toBe(ACHIEVEMENTS.length + 1);
+  });
+
+  it("updates stale rows with new values on re-sync", async () => {
+    await syncAchievementRegistry();
+
+    // Manually mutate one row to simulate stale data
+    const db = getDb();
+    const firstKey = ACHIEVEMENTS[0].key;
+    await db.update(achievements)
+      .set({ title: "Stale Title" })
+      .where(eq(achievements.key, firstKey))
+      .run();
+
+    // Verify it's stale
+    const before = await listAchievementDefs();
+    const staleRow = before.find((d) => d.key === firstKey);
+    expect(staleRow?.title).toBe("Stale Title");
+
+    // Re-sync
+    await syncAchievementRegistry();
+    const after = await listAchievementDefs();
+    const updated = after.find((d) => d.key === firstKey);
+    expect(updated?.title).toBe(ACHIEVEMENTS[0].title);
+  });
+});

--- a/server/achievements/sync.ts
+++ b/server/achievements/sync.ts
@@ -1,0 +1,20 @@
+import { ACHIEVEMENTS } from "./definitions";
+import { upsertAchievementDef } from "../db/repository/achievements";
+import { logger } from "../logger";
+
+const log = logger.child({ module: "achievements-sync" });
+
+/**
+ * Sync the ACHIEVEMENTS registry into the `achievements` table.
+ * UPSERTs each entry — does NOT delete missing keys (orphan rows are tolerated).
+ * Safe to call multiple times (idempotent).
+ */
+export async function syncAchievementRegistry(): Promise<void> {
+  log.info("Syncing achievement registry", { count: ACHIEVEMENTS.length });
+
+  for (const achievement of ACHIEVEMENTS) {
+    await upsertAchievementDef(achievement);
+  }
+
+  log.info("Achievement registry sync complete");
+}

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -133,6 +133,6 @@ describe("fixSkippedMigrations", () => {
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(49);
+    expect(migrations.cnt).toBe(50);
   });
 });

--- a/server/db/repository/achievements.test.ts
+++ b/server/db/repository/achievements.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
+import { createUser } from "../repository";
+import {
+  upsertAchievementDef,
+  listAchievementDefs,
+  getUserAchievements,
+  upsertUserAchievement,
+  listEarnedSince,
+  markAchievementsNotified,
+  sumXpForUser,
+  sumXpBatch,
+} from "./achievements";
+
+function makeAchievementDef(key: string, points = 10) {
+  return {
+    key,
+    kind: "count_movies" as const,
+    threshold: 10,
+    points,
+    title: `Achievement ${key}`,
+    description: `Description for ${key}`,
+    icon: "Star",
+  };
+}
+
+beforeEach(async () => {
+  setupTestDb();
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+describe("upsertAchievementDef", () => {
+  it("inserts a new achievement definition", async () => {
+    await upsertAchievementDef(makeAchievementDef("test_key_1", 20));
+    const defs = await listAchievementDefs();
+    const found = defs.find((d) => d.key === "test_key_1");
+    expect(found).toBeDefined();
+    expect(found?.points).toBe(20);
+  });
+
+  it("updates an existing definition on conflict", async () => {
+    await upsertAchievementDef(makeAchievementDef("test_key_2", 10));
+    await upsertAchievementDef({ ...makeAchievementDef("test_key_2", 50), title: "Updated Title" });
+    const defs = await listAchievementDefs();
+    const found = defs.find((d) => d.key === "test_key_2");
+    expect(found?.points).toBe(50);
+    expect(found?.title).toBe("Updated Title");
+  });
+
+  it("stores metadata JSON for genre/seasons/windowHours fields", async () => {
+    await upsertAchievementDef({
+      key: "genre_test",
+      kind: "genre_count",
+      threshold: 25,
+      points: 40,
+      title: "Genre Test",
+      description: "desc",
+      icon: "Star",
+      genre: "Action",
+    });
+    const defs = await listAchievementDefs();
+    const found = defs.find((d) => d.key === "genre_test");
+    expect(found?.metadata).toBeTruthy();
+    const meta = JSON.parse(found!.metadata!);
+    expect(meta.genre).toBe("Action");
+  });
+});
+
+describe("getUserAchievements", () => {
+  it("returns empty array when user has no achievements", async () => {
+    const userId = await createUser("ua-test-user", "hash");
+    const result = await getUserAchievements(userId);
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns user achievements after upsert", async () => {
+    const userId = await createUser("ua-test-user2", "hash");
+    await upsertAchievementDef(makeAchievementDef("ua_key_1"));
+    await upsertUserAchievement(userId, "ua_key_1", 5, null);
+
+    const result = await getUserAchievements(userId);
+    expect(result).toHaveLength(1);
+    expect(result[0].achievementKey).toBe("ua_key_1");
+    expect(result[0].progress).toBe(5);
+    expect(result[0].earnedAt).toBeNull();
+  });
+});
+
+describe("upsertUserAchievement newlyEarned detection", () => {
+  it("newlyEarned = false on first insert with no earnedAt", async () => {
+    const userId = await createUser("newly-earned-1", "hash");
+    await upsertAchievementDef(makeAchievementDef("ne_key_1"));
+    const result = await upsertUserAchievement(userId, "ne_key_1", 5, null);
+    expect(result.newlyEarned).toBe(false);
+  });
+
+  it("newlyEarned = true when transitioning null → earned", async () => {
+    const userId = await createUser("newly-earned-2", "hash");
+    await upsertAchievementDef(makeAchievementDef("ne_key_2"));
+    await upsertUserAchievement(userId, "ne_key_2", 5, null);
+    const result = await upsertUserAchievement(userId, "ne_key_2", 10, "2024-01-01T00:00:00.000Z");
+    expect(result.newlyEarned).toBe(true);
+  });
+
+  it("newlyEarned = false when already earned", async () => {
+    const userId = await createUser("newly-earned-3", "hash");
+    await upsertAchievementDef(makeAchievementDef("ne_key_3"));
+    await upsertUserAchievement(userId, "ne_key_3", 10, "2024-01-01T00:00:00.000Z");
+    const result = await upsertUserAchievement(userId, "ne_key_3", 15, "2024-01-02T00:00:00.000Z");
+    expect(result.newlyEarned).toBe(false);
+  });
+});
+
+describe("listEarnedSince", () => {
+  it("returns achievements earned after the given timestamp", async () => {
+    const userId = await createUser("earned-since-1", "hash");
+    await upsertAchievementDef(makeAchievementDef("es_key_1"));
+    await upsertAchievementDef(makeAchievementDef("es_key_2"));
+
+    await upsertUserAchievement(userId, "es_key_1", 10, "2024-01-01T00:00:00.000Z");
+    await upsertUserAchievement(userId, "es_key_2", 10, "2024-06-01T00:00:00.000Z");
+
+    const result = await listEarnedSince(userId, "2024-03-01T00:00:00.000Z");
+    expect(result).toHaveLength(1);
+    expect(result[0].achievementKey).toBe("es_key_2");
+  });
+
+  it("returns empty when no achievements earned since the timestamp", async () => {
+    const userId = await createUser("earned-since-2", "hash");
+    await upsertAchievementDef(makeAchievementDef("es_key_3"));
+    await upsertUserAchievement(userId, "es_key_3", 10, "2024-01-01T00:00:00.000Z");
+
+    const result = await listEarnedSince(userId, "2025-01-01T00:00:00.000Z");
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe("markAchievementsNotified", () => {
+  it("sets earnedNotified = 1 for specified keys", async () => {
+    const userId = await createUser("notified-1", "hash");
+    await upsertAchievementDef(makeAchievementDef("notif_key_1"));
+    await upsertUserAchievement(userId, "notif_key_1", 10, "2024-01-01T00:00:00.000Z");
+
+    await markAchievementsNotified(userId, ["notif_key_1"]);
+
+    const result = await getUserAchievements(userId);
+    expect(result[0].earnedNotified).toBe(1);
+  });
+
+  it("is a no-op with empty keys array", async () => {
+    const userId = await createUser("notified-2", "hash");
+    // Should not throw
+    await markAchievementsNotified(userId, []);
+  });
+});
+
+describe("sumXpForUser", () => {
+  it("returns 0 when user has no earned achievements", async () => {
+    const userId = await createUser("xp-user-1", "hash");
+    const xp = await sumXpForUser(userId);
+    expect(xp).toBe(0);
+  });
+
+  it("sums points of earned achievements", async () => {
+    const userId = await createUser("xp-user-2", "hash");
+    await upsertAchievementDef(makeAchievementDef("xp_key_1", 10));
+    await upsertAchievementDef(makeAchievementDef("xp_key_2", 25));
+    await upsertUserAchievement(userId, "xp_key_1", 10, "2024-01-01T00:00:00.000Z");
+    await upsertUserAchievement(userId, "xp_key_2", 5, null); // not earned
+
+    const xp = await sumXpForUser(userId);
+    expect(xp).toBe(10); // only xp_key_1 is earned
+  });
+});
+
+describe("sumXpBatch with >50 users (chunking)", () => {
+  it("returns correct XP for all users when userIds exceed 50", async () => {
+    // Seed an achievement definition
+    await upsertAchievementDef(makeAchievementDef("batch_key", 5));
+
+    // Create 51 users, each with the achievement earned
+    const userIds: string[] = [];
+    for (let i = 0; i < 51; i++) {
+      const uid = await createUser(`batch-user-${i}`, "hash");
+      userIds.push(uid);
+      await upsertUserAchievement(uid, "batch_key", 10, "2024-01-01T00:00:00.000Z");
+    }
+
+    const result = await sumXpBatch(userIds);
+
+    // All 51 users should have XP = 5
+    expect(result.size).toBe(51);
+    for (const uid of userIds) {
+      expect(result.get(uid)).toBe(5);
+    }
+  });
+
+  it("returns empty map for empty input", async () => {
+    const result = await sumXpBatch([]);
+    expect(result.size).toBe(0);
+  });
+
+  it("users with no earned achievements are not in the result map", async () => {
+    await upsertAchievementDef(makeAchievementDef("batch_key_2", 10));
+    const uid = await createUser("batch-no-earn", "hash");
+    await upsertUserAchievement(uid, "batch_key_2", 5, null); // not earned
+
+    const result = await sumXpBatch([uid]);
+    // Not earned means no row in the result (or 0)
+    expect(result.get(uid) ?? 0).toBe(0);
+  });
+});

--- a/server/db/repository/achievements.ts
+++ b/server/db/repository/achievements.ts
@@ -1,0 +1,215 @@
+import { eq, and, inArray, sql, sum } from "drizzle-orm";
+import { getDb } from "../schema";
+import { achievements, userAchievements } from "../schema";
+import type { AchievementDefRow, UserAchievementRow } from "../schema";
+import type { Achievement } from "../../achievements/definitions";
+import { traceDbQuery } from "../../tracing";
+
+export type { AchievementDefRow, UserAchievementRow };
+
+/**
+ * Upsert a single achievement definition into the achievements table.
+ * metadata stores optional fields (genre, seasons, windowHours) as JSON.
+ */
+export async function upsertAchievementDef(a: Achievement): Promise<void> {
+  return traceDbQuery("upsertAchievementDef", async () => {
+    const db = getDb();
+    const metadataFields: Record<string, unknown> = {};
+    if (a.genre !== undefined) metadataFields.genre = a.genre;
+    if (a.seasons !== undefined) metadataFields.seasons = a.seasons;
+    if (a.windowHours !== undefined) metadataFields.windowHours = a.windowHours;
+    const metadata = Object.keys(metadataFields).length > 0
+      ? JSON.stringify(metadataFields)
+      : null;
+
+    await db
+      .insert(achievements)
+      .values({
+        key: a.key,
+        kind: a.kind,
+        threshold: a.threshold,
+        points: a.points,
+        title: a.title,
+        description: a.description,
+        icon: a.icon,
+        metadata,
+      })
+      .onConflictDoUpdate({
+        target: achievements.key,
+        set: {
+          kind: a.kind,
+          threshold: a.threshold,
+          points: a.points,
+          title: a.title,
+          description: a.description,
+          icon: a.icon,
+          metadata,
+        },
+      })
+      .run();
+  });
+}
+
+/** List all achievement definitions from the DB. */
+export async function listAchievementDefs(): Promise<AchievementDefRow[]> {
+  return traceDbQuery("listAchievementDefs", async () => {
+    const db = getDb();
+    return await db.select().from(achievements).all();
+  });
+}
+
+/** Get all user_achievements rows for a user. */
+export async function getUserAchievements(userId: string): Promise<UserAchievementRow[]> {
+  return traceDbQuery("getUserAchievements", async () => {
+    const db = getDb();
+    return await db
+      .select()
+      .from(userAchievements)
+      .where(eq(userAchievements.userId, userId))
+      .all();
+  });
+}
+
+/**
+ * Upsert a user_achievement row, tracking progress and earned status.
+ * Returns whether this call newly earned the achievement
+ * (transitioned earnedAt from null to non-null).
+ */
+export async function upsertUserAchievement(
+  userId: string,
+  key: string,
+  progress: number,
+  earnedAt: string | null
+): Promise<{ newlyEarned: boolean }> {
+  return traceDbQuery("upsertUserAchievement", async () => {
+    const db = getDb();
+
+    // Check current state
+    const existing = await db
+      .select({ earnedAt: userAchievements.earnedAt })
+      .from(userAchievements)
+      .where(and(eq(userAchievements.userId, userId), eq(userAchievements.achievementKey, key)))
+      .get();
+
+    const wasEarned = existing?.earnedAt != null;
+    const nowEarned = earnedAt != null;
+    const newlyEarned = !wasEarned && nowEarned;
+
+    await db
+      .insert(userAchievements)
+      .values({
+        userId,
+        achievementKey: key,
+        progress,
+        earnedAt,
+        earnedNotified: 0,
+        updatedAt: new Date().toISOString(),
+      })
+      .onConflictDoUpdate({
+        target: [userAchievements.userId, userAchievements.achievementKey],
+        set: {
+          progress,
+          earnedAt: earnedAt ?? existing?.earnedAt ?? null,
+          updatedAt: new Date().toISOString(),
+        },
+      })
+      .run();
+
+    return { newlyEarned };
+  });
+}
+
+/**
+ * List earned achievements since a given ISO timestamp.
+ */
+export async function listEarnedSince(userId: string, since: string): Promise<UserAchievementRow[]> {
+  return traceDbQuery("listEarnedSince", async () => {
+    const db = getDb();
+    return await db
+      .select()
+      .from(userAchievements)
+      .where(and(
+        eq(userAchievements.userId, userId),
+        sql`${userAchievements.earnedAt} >= ${since}`
+      ))
+      .all();
+  });
+}
+
+/**
+ * Mark a batch of achievement keys as notified for a user.
+ */
+export async function markAchievementsNotified(userId: string, keys: string[]): Promise<void> {
+  return traceDbQuery("markAchievementsNotified", async () => {
+    if (keys.length === 0) return;
+    const db = getDb();
+    await db
+      .update(userAchievements)
+      .set({ earnedNotified: 1 })
+      .where(and(
+        eq(userAchievements.userId, userId),
+        inArray(userAchievements.achievementKey, keys)
+      ))
+      .run();
+  });
+}
+
+/**
+ * Sum XP (points from earned achievements) for a single user.
+ */
+export async function sumXpForUser(userId: string): Promise<number> {
+  return traceDbQuery("sumXpForUser", async () => {
+    const db = getDb();
+    const row = await db
+      .select({ total: sum(achievements.points) })
+      .from(userAchievements)
+      .innerJoin(achievements, eq(achievements.key, userAchievements.achievementKey))
+      .where(and(
+        eq(userAchievements.userId, userId),
+        sql`${userAchievements.earnedAt} IS NOT NULL`
+      ))
+      .get();
+    return Number(row?.total ?? 0);
+  });
+}
+
+// D1 caps bound parameters per statement at 100.
+// Chunk at 50 IDs to stay safely under the cap.
+const XP_BATCH_CHUNK_SIZE = 50;
+
+/**
+ * Sum XP for multiple users in chunks of 50 (D1 100-param safety).
+ * Returns a Map<userId, xp>.
+ */
+export async function sumXpBatch(userIds: string[]): Promise<Map<string, number>> {
+  return traceDbQuery("sumXpBatch", async () => {
+    const result = new Map<string, number>();
+    if (userIds.length === 0) return result;
+
+    const db = getDb();
+
+    for (let i = 0; i < userIds.length; i += XP_BATCH_CHUNK_SIZE) {
+      const chunk = userIds.slice(i, i + XP_BATCH_CHUNK_SIZE);
+
+      const rows = await db
+        .select({
+          userId: userAchievements.userId,
+          total: sum(achievements.points),
+        })
+        .from(userAchievements)
+        .innerJoin(achievements, eq(achievements.key, userAchievements.achievementKey))
+        .where(and(
+          inArray(userAchievements.userId, chunk),
+          sql`${userAchievements.earnedAt} IS NOT NULL`
+        ))
+        .groupBy(userAchievements.userId)
+        .all();
+
+      for (const row of rows) {
+        result.set(row.userId, Number(row.total ?? 0));
+      }
+    }
+
+    return result;
+  });
+}

--- a/server/db/repository/streaks.test.ts
+++ b/server/db/repository/streaks.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
+import { createUser } from "../repository";
+import { logWatch } from "./watch-history";
+import { getStreak, bumpStreak, recomputeStreakFromHistory } from "./streaks";
+
+let userId: string;
+
+beforeEach(async () => {
+  setupTestDb();
+  userId = await createUser("streak-testuser", "hash");
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+describe("getStreak", () => {
+  it("returns null when no streak row exists", async () => {
+    const result = await getStreak(userId);
+    expect(result).toBeNull();
+  });
+
+  it("returns the streak row after bumpStreak", async () => {
+    await bumpStreak(userId, "2024-01-01T10:00:00.000Z");
+    const result = await getStreak(userId);
+    expect(result).not.toBeNull();
+    expect(result?.currentStreak).toBe(1);
+    expect(result?.userId).toBe(userId);
+  });
+});
+
+describe("bumpStreak — same-day double watch", () => {
+  it("same-day second watch is a no-op", async () => {
+    await bumpStreak(userId, "2024-01-01T08:00:00.000Z");
+    const first = await getStreak(userId);
+    expect(first?.currentStreak).toBe(1);
+
+    await bumpStreak(userId, "2024-01-01T22:00:00.000Z");
+    const second = await getStreak(userId);
+    expect(second?.currentStreak).toBe(1);
+    expect(second?.longestStreak).toBe(1);
+  });
+});
+
+describe("bumpStreak — next day increments streak", () => {
+  it("watching on consecutive days increases currentStreak", async () => {
+    await bumpStreak(userId, "2024-01-01T10:00:00.000Z");
+    await bumpStreak(userId, "2024-01-02T10:00:00.000Z");
+    const result = await getStreak(userId);
+    expect(result?.currentStreak).toBe(2);
+    expect(result?.longestStreak).toBe(2);
+  });
+
+  it("watching three consecutive days builds streak to 3", async () => {
+    await bumpStreak(userId, "2024-01-01T10:00:00.000Z");
+    await bumpStreak(userId, "2024-01-02T10:00:00.000Z");
+    await bumpStreak(userId, "2024-01-03T10:00:00.000Z");
+    const result = await getStreak(userId);
+    expect(result?.currentStreak).toBe(3);
+    expect(result?.longestStreak).toBe(3);
+  });
+});
+
+describe("bumpStreak — gap resets streak to 1", () => {
+  it("gap of 2 days resets currentStreak to 1", async () => {
+    await bumpStreak(userId, "2024-01-01T10:00:00.000Z");
+    await bumpStreak(userId, "2024-01-02T10:00:00.000Z");
+    // Day 4 — gap of 2 days after day 2
+    await bumpStreak(userId, "2024-01-04T10:00:00.000Z");
+    const result = await getStreak(userId);
+    expect(result?.currentStreak).toBe(1);
+  });
+
+  it("longestStreak does not decrease on reset", async () => {
+    await bumpStreak(userId, "2024-01-01T10:00:00.000Z");
+    await bumpStreak(userId, "2024-01-02T10:00:00.000Z");
+    await bumpStreak(userId, "2024-01-03T10:00:00.000Z"); // longest = 3
+    await bumpStreak(userId, "2024-01-10T10:00:00.000Z"); // reset, longest stays 3
+    const result = await getStreak(userId);
+    expect(result?.currentStreak).toBe(1);
+    expect(result?.longestStreak).toBe(3);
+  });
+});
+
+describe("bumpStreak — longestStreak only increases", () => {
+  it("longestStreak tracks the best streak ever", async () => {
+    // First run: 3-day streak
+    await bumpStreak(userId, "2024-01-01T10:00:00.000Z");
+    await bumpStreak(userId, "2024-01-02T10:00:00.000Z");
+    await bumpStreak(userId, "2024-01-03T10:00:00.000Z");
+
+    // Gap — reset
+    await bumpStreak(userId, "2024-01-10T10:00:00.000Z");
+
+    // Second run: only 2-day streak
+    await bumpStreak(userId, "2024-01-11T10:00:00.000Z");
+
+    const result = await getStreak(userId);
+    expect(result?.currentStreak).toBe(2);
+    expect(result?.longestStreak).toBe(3); // preserved from first run
+  });
+});
+
+describe("bumpStreak — first watch", () => {
+  it("creates streak row with currentStreak=1, longestStreak=1", async () => {
+    const result = await bumpStreak(userId, "2024-06-01T12:00:00.000Z");
+    expect(result.currentStreak).toBe(1);
+    expect(result.longestStreak).toBe(1);
+    expect(result.lastWatchDate).toBe("2024-06-01");
+  });
+});
+
+// ─── recomputeStreakFromHistory ───────────────────────────────────────────────
+
+describe("recomputeStreakFromHistory", () => {
+  it("returns 0 streak when no watch history exists", async () => {
+    const result = await recomputeStreakFromHistory(userId);
+    expect(result.currentStreak).toBe(0);
+    expect(result.longestStreak).toBe(0);
+    expect(result.lastWatchDate).toBeNull();
+  });
+
+  it("computes correct streak from consecutive watch history rows", async () => {
+    // We need a title in the DB for FK constraints
+    const { getDb } = await import("../schema");
+    const { titles, watchHistory } = await import("../schema");
+    const { randomUUID } = await import("node:crypto");
+
+    const db = getDb();
+
+    // Insert a title directly
+    await db.insert(titles).values({
+      id: "title-streak-hist",
+      objectType: "MOVIE",
+      title: "Streak Movie",
+      offersChecked: 0,
+    }).onConflictDoNothing().run();
+
+    // Insert watch history for 3 consecutive days
+    const dates = ["2024-03-01", "2024-03-02", "2024-03-03"];
+    for (const date of dates) {
+      await db.insert(watchHistory).values({
+        id: randomUUID(),
+        userId,
+        titleId: "title-streak-hist",
+        watchedAt: `${date}T12:00:00.000Z`,
+      }).run();
+    }
+
+    // recomputeStreakFromHistory uses today's date to decide if streak is active.
+    // Since dates are in the past, currentStreak may be 0 (expired).
+    const result = await recomputeStreakFromHistory(userId);
+    expect(result.longestStreak).toBe(3);
+  });
+
+  it("identifies longest streak across gaps", async () => {
+    const { getDb } = await import("../schema");
+    const { titles, watchHistory } = await import("../schema");
+    const { randomUUID } = await import("node:crypto");
+
+    const db = getDb();
+    await db.insert(titles).values({
+      id: "title-streak-hist2",
+      objectType: "MOVIE",
+      title: "Streak Movie 2",
+      offersChecked: 0,
+    }).onConflictDoNothing().run();
+
+    // 2-day run, then gap, then 4-day run
+    const dates = [
+      "2024-03-01", "2024-03-02",          // run of 2
+      "2024-03-10", "2024-03-11", "2024-03-12", "2024-03-13", // run of 4
+    ];
+    for (const date of dates) {
+      await db.insert(watchHistory).values({
+        id: randomUUID(),
+        userId,
+        titleId: "title-streak-hist2",
+        watchedAt: `${date}T12:00:00.000Z`,
+      }).run();
+    }
+
+    const result = await recomputeStreakFromHistory(userId);
+    expect(result.longestStreak).toBe(4);
+  });
+});

--- a/server/db/repository/streaks.ts
+++ b/server/db/repository/streaks.ts
@@ -1,0 +1,244 @@
+import { eq, sql, and } from "drizzle-orm";
+import { getDb } from "../schema";
+import { userStreaks, watchHistory } from "../schema";
+import { traceDbQuery } from "../../tracing";
+
+export interface StreakRow {
+  userId: string;
+  currentStreak: number;
+  longestStreak: number;
+  lastWatchDate: string | null;
+  updatedAt: string;
+}
+
+/** Get the current streak row for a user. Returns null if no streak exists. */
+export async function getStreak(userId: string): Promise<StreakRow | null> {
+  return traceDbQuery("getStreak", async () => {
+    const db = getDb();
+    const row = await db
+      .select()
+      .from(userStreaks)
+      .where(eq(userStreaks.userId, userId))
+      .get();
+
+    if (!row) return null;
+
+    return {
+      userId: row.userId,
+      currentStreak: row.currentStreak,
+      longestStreak: row.longestStreak,
+      lastWatchDate: row.lastWatchDate,
+      updatedAt: row.updatedAt ?? new Date().toISOString(),
+    };
+  });
+}
+
+/**
+ * Bump the streak for a user based on a watch event.
+ *
+ * NOTE: All dates are computed in UTC. users.locale is a BCP-47 locale tag
+ * (not a timezone), so we cannot derive user timezones from it.
+ * All streak logic runs on UTC date buckets.
+ *
+ * Algorithm (UTC date buckets):
+ * - No row → INSERT current=1, longest=1, last=today
+ * - last == today → no-op (same-day double-watch)
+ * - day diff == 1 → current += 1; longest = max(longest, current)
+ * - day diff >= 2 → current = 1 (new watch is day 1, not 0)
+ *
+ * Concurrent-write safety: use conditional UPDATE WHERE last_watch_date IS <old value>;
+ * retries up to 3× on conflict.
+ */
+export async function bumpStreak(userId: string, watchedAt?: string): Promise<StreakRow> {
+  return traceDbQuery("bumpStreak", async () => {
+    const db = getDb();
+    const today = toUtcDateString(watchedAt ?? new Date().toISOString());
+    const updatedAt = new Date().toISOString();
+
+    const MAX_RETRIES = 3;
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      const existing = await db
+        .select()
+        .from(userStreaks)
+        .where(eq(userStreaks.userId, userId))
+        .get();
+
+      if (!existing) {
+        // No row — insert new streak starting at 1
+        try {
+          await db
+            .insert(userStreaks)
+            .values({
+              userId,
+              currentStreak: 1,
+              longestStreak: 1,
+              lastWatchDate: today,
+              updatedAt,
+            })
+            .run();
+          return { userId, currentStreak: 1, longestStreak: 1, lastWatchDate: today, updatedAt };
+        } catch {
+          // Race — another insert beat us, retry
+          continue;
+        }
+      }
+
+      const last = existing.lastWatchDate;
+      const dayDiff = last ? dateDiffDays(last, today) : 999;
+
+      if (dayDiff === 0) {
+        // Same day — no-op
+        return {
+          userId: existing.userId,
+          currentStreak: existing.currentStreak,
+          longestStreak: existing.longestStreak,
+          lastWatchDate: existing.lastWatchDate,
+          updatedAt: existing.updatedAt ?? updatedAt,
+        };
+      }
+
+      let newCurrent: number;
+      if (dayDiff === 1) {
+        newCurrent = existing.currentStreak + 1;
+      } else {
+        newCurrent = 1;
+      }
+      const newLongest = Math.max(existing.longestStreak, newCurrent);
+
+      // Conditional update — only if lastWatchDate hasn't changed (optimistic lock)
+      const result = await db
+        .update(userStreaks)
+        .set({
+          currentStreak: newCurrent,
+          longestStreak: newLongest,
+          lastWatchDate: today,
+          updatedAt,
+        })
+        .where(and(eq(userStreaks.userId, userId), last
+          ? eq(userStreaks.lastWatchDate, last)
+          : sql`${userStreaks.lastWatchDate} IS NULL`
+        ))
+        .run();
+
+      if ((result as unknown as { changes?: number }).changes !== 0) {
+        return { userId, currentStreak: newCurrent, longestStreak: newLongest, lastWatchDate: today, updatedAt };
+      }
+      // Another write modified last_watch_date — retry
+    }
+
+    // After all retries, just return current state
+    const row = await db.select().from(userStreaks).where(eq(userStreaks.userId, userId)).get();
+    return {
+      userId: row?.userId ?? userId,
+      currentStreak: row?.currentStreak ?? 0,
+      longestStreak: row?.longestStreak ?? 0,
+      lastWatchDate: row?.lastWatchDate ?? null,
+      updatedAt: row?.updatedAt ?? new Date().toISOString(),
+    };
+  });
+}
+
+/**
+ * Recompute streak from full watch_history — used only by backfill job.
+ * Reads DISTINCT date(watched_at) UTC from watch_history, runs the same
+ * algorithm over sorted dates, then persists the result.
+ */
+export async function recomputeStreakFromHistory(userId: string): Promise<StreakRow> {
+  return traceDbQuery("recomputeStreakFromHistory", async () => {
+    const db = getDb();
+
+    // Get all distinct UTC dates from watch_history for this user
+    const rows = await db.all<{ watch_date: string }>(sql`
+      SELECT DISTINCT date(watched_at) as watch_date
+      FROM watch_history
+      WHERE user_id = ${userId}
+        AND watched_at IS NOT NULL
+      ORDER BY watch_date ASC
+    `);
+
+    const dates = rows.map((r) => r.watch_date);
+
+    if (dates.length === 0) {
+      // No history — reset streak
+      const updatedAt = new Date().toISOString();
+      await db
+        .insert(userStreaks)
+        .values({ userId, currentStreak: 0, longestStreak: 0, lastWatchDate: null, updatedAt })
+        .onConflictDoUpdate({
+          target: userStreaks.userId,
+          set: { currentStreak: 0, longestStreak: 0, lastWatchDate: null, updatedAt },
+        })
+        .run();
+      return { userId, currentStreak: 0, longestStreak: 0, lastWatchDate: null, updatedAt };
+    }
+
+    // Run the streak algorithm over sorted dates
+    let currentStreak = 1;
+    let longestStreak = 1;
+    let runLength = 1;
+
+    for (let i = 1; i < dates.length; i++) {
+      const diff = dateDiffDays(dates[i - 1], dates[i]);
+      if (diff === 1) {
+        runLength++;
+        if (runLength > longestStreak) longestStreak = runLength;
+      } else {
+        runLength = 1;
+      }
+    }
+
+    // Check if the last date is today or yesterday to determine currentStreak
+    const today = toUtcDateString(new Date().toISOString());
+    const lastDate = dates[dates.length - 1];
+    const daysSinceLast = dateDiffDays(lastDate, today);
+
+    if (daysSinceLast <= 1) {
+      // Streak is still active — compute current streak from the end
+      currentStreak = 1;
+      for (let i = dates.length - 1; i > 0; i--) {
+        const diff = dateDiffDays(dates[i - 1], dates[i]);
+        if (diff === 1) {
+          currentStreak++;
+        } else {
+          break;
+        }
+      }
+    } else {
+      // Streak expired
+      currentStreak = 0;
+    }
+
+    longestStreak = Math.max(longestStreak, currentStreak);
+
+    const updatedAt = new Date().toISOString();
+    await db
+      .insert(userStreaks)
+      .values({ userId, currentStreak, longestStreak, lastWatchDate: lastDate, updatedAt })
+      .onConflictDoUpdate({
+        target: userStreaks.userId,
+        set: { currentStreak, longestStreak, lastWatchDate: lastDate, updatedAt },
+      })
+      .run();
+
+    return { userId, currentStreak, longestStreak, lastWatchDate: lastDate, updatedAt };
+  });
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+/** Convert an ISO datetime string to a UTC date string (YYYY-MM-DD). */
+function toUtcDateString(isoString: string): string {
+  const d = new Date(isoString);
+  const year = d.getUTCFullYear();
+  const month = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/** Compute the signed difference in days between two UTC date strings (b - a). */
+function dateDiffDays(a: string, b: string): number {
+  const aMs = new Date(`${a}T00:00:00Z`).getTime();
+  const bMs = new Date(`${b}T00:00:00Z`).getTime();
+  return Math.round((bMs - aMs) / (1000 * 60 * 60 * 24));
+}
+

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -343,6 +343,7 @@ export const notifiers = sqliteTable(
     quietHoursDays: text("quiet_hours_days").notNull().default(""),
     leavingSoonAlertsEnabled: integer("leaving_soon_alerts_enabled").notNull().default(1),
     friendActivityAlertsEnabled: integer("friend_activity_alerts_enabled").notNull().default(0),
+    achievementsEnabled: integer("achievements_enabled").notNull().default(0),
     createdAt: text("created_at").default(sql`(datetime('now'))`),
     updatedAt: text("updated_at").default(sql`(datetime('now'))`),
   },
@@ -781,10 +782,56 @@ export const dismissedSuggestions = sqliteTable(
   ]
 );
 
+export const achievements = sqliteTable("achievements", {
+  key: text("key").primaryKey(),
+  kind: text("kind").notNull(),
+  threshold: integer("threshold").notNull(),
+  points: integer("points").notNull(),
+  title: text("title").notNull(),
+  description: text("description").notNull(),
+  icon: text("icon").notNull(),
+  metadata: text("metadata"),
+});
+
+export const userAchievements = sqliteTable(
+  "user_achievements",
+  {
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    achievementKey: text("achievement_key")
+      .notNull()
+      .references(() => achievements.key, { onDelete: "cascade" }),
+    progress: integer("progress").notNull().default(0),
+    earnedAt: text("earned_at"),
+    earnedNotified: integer("earned_notified").notNull().default(0),
+    updatedAt: text("updated_at").default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.achievementKey] }),
+    index("idx_user_achievements_earned").on(table.userId, table.earnedAt),
+  ]
+);
+
+export const userStreaks = sqliteTable("user_streaks", {
+  userId: text("user_id")
+    .primaryKey()
+    .references(() => users.id, { onDelete: "cascade" }),
+  currentStreak: integer("current_streak").notNull().default(0),
+  longestStreak: integer("longest_streak").notNull().default(0),
+  lastWatchDate: text("last_watch_date"),
+  updatedAt: text("updated_at").default(sql`(datetime('now'))`),
+});
+
+export type AchievementDefRow = typeof achievements.$inferSelect;
+export type UserAchievementRow = typeof userAchievements.$inferSelect;
+export type UserStreakRow = typeof userStreaks.$inferSelect;
+
 export const schemaExports = {
   titles, providers, offers, scores, titleGenres, episodes, users, sessions, account, verification, passkey, settings, tracked, watchedEpisodes, watchedTitles, notifiers, oidcStates, jobs, cronJobs, userSubscribedProviders,
   follows, ratings, episodeRatings, recommendations, recommendationReads, invitations, integrations, plexLibraryItems, titleTags,
   watchHistory, streamingAlerts, activityKindVisibility, hiddenActivityEvents, notificationLog, dismissedSuggestions,
+  achievements, userAchievements, userStreaks,
   titlesRelations, providersRelations, offersRelations, scoresRelations, titleGenresRelations, episodesRelations,
   passkeyRelations,
   usersRelations, sessionsRelations, accountRelations, trackedRelations, watchedEpisodesRelations, watchedTitlesRelations, notifiersRelations,

--- a/server/index.ts
+++ b/server/index.ts
@@ -58,6 +58,7 @@ import { createAuthWithOidc, type BetterAuthInstance } from "./auth/better-auth"
 import { migrateAuthData } from "./db/migrate-auth";
 import { validateStartup } from "./startup-validation";
 import { createCache, initCache } from "./cache";
+import { syncAchievementRegistry } from "./achievements";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -66,6 +67,9 @@ validateStartup();
 
 // Initialize DB on startup
 initBunDb();
+
+// Sync achievement registry to DB (idempotent — safe on every startup)
+await syncAchievementRegistry();
 
 // Initialize distributed cache
 const cache = await createCache();

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -85,6 +85,7 @@ import { armCron, enqueueOnce, processPending, recoverStale, runWithEnv, CRON_JO
 export { JobQueueDO } from "./jobs/durable-object";
 import { createAuth } from "./auth/better-auth";
 import { migrateAuthData } from "./db/migrate-auth";
+import { syncAchievementRegistry } from "./achievements";
 import type { DrizzleDb } from "./platform/types";
 import { runWithCache } from "./cache";
 import { CloudflareKvCache } from "./cache/cloudflare-kv";
@@ -166,6 +167,7 @@ function patchConfigFromEnv(env: Env): void {
 // ─── Per-isolate state (survives across requests within the same Worker instance) ──
 
 let adminChecked = false;
+let achievementRegistrySynced = false;
 let oidcConfigLoaded = false;
 let cachedOidcConfig: Parameters<typeof createAuth>[2] | undefined;
 
@@ -211,6 +213,12 @@ function createApp(env: Env) {
 
     // One-time data migration (skipped after first successful check)
     await migrateAuthData();
+
+    // Sync achievement registry once per isolate (idempotent UPSERT)
+    if (!achievementRegistrySynced) {
+      achievementRegistrySynced = true;
+      await syncAchievementRegistry();
+    }
 
     // Create admin on first request if no users exist
     if (!adminChecked) {


### PR DESCRIPTION
## Summary

Part 1/3 of #375. Establishes the complete data layer and pure evaluation logic for the gamification feature. Downstream PRs (write-path triggers, frontend) depend on this.

- **DB migration** (`drizzle/0047_achievements.sql`): creates `achievements`, `user_achievements`, `user_streaks` tables and adds `achievements_enabled` column to `notifiers`
- **Drizzle schema** (`server/db/schema.ts`): three new table definitions + exported row types + `achievementsEnabled` on notifiers
- **Achievement registry** (`server/achievements/definitions.ts`): 20 achievements across 8 kinds (count_movies, count_episodes, streak_days, genre_count, completionist, social_first_recommendation, social_first_follow, speed_binge_season)
- **Pure evaluators** (`server/achievements/evaluate.ts`): one function per kind, read-only, all wrapped in `traceDbQuery`
- **Registry sync** (`server/achievements/sync.ts`): UPSERT of registry into DB on startup (idempotent, does not delete orphan rows)
- **Repositories** (`server/db/repository/achievements.ts`, `server/db/repository/streaks.ts`): full CRUD for achievements/XP and streak logic with UTC date buckets, optimistic-lock retry, and D1-safe 50-ID chunking for `sumXpBatch`
- **Startup wiring** (`server/index.ts`, `server/worker.ts`): `syncAchievementRegistry()` called once after DB init

## Test plan

- [x] `bun test server/achievements/definitions.test.ts` — no duplicate keys, valid fields (7 tests)
- [x] `bun test server/achievements/sync.test.ts` — idempotent sync, orphan row preservation (4 tests)
- [x] `bun test server/achievements/evaluate.test.ts` — zero/partial/threshold/past-threshold for each kind (28 tests)
- [x] `bun test server/db/repository/achievements.test.ts` — upsert, newlyEarned detection, sumXpBatch chunking >50 users (17 tests)
- [x] `bun test server/db/repository/streaks.test.ts` — same-day no-op, consecutive increment, gap reset, longestStreak, recomputeFromHistory (12 tests)
- [x] `bun test server/db/migrations.test.ts` — FK-cascade regression guard passes with new migration
- [x] `bun run check` — all 2770 tests pass, server tsc clean, frontend tsc clean, ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)