### PR TITLE
feat(gamification): triggers, routes, jobs & notifications

### DIFF
--- a/server/achievements/sync.ts
+++ b/server/achievements/sync.ts
@@ -1,6 +1,7 @@
 import { ACHIEVEMENTS } from "./definitions";
 import { upsertAchievementDef } from "../db/repository/achievements";
 import { getSetting } from "../db/repository/settings";
+import { enqueueJob, hasActiveJob } from "../jobs/enqueue";
 import { logger } from "../logger";
 
 const log = logger.child({ module: "achievements-sync" });
@@ -20,7 +21,6 @@ export async function syncAchievementRegistry(): Promise<void> {
   log.info("Achievement registry sync complete");
 
   // Auto-trigger backfill once (idempotent via hasActiveJob guard)
-  const { hasActiveJob, enqueueJob } = await import("../jobs/queue");
   const done = await getSetting("achievements_backfill_done");
   if (!done && !(await hasActiveJob("backfill-achievements"))) {
     await enqueueJob("backfill-achievements", {});

--- a/server/achievements/sync.ts
+++ b/server/achievements/sync.ts
@@ -1,5 +1,6 @@
 import { ACHIEVEMENTS } from "./definitions";
 import { upsertAchievementDef } from "../db/repository/achievements";
+import { getSetting } from "../db/repository/settings";
 import { logger } from "../logger";
 
 const log = logger.child({ module: "achievements-sync" });
@@ -17,4 +18,12 @@ export async function syncAchievementRegistry(): Promise<void> {
   }
 
   log.info("Achievement registry sync complete");
+
+  // Auto-trigger backfill once (idempotent via hasActiveJob guard)
+  const { hasActiveJob, enqueueJob } = await import("../jobs/queue");
+  const done = await getSetting("achievements_backfill_done");
+  if (!done && !(await hasActiveJob("backfill-achievements"))) {
+    await enqueueJob("backfill-achievements", {});
+    log.info("Enqueued achievements backfill job");
+  }
 }

--- a/server/achievements/triggers.test.ts
+++ b/server/achievements/triggers.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { Hono } from "hono";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
 import { createUser, upsertTitles, upsertEpisodes } from "../db/repository";
 import { makeParsedTitle } from "../test-utils/fixtures";
@@ -6,6 +7,8 @@ import * as queue from "../jobs/queue";
 import * as achievementsRepo from "../db/repository/achievements";
 import * as streaksRepo from "../db/repository/streaks";
 import * as evaluate from "./evaluate";
+import * as triggers from "./triggers";
+import type { AppEnv } from "../types";
 
 // Do NOT import triggers at module top level — DB must be set up first.
 // Import inside tests after setupTestDb().
@@ -221,5 +224,105 @@ describe("onRecommendation", () => {
     upsertSpy.mockRestore();
     enqueueSpy.mockRestore();
     evalRecSpy.mockRestore();
+  });
+});
+
+// ─── DELETE-path tests: triggers must NOT fire on un-watch / unfollow ─────────
+
+describe("DELETE /watched/:episodeId — no trigger fired", () => {
+  it("does not call onWatchedEpisode, bumpStreak, or enqueueJob when un-watching an episode", async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    await upsertTitles([makeParsedTitle({ id: "show-del-1", objectType: "SHOW" })]);
+    await upsertEpisodes([
+      { title_id: "show-del-1", season_number: 1, episode_number: 1, name: "Pilot", overview: null, air_date: today, still_path: null },
+    ]);
+
+    const { getDb } = await import("../db/schema");
+    const { episodes } = await import("../db/schema");
+    const { eq } = await import("drizzle-orm");
+    const db = getDb();
+    const ep = await db.select().from(episodes).where(eq(episodes.titleId, "show-del-1")).get();
+    const epId = ep!.id;
+
+    const onWatchedEpisodeSpy = spyOn(triggers, "onWatchedEpisode").mockResolvedValue(undefined);
+    const bumpSpy = spyOn(streaksRepo, "bumpStreak").mockResolvedValue({
+      userId,
+      currentStreak: 0,
+      longestStreak: 0,
+      lastWatchDate: null,
+      updatedAt: new Date().toISOString(),
+    });
+    const enqueueSpy = spyOn(queue, "enqueueJob").mockReturnValue(1);
+
+    const watchedApp = (await import("../routes/watched")).default;
+    const app = new Hono<AppEnv>();
+    app.use("*", async (c, next) => {
+      c.set("user", { id: userId, username: "testuser", name: null, role: null, is_admin: false });
+      await next();
+    });
+    app.route("/watched", watchedApp);
+
+    const res = await app.request(`/watched/${epId}`, { method: "DELETE" });
+    expect(res.status).toBe(200);
+
+    expect(onWatchedEpisodeSpy).not.toHaveBeenCalled();
+    expect(bumpSpy).not.toHaveBeenCalled();
+    expect(enqueueSpy).not.toHaveBeenCalled();
+
+    onWatchedEpisodeSpy.mockRestore();
+    bumpSpy.mockRestore();
+    enqueueSpy.mockRestore();
+  });
+});
+
+describe("DELETE /watched/movies/:titleId — no trigger fired", () => {
+  it("does not call onWatchedTitle when un-watching a movie", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-del-1", objectType: "MOVIE", title: "Delete Me" })]);
+
+    const onWatchedTitleSpy = spyOn(triggers, "onWatchedTitle").mockResolvedValue(undefined);
+    const enqueueSpy = spyOn(queue, "enqueueJob").mockReturnValue(1);
+
+    const watchedApp = (await import("../routes/watched")).default;
+    const app = new Hono<AppEnv>();
+    app.use("*", async (c, next) => {
+      c.set("user", { id: userId, username: "testuser", name: null, role: null, is_admin: false });
+      await next();
+    });
+    app.route("/watched", watchedApp);
+
+    const res = await app.request("/watched/movies/movie-del-1", { method: "DELETE" });
+    expect(res.status).toBe(200);
+
+    expect(onWatchedTitleSpy).not.toHaveBeenCalled();
+    expect(enqueueSpy).not.toHaveBeenCalled();
+
+    onWatchedTitleSpy.mockRestore();
+    enqueueSpy.mockRestore();
+  });
+});
+
+describe("DELETE /social/follow/:userId — no trigger fired", () => {
+  it("does not call onFollow when unfollowing a user", async () => {
+    const targetUserId = await createUser("targetuser", "hash2", "Target User");
+
+    const onFollowSpy = spyOn(triggers, "onFollow").mockResolvedValue(undefined);
+    const enqueueSpy = spyOn(queue, "enqueueJob").mockReturnValue(1);
+
+    const socialApp = (await import("../routes/social")).default;
+    const app = new Hono<AppEnv>();
+    app.use("*", async (c, next) => {
+      c.set("user", { id: userId, username: "testuser", name: null, role: null, is_admin: false });
+      await next();
+    });
+    app.route("/social", socialApp);
+
+    const res = await app.request(`/social/follow/${targetUserId}`, { method: "DELETE" });
+    expect(res.status).toBe(200);
+
+    expect(onFollowSpy).not.toHaveBeenCalled();
+    expect(enqueueSpy).not.toHaveBeenCalled();
+
+    onFollowSpy.mockRestore();
+    enqueueSpy.mockRestore();
   });
 });

--- a/server/achievements/triggers.test.ts
+++ b/server/achievements/triggers.test.ts
@@ -3,7 +3,7 @@ import { Hono } from "hono";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
 import { createUser, upsertTitles, upsertEpisodes } from "../db/repository";
 import { makeParsedTitle } from "../test-utils/fixtures";
-import * as queue from "../jobs/queue";
+import * as enqueue from "../jobs/enqueue";
 import * as achievementsRepo from "../db/repository/achievements";
 import * as streaksRepo from "../db/repository/streaks";
 import * as evaluate from "./evaluate";
@@ -67,7 +67,7 @@ describe("onWatchedTitle", () => {
       updatedAt: new Date().toISOString(),
     });
     const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: false });
-    const enqueueSpy = spyOn(queue, "enqueueJob").mockReturnValue(1);
+    const enqueueSpy = spyOn(enqueue, "enqueueJob").mockResolvedValue(undefined);
     const evalMoviesSpy = spyOn(evaluate, "evaluateCountMovies").mockResolvedValue({ progress: 1, earned: false });
     const evalStreakSpy = spyOn(evaluate, "evaluateStreak").mockResolvedValue({ progress: 1, earned: false });
 
@@ -99,7 +99,7 @@ describe("onWatchedTitle", () => {
       updatedAt: new Date().toISOString(),
     });
     const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: false });
-    const enqueueSpy = spyOn(queue, "enqueueJob").mockReturnValue(1);
+    const enqueueSpy = spyOn(enqueue, "enqueueJob").mockResolvedValue(undefined);
     const evalMoviesSpy = spyOn(evaluate, "evaluateCountMovies").mockResolvedValue({ progress: 1, earned: false });
     const evalStreakSpy = spyOn(evaluate, "evaluateStreak").mockResolvedValue({ progress: 1, earned: false });
 
@@ -130,7 +130,7 @@ describe("onWatchedEpisode", () => {
       updatedAt: new Date().toISOString(),
     });
     const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: false });
-    const enqueueSpy = spyOn(queue, "enqueueJob").mockReturnValue(1);
+    const enqueueSpy = spyOn(enqueue, "enqueueJob").mockResolvedValue(undefined);
     const evalEpsSpy = spyOn(evaluate, "evaluateCountEpisodes").mockResolvedValue({ progress: 1, earned: false });
     const evalStreakSpy = spyOn(evaluate, "evaluateStreak").mockResolvedValue({ progress: 1, earned: false });
 
@@ -167,7 +167,7 @@ describe("onWatchedEpisodesBulk", () => {
       updatedAt: new Date().toISOString(),
     });
     const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: false });
-    const enqueueSpy = spyOn(queue, "enqueueJob").mockReturnValue(1);
+    const enqueueSpy = spyOn(enqueue, "enqueueJob").mockResolvedValue(undefined);
     const evalEpsSpy = spyOn(evaluate, "evaluateCountEpisodes").mockResolvedValue({ progress: 5, earned: false });
     const evalStreakSpy = spyOn(evaluate, "evaluateStreak").mockResolvedValue({ progress: 1, earned: false });
 
@@ -192,7 +192,7 @@ describe("onFollow", () => {
     const { onFollow } = await import("./triggers");
 
     const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: true });
-    const enqueueSpy = spyOn(queue, "enqueueJob").mockReturnValue(1);
+    const enqueueSpy = spyOn(enqueue, "enqueueJob").mockResolvedValue(undefined);
     const evalFollowSpy = spyOn(evaluate, "evaluateSocialFirstFollow").mockResolvedValue({ progress: 1, earned: true });
 
     await onFollow(userId);
@@ -212,7 +212,7 @@ describe("onRecommendation", () => {
     const { onRecommendation } = await import("./triggers");
 
     const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: true });
-    const enqueueSpy = spyOn(queue, "enqueueJob").mockReturnValue(1);
+    const enqueueSpy = spyOn(enqueue, "enqueueJob").mockResolvedValue(undefined);
     const evalRecSpy = spyOn(evaluate, "evaluateSocialFirstRecommendation").mockResolvedValue({ progress: 1, earned: true });
 
     await onRecommendation(userId);
@@ -252,7 +252,7 @@ describe("DELETE /watched/:episodeId — no trigger fired", () => {
       lastWatchDate: null,
       updatedAt: new Date().toISOString(),
     });
-    const enqueueSpy = spyOn(queue, "enqueueJob").mockReturnValue(1);
+    const enqueueSpy = spyOn(enqueue, "enqueueJob").mockResolvedValue(undefined);
 
     const watchedApp = (await import("../routes/watched")).default;
     const app = new Hono<AppEnv>();
@@ -280,7 +280,7 @@ describe("DELETE /watched/movies/:titleId — no trigger fired", () => {
     await upsertTitles([makeParsedTitle({ id: "movie-del-1", objectType: "MOVIE", title: "Delete Me" })]);
 
     const onWatchedTitleSpy = spyOn(triggers, "onWatchedTitle").mockResolvedValue(undefined);
-    const enqueueSpy = spyOn(queue, "enqueueJob").mockReturnValue(1);
+    const enqueueSpy = spyOn(enqueue, "enqueueJob").mockResolvedValue(undefined);
 
     const watchedApp = (await import("../routes/watched")).default;
     const app = new Hono<AppEnv>();
@@ -306,7 +306,7 @@ describe("DELETE /social/follow/:userId — no trigger fired", () => {
     const targetUserId = await createUser("targetuser", "hash2", "Target User");
 
     const onFollowSpy = spyOn(triggers, "onFollow").mockResolvedValue(undefined);
-    const enqueueSpy = spyOn(queue, "enqueueJob").mockReturnValue(1);
+    const enqueueSpy = spyOn(enqueue, "enqueueJob").mockResolvedValue(undefined);
 
     const socialApp = (await import("../routes/social")).default;
     const app = new Hono<AppEnv>();

--- a/server/achievements/triggers.test.ts
+++ b/server/achievements/triggers.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { createUser, upsertTitles, upsertEpisodes } from "../db/repository";
+import { makeParsedTitle } from "../test-utils/fixtures";
+import * as queue from "../jobs/queue";
+import * as achievementsRepo from "../db/repository/achievements";
+import * as streaksRepo from "../db/repository/streaks";
+import * as evaluate from "./evaluate";
+
+// Do NOT import triggers at module top level — DB must be set up first.
+// Import inside tests after setupTestDb().
+
+let userId: string;
+let movieTitleId: string;
+let showTitleId: string;
+let episodeId: number;
+
+beforeEach(async () => {
+  setupTestDb();
+
+  userId = await createUser("testuser", "hash", "Test User");
+
+  // Insert a movie title
+  await upsertTitles([makeParsedTitle({ id: "movie-1", objectType: "MOVIE", title: "Test Movie" })]);
+  movieTitleId = "movie-1";
+
+  // Insert a show title
+  await upsertTitles([makeParsedTitle({ id: "show-1", objectType: "SHOW", title: "Test Show" })]);
+  showTitleId = "show-1";
+
+  // Insert an episode
+  await upsertEpisodes([{
+    title_id: showTitleId,
+    season_number: 1,
+    episode_number: 1,
+    name: "Pilot",
+    air_date: "2024-01-01",
+    overview: null,
+    still_path: null,
+  }]);
+
+  // Get the episode ID by querying
+  const { getDb } = await import("../db/schema");
+  const { episodes } = await import("../db/schema");
+  const { eq } = await import("drizzle-orm");
+  const db = getDb();
+  const ep = await db.select().from(episodes).where(eq(episodes.titleId, showTitleId)).get();
+  episodeId = ep!.id;
+});
+
+afterEach(() => {
+  teardownTestDb();
+});
+
+describe("onWatchedTitle", () => {
+  it("bumps streak and evaluates count_movies inline for movies", async () => {
+    const { onWatchedTitle } = await import("./triggers");
+
+    const bumpSpy = spyOn(streaksRepo, "bumpStreak").mockResolvedValue({
+      userId,
+      currentStreak: 1,
+      longestStreak: 1,
+      lastWatchDate: "2026-01-01",
+      updatedAt: new Date().toISOString(),
+    });
+    const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: false });
+    const enqueueSpy = spyOn(queue, "enqueueJob").mockReturnValue(1);
+    const evalMoviesSpy = spyOn(evaluate, "evaluateCountMovies").mockResolvedValue({ progress: 1, earned: false });
+    const evalStreakSpy = spyOn(evaluate, "evaluateStreak").mockResolvedValue({ progress: 1, earned: false });
+
+    await onWatchedTitle(userId, movieTitleId, true);
+
+    expect(bumpSpy).toHaveBeenCalledWith(userId);
+    expect(evalMoviesSpy).toHaveBeenCalled();
+    expect(evalStreakSpy).toHaveBeenCalled();
+    expect(enqueueSpy).toHaveBeenCalledWith(
+      "evaluate-achievements",
+      expect.objectContaining({ userId, kinds: expect.arrayContaining(["completionist", "genre_count"]), titleId: movieTitleId })
+    );
+
+    bumpSpy.mockRestore();
+    upsertSpy.mockRestore();
+    enqueueSpy.mockRestore();
+    evalMoviesSpy.mockRestore();
+    evalStreakSpy.mockRestore();
+  });
+
+  it("bumps streak but does NOT evaluate count_movies inline for TV shows", async () => {
+    const { onWatchedTitle } = await import("./triggers");
+
+    const bumpSpy = spyOn(streaksRepo, "bumpStreak").mockResolvedValue({
+      userId,
+      currentStreak: 1,
+      longestStreak: 1,
+      lastWatchDate: "2026-01-01",
+      updatedAt: new Date().toISOString(),
+    });
+    const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: false });
+    const enqueueSpy = spyOn(queue, "enqueueJob").mockReturnValue(1);
+    const evalMoviesSpy = spyOn(evaluate, "evaluateCountMovies").mockResolvedValue({ progress: 1, earned: false });
+    const evalStreakSpy = spyOn(evaluate, "evaluateStreak").mockResolvedValue({ progress: 1, earned: false });
+
+    await onWatchedTitle(userId, showTitleId, false);
+
+    expect(bumpSpy).toHaveBeenCalledWith(userId);
+    expect(evalMoviesSpy).not.toHaveBeenCalled();
+    expect(evalStreakSpy).toHaveBeenCalled();
+    expect(enqueueSpy).toHaveBeenCalled();
+
+    bumpSpy.mockRestore();
+    upsertSpy.mockRestore();
+    enqueueSpy.mockRestore();
+    evalMoviesSpy.mockRestore();
+    evalStreakSpy.mockRestore();
+  });
+});
+
+describe("onWatchedEpisode", () => {
+  it("bumps streak, evaluates count_episodes inline, and enqueues deferred job", async () => {
+    const { onWatchedEpisode } = await import("./triggers");
+
+    const bumpSpy = spyOn(streaksRepo, "bumpStreak").mockResolvedValue({
+      userId,
+      currentStreak: 1,
+      longestStreak: 1,
+      lastWatchDate: "2026-01-01",
+      updatedAt: new Date().toISOString(),
+    });
+    const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: false });
+    const enqueueSpy = spyOn(queue, "enqueueJob").mockReturnValue(1);
+    const evalEpsSpy = spyOn(evaluate, "evaluateCountEpisodes").mockResolvedValue({ progress: 1, earned: false });
+    const evalStreakSpy = spyOn(evaluate, "evaluateStreak").mockResolvedValue({ progress: 1, earned: false });
+
+    await onWatchedEpisode(userId, String(episodeId));
+
+    expect(bumpSpy).toHaveBeenCalled();
+    expect(evalEpsSpy).toHaveBeenCalled();
+    expect(evalStreakSpy).toHaveBeenCalled();
+    expect(enqueueSpy).toHaveBeenCalledWith(
+      "evaluate-achievements",
+      expect.objectContaining({
+        userId,
+        kinds: expect.arrayContaining(["completionist", "genre_count", "speed_binge_season"]),
+      })
+    );
+
+    bumpSpy.mockRestore();
+    upsertSpy.mockRestore();
+    enqueueSpy.mockRestore();
+    evalEpsSpy.mockRestore();
+    evalStreakSpy.mockRestore();
+  });
+});
+
+describe("onWatchedEpisodesBulk", () => {
+  it("enqueues one job per distinct title, not per episode", async () => {
+    const { onWatchedEpisodesBulk } = await import("./triggers");
+
+    const bumpSpy = spyOn(streaksRepo, "bumpStreak").mockResolvedValue({
+      userId,
+      currentStreak: 1,
+      longestStreak: 1,
+      lastWatchDate: "2026-01-01",
+      updatedAt: new Date().toISOString(),
+    });
+    const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: false });
+    const enqueueSpy = spyOn(queue, "enqueueJob").mockReturnValue(1);
+    const evalEpsSpy = spyOn(evaluate, "evaluateCountEpisodes").mockResolvedValue({ progress: 5, earned: false });
+    const evalStreakSpy = spyOn(evaluate, "evaluateStreak").mockResolvedValue({ progress: 1, earned: false });
+
+    // 5 episodes across 2 shows
+    const titleIds = new Set(["show-1", "show-2"]);
+    await onWatchedEpisodesBulk(userId, ["1", "2", "3", "4", "5"], titleIds);
+
+    // Should enqueue 2 jobs (one per distinct titleId), not 5
+    const jobCalls = enqueueSpy.mock.calls.filter((c) => c[0] === "evaluate-achievements");
+    expect(jobCalls.length).toBe(2);
+
+    bumpSpy.mockRestore();
+    upsertSpy.mockRestore();
+    enqueueSpy.mockRestore();
+    evalEpsSpy.mockRestore();
+    evalStreakSpy.mockRestore();
+  });
+});
+
+describe("onFollow", () => {
+  it("evaluates social_first_follow inline and does not enqueue any job", async () => {
+    const { onFollow } = await import("./triggers");
+
+    const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: true });
+    const enqueueSpy = spyOn(queue, "enqueueJob").mockReturnValue(1);
+    const evalFollowSpy = spyOn(evaluate, "evaluateSocialFirstFollow").mockResolvedValue({ progress: 1, earned: true });
+
+    await onFollow(userId);
+
+    expect(evalFollowSpy).toHaveBeenCalledWith(userId);
+    expect(upsertSpy).toHaveBeenCalled();
+    expect(enqueueSpy).not.toHaveBeenCalled();
+
+    upsertSpy.mockRestore();
+    enqueueSpy.mockRestore();
+    evalFollowSpy.mockRestore();
+  });
+});
+
+describe("onRecommendation", () => {
+  it("evaluates social_first_recommendation inline and does not enqueue any job", async () => {
+    const { onRecommendation } = await import("./triggers");
+
+    const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: true });
+    const enqueueSpy = spyOn(queue, "enqueueJob").mockReturnValue(1);
+    const evalRecSpy = spyOn(evaluate, "evaluateSocialFirstRecommendation").mockResolvedValue({ progress: 1, earned: true });
+
+    await onRecommendation(userId);
+
+    expect(evalRecSpy).toHaveBeenCalledWith(userId);
+    expect(upsertSpy).toHaveBeenCalled();
+    expect(enqueueSpy).not.toHaveBeenCalled();
+
+    upsertSpy.mockRestore();
+    enqueueSpy.mockRestore();
+    evalRecSpy.mockRestore();
+  });
+});

--- a/server/achievements/triggers.ts
+++ b/server/achievements/triggers.ts
@@ -1,6 +1,3 @@
-import { eq } from "drizzle-orm";
-import { getDb } from "../db/schema";
-import { episodes } from "../db/schema";
 import { ACHIEVEMENTS, type AchievementKind } from "./definitions";
 import {
   evaluateCountMovies,
@@ -11,6 +8,7 @@ import {
 } from "./evaluate";
 import { upsertUserAchievement } from "../db/repository/achievements";
 import { bumpStreak } from "../db/repository/streaks";
+import { getEpisodeTitleId } from "../db/repository";
 import { enqueueJob } from "../jobs/queue";
 import { logger } from "../logger";
 
@@ -28,17 +26,6 @@ async function evaluateAndPersist(
   if (newlyEarned) {
     log.info("Achievement newly earned", { userId, key, kind, progress: result.progress });
   }
-}
-
-async function getEpisodeTitleId(episodeId: string): Promise<string | null> {
-  const db = getDb();
-  const numericId = typeof episodeId === "string" ? parseInt(episodeId, 10) : episodeId;
-  const row = await db
-    .select({ titleId: episodes.titleId })
-    .from(episodes)
-    .where(eq(episodes.id, numericId as unknown as number))
-    .get();
-  return row?.titleId ?? null;
 }
 
 /**
@@ -93,7 +80,7 @@ export async function onWatchedEpisode(userId: string, episodeId: string, watche
     }
 
     // Deferred: look up titleId then enqueue completionist + genre_count + speed_binge_season
-    const titleId = await getEpisodeTitleId(episodeId);
+    const titleId = await getEpisodeTitleId(parseInt(episodeId, 10));
     if (titleId) {
       enqueueJob("evaluate-achievements", {
         userId,

--- a/server/achievements/triggers.ts
+++ b/server/achievements/triggers.ts
@@ -1,0 +1,178 @@
+import { eq } from "drizzle-orm";
+import { getDb } from "../db/schema";
+import { episodes } from "../db/schema";
+import { ACHIEVEMENTS, type AchievementKind } from "./definitions";
+import {
+  evaluateCountMovies,
+  evaluateCountEpisodes,
+  evaluateStreak,
+  evaluateSocialFirstFollow,
+  evaluateSocialFirstRecommendation,
+} from "./evaluate";
+import { upsertUserAchievement } from "../db/repository/achievements";
+import { bumpStreak } from "../db/repository/streaks";
+import { enqueueJob } from "../jobs/queue";
+import { logger } from "../logger";
+
+const log = logger.child({ module: "achievement-triggers" });
+
+async function evaluateAndPersist(
+  userId: string,
+  key: string,
+  kind: AchievementKind,
+  evaluator: () => Promise<{ progress: number; earned: boolean }>
+): Promise<void> {
+  const result = await evaluator();
+  const earnedAt = result.earned ? new Date().toISOString() : null;
+  const { newlyEarned } = await upsertUserAchievement(userId, key, result.progress, earnedAt);
+  if (newlyEarned) {
+    log.info("Achievement newly earned", { userId, key, kind, progress: result.progress });
+  }
+}
+
+async function getEpisodeTitleId(episodeId: string): Promise<string | null> {
+  const db = getDb();
+  const numericId = typeof episodeId === "string" ? parseInt(episodeId, 10) : episodeId;
+  const row = await db
+    .select({ titleId: episodes.titleId })
+    .from(episodes)
+    .where(eq(episodes.id, numericId as unknown as number))
+    .get();
+  return row?.titleId ?? null;
+}
+
+/**
+ * Called after watchTitle + logWatch (movies only triggers count_movies inline)
+ */
+export async function onWatchedTitle(userId: string, titleId: string, isMovie?: boolean): Promise<void> {
+  try {
+    await bumpStreak(userId);
+
+    // Inline: count_movies (only if this is a movie)
+    if (isMovie) {
+      for (const a of ACHIEVEMENTS.filter((a) => a.kind === "count_movies")) {
+        await evaluateAndPersist(userId, a.key, a.kind, () =>
+          evaluateCountMovies(userId, a.threshold)
+        );
+      }
+    }
+
+    // Inline: streak_days
+    for (const a of ACHIEVEMENTS.filter((a) => a.kind === "streak_days")) {
+      await evaluateAndPersist(userId, a.key, a.kind, () =>
+        evaluateStreak(userId, a.threshold)
+      );
+    }
+
+    // Deferred: completionist + genre_count
+    enqueueJob("evaluate-achievements", { userId, kinds: ["completionist", "genre_count"] as AchievementKind[], titleId });
+  } catch (err) {
+    log.error("onWatchedTitle trigger failed", { userId, titleId, err });
+  }
+}
+
+/**
+ * Called after watchEpisode + logWatch
+ */
+export async function onWatchedEpisode(userId: string, episodeId: string, watchedAt?: string): Promise<void> {
+  try {
+    await bumpStreak(userId, watchedAt);
+
+    // Inline: count_episodes
+    for (const a of ACHIEVEMENTS.filter((a) => a.kind === "count_episodes")) {
+      await evaluateAndPersist(userId, a.key, a.kind, () =>
+        evaluateCountEpisodes(userId, a.threshold)
+      );
+    }
+
+    // Inline: streak_days
+    for (const a of ACHIEVEMENTS.filter((a) => a.kind === "streak_days")) {
+      await evaluateAndPersist(userId, a.key, a.kind, () =>
+        evaluateStreak(userId, a.threshold)
+      );
+    }
+
+    // Deferred: look up titleId then enqueue completionist + genre_count + speed_binge_season
+    const titleId = await getEpisodeTitleId(episodeId);
+    if (titleId) {
+      enqueueJob("evaluate-achievements", {
+        userId,
+        kinds: ["completionist", "genre_count", "speed_binge_season"] as AchievementKind[],
+        titleId,
+      });
+    }
+  } catch (err) {
+    log.error("onWatchedEpisode trigger failed", { userId, episodeId, err });
+  }
+}
+
+/**
+ * Called after watchEpisodesBulk + logWatch loop
+ */
+export async function onWatchedEpisodesBulk(
+  userId: string,
+  episodeIds: (string | number)[],
+  titleIds: Set<string>,
+  watchedAt?: string
+): Promise<void> {
+  try {
+    await bumpStreak(userId, watchedAt);
+
+    // Inline: count_episodes
+    for (const a of ACHIEVEMENTS.filter((a) => a.kind === "count_episodes")) {
+      await evaluateAndPersist(userId, a.key, a.kind, () =>
+        evaluateCountEpisodes(userId, a.threshold)
+      );
+    }
+
+    // Inline: streak_days
+    for (const a of ACHIEVEMENTS.filter((a) => a.kind === "streak_days")) {
+      await evaluateAndPersist(userId, a.key, a.kind, () =>
+        evaluateStreak(userId, a.threshold)
+      );
+    }
+
+    // Deferred: one job per distinct titleId
+    for (const titleId of titleIds) {
+      enqueueJob("evaluate-achievements", {
+        userId,
+        kinds: ["completionist", "genre_count", "speed_binge_season"] as AchievementKind[],
+        titleId,
+      });
+    }
+  } catch (err) {
+    log.error("onWatchedEpisodesBulk trigger failed", { userId, err });
+  }
+}
+
+/**
+ * Called after follow()
+ */
+export async function onFollow(followerId: string): Promise<void> {
+  try {
+    for (const a of ACHIEVEMENTS.filter((a) => a.kind === "social_first_follow")) {
+      await evaluateAndPersist(followerId, a.key, a.kind, () =>
+        evaluateSocialFirstFollow(followerId)
+      );
+    }
+    // No job enqueued for social triggers
+  } catch (err) {
+    log.error("onFollow trigger failed", { followerId, err });
+  }
+}
+
+/**
+ * Called after createRecommendation()
+ */
+export async function onRecommendation(fromUserId: string): Promise<void> {
+  try {
+    for (const a of ACHIEVEMENTS.filter((a) => a.kind === "social_first_recommendation")) {
+      await evaluateAndPersist(fromUserId, a.key, a.kind, () =>
+        evaluateSocialFirstRecommendation(fromUserId)
+      );
+    }
+    // No job enqueued for social triggers
+  } catch (err) {
+    log.error("onRecommendation trigger failed", { fromUserId, err });
+  }
+}

--- a/server/achievements/triggers.ts
+++ b/server/achievements/triggers.ts
@@ -9,7 +9,7 @@ import {
 import { upsertUserAchievement } from "../db/repository/achievements";
 import { bumpStreak } from "../db/repository/streaks";
 import { getEpisodeTitleId } from "../db/repository";
-import { enqueueJob } from "../jobs/queue";
+import { enqueueJob } from "../jobs/enqueue";
 import { logger } from "../logger";
 
 const log = logger.child({ module: "achievement-triggers" });
@@ -52,7 +52,7 @@ export async function onWatchedTitle(userId: string, titleId: string, isMovie?: 
     }
 
     // Deferred: completionist + genre_count
-    enqueueJob("evaluate-achievements", { userId, kinds: ["completionist", "genre_count"] as AchievementKind[], titleId });
+    await enqueueJob("evaluate-achievements", { userId, kinds: ["completionist", "genre_count"] as AchievementKind[], titleId });
   } catch (err) {
     log.error("onWatchedTitle trigger failed", { userId, titleId, err });
   }
@@ -82,7 +82,7 @@ export async function onWatchedEpisode(userId: string, episodeId: string, watche
     // Deferred: look up titleId then enqueue completionist + genre_count + speed_binge_season
     const titleId = await getEpisodeTitleId(parseInt(episodeId, 10));
     if (titleId) {
-      enqueueJob("evaluate-achievements", {
+      await enqueueJob("evaluate-achievements", {
         userId,
         kinds: ["completionist", "genre_count", "speed_binge_season"] as AchievementKind[],
         titleId,
@@ -121,7 +121,7 @@ export async function onWatchedEpisodesBulk(
 
     // Deferred: one job per distinct titleId
     for (const titleId of titleIds) {
-      enqueueJob("evaluate-achievements", {
+      await enqueueJob("evaluate-achievements", {
         userId,
         kinds: ["completionist", "genre_count", "speed_binge_season"] as AchievementKind[],
         titleId,

--- a/server/db/repository/achievements.ts
+++ b/server/db/repository/achievements.ts
@@ -74,12 +74,16 @@ export async function getUserAchievements(userId: string): Promise<UserAchieveme
  * Upsert a user_achievement row, tracking progress and earned status.
  * Returns whether this call newly earned the achievement
  * (transitioned earnedAt from null to non-null).
+ *
+ * @param opts.earnedNotified - If 1, marks the achievement as already notified
+ *   (used by the backfill job to prevent notification bursts for historical earns).
  */
 export async function upsertUserAchievement(
   userId: string,
   key: string,
   progress: number,
-  earnedAt: string | null
+  earnedAt: string | null,
+  opts?: { earnedNotified?: 1 }
 ): Promise<{ newlyEarned: boolean }> {
   return traceDbQuery("upsertUserAchievement", async () => {
     const db = getDb();
@@ -95,6 +99,8 @@ export async function upsertUserAchievement(
     const nowEarned = earnedAt != null;
     const newlyEarned = !wasEarned && nowEarned;
 
+    const earnedNotified = opts?.earnedNotified ?? 0;
+
     await db
       .insert(userAchievements)
       .values({
@@ -102,7 +108,7 @@ export async function upsertUserAchievement(
         achievementKey: key,
         progress,
         earnedAt,
-        earnedNotified: 0,
+        earnedNotified,
         updatedAt: new Date().toISOString(),
       })
       .onConflictDoUpdate({
@@ -110,6 +116,8 @@ export async function upsertUserAchievement(
         set: {
           progress,
           earnedAt: earnedAt ?? existing?.earnedAt ?? null,
+          // Only force earnedNotified=1 when explicitly requested (backfill path)
+          ...(opts?.earnedNotified === 1 ? { earnedNotified: 1 } : {}),
           updatedAt: new Date().toISOString(),
         },
       })

--- a/server/db/repository/notifiers.ts
+++ b/server/db/repository/notifiers.ts
@@ -242,6 +242,7 @@ export async function getDueNotifiers(
         quiet_hours_days: notifiers.quietHoursDays,
         leaving_soon_alerts_enabled: notifiers.leavingSoonAlertsEnabled,
         friend_activity_alerts_enabled: notifiers.friendActivityAlertsEnabled,
+        achievements_enabled: notifiers.achievementsEnabled,
       })
       .from(notifiers)
       .where(eq(notifiers.enabled, 1))
@@ -282,6 +283,7 @@ export async function getDueNotifiers(
           streaming_alerts_enabled: Boolean(n.streaming_alerts_enabled),
           leaving_soon_alerts_enabled: Boolean(n.leaving_soon_alerts_enabled),
           friend_activity_alerts_enabled: Boolean(n.friend_activity_alerts_enabled),
+          achievementsEnabled: Boolean(n.achievements_enabled),
         };
       });
   });

--- a/server/index.ts
+++ b/server/index.ts
@@ -40,6 +40,7 @@ import kioskRoutes from "./routes/kiosk";
 import upNextRoutes from "./routes/up-next";
 import shareRoutes from "./routes/share";
 import overlapRoutes from "./routes/overlap";
+import achievementsRoutes, { leaderboardApp, streakApp } from "./routes/achievements";
 import type { AppEnv } from "./types";
 import Sentry from "./sentry";
 import { logger, requestLogger } from "./logger";
@@ -49,6 +50,8 @@ import { registerSyncJobs } from "./jobs/sync";
 import { registerNotificationJobs } from "./jobs/notifications";
 import { registerBackupJob } from "./jobs/backup";
 import { registerPruneNotificationLogJob } from "./jobs/prune-notification-log";
+import "./jobs/evaluate-achievements";
+import "./jobs/backfill-achievements";
 import { startWorker, stopWorker } from "./jobs/worker";
 import { createShutdownHandler } from "./graceful-shutdown";
 import { registerCron } from "./jobs/queue";
@@ -315,6 +318,21 @@ app.route("/api/up-next", upNextRoutes);
 app.use("/api/overlap/*", requireAuth);
 app.use("/api/overlap", requireAuth);
 app.route("/api/overlap", overlapRoutes);
+
+// Achievements — GET /api/achievements is public; /me, /u/:username require auth (applied per-route)
+app.use("/api/achievements/*", optionalAuth);
+app.use("/api/achievements", optionalAuth);
+app.route("/api/achievements", achievementsRoutes);
+
+// Leaderboard — requireAuth applied per-route
+app.use("/api/leaderboard/*", optionalAuth);
+app.use("/api/leaderboard", optionalAuth);
+app.route("/api/leaderboard", leaderboardApp);
+
+// Streak — requireAuth applied per-route
+app.use("/api/streak/*", optionalAuth);
+app.use("/api/streak", optionalAuth);
+app.route("/api/streak", streakApp);
 
 app.use("/api/user/settings/*", requireAuth);
 app.use("/api/user/settings", requireAuth);

--- a/server/jobs/backfill-achievements.test.ts
+++ b/server/jobs/backfill-achievements.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
-import { createUser, upsertTitles } from "../db/repository";
-import { makeParsedTitle } from "../test-utils/fixtures";
+import { createUser } from "../db/repository";
 import * as achievementsRepo from "../db/repository/achievements";
 import * as streaksRepo from "../db/repository/streaks";
 import * as settingsRepo from "../db/repository/settings";
 import * as queue from "../jobs/queue";
 import * as evaluate from "../achievements/evaluate";
+import { runBackfillAchievements } from "./backfill-achievements";
 
 beforeEach(async () => {
   setupTestDb();
@@ -19,10 +19,8 @@ afterEach(() => {
 describe("backfill-achievements job", () => {
   it("processes 50 users, updates cursor, re-enqueues itself", async () => {
     // Create 50 users
-    const userIds: string[] = [];
     for (let i = 0; i < 50; i++) {
-      const uid = await createUser(`user${i}`, "hash", `User ${i}`);
-      userIds.push(uid);
+      await createUser(`user${String(i).padStart(3, "0")}`, "hash", `User ${i}`);
     }
 
     const recomputeSpy = spyOn(streaksRepo, "recomputeStreakFromHistory").mockResolvedValue({
@@ -34,9 +32,8 @@ describe("backfill-achievements job", () => {
     });
     const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: false });
     const setSettingSpy = spyOn(settingsRepo, "setSetting").mockResolvedValue(undefined);
+    const getSettingSpy = spyOn(settingsRepo, "getSetting").mockResolvedValue(null);
     const enqueueSpy = spyOn(queue, "enqueueJob").mockReturnValue(1);
-
-    // Mock all evaluators
     const evalMoviesSpy = spyOn(evaluate, "evaluateCountMovies").mockResolvedValue({ progress: 0, earned: false });
     const evalEpsSpy = spyOn(evaluate, "evaluateCountEpisodes").mockResolvedValue({ progress: 0, earned: false });
     const evalStreakSpy = spyOn(evaluate, "evaluateStreak").mockResolvedValue({ progress: 0, earned: false });
@@ -46,52 +43,13 @@ describe("backfill-achievements job", () => {
     const evalRecSpy = spyOn(evaluate, "evaluateSocialFirstRecommendation").mockResolvedValue({ progress: 0, earned: false });
     const evalSpeedSpy = spyOn(evaluate, "evaluateSpeedBingeSeason").mockResolvedValue({ progress: 0, earned: false });
 
-    // getSetting returns null (no cursor yet)
-    const getSettingSpy = spyOn(settingsRepo, "getSetting").mockResolvedValue(null);
-
-    // Simulate what the job does by running the core logic
-    const { getDb } = await import("../db/schema");
-    const { sql } = await import("drizzle-orm");
-    const { ACHIEVEMENTS } = await import("../achievements/definitions");
-
-    const db = getDb();
-    const cursor = "";
-    const PAGE_SIZE = 50;
-
-    const rows = await db.all<{ id: string }>(sql`
-      SELECT id FROM users
-      WHERE id > ${cursor}
-      ORDER BY id ASC
-      LIMIT ${PAGE_SIZE}
-    `);
-
-    expect(rows.length).toBe(50);
-
-    // Simulate processing
-    for (const row of rows) {
-      await streaksRepo.recomputeStreakFromHistory(row.id);
-      for (const a of ACHIEVEMENTS) {
-        let result = { progress: 0, earned: false };
-        switch (a.kind) {
-          case "count_movies": result = await evaluate.evaluateCountMovies(row.id, a.threshold); break;
-          default: continue;
-        }
-        await achievementsRepo.upsertUserAchievement(row.id, a.key, result.progress, null, { earnedNotified: 1 });
-      }
-    }
-
-    const lastUserId = rows[rows.length - 1].id;
-    await settingsRepo.setSetting("achievements_backfill_cursor", lastUserId);
-
-    if (rows.length === PAGE_SIZE) {
-      queue.enqueueJob("backfill-achievements", {}, { runAt: new Date(Date.now() + 5000) });
-    }
+    await runBackfillAchievements(null);
 
     expect(recomputeSpy).toHaveBeenCalledTimes(50);
     expect(setSettingSpy).toHaveBeenCalledWith("achievements_backfill_cursor", expect.any(String));
     expect(enqueueSpy).toHaveBeenCalledWith("backfill-achievements", {}, expect.objectContaining({ runAt: expect.any(Date) }));
 
-    // Verify earnedNotified=1 is passed
+    // Verify all upserts use earnedNotified=1
     const upsertCalls = upsertSpy.mock.calls;
     expect(upsertCalls.length).toBeGreaterThan(0);
     for (const call of upsertCalls) {
@@ -101,6 +59,7 @@ describe("backfill-achievements job", () => {
     recomputeSpy.mockRestore();
     upsertSpy.mockRestore();
     setSettingSpy.mockRestore();
+    getSettingSpy.mockRestore();
     enqueueSpy.mockRestore();
     evalMoviesSpy.mockRestore();
     evalEpsSpy.mockRestore();
@@ -110,7 +69,6 @@ describe("backfill-achievements job", () => {
     evalFollowSpy.mockRestore();
     evalRecSpy.mockRestore();
     evalSpeedSpy.mockRestore();
-    getSettingSpy.mockRestore();
   });
 
   it("on last batch: sets achievements_backfill_done=1, does NOT re-enqueue", async () => {
@@ -128,6 +86,7 @@ describe("backfill-achievements job", () => {
     });
     const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: false });
     const setSettingSpy = spyOn(settingsRepo, "setSetting").mockResolvedValue(undefined);
+    const getSettingSpy = spyOn(settingsRepo, "getSetting").mockResolvedValue(null);
     const enqueueSpy = spyOn(queue, "enqueueJob").mockReturnValue(1);
     const evalMoviesSpy = spyOn(evaluate, "evaluateCountMovies").mockResolvedValue({ progress: 0, earned: false });
     const evalEpsSpy = spyOn(evaluate, "evaluateCountEpisodes").mockResolvedValue({ progress: 0, earned: false });
@@ -137,34 +96,17 @@ describe("backfill-achievements job", () => {
     const evalFollowSpy = spyOn(evaluate, "evaluateSocialFirstFollow").mockResolvedValue({ progress: 0, earned: false });
     const evalRecSpy = spyOn(evaluate, "evaluateSocialFirstRecommendation").mockResolvedValue({ progress: 0, earned: false });
 
-    const { getDb } = await import("../db/schema");
-    const { sql } = await import("drizzle-orm");
+    await runBackfillAchievements(null);
 
-    const db = getDb();
-    const PAGE_SIZE = 50;
-
-    const rows = await db.all<{ id: string }>(sql`
-      SELECT id FROM users
-      WHERE id > ''
-      ORDER BY id ASC
-      LIMIT ${PAGE_SIZE}
-    `);
-
-    expect(rows.length).toBe(3);
-
-    // Simulate last batch behavior
-    if (rows.length < PAGE_SIZE) {
-      await settingsRepo.setSetting("achievements_backfill_done", "1");
-    }
-
+    // Last batch (< 50): sets done flag and does NOT re-enqueue
     expect(setSettingSpy).toHaveBeenCalledWith("achievements_backfill_done", "1");
-    // Should NOT have re-enqueued backfill job
     const backfillEnqueues = enqueueSpy.mock.calls.filter((c) => c[0] === "backfill-achievements");
     expect(backfillEnqueues.length).toBe(0);
 
     recomputeSpy.mockRestore();
     upsertSpy.mockRestore();
     setSettingSpy.mockRestore();
+    getSettingSpy.mockRestore();
     enqueueSpy.mockRestore();
     evalMoviesSpy.mockRestore();
     evalEpsSpy.mockRestore();
@@ -178,7 +120,6 @@ describe("backfill-achievements job", () => {
   it("all earns written with earnedNotified=1 (no notification burst)", async () => {
     await createUser("notifuser", "hash", "Notif User");
 
-    const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: true });
     const recomputeSpy = spyOn(streaksRepo, "recomputeStreakFromHistory").mockResolvedValue({
       userId: "",
       currentStreak: 0,
@@ -186,6 +127,10 @@ describe("backfill-achievements job", () => {
       lastWatchDate: null,
       updatedAt: new Date().toISOString(),
     });
+    const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: true });
+    const setSettingSpy = spyOn(settingsRepo, "setSetting").mockResolvedValue(undefined);
+    const getSettingSpy = spyOn(settingsRepo, "getSetting").mockResolvedValue(null);
+    const enqueueSpy = spyOn(queue, "enqueueJob").mockReturnValue(1);
     const evalMoviesSpy = spyOn(evaluate, "evaluateCountMovies").mockResolvedValue({ progress: 100, earned: true });
     const evalEpsSpy = spyOn(evaluate, "evaluateCountEpisodes").mockResolvedValue({ progress: 0, earned: false });
     const evalStreakSpy = spyOn(evaluate, "evaluateStreak").mockResolvedValue({ progress: 0, earned: false });
@@ -194,30 +139,19 @@ describe("backfill-achievements job", () => {
     const evalFollowSpy = spyOn(evaluate, "evaluateSocialFirstFollow").mockResolvedValue({ progress: 0, earned: false });
     const evalRecSpy = spyOn(evaluate, "evaluateSocialFirstRecommendation").mockResolvedValue({ progress: 0, earned: false });
 
-    // Simulate calling upsertUserAchievement with earnedNotified=1
-    const { ACHIEVEMENTS } = await import("../achievements/definitions");
-    const { getDb } = await import("../db/schema");
-    const { sql } = await import("drizzle-orm");
-    const db = getDb();
-
-    const rows = await db.all<{ id: string }>(sql`SELECT id FROM users ORDER BY id ASC LIMIT 50`);
-
-    for (const row of rows) {
-      await streaksRepo.recomputeStreakFromHistory(row.id);
-      for (const a of ACHIEVEMENTS.filter((a) => a.kind === "count_movies")) {
-        const result = await evaluate.evaluateCountMovies(row.id, a.threshold);
-        const earnedAt = result.earned ? new Date().toISOString() : null;
-        await achievementsRepo.upsertUserAchievement(row.id, a.key, result.progress, earnedAt, { earnedNotified: 1 });
-      }
-    }
+    await runBackfillAchievements(null);
 
     const upsertCalls = upsertSpy.mock.calls;
+    expect(upsertCalls.length).toBeGreaterThan(0);
     for (const call of upsertCalls) {
       expect(call[4]).toEqual({ earnedNotified: 1 });
     }
 
-    upsertSpy.mockRestore();
     recomputeSpy.mockRestore();
+    upsertSpy.mockRestore();
+    setSettingSpy.mockRestore();
+    getSettingSpy.mockRestore();
+    enqueueSpy.mockRestore();
     evalMoviesSpy.mockRestore();
     evalEpsSpy.mockRestore();
     evalStreakSpy.mockRestore();

--- a/server/jobs/backfill-achievements.test.ts
+++ b/server/jobs/backfill-achievements.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { createUser, upsertTitles } from "../db/repository";
+import { makeParsedTitle } from "../test-utils/fixtures";
+import * as achievementsRepo from "../db/repository/achievements";
+import * as streaksRepo from "../db/repository/streaks";
+import * as settingsRepo from "../db/repository/settings";
+import * as queue from "../jobs/queue";
+import * as evaluate from "../achievements/evaluate";
+
+beforeEach(async () => {
+  setupTestDb();
+});
+
+afterEach(() => {
+  teardownTestDb();
+});
+
+describe("backfill-achievements job", () => {
+  it("processes 50 users, updates cursor, re-enqueues itself", async () => {
+    // Create 50 users
+    const userIds: string[] = [];
+    for (let i = 0; i < 50; i++) {
+      const uid = await createUser(`user${i}`, "hash", `User ${i}`);
+      userIds.push(uid);
+    }
+
+    const recomputeSpy = spyOn(streaksRepo, "recomputeStreakFromHistory").mockResolvedValue({
+      userId: "",
+      currentStreak: 0,
+      longestStreak: 0,
+      lastWatchDate: null,
+      updatedAt: new Date().toISOString(),
+    });
+    const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: false });
+    const setSettingSpy = spyOn(settingsRepo, "setSetting").mockResolvedValue(undefined);
+    const enqueueSpy = spyOn(queue, "enqueueJob").mockReturnValue(1);
+
+    // Mock all evaluators
+    const evalMoviesSpy = spyOn(evaluate, "evaluateCountMovies").mockResolvedValue({ progress: 0, earned: false });
+    const evalEpsSpy = spyOn(evaluate, "evaluateCountEpisodes").mockResolvedValue({ progress: 0, earned: false });
+    const evalStreakSpy = spyOn(evaluate, "evaluateStreak").mockResolvedValue({ progress: 0, earned: false });
+    const evalGenreSpy = spyOn(evaluate, "evaluateGenreCount").mockResolvedValue({ progress: 0, earned: false });
+    const evalCompSpy = spyOn(evaluate, "evaluateCompletionist").mockResolvedValue({ progress: 0, earned: false });
+    const evalFollowSpy = spyOn(evaluate, "evaluateSocialFirstFollow").mockResolvedValue({ progress: 0, earned: false });
+    const evalRecSpy = spyOn(evaluate, "evaluateSocialFirstRecommendation").mockResolvedValue({ progress: 0, earned: false });
+    const evalSpeedSpy = spyOn(evaluate, "evaluateSpeedBingeSeason").mockResolvedValue({ progress: 0, earned: false });
+
+    // getSetting returns null (no cursor yet)
+    const getSettingSpy = spyOn(settingsRepo, "getSetting").mockResolvedValue(null);
+
+    // Simulate what the job does by running the core logic
+    const { getDb } = await import("../db/schema");
+    const { sql } = await import("drizzle-orm");
+    const { ACHIEVEMENTS } = await import("../achievements/definitions");
+
+    const db = getDb();
+    const cursor = "";
+    const PAGE_SIZE = 50;
+
+    const rows = await db.all<{ id: string }>(sql`
+      SELECT id FROM users
+      WHERE id > ${cursor}
+      ORDER BY id ASC
+      LIMIT ${PAGE_SIZE}
+    `);
+
+    expect(rows.length).toBe(50);
+
+    // Simulate processing
+    for (const row of rows) {
+      await streaksRepo.recomputeStreakFromHistory(row.id);
+      for (const a of ACHIEVEMENTS) {
+        let result = { progress: 0, earned: false };
+        switch (a.kind) {
+          case "count_movies": result = await evaluate.evaluateCountMovies(row.id, a.threshold); break;
+          default: continue;
+        }
+        await achievementsRepo.upsertUserAchievement(row.id, a.key, result.progress, null, { earnedNotified: 1 });
+      }
+    }
+
+    const lastUserId = rows[rows.length - 1].id;
+    await settingsRepo.setSetting("achievements_backfill_cursor", lastUserId);
+
+    if (rows.length === PAGE_SIZE) {
+      queue.enqueueJob("backfill-achievements", {}, { runAt: new Date(Date.now() + 5000) });
+    }
+
+    expect(recomputeSpy).toHaveBeenCalledTimes(50);
+    expect(setSettingSpy).toHaveBeenCalledWith("achievements_backfill_cursor", expect.any(String));
+    expect(enqueueSpy).toHaveBeenCalledWith("backfill-achievements", {}, expect.objectContaining({ runAt: expect.any(Date) }));
+
+    // Verify earnedNotified=1 is passed
+    const upsertCalls = upsertSpy.mock.calls;
+    expect(upsertCalls.length).toBeGreaterThan(0);
+    for (const call of upsertCalls) {
+      expect(call[4]).toEqual({ earnedNotified: 1 });
+    }
+
+    recomputeSpy.mockRestore();
+    upsertSpy.mockRestore();
+    setSettingSpy.mockRestore();
+    enqueueSpy.mockRestore();
+    evalMoviesSpy.mockRestore();
+    evalEpsSpy.mockRestore();
+    evalStreakSpy.mockRestore();
+    evalGenreSpy.mockRestore();
+    evalCompSpy.mockRestore();
+    evalFollowSpy.mockRestore();
+    evalRecSpy.mockRestore();
+    evalSpeedSpy.mockRestore();
+    getSettingSpy.mockRestore();
+  });
+
+  it("on last batch: sets achievements_backfill_done=1, does NOT re-enqueue", async () => {
+    // Create fewer than 50 users
+    for (let i = 0; i < 3; i++) {
+      await createUser(`smalluser${i}`, "hash", `Small User ${i}`);
+    }
+
+    const recomputeSpy = spyOn(streaksRepo, "recomputeStreakFromHistory").mockResolvedValue({
+      userId: "",
+      currentStreak: 0,
+      longestStreak: 0,
+      lastWatchDate: null,
+      updatedAt: new Date().toISOString(),
+    });
+    const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: false });
+    const setSettingSpy = spyOn(settingsRepo, "setSetting").mockResolvedValue(undefined);
+    const enqueueSpy = spyOn(queue, "enqueueJob").mockReturnValue(1);
+    const evalMoviesSpy = spyOn(evaluate, "evaluateCountMovies").mockResolvedValue({ progress: 0, earned: false });
+    const evalEpsSpy = spyOn(evaluate, "evaluateCountEpisodes").mockResolvedValue({ progress: 0, earned: false });
+    const evalStreakSpy = spyOn(evaluate, "evaluateStreak").mockResolvedValue({ progress: 0, earned: false });
+    const evalGenreSpy = spyOn(evaluate, "evaluateGenreCount").mockResolvedValue({ progress: 0, earned: false });
+    const evalCompSpy = spyOn(evaluate, "evaluateCompletionist").mockResolvedValue({ progress: 0, earned: false });
+    const evalFollowSpy = spyOn(evaluate, "evaluateSocialFirstFollow").mockResolvedValue({ progress: 0, earned: false });
+    const evalRecSpy = spyOn(evaluate, "evaluateSocialFirstRecommendation").mockResolvedValue({ progress: 0, earned: false });
+
+    const { getDb } = await import("../db/schema");
+    const { sql } = await import("drizzle-orm");
+
+    const db = getDb();
+    const PAGE_SIZE = 50;
+
+    const rows = await db.all<{ id: string }>(sql`
+      SELECT id FROM users
+      WHERE id > ''
+      ORDER BY id ASC
+      LIMIT ${PAGE_SIZE}
+    `);
+
+    expect(rows.length).toBe(3);
+
+    // Simulate last batch behavior
+    if (rows.length < PAGE_SIZE) {
+      await settingsRepo.setSetting("achievements_backfill_done", "1");
+    }
+
+    expect(setSettingSpy).toHaveBeenCalledWith("achievements_backfill_done", "1");
+    // Should NOT have re-enqueued backfill job
+    const backfillEnqueues = enqueueSpy.mock.calls.filter((c) => c[0] === "backfill-achievements");
+    expect(backfillEnqueues.length).toBe(0);
+
+    recomputeSpy.mockRestore();
+    upsertSpy.mockRestore();
+    setSettingSpy.mockRestore();
+    enqueueSpy.mockRestore();
+    evalMoviesSpy.mockRestore();
+    evalEpsSpy.mockRestore();
+    evalStreakSpy.mockRestore();
+    evalGenreSpy.mockRestore();
+    evalCompSpy.mockRestore();
+    evalFollowSpy.mockRestore();
+    evalRecSpy.mockRestore();
+  });
+
+  it("all earns written with earnedNotified=1 (no notification burst)", async () => {
+    await createUser("notifuser", "hash", "Notif User");
+
+    const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: true });
+    const recomputeSpy = spyOn(streaksRepo, "recomputeStreakFromHistory").mockResolvedValue({
+      userId: "",
+      currentStreak: 0,
+      longestStreak: 0,
+      lastWatchDate: null,
+      updatedAt: new Date().toISOString(),
+    });
+    const evalMoviesSpy = spyOn(evaluate, "evaluateCountMovies").mockResolvedValue({ progress: 100, earned: true });
+    const evalEpsSpy = spyOn(evaluate, "evaluateCountEpisodes").mockResolvedValue({ progress: 0, earned: false });
+    const evalStreakSpy = spyOn(evaluate, "evaluateStreak").mockResolvedValue({ progress: 0, earned: false });
+    const evalGenreSpy = spyOn(evaluate, "evaluateGenreCount").mockResolvedValue({ progress: 0, earned: false });
+    const evalCompSpy = spyOn(evaluate, "evaluateCompletionist").mockResolvedValue({ progress: 0, earned: false });
+    const evalFollowSpy = spyOn(evaluate, "evaluateSocialFirstFollow").mockResolvedValue({ progress: 0, earned: false });
+    const evalRecSpy = spyOn(evaluate, "evaluateSocialFirstRecommendation").mockResolvedValue({ progress: 0, earned: false });
+
+    // Simulate calling upsertUserAchievement with earnedNotified=1
+    const { ACHIEVEMENTS } = await import("../achievements/definitions");
+    const { getDb } = await import("../db/schema");
+    const { sql } = await import("drizzle-orm");
+    const db = getDb();
+
+    const rows = await db.all<{ id: string }>(sql`SELECT id FROM users ORDER BY id ASC LIMIT 50`);
+
+    for (const row of rows) {
+      await streaksRepo.recomputeStreakFromHistory(row.id);
+      for (const a of ACHIEVEMENTS.filter((a) => a.kind === "count_movies")) {
+        const result = await evaluate.evaluateCountMovies(row.id, a.threshold);
+        const earnedAt = result.earned ? new Date().toISOString() : null;
+        await achievementsRepo.upsertUserAchievement(row.id, a.key, result.progress, earnedAt, { earnedNotified: 1 });
+      }
+    }
+
+    const upsertCalls = upsertSpy.mock.calls;
+    for (const call of upsertCalls) {
+      expect(call[4]).toEqual({ earnedNotified: 1 });
+    }
+
+    upsertSpy.mockRestore();
+    recomputeSpy.mockRestore();
+    evalMoviesSpy.mockRestore();
+    evalEpsSpy.mockRestore();
+    evalStreakSpy.mockRestore();
+    evalGenreSpy.mockRestore();
+    evalCompSpy.mockRestore();
+    evalFollowSpy.mockRestore();
+    evalRecSpy.mockRestore();
+  });
+});

--- a/server/jobs/backfill-achievements.ts
+++ b/server/jobs/backfill-achievements.ts
@@ -1,0 +1,146 @@
+import { sql } from "drizzle-orm";
+import { getDb } from "../db/schema";
+import { users } from "../db/schema";
+import { ACHIEVEMENTS } from "../achievements/definitions";
+import {
+  evaluateCountMovies,
+  evaluateCountEpisodes,
+  evaluateStreak,
+  evaluateGenreCount,
+  evaluateCompletionist,
+  evaluateSpeedBingeSeason,
+  evaluateSocialFirstFollow,
+  evaluateSocialFirstRecommendation,
+} from "../achievements/evaluate";
+import { upsertUserAchievement } from "../db/repository/achievements";
+import { recomputeStreakFromHistory } from "../db/repository/streaks";
+import { getSetting, setSetting } from "../db/repository/settings";
+import { enqueueJob } from "./queue";
+import { logger } from "../logger";
+import { registerHandler } from "./worker";
+
+const log = logger.child({ module: "backfill-achievements" });
+const PAGE_SIZE = 50;
+
+registerHandler("backfill-achievements", async () => {
+  const db = getDb();
+
+  // 1. Read cursor
+  const cursor = (await getSetting("achievements_backfill_cursor")) ?? "";
+
+  // 2. Fetch next page of users
+  const rows = await db.all<{ id: string }>(sql`
+    SELECT id FROM users
+    WHERE id > ${cursor}
+    ORDER BY id ASC
+    LIMIT ${PAGE_SIZE}
+  `);
+
+  if (rows.length === 0) {
+    await setSetting("achievements_backfill_done", "1");
+    log.info("Backfill complete — no more users");
+    return;
+  }
+
+  log.info("Backfill: processing page", { count: rows.length, cursor });
+
+  for (const row of rows) {
+    const userId = row.id;
+    try {
+      // 3a. Recompute streak from history
+      await recomputeStreakFromHistory(userId);
+
+      // 3b. Evaluate every achievement with earnedNotified=1 (backfill should not burst notifications)
+      for (const a of ACHIEVEMENTS) {
+        try {
+          let result: { progress: number; earned: boolean };
+
+          switch (a.kind) {
+            case "count_movies":
+              result = await evaluateCountMovies(userId, a.threshold);
+              break;
+            case "count_episodes":
+              result = await evaluateCountEpisodes(userId, a.threshold);
+              break;
+            case "streak_days":
+              result = await evaluateStreak(userId, a.threshold);
+              break;
+            case "genre_count":
+              result = await evaluateGenreCount(userId, a.threshold, a.genre ?? "__any__");
+              break;
+            case "completionist":
+              // Without titleId — checks all shows the user has episodes for
+              result = await evaluateCompletionist(userId, a.threshold);
+              break;
+            case "speed_binge_season": {
+              // Query for candidate (user, title) pairs with >= threshold episodes
+              const threshold = a.threshold;
+              const windowHours = a.windowHours ?? 24;
+              const candidateRows = await db.all<{ title_id: string }>(sql`
+                SELECT e.title_id
+                FROM watched_episodes we
+                JOIN episodes e ON e.id = we.episode_id
+                WHERE we.user_id = ${userId}
+                  AND we.watched_at IS NOT NULL
+                GROUP BY e.title_id
+                HAVING COUNT(*) >= ${threshold}
+              `);
+
+              let maxProgress = 0;
+              let anyEarned = false;
+
+              for (const c of candidateRows) {
+                const r = await evaluateSpeedBingeSeason(userId, threshold, windowHours, c.title_id);
+                if (r.earned) {
+                  anyEarned = true;
+                  maxProgress = Math.max(maxProgress, r.progress);
+                } else {
+                  maxProgress = Math.max(maxProgress, r.progress);
+                }
+              }
+
+              result = { progress: maxProgress, earned: anyEarned };
+              break;
+            }
+            case "social_first_follow":
+              result = await evaluateSocialFirstFollow(userId);
+              break;
+            case "social_first_recommendation":
+              result = await evaluateSocialFirstRecommendation(userId);
+              break;
+            default:
+              continue;
+          }
+
+          const earnedAt = result.earned ? new Date().toISOString() : null;
+          await upsertUserAchievement(userId, a.key, result.progress, earnedAt, { earnedNotified: 1 });
+        } catch (err) {
+          log.warn("Backfill: error evaluating achievement for user", {
+            userId,
+            key: a.key,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    } catch (err) {
+      log.warn("Backfill: error processing user", {
+        userId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // 4. Update cursor
+  const lastUserId = rows[rows.length - 1].id;
+  await setSetting("achievements_backfill_cursor", lastUserId);
+
+  // 5. If full page returned, enqueue next batch
+  if (rows.length === PAGE_SIZE) {
+    enqueueJob("backfill-achievements", {}, { runAt: new Date(Date.now() + 5000) });
+    log.info("Backfill: enqueued next batch", { nextCursor: lastUserId });
+  } else {
+    // 6. Done
+    await setSetting("achievements_backfill_done", "1");
+    log.info("Backfill: complete", { totalProcessed: rows.length });
+  }
+});

--- a/server/jobs/backfill-achievements.ts
+++ b/server/jobs/backfill-achievements.ts
@@ -22,7 +22,10 @@ import { registerHandler } from "./worker";
 const log = logger.child({ module: "backfill-achievements" });
 const PAGE_SIZE = 50;
 
-registerHandler("backfill-achievements", async () => {
+/**
+ * Core handler logic — shared between Bun (registerHandler) and CF Workers (processor.ts).
+ */
+export async function runBackfillAchievements(_data?: string | null): Promise<void> {
   const db = getDb();
 
   // 1. Read cursor
@@ -143,4 +146,6 @@ registerHandler("backfill-achievements", async () => {
     await setSetting("achievements_backfill_done", "1");
     log.info("Backfill: complete", { totalProcessed: rows.length });
   }
-});
+}
+
+registerHandler("backfill-achievements", () => runBackfillAchievements());

--- a/server/jobs/enqueue.ts
+++ b/server/jobs/enqueue.ts
@@ -1,0 +1,22 @@
+/**
+ * CF-safe job enqueue using Drizzle ORM (no bun:sqlite dependency).
+ *
+ * Use this module instead of queue.ts in shared server code (routes, triggers,
+ * etc.) that is bundled for both Bun and Cloudflare Workers. The Bun job
+ * worker polls the DB for pending rows the same as it does for any other insert.
+ */
+import { getDb, jobs } from "../db/schema";
+
+export async function enqueueJob(
+  name: string,
+  data?: Record<string, unknown>,
+  options?: { runAt?: Date; maxAttempts?: number }
+): Promise<void> {
+  const db = getDb();
+  await db.insert(jobs).values({
+    name,
+    data: data ? JSON.stringify(data) : null,
+    runAt: (options?.runAt ?? new Date()).toISOString(),
+    maxAttempts: options?.maxAttempts ?? 3,
+  });
+}

--- a/server/jobs/enqueue.ts
+++ b/server/jobs/enqueue.ts
@@ -5,6 +5,7 @@
  * etc.) that is bundled for both Bun and Cloudflare Workers. The Bun job
  * worker polls the DB for pending rows the same as it does for any other insert.
  */
+import { and, eq, inArray } from "drizzle-orm";
 import { getDb, jobs } from "../db/schema";
 
 export async function enqueueJob(
@@ -19,4 +20,15 @@ export async function enqueueJob(
     runAt: (options?.runAt ?? new Date()).toISOString(),
     maxAttempts: options?.maxAttempts ?? 3,
   });
+}
+
+/** Returns true if a job with the given name is pending, running, or already completed. */
+export async function hasActiveJob(name: string): Promise<boolean> {
+  const db = getDb();
+  const row = await db
+    .select({ id: jobs.id })
+    .from(jobs)
+    .where(and(eq(jobs.name, name), inArray(jobs.status, ["pending", "running", "completed"])))
+    .get();
+  return row !== null;
 }

--- a/server/jobs/evaluate-achievements.test.ts
+++ b/server/jobs/evaluate-achievements.test.ts
@@ -5,19 +5,13 @@ import { makeParsedTitle } from "../test-utils/fixtures";
 import * as achievementsRepo from "../db/repository/achievements";
 import * as evaluate from "../achievements/evaluate";
 
-// Import the handler registration side effect
+// Import the handler registration side effect — this calls registerHandler()
 import "../jobs/evaluate-achievements";
 
-// Import the actual handler by simulating a job run
-import { registerHandler } from "./worker";
+// Retrieve the registered handler via the exported getHandler
+import { getHandler } from "./worker";
 
 let userId: string;
-
-// Capture the registered handler
-let capturedHandler: ((job: any) => Promise<void>) | null = null;
-
-// Override registerHandler to capture the evaluate-achievements handler
-const originalRegister = registerHandler;
 
 beforeEach(async () => {
   setupTestDb();
@@ -45,61 +39,109 @@ function makeJob(data: Record<string, unknown>) {
   };
 }
 
-describe("evaluate-achievements job", () => {
-  it("evaluates count_movies kind and persists result", async () => {
+describe("evaluate-achievements job handler", () => {
+  it("is registered and callable via getHandler", () => {
+    const handler = getHandler("evaluate-achievements");
+    expect(handler).toBeDefined();
+    expect(typeof handler).toBe("function");
+  });
+
+  it("evaluates count_movies kind and calls upsertUserAchievement", async () => {
+    const handler = getHandler("evaluate-achievements")!;
     const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: false });
     const evalSpy = spyOn(evaluate, "evaluateCountMovies").mockResolvedValue({ progress: 5, earned: false });
 
-    // Import triggers the registerHandler call via side effect
-    // We need to manually invoke the job logic by importing the module and simulating
-    // The module uses registerHandler internally, so we need to re-invoke it
-    // The handler is registered on module import — we'll test via the worker module
+    await handler(makeJob({ userId, kinds: ["count_movies"], titleId: undefined }));
 
-    // Direct test: call evaluators directly to verify they're called with right kinds
-    const { ACHIEVEMENTS } = await import("../achievements/definitions");
-    const movieAchievements = ACHIEVEMENTS.filter((a) => a.kind === "count_movies");
+    expect(evalSpy).toHaveBeenCalled();
+    expect(upsertSpy).toHaveBeenCalled();
 
-    for (const a of movieAchievements) {
-      const result = await evaluate.evaluateCountMovies(userId, a.threshold);
-      const earnedAt = result.earned ? new Date().toISOString() : null;
-      await achievementsRepo.upsertUserAchievement(userId, a.key, result.progress, earnedAt);
-    }
-
-    expect(evalSpy).toHaveBeenCalledTimes(movieAchievements.length);
-    expect(upsertSpy).toHaveBeenCalledTimes(movieAchievements.length);
+    // Verify upsert was called with the right userId and a non-null key
+    const calls = upsertSpy.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls[0][0]).toBe(userId);
+    expect(typeof calls[0][1]).toBe("string"); // key
 
     upsertSpy.mockRestore();
     evalSpy.mockRestore();
   });
 
-  it("persists results via upsertUserAchievement", async () => {
+  it("evaluates count_episodes kind and calls upsertUserAchievement", async () => {
+    const handler = getHandler("evaluate-achievements")!;
     const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: true });
     const evalSpy = spyOn(evaluate, "evaluateCountEpisodes").mockResolvedValue({ progress: 100, earned: true });
 
-    const { ACHIEVEMENTS } = await import("../achievements/definitions");
-    const epAchievements = ACHIEVEMENTS.filter((a) => a.kind === "count_episodes");
+    await handler(makeJob({ userId, kinds: ["count_episodes"], titleId: undefined }));
 
-    for (const a of epAchievements) {
-      const result = await evaluate.evaluateCountEpisodes(userId, a.threshold);
-      const earnedAt = result.earned ? new Date().toISOString() : null;
-      await achievementsRepo.upsertUserAchievement(userId, a.key, result.progress, earnedAt);
-    }
-
+    expect(evalSpy).toHaveBeenCalled();
     expect(upsertSpy).toHaveBeenCalled();
-    // Verify newly earned was returned
+
+    // Verify earnedAt is a non-null ISO string when earned=true
     const calls = upsertSpy.mock.calls;
     expect(calls.length).toBeGreaterThan(0);
+    // earnedAt (4th arg) should be a string (ISO date) when earned=true
+    expect(typeof calls[0][3]).toBe("string");
 
     upsertSpy.mockRestore();
     evalSpy.mockRestore();
   });
 
-  it("gracefully skips unknown kinds without crashing", async () => {
-    // This test verifies the job doesn't crash on unknown kinds
-    // We simulate the behavior by checking the switch statement handles default
-    const unknownKind = "unknown_kind" as any;
-    const { ACHIEVEMENTS } = await import("../achievements/definitions");
-    const matching = ACHIEVEMENTS.filter((a) => a.kind === unknownKind);
-    expect(matching.length).toBe(0); // No achievements match unknown kind
+  it("skips speed_binge_season when titleId is missing", async () => {
+    const handler = getHandler("evaluate-achievements")!;
+    const evalSpeedSpy = spyOn(evaluate, "evaluateSpeedBingeSeason").mockResolvedValue({ progress: 0, earned: false });
+    const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: false });
+
+    await handler(makeJob({ userId, kinds: ["speed_binge_season"], titleId: undefined }));
+
+    // speed_binge_season without titleId should be skipped
+    expect(evalSpeedSpy).not.toHaveBeenCalled();
+
+    upsertSpy.mockRestore();
+    evalSpeedSpy.mockRestore();
+  });
+
+  it("evaluates speed_binge_season when titleId is provided", async () => {
+    const handler = getHandler("evaluate-achievements")!;
+    const evalSpeedSpy = spyOn(evaluate, "evaluateSpeedBingeSeason").mockResolvedValue({ progress: 3, earned: false });
+    const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: false });
+
+    await handler(makeJob({ userId, kinds: ["speed_binge_season"], titleId: "movie-1" }));
+
+    expect(evalSpeedSpy).toHaveBeenCalled();
+    expect(upsertSpy).toHaveBeenCalled();
+
+    upsertSpy.mockRestore();
+    evalSpeedSpy.mockRestore();
+  });
+
+  it("gracefully handles invalid job data without crashing", async () => {
+    const handler = getHandler("evaluate-achievements")!;
+    const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: false });
+
+    // Missing userId
+    await handler(makeJob({ kinds: ["count_movies"] }));
+    expect(upsertSpy).not.toHaveBeenCalled();
+
+    // Missing kinds array
+    await handler(makeJob({ userId }));
+    expect(upsertSpy).not.toHaveBeenCalled();
+
+    upsertSpy.mockRestore();
+  });
+
+  it("sets earnedAt to null when achievement is not yet earned", async () => {
+    const handler = getHandler("evaluate-achievements")!;
+    const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: false });
+    const evalSpy = spyOn(evaluate, "evaluateCountMovies").mockResolvedValue({ progress: 2, earned: false });
+
+    await handler(makeJob({ userId, kinds: ["count_movies"], titleId: undefined }));
+
+    const calls = upsertSpy.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    // earnedAt (4th arg) should be null when earned=false
+    expect(calls[0][3]).toBeNull();
+
+    upsertSpy.mockRestore();
+    evalSpy.mockRestore();
   });
 });

--- a/server/jobs/evaluate-achievements.test.ts
+++ b/server/jobs/evaluate-achievements.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { createUser, upsertTitles } from "../db/repository";
+import { makeParsedTitle } from "../test-utils/fixtures";
+import * as achievementsRepo from "../db/repository/achievements";
+import * as evaluate from "../achievements/evaluate";
+
+// Import the handler registration side effect
+import "../jobs/evaluate-achievements";
+
+// Import the actual handler by simulating a job run
+import { registerHandler } from "./worker";
+
+let userId: string;
+
+// Capture the registered handler
+let capturedHandler: ((job: any) => Promise<void>) | null = null;
+
+// Override registerHandler to capture the evaluate-achievements handler
+const originalRegister = registerHandler;
+
+beforeEach(async () => {
+  setupTestDb();
+  userId = await createUser("testuser", "hash", "Test User");
+  await upsertTitles([makeParsedTitle({ id: "movie-1", objectType: "MOVIE", title: "Test Movie" })]);
+});
+
+afterEach(() => {
+  teardownTestDb();
+});
+
+function makeJob(data: Record<string, unknown>) {
+  return {
+    id: 1,
+    name: "evaluate-achievements",
+    data: JSON.stringify(data),
+    status: "running" as const,
+    attempts: 1,
+    max_attempts: 3,
+    error: null,
+    run_at: new Date().toISOString(),
+    started_at: new Date().toISOString(),
+    completed_at: null,
+    created_at: new Date().toISOString(),
+  };
+}
+
+describe("evaluate-achievements job", () => {
+  it("evaluates count_movies kind and persists result", async () => {
+    const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: false });
+    const evalSpy = spyOn(evaluate, "evaluateCountMovies").mockResolvedValue({ progress: 5, earned: false });
+
+    // Import triggers the registerHandler call via side effect
+    // We need to manually invoke the job logic by importing the module and simulating
+    // The module uses registerHandler internally, so we need to re-invoke it
+    // The handler is registered on module import — we'll test via the worker module
+
+    // Direct test: call evaluators directly to verify they're called with right kinds
+    const { ACHIEVEMENTS } = await import("../achievements/definitions");
+    const movieAchievements = ACHIEVEMENTS.filter((a) => a.kind === "count_movies");
+
+    for (const a of movieAchievements) {
+      const result = await evaluate.evaluateCountMovies(userId, a.threshold);
+      const earnedAt = result.earned ? new Date().toISOString() : null;
+      await achievementsRepo.upsertUserAchievement(userId, a.key, result.progress, earnedAt);
+    }
+
+    expect(evalSpy).toHaveBeenCalledTimes(movieAchievements.length);
+    expect(upsertSpy).toHaveBeenCalledTimes(movieAchievements.length);
+
+    upsertSpy.mockRestore();
+    evalSpy.mockRestore();
+  });
+
+  it("persists results via upsertUserAchievement", async () => {
+    const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: true });
+    const evalSpy = spyOn(evaluate, "evaluateCountEpisodes").mockResolvedValue({ progress: 100, earned: true });
+
+    const { ACHIEVEMENTS } = await import("../achievements/definitions");
+    const epAchievements = ACHIEVEMENTS.filter((a) => a.kind === "count_episodes");
+
+    for (const a of epAchievements) {
+      const result = await evaluate.evaluateCountEpisodes(userId, a.threshold);
+      const earnedAt = result.earned ? new Date().toISOString() : null;
+      await achievementsRepo.upsertUserAchievement(userId, a.key, result.progress, earnedAt);
+    }
+
+    expect(upsertSpy).toHaveBeenCalled();
+    // Verify newly earned was returned
+    const calls = upsertSpy.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+
+    upsertSpy.mockRestore();
+    evalSpy.mockRestore();
+  });
+
+  it("gracefully skips unknown kinds without crashing", async () => {
+    // This test verifies the job doesn't crash on unknown kinds
+    // We simulate the behavior by checking the switch statement handles default
+    const unknownKind = "unknown_kind" as any;
+    const { ACHIEVEMENTS } = await import("../achievements/definitions");
+    const matching = ACHIEVEMENTS.filter((a) => a.kind === unknownKind);
+    expect(matching.length).toBe(0); // No achievements match unknown kind
+  });
+});

--- a/server/jobs/evaluate-achievements.ts
+++ b/server/jobs/evaluate-achievements.ts
@@ -15,16 +15,19 @@ import { registerHandler } from "./worker";
 
 const log = logger.child({ module: "evaluate-achievements" });
 
-registerHandler("evaluate-achievements", async (job) => {
-  const raw = typeof job.data === "string" ? JSON.parse(job.data) : job.data;
-  const { userId, kinds, titleId } = raw as {
+/**
+ * Core handler logic — shared between Bun (registerHandler) and CF Workers (processor.ts).
+ */
+export async function runEvaluateAchievements(data: string | null): Promise<void> {
+  const raw = typeof data === "string" ? JSON.parse(data) : data;
+  const { userId, kinds, titleId } = (raw ?? {}) as {
     userId: string;
     kinds: AchievementKind[];
     titleId?: string;
   };
 
   if (!userId || !Array.isArray(kinds)) {
-    log.warn("evaluate-achievements: invalid job data", { jobId: job.id });
+    log.warn("evaluate-achievements: invalid job data");
     return;
   }
 
@@ -86,4 +89,6 @@ registerHandler("evaluate-achievements", async (job) => {
       }
     }
   }
-});
+}
+
+registerHandler("evaluate-achievements", (job) => runEvaluateAchievements(job.data));

--- a/server/jobs/evaluate-achievements.ts
+++ b/server/jobs/evaluate-achievements.ts
@@ -1,0 +1,89 @@
+import { ACHIEVEMENTS, type AchievementKind } from "../achievements/definitions";
+import {
+  evaluateCountMovies,
+  evaluateCountEpisodes,
+  evaluateStreak,
+  evaluateGenreCount,
+  evaluateCompletionist,
+  evaluateSpeedBingeSeason,
+  evaluateSocialFirstFollow,
+  evaluateSocialFirstRecommendation,
+} from "../achievements/evaluate";
+import { upsertUserAchievement } from "../db/repository/achievements";
+import { logger } from "../logger";
+import { registerHandler } from "./worker";
+
+const log = logger.child({ module: "evaluate-achievements" });
+
+registerHandler("evaluate-achievements", async (job) => {
+  const raw = typeof job.data === "string" ? JSON.parse(job.data) : job.data;
+  const { userId, kinds, titleId } = raw as {
+    userId: string;
+    kinds: AchievementKind[];
+    titleId?: string;
+  };
+
+  if (!userId || !Array.isArray(kinds)) {
+    log.warn("evaluate-achievements: invalid job data", { jobId: job.id });
+    return;
+  }
+
+  for (const kind of kinds) {
+    const matchingAchievements = ACHIEVEMENTS.filter((a) => a.kind === kind);
+
+    for (const a of matchingAchievements) {
+      try {
+        let result: { progress: number; earned: boolean };
+
+        switch (kind) {
+          case "count_movies":
+            result = await evaluateCountMovies(userId, a.threshold);
+            break;
+          case "count_episodes":
+            result = await evaluateCountEpisodes(userId, a.threshold);
+            break;
+          case "streak_days":
+            result = await evaluateStreak(userId, a.threshold);
+            break;
+          case "genre_count":
+            result = await evaluateGenreCount(userId, a.threshold, a.genre ?? "__any__");
+            break;
+          case "completionist":
+            result = await evaluateCompletionist(userId, a.threshold, titleId);
+            break;
+          case "speed_binge_season":
+            if (!titleId) {
+              // speed_binge_season requires a titleId — skip without titleId
+              continue;
+            }
+            result = await evaluateSpeedBingeSeason(userId, a.threshold, a.windowHours ?? 24, titleId);
+            break;
+          case "social_first_follow":
+            result = await evaluateSocialFirstFollow(userId);
+            break;
+          case "social_first_recommendation":
+            result = await evaluateSocialFirstRecommendation(userId);
+            break;
+          default:
+            // Unknown kind — skip gracefully
+            log.warn("evaluate-achievements: unknown kind, skipping", { kind, userId });
+            continue;
+        }
+
+        const earnedAt = result.earned ? new Date().toISOString() : null;
+        const { newlyEarned } = await upsertUserAchievement(userId, a.key, result.progress, earnedAt);
+        if (newlyEarned) {
+          log.info("Achievement newly earned (deferred)", { userId, key: a.key, kind });
+        }
+      } catch (err) {
+        log.error("evaluate-achievements: error evaluating achievement", {
+          userId,
+          key: a.key,
+          kind,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        // Continue with other achievements even if one fails
+      }
+    }
+  }
+});

--- a/server/jobs/notifications.ts
+++ b/server/jobs/notifications.ts
@@ -13,6 +13,8 @@ import { SubscriptionExpiredError } from "../notifications/webpush";
 import { refreshNotificationSchedule } from "./schedule";
 import { getCurrentTimeInTimezone } from "./time-utils";
 import { notificationsSentTotal } from "../metrics";
+import { listEarnedSince, markAchievementsNotified } from "../db/repository/achievements";
+import { ACHIEVEMENTS } from "../achievements/definitions";
 
 // Re-export portable scheduling functions for backward compatibility (tests import from here)
 export { convertToLocalTime, computeNotificationCron, refreshNotificationSchedule } from "./schedule";
@@ -133,8 +135,30 @@ export async function registerNotificationJobs() {
             notifier.todayDate
           );
 
+          // Inject achievements if enabled for this notifier
+          let achievementKeys: string[] = [];
+          if (notifier.achievementsEnabled) {
+            const lastSentDate = notifier.last_sent_date ?? "1970-01-01T00:00:00.000Z";
+            const earnedSince = await listEarnedSince(notifier.user_id, lastSentDate);
+            const unnotified = earnedSince.filter((ua) => !ua.earnedNotified && ua.earnedAt != null);
+            if (unnotified.length > 0) {
+              content.achievementsEarned = unnotified.map((ua) => {
+                const def = ACHIEVEMENTS.find((a) => a.key === ua.achievementKey);
+                return {
+                  key: ua.achievementKey,
+                  title: def?.title ?? ua.achievementKey,
+                  description: def?.description ?? "",
+                  icon: def?.icon ?? "",
+                  points: def?.points ?? 0,
+                  earnedAt: ua.earnedAt!,
+                };
+              });
+              achievementKeys = unnotified.map((ua) => ua.achievementKey);
+            }
+          }
+
           // Skip if nothing to notify about
-          if (content.episodes.length === 0 && content.movies.length === 0) {
+          if (content.episodes.length === 0 && content.movies.length === 0 && !(content.achievementsEarned?.length)) {
             await markNotifierSent(notifier.id, notifier.todayDate);
             continue;
           }
@@ -148,6 +172,10 @@ export async function registerNotificationJobs() {
             await recordDelivery({ notifierId: notifier.id, status: "failure", latencyMs: Date.now() - dailyStart, errorMessage: sendErr instanceof Error ? sendErr.message : String(sendErr), eventKind: "episode_air" });
             notificationsSentTotal.inc({ provider: notifier.provider, kind: "daily", outcome: "failure" });
             throw sendErr;
+          }
+          // Mark achievements as notified after successful send
+          if (achievementKeys.length > 0) {
+            await markAchievementsNotified(notifier.user_id, achievementKeys);
           }
           await markNotifierSent(notifier.id, notifier.todayDate);
           log.info("Sent notification", { provider: notifier.provider, userId: notifier.user_id });

--- a/server/jobs/processor.ts
+++ b/server/jobs/processor.ts
@@ -24,8 +24,20 @@ import { getProvider } from "../notifications/registry";
 import { buildNotificationContent } from "../notifications/content";
 import { SubscriptionExpiredError } from "../notifications/webpush";
 import { getCurrentTimeInTimezone } from "./time-utils";
-import { listEarnedSince, markAchievementsNotified } from "../db/repository/achievements";
-import { ACHIEVEMENTS } from "../achievements/definitions";
+import { listEarnedSince, markAchievementsNotified, upsertUserAchievement } from "../db/repository/achievements";
+import { recomputeStreakFromHistory } from "../db/repository/streaks";
+import { getSetting, setSetting } from "../db/repository/settings";
+import { ACHIEVEMENTS, type AchievementKind } from "../achievements/definitions";
+import {
+  evaluateCountMovies,
+  evaluateCountEpisodes,
+  evaluateStreak,
+  evaluateGenreCount,
+  evaluateCompletionist,
+  evaluateSpeedBingeSeason,
+  evaluateSocialFirstFollow,
+  evaluateSocialFirstRecommendation,
+} from "../achievements/evaluate";
 
 const log = logger.child({ module: "job-processor" });
 
@@ -238,14 +250,177 @@ async function handleCleanup() {
   await cleanupOldJobs(30);
 }
 
+const BACKFILL_PAGE_SIZE = 50;
+
 async function handleEvaluateAchievements(data: string | null): Promise<void> {
-  const { runEvaluateAchievements } = await import("./evaluate-achievements");
-  await runEvaluateAchievements(data);
+  const raw = typeof data === "string" ? JSON.parse(data) : data;
+  const { userId, kinds, titleId } = (raw ?? {}) as {
+    userId: string;
+    kinds: AchievementKind[];
+    titleId?: string;
+  };
+
+  if (!userId || !Array.isArray(kinds)) {
+    log.warn("evaluate-achievements: invalid job data");
+    return;
+  }
+
+  for (const kind of kinds) {
+    const matchingAchievements = ACHIEVEMENTS.filter((a) => a.kind === kind);
+    for (const a of matchingAchievements) {
+      try {
+        let result: { progress: number; earned: boolean };
+        switch (kind) {
+          case "count_movies":
+            result = await evaluateCountMovies(userId, a.threshold);
+            break;
+          case "count_episodes":
+            result = await evaluateCountEpisodes(userId, a.threshold);
+            break;
+          case "streak_days":
+            result = await evaluateStreak(userId, a.threshold);
+            break;
+          case "genre_count":
+            result = await evaluateGenreCount(userId, a.threshold, a.genre ?? "__any__");
+            break;
+          case "completionist":
+            result = await evaluateCompletionist(userId, a.threshold, titleId);
+            break;
+          case "speed_binge_season":
+            if (!titleId) continue;
+            result = await evaluateSpeedBingeSeason(userId, a.threshold, a.windowHours ?? 24, titleId);
+            break;
+          case "social_first_follow":
+            result = await evaluateSocialFirstFollow(userId);
+            break;
+          case "social_first_recommendation":
+            result = await evaluateSocialFirstRecommendation(userId);
+            break;
+          default:
+            log.warn("evaluate-achievements: unknown kind, skipping", { kind, userId });
+            continue;
+        }
+        const earnedAt = result.earned ? new Date().toISOString() : null;
+        const { newlyEarned } = await upsertUserAchievement(userId, a.key, result.progress, earnedAt);
+        if (newlyEarned) {
+          log.info("Achievement newly earned (deferred)", { userId, key: a.key, kind });
+        }
+      } catch (err) {
+        log.error("evaluate-achievements: error evaluating achievement", {
+          userId,
+          key: a.key,
+          kind,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
 }
 
-async function handleBackfillAchievements(data: string | null): Promise<void> {
-  const { runBackfillAchievements } = await import("./backfill-achievements");
-  await runBackfillAchievements(data);
+async function handleBackfillAchievements(_data?: string | null): Promise<void> {
+  const db = getDb();
+
+  const cursor = (await getSetting("achievements_backfill_cursor")) ?? "";
+
+  const rows = await db.all<{ id: string }>(sql`
+    SELECT id FROM users
+    WHERE id > ${cursor}
+    ORDER BY id ASC
+    LIMIT ${BACKFILL_PAGE_SIZE}
+  `);
+
+  if (rows.length === 0) {
+    await setSetting("achievements_backfill_done", "1");
+    log.info("Backfill complete — no more users");
+    return;
+  }
+
+  log.info("Backfill: processing page", { count: rows.length, cursor });
+
+  for (const row of rows) {
+    const userId = row.id;
+    try {
+      await recomputeStreakFromHistory(userId);
+
+      for (const a of ACHIEVEMENTS) {
+        try {
+          let result: { progress: number; earned: boolean };
+          switch (a.kind) {
+            case "count_movies":
+              result = await evaluateCountMovies(userId, a.threshold);
+              break;
+            case "count_episodes":
+              result = await evaluateCountEpisodes(userId, a.threshold);
+              break;
+            case "streak_days":
+              result = await evaluateStreak(userId, a.threshold);
+              break;
+            case "genre_count":
+              result = await evaluateGenreCount(userId, a.threshold, a.genre ?? "__any__");
+              break;
+            case "completionist":
+              result = await evaluateCompletionist(userId, a.threshold);
+              break;
+            case "speed_binge_season": {
+              const threshold = a.threshold;
+              const windowHours = a.windowHours ?? 24;
+              const candidateRows = await db.all<{ title_id: string }>(sql`
+                SELECT e.title_id
+                FROM watched_episodes we
+                JOIN episodes e ON e.id = we.episode_id
+                WHERE we.user_id = ${userId}
+                  AND we.watched_at IS NOT NULL
+                GROUP BY e.title_id
+                HAVING COUNT(*) >= ${threshold}
+              `);
+              let maxProgress = 0;
+              let anyEarned = false;
+              for (const c of candidateRows) {
+                const r = await evaluateSpeedBingeSeason(userId, threshold, windowHours, c.title_id);
+                if (r.earned) anyEarned = true;
+                maxProgress = Math.max(maxProgress, r.progress);
+              }
+              result = { progress: maxProgress, earned: anyEarned };
+              break;
+            }
+            case "social_first_follow":
+              result = await evaluateSocialFirstFollow(userId);
+              break;
+            case "social_first_recommendation":
+              result = await evaluateSocialFirstRecommendation(userId);
+              break;
+            default:
+              continue;
+          }
+          const earnedAt = result.earned ? new Date().toISOString() : null;
+          await upsertUserAchievement(userId, a.key, result.progress, earnedAt, { earnedNotified: 1 });
+        } catch (err) {
+          log.warn("Backfill: error evaluating achievement for user", {
+            userId,
+            key: a.key,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    } catch (err) {
+      log.warn("Backfill: error processing user", {
+        userId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  const lastUserId = rows[rows.length - 1].id;
+  await setSetting("achievements_backfill_cursor", lastUserId);
+
+  if (rows.length === BACKFILL_PAGE_SIZE) {
+    // Direct insert is CF-safe (no bun:sqlite); mirrors handleMigrateOffers pattern
+    await db.insert(jobs).values({ name: "backfill-achievements", runAt: new Date(Date.now() + 5000).toISOString() });
+    log.info("Backfill: enqueued next batch", { nextCursor: lastUserId });
+  } else {
+    await setSetting("achievements_backfill_done", "1");
+    log.info("Backfill: complete", { totalProcessed: rows.length });
+  }
 }
 
 export const handlers: Record<string, (data: string | null) => Promise<void>> = {

--- a/server/jobs/processor.ts
+++ b/server/jobs/processor.ts
@@ -14,6 +14,7 @@ import {
   getDistinctNotifierTimezones,
   markNotifierSent,
   disableNotifier,
+  recordDelivery,
 } from "../db/repository";
 import { fetchNewReleases } from "../tmdb/sync-titles";
 import { syncEpisodes, syncEpisodesForShow } from "../tmdb/sync";
@@ -23,6 +24,8 @@ import { getProvider } from "../notifications/registry";
 import { buildNotificationContent } from "../notifications/content";
 import { SubscriptionExpiredError } from "../notifications/webpush";
 import { getCurrentTimeInTimezone } from "./time-utils";
+import { listEarnedSince, markAchievementsNotified } from "../db/repository/achievements";
+import { ACHIEVEMENTS } from "../achievements/definitions";
 
 const log = logger.child({ module: "job-processor" });
 
@@ -70,18 +73,18 @@ async function handleSendNotifications(): Promise<void> {
 
   log.info("Processing due notifiers", { count: dueNotifiers.length });
 
-  // Per-invocation cache keyed by "userId|date" — local to this job run, not global.
+  // Per-invocation caches keyed by "userId|date" — local to this job run, not global.
   // For N notifiers sharing the same user+date, DB queries drop from 2N to 2.
-  const contentCache = new Map<string, Awaited<ReturnType<typeof buildNotificationContent>>>();
+  const dailyContentCache = new Map<string, Awaited<ReturnType<typeof buildNotificationContent>>>();
 
-  async function getContentCached(userId: string, date: string) {
+  async function getDailyContentCached(userId: string, date: string) {
     const key = `${userId}|${date}`;
-    if (contentCache.has(key)) {
+    if (dailyContentCache.has(key)) {
       log.debug("Notification content cache hit", { userId, date });
-      return contentCache.get(key)!;
+      return dailyContentCache.get(key)!;
     }
     const result = await buildNotificationContent(userId, date);
-    contentCache.set(key, result);
+    dailyContentCache.set(key, result);
     return result;
   }
 
@@ -93,14 +96,49 @@ async function handleSendNotifications(): Promise<void> {
         continue;
       }
 
-      const content = await getContentCached(notifier.user_id, notifier.todayDate);
+      // Default daily behavior
+      const content = await getDailyContentCached(notifier.user_id, notifier.todayDate);
 
-      if (content.episodes.length === 0 && content.movies.length === 0) {
+      // Inject achievements if enabled for this notifier
+      let achievementKeys: string[] = [];
+      if (notifier.achievementsEnabled) {
+        const lastSentDate = notifier.last_sent_date ?? "1970-01-01T00:00:00.000Z";
+        const earnedSince = await listEarnedSince(notifier.user_id, lastSentDate);
+        const unnotified = earnedSince.filter((ua) => !ua.earnedNotified && ua.earnedAt != null);
+        if (unnotified.length > 0) {
+          content.achievementsEarned = unnotified.map((ua) => {
+            const def = ACHIEVEMENTS.find((a) => a.key === ua.achievementKey);
+            return {
+              key: ua.achievementKey,
+              title: def?.title ?? ua.achievementKey,
+              description: def?.description ?? "",
+              icon: def?.icon ?? "",
+              points: def?.points ?? 0,
+              earnedAt: ua.earnedAt!,
+            };
+          });
+          achievementKeys = unnotified.map((ua) => ua.achievementKey);
+        }
+      }
+
+      // Skip if nothing to notify about
+      if (content.episodes.length === 0 && content.movies.length === 0 && !(content.achievementsEarned?.length)) {
         await markNotifierSent(notifier.id, notifier.todayDate);
         continue;
       }
 
-      await provider.send(notifier.config, content);
+      const dailyStart = Date.now();
+      try {
+        await provider.send(notifier.config, content);
+        await recordDelivery({ notifierId: notifier.id, status: "success", latencyMs: Date.now() - dailyStart, eventKind: "episode_air" });
+      } catch (sendErr) {
+        await recordDelivery({ notifierId: notifier.id, status: "failure", latencyMs: Date.now() - dailyStart, errorMessage: sendErr instanceof Error ? sendErr.message : String(sendErr), eventKind: "episode_air" });
+        throw sendErr;
+      }
+      // Mark achievements as notified after successful send
+      if (achievementKeys.length > 0) {
+        await markAchievementsNotified(notifier.user_id, achievementKeys);
+      }
       await markNotifierSent(notifier.id, notifier.todayDate);
       log.info("Sent notification", { provider: notifier.provider, userId: notifier.user_id });
     } catch (err) {

--- a/server/jobs/processor.ts
+++ b/server/jobs/processor.ts
@@ -200,6 +200,16 @@ async function handleCleanup() {
   await cleanupOldJobs(30);
 }
 
+async function handleEvaluateAchievements(data: string | null): Promise<void> {
+  const { runEvaluateAchievements } = await import("./evaluate-achievements");
+  await runEvaluateAchievements(data);
+}
+
+async function handleBackfillAchievements(data: string | null): Promise<void> {
+  const { runBackfillAchievements } = await import("./backfill-achievements");
+  await runBackfillAchievements(data);
+}
+
 export const handlers: Record<string, (data: string | null) => Promise<void>> = {
   "sync-titles": () => handleSyncTitles(),
   "sync-episodes": () => handleSyncEpisodes(),
@@ -209,6 +219,8 @@ export const handlers: Record<string, (data: string | null) => Promise<void>> = 
   "migrate-offers": () => handleMigrateOffers(),
   "sync-deep-links": () => handleSyncDeepLinks(),
   "cleanup": () => handleCleanup(),
+  "evaluate-achievements": (data) => handleEvaluateAchievements(data),
+  "backfill-achievements": (data) => handleBackfillAchievements(data),
 };
 
 export interface JobRow {

--- a/server/jobs/worker.ts
+++ b/server/jobs/worker.ts
@@ -29,6 +29,10 @@ export function registerHandler(name: string, handler: JobHandler) {
   handlers.set(name, handler);
 }
 
+export function getHandler(name: string): JobHandler | undefined {
+  return handlers.get(name);
+}
+
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, jobName: string): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {

--- a/server/notifications/discord.test.ts
+++ b/server/notifications/discord.test.ts
@@ -140,4 +140,43 @@ describe("DiscordProvider.send", () => {
       )
     ).rejects.toThrow("Discord webhook failed");
   });
+
+  it("renders achievement embed when achievementsEarned is populated", async () => {
+    const contentWithAchievements: NotificationContent = {
+      ...sampleContent,
+      achievementsEarned: [
+        { key: "movies_10", title: "Cinephile I", description: "Watch 10 movies", icon: "Film", points: 10, earnedAt: "2026-01-01T00:00:00.000Z" },
+      ],
+    };
+
+    await discord.send(
+      { webhookUrl: "https://discord.com/api/webhooks/123/abc" },
+      contentWithAchievements
+    );
+
+    expect(fetchCalls).toHaveLength(1);
+    const body = JSON.parse(fetchCalls[0].options.body);
+    const achievementEmbed = body.embeds.find((e: any) => e.title?.includes("New badges"));
+    expect(achievementEmbed).toBeDefined();
+    expect(achievementEmbed.fields).toBeArray();
+    expect(achievementEmbed.fields[0].name).toContain("Cinephile I");
+    expect(achievementEmbed.fields[0].name).toContain("10 XP");
+  });
+
+  it("does NOT render achievement embed when achievementsEarned is empty", async () => {
+    const contentNoAchievements: NotificationContent = {
+      ...sampleContent,
+      achievementsEarned: [],
+    };
+
+    await discord.send(
+      { webhookUrl: "https://discord.com/api/webhooks/123/abc" },
+      contentNoAchievements
+    );
+
+    expect(fetchCalls).toHaveLength(1);
+    const body = JSON.parse(fetchCalls[0].options.body);
+    const achievementEmbed = body.embeds.find((e: any) => e.title?.includes("New badges"));
+    expect(achievementEmbed).toBeUndefined();
+  });
 });

--- a/server/notifications/discord.ts
+++ b/server/notifications/discord.ts
@@ -11,6 +11,7 @@ interface DiscordEmbed {
   color?: number;
   thumbnail?: { url: string };
   footer?: { text: string };
+  fields?: Array<{ name: string; value: string; inline: boolean }>;
 }
 
 const DISCORD_WEBHOOK_PATTERN =
@@ -62,11 +63,11 @@ export class DiscordProvider implements NotificationProvider {
     });
   }
 
-  private buildEmbeds(content: NotificationContent) {
+  private buildEmbeds(content: NotificationContent, _config?: Record<string, string>) {
     const embeds: DiscordEmbed[] = [];
-    const { episodes, movies, date, streamingAlerts = [] } = content;
+    const { episodes, movies, date, streamingAlerts = [], achievementsEarned = [] } = content;
 
-    if (episodes.length === 0 && movies.length === 0 && streamingAlerts.length === 0) return [];
+    if (episodes.length === 0 && movies.length === 0 && streamingAlerts.length === 0 && achievementsEarned.length === 0) return [];
 
     // Header embed
     const parts: string[] = [];
@@ -168,6 +169,20 @@ export class DiscordProvider implements NotificationProvider {
         };
       }
       embeds.push(embed);
+    }
+
+    // Achievement embeds
+    if (achievementsEarned.length > 0) {
+      const fields = achievementsEarned.map((ae) => ({
+        name: `${ae.title} · +${ae.points} XP`,
+        value: ae.description,
+        inline: false,
+      }));
+      embeds.push({
+        title: "🏆 New badges earned",
+        color: 0xf59e0b, // amber-500
+        fields,
+      });
     }
 
     // Discord has a limit of 10 embeds per message

--- a/server/notifications/gotify.test.ts
+++ b/server/notifications/gotify.test.ts
@@ -134,4 +134,28 @@ describe("GotifyProvider.send", () => {
     fetchSpy.mockImplementation(async () => new Response("Unauthorized", { status: 401 }));
     await expect(gotify.send(config, sampleContent)).rejects.toThrow("401");
   });
+
+  it("includes achievement section when achievementsEarned is populated", async () => {
+    const contentWithAchievements: NotificationContent = {
+      ...sampleContent,
+      achievementsEarned: [
+        { key: "movies_10", title: "Cinephile I", description: "Watch 10 movies", icon: "Film", points: 10, earnedAt: "2026-01-01T00:00:00.000Z" },
+      ],
+    };
+    await gotify.send(config, contentWithAchievements);
+    const body = JSON.parse(fetchCalls[0].options.body as string);
+    expect(body.message).toContain("Cinephile I");
+    expect(body.message).toContain("10 XP");
+    expect(body.message).toContain("New badges");
+  });
+
+  it("does NOT include achievement section when achievementsEarned is empty", async () => {
+    const contentNoAchievements: NotificationContent = {
+      ...sampleContent,
+      achievementsEarned: [],
+    };
+    await gotify.send(config, contentNoAchievements);
+    const body = JSON.parse(fetchCalls[0].options.body as string);
+    expect(body.message).not.toContain("New badges");
+  });
 });

--- a/server/notifications/gotify.ts
+++ b/server/notifications/gotify.ts
@@ -26,8 +26,8 @@ export class GotifyProvider implements NotificationProvider {
   }
 
   async send(config: Record<string, string>, content: NotificationContent): Promise<void> {
-    const { episodes, movies, streamingAlerts = [] } = content;
-    if (episodes.length === 0 && movies.length === 0 && streamingAlerts.length === 0) return;
+    const { episodes, movies, streamingAlerts = [], achievementsEarned = [] } = content;
+    if (episodes.length === 0 && movies.length === 0 && streamingAlerts.length === 0 && achievementsEarned.length === 0) return;
 
     const title = this.buildTitle(content);
     const message = this.buildMessage(content);
@@ -49,16 +49,17 @@ export class GotifyProvider implements NotificationProvider {
   }
 
   private buildTitle(content: NotificationContent): string {
-    const { episodes, movies, streamingAlerts = [] } = content;
+    const { episodes, movies, streamingAlerts = [], achievementsEarned = [] } = content;
     const parts: string[] = [];
     if (episodes.length > 0) parts.push(`${episodes.length} episode${episodes.length !== 1 ? "s" : ""}`);
     if (movies.length > 0) parts.push(`${movies.length} movie${movies.length !== 1 ? "s" : ""}`);
     if (streamingAlerts.length > 0) parts.push(`${streamingAlerts.length} now streaming`);
+    if (achievementsEarned.length > 0) parts.push(`${achievementsEarned.length} new badge${achievementsEarned.length !== 1 ? "s" : ""}`);
     return `Remindarr — ${parts.join(" and ")}`;
   }
 
   private buildMessage(content: NotificationContent): string {
-    const { streamingAlerts = [] } = content;
+    const { streamingAlerts = [], achievementsEarned = [] } = content;
     const lines: string[] = [];
 
     const showMap = groupEpisodesByShow(content.episodes);
@@ -82,6 +83,14 @@ export class GotifyProvider implements NotificationProvider {
         lines.push(`${alert.title} — ${formatLeavingCopy(alert.providerName, alert.leavingAt)}`);
       } else {
         lines.push(`${alert.title} — now on ${alert.providerName}`);
+      }
+    }
+
+    if (achievementsEarned.length > 0) {
+      lines.push("");
+      lines.push("🏆 New badges:");
+      for (const ae of achievementsEarned) {
+        lines.push(`${ae.title} +${ae.points} XP — ${ae.description}`);
       }
     }
 

--- a/server/notifications/ntfy.test.ts
+++ b/server/notifications/ntfy.test.ts
@@ -146,4 +146,29 @@ describe("NtfyProvider.send", () => {
     fetchSpy.mockImplementation(async () => new Response("Forbidden", { status: 403 }));
     await expect(ntfy.send({ url: "https://ntfy.sh/my-topic" }, sampleContent)).rejects.toThrow("403");
   });
+
+  it("includes achievement section when achievementsEarned is populated", async () => {
+    const contentWithAchievements: NotificationContent = {
+      ...sampleContent,
+      achievementsEarned: [
+        { key: "movies_10", title: "Cinephile I", description: "Watch 10 movies", icon: "Film", points: 10, earnedAt: "2026-01-01T00:00:00.000Z" },
+      ],
+    };
+    await ntfy.send({ url: "https://ntfy.sh/my-topic" }, contentWithAchievements);
+    expect(fetchCalls).toHaveLength(1);
+    const body = fetchCalls[0].options.body as string;
+    expect(body).toContain("Cinephile I");
+    expect(body).toContain("10 XP");
+  });
+
+  it("does NOT include achievement section when achievementsEarned is empty", async () => {
+    const contentNoAchievements: NotificationContent = {
+      ...sampleContent,
+      achievementsEarned: [],
+    };
+    await ntfy.send({ url: "https://ntfy.sh/my-topic" }, contentNoAchievements);
+    expect(fetchCalls).toHaveLength(1);
+    const body = fetchCalls[0].options.body as string;
+    expect(body).not.toContain("New badges");
+  });
 });

--- a/server/notifications/ntfy.ts
+++ b/server/notifications/ntfy.ts
@@ -27,8 +27,8 @@ export class NtfyProvider implements NotificationProvider {
   }
 
   async send(config: Record<string, string>, content: NotificationContent): Promise<void> {
-    const { episodes, movies, streamingAlerts = [] } = content;
-    if (episodes.length === 0 && movies.length === 0 && streamingAlerts.length === 0) return;
+    const { episodes, movies, streamingAlerts = [], achievementsEarned = [] } = content;
+    if (episodes.length === 0 && movies.length === 0 && streamingAlerts.length === 0 && achievementsEarned.length === 0) return;
 
     const title = this.buildTitle(content);
     const message = this.buildMessage(content);
@@ -59,16 +59,17 @@ export class NtfyProvider implements NotificationProvider {
   }
 
   private buildTitle(content: NotificationContent): string {
-    const { episodes, movies, streamingAlerts = [] } = content;
+    const { episodes, movies, streamingAlerts = [], achievementsEarned = [] } = content;
     const parts: string[] = [];
     if (episodes.length > 0) parts.push(`${episodes.length} episode${episodes.length !== 1 ? "s" : ""}`);
     if (movies.length > 0) parts.push(`${movies.length} movie${movies.length !== 1 ? "s" : ""}`);
     if (streamingAlerts.length > 0) parts.push(`${streamingAlerts.length} now streaming`);
+    if (achievementsEarned.length > 0) parts.push(`${achievementsEarned.length} new badge${achievementsEarned.length !== 1 ? "s" : ""}`);
     return `Remindarr — ${parts.join(" and ")}`;
   }
 
   private buildMessage(content: NotificationContent): string {
-    const { streamingAlerts = [] } = content;
+    const { streamingAlerts = [], achievementsEarned = [] } = content;
     const lines: string[] = [];
 
     const showMap = groupEpisodesByShow(content.episodes);
@@ -92,6 +93,14 @@ export class NtfyProvider implements NotificationProvider {
         lines.push(`${alert.title} — ${formatLeavingCopy(alert.providerName, alert.leavingAt)}`);
       } else {
         lines.push(`${alert.title} — now on ${alert.providerName}`);
+      }
+    }
+
+    if (achievementsEarned.length > 0) {
+      lines.push("");
+      lines.push("🏆 New badges:");
+      for (const ae of achievementsEarned) {
+        lines.push(`${ae.title} +${ae.points} XP — ${ae.description}`);
       }
     }
 

--- a/server/notifications/telegram.test.ts
+++ b/server/notifications/telegram.test.ts
@@ -161,4 +161,28 @@ describe("TelegramProvider.send", () => {
     );
     await expect(telegram.send(config, sampleContent)).rejects.toThrow("400");
   });
+
+  it("includes achievement section when achievementsEarned is populated", async () => {
+    const contentWithAchievements: NotificationContent = {
+      ...sampleContent,
+      achievementsEarned: [
+        { key: "movies_10", title: "Cinephile I", description: "Watch 10 movies", icon: "Film", points: 10, earnedAt: "2026-01-01T00:00:00.000Z" },
+      ],
+    };
+    await telegram.send(config, contentWithAchievements);
+    const body = JSON.parse(fetchCalls[0].options.body as string);
+    expect(body.text).toContain("Cinephile I");
+    expect(body.text).toContain("10 XP");
+    expect(body.text).toContain("New badges");
+  });
+
+  it("does NOT include achievement section when achievementsEarned is empty", async () => {
+    const contentNoAchievements: NotificationContent = {
+      ...sampleContent,
+      achievementsEarned: [],
+    };
+    await telegram.send(config, contentNoAchievements);
+    const body = JSON.parse(fetchCalls[0].options.body as string);
+    expect(body.text).not.toContain("New badges");
+  });
 });

--- a/server/notifications/telegram.ts
+++ b/server/notifications/telegram.ts
@@ -26,8 +26,8 @@ export class TelegramProvider implements NotificationProvider {
   }
 
   async send(config: Record<string, string>, content: NotificationContent): Promise<void> {
-    const { episodes, movies, streamingAlerts = [] } = content;
-    if (episodes.length === 0 && movies.length === 0 && streamingAlerts.length === 0) return;
+    const { episodes, movies, streamingAlerts = [], achievementsEarned = [] } = content;
+    if (episodes.length === 0 && movies.length === 0 && streamingAlerts.length === 0 && achievementsEarned.length === 0) return;
 
     const text = this.buildMessage(content);
     const url = `${TELEGRAM_API}/bot${config.botToken}/sendMessage`;
@@ -52,11 +52,12 @@ export class TelegramProvider implements NotificationProvider {
   }
 
   private buildMessage(content: NotificationContent): string {
-    const { episodes, movies, date, streamingAlerts = [] } = content;
+    const { episodes, movies, date, streamingAlerts = [], achievementsEarned = [] } = content;
     const parts: string[] = [];
     if (episodes.length > 0) parts.push(`${episodes.length} episode${episodes.length !== 1 ? "s" : ""}`);
     if (movies.length > 0) parts.push(`${movies.length} movie${movies.length !== 1 ? "s" : ""}`);
     if (streamingAlerts.length > 0) parts.push(`${streamingAlerts.length} now streaming`);
+    if (achievementsEarned.length > 0) parts.push(`${achievementsEarned.length} new badge${achievementsEarned.length !== 1 ? "s" : ""}`);
 
     const lines: string[] = [`<b>📺 Remindarr — ${parts.join(" and ")} today (${date})</b>`, ""];
 
@@ -84,6 +85,14 @@ export class TelegramProvider implements NotificationProvider {
         lines.push(`🔕 <b>${escapeHtml(alert.title)}</b> — ${escapeHtml(copy)}`);
       } else {
         lines.push(`🔔 <b>${escapeHtml(alert.title)}</b> — now on <i>${escapeHtml(alert.providerName)}</i>`);
+      }
+    }
+
+    if (achievementsEarned.length > 0) {
+      lines.push("");
+      lines.push("<b>🏆 New badges:</b>");
+      for (const ae of achievementsEarned) {
+        lines.push(`🎖 <b>${escapeHtml(ae.title)}</b> +${ae.points} XP — <i>${escapeHtml(ae.description)}</i>`);
       }
     }
 

--- a/server/notifications/types.ts
+++ b/server/notifications/types.ts
@@ -23,11 +23,21 @@ export interface NotificationStreamingAlert {
   leavingAt?: string | null;
 }
 
+export interface NotificationAchievementEarned {
+  key: string;
+  title: string;
+  description: string;
+  icon: string;
+  points: number;
+  earnedAt: string;
+}
+
 export interface NotificationContent {
   episodes: NotificationEpisode[];
   movies: NotificationMovie[];
   date: string;
   streamingAlerts?: NotificationStreamingAlert[];
+  achievementsEarned?: NotificationAchievementEarned[];
 }
 
 export interface NotificationProvider {

--- a/server/notifications/webhook.test.ts
+++ b/server/notifications/webhook.test.ts
@@ -143,4 +143,30 @@ describe("WebhookProvider.send", () => {
     const sig2 = (fetchCalls[1].options.headers as Record<string, string>)["X-Remindarr-Signature"];
     expect(sig1).toBe(sig2);
   });
+
+  it("includes achievements_earned in payload when achievementsEarned is populated", async () => {
+    const contentWithAchievements: NotificationContent = {
+      ...sampleContent,
+      achievementsEarned: [
+        { key: "movies_10", title: "Cinephile I", description: "Watch 10 movies", icon: "Film", points: 10, earnedAt: "2026-01-01T00:00:00.000Z" },
+      ],
+    };
+    await webhook.send({ url: "https://example.com/hook" }, contentWithAchievements);
+    const body = JSON.parse(fetchCalls[0].options.body as string);
+    expect(body.achievements_earned).toBeArray();
+    expect(body.achievements_earned.length).toBe(1);
+    expect(body.achievements_earned[0].title).toBe("Cinephile I");
+    expect(body.achievements_earned[0].points).toBe(10);
+  });
+
+  it("includes empty achievements_earned when achievementsEarned is empty", async () => {
+    const contentNoAchievements: NotificationContent = {
+      ...sampleContent,
+      achievementsEarned: [],
+    };
+    await webhook.send({ url: "https://example.com/hook" }, contentNoAchievements);
+    const body = JSON.parse(fetchCalls[0].options.body as string);
+    expect(body.achievements_earned).toBeArray();
+    expect(body.achievements_earned.length).toBe(0);
+  });
 });

--- a/server/notifications/webhook.ts
+++ b/server/notifications/webhook.ts
@@ -22,8 +22,8 @@ export class WebhookProvider implements NotificationProvider {
   }
 
   async send(config: Record<string, string>, content: NotificationContent): Promise<void> {
-    const { episodes, movies, streamingAlerts = [] } = content;
-    if (episodes.length === 0 && movies.length === 0 && streamingAlerts.length === 0) return;
+    const { episodes, movies, streamingAlerts = [], achievementsEarned = [] } = content;
+    if (episodes.length === 0 && movies.length === 0 && streamingAlerts.length === 0 && achievementsEarned.length === 0) return;
 
     const payload = this.buildPayload(content);
     const body = JSON.stringify(payload);
@@ -52,7 +52,7 @@ export class WebhookProvider implements NotificationProvider {
   }
 
   private buildPayload(content: NotificationContent) {
-    const { episodes, movies, date, streamingAlerts = [] } = content;
+    const { episodes, movies, date, streamingAlerts = [], achievementsEarned = [] } = content;
 
     const summaryLines: string[] = [];
     const showMap = groupEpisodesByShow(episodes);
@@ -91,6 +91,14 @@ export class WebhookProvider implements NotificationProvider {
         providerName: a.providerName,
         kind: a.kind,
         leavingAt: a.leavingAt ?? null,
+      })),
+      achievements_earned: achievementsEarned.map((ae) => ({
+        key: ae.key,
+        title: ae.title,
+        description: ae.description,
+        icon: ae.icon,
+        points: ae.points,
+        earnedAt: ae.earnedAt,
       })),
     };
   }

--- a/server/notifications/webpush.test.ts
+++ b/server/notifications/webpush.test.ts
@@ -155,4 +155,47 @@ describe("WebPushProvider.send", () => {
 
     sendSpy.mockRestore();
   });
+
+  it("includes achievement info in body when achievementsEarned is populated", async () => {
+    const webpush = await import("web-push");
+    let capturedPayload: string | null = null;
+    const sendSpy = spyOn(webpush.default, "sendNotification").mockImplementation(async (sub: any, payload: any) => {
+      capturedPayload = payload;
+      return { statusCode: 201, body: "", headers: {} } as any;
+    });
+
+    const contentWithAchievements: NotificationContent = {
+      ...sampleContent,
+      achievementsEarned: [
+        { key: "movies_10", title: "Cinephile I", description: "Watch 10 movies", icon: "Film", points: 10, earnedAt: "2026-01-01T00:00:00.000Z" },
+      ],
+    };
+    await provider.send(validConfig, contentWithAchievements);
+    expect(capturedPayload).not.toBeNull();
+    const parsed = JSON.parse(capturedPayload!);
+    expect(parsed.body).toContain("Cinephile I");
+    expect(parsed.body).toContain("10 XP");
+
+    sendSpy.mockRestore();
+  });
+
+  it("does NOT include achievement info when achievementsEarned is empty", async () => {
+    const webpush = await import("web-push");
+    let capturedPayload: string | null = null;
+    const sendSpy = spyOn(webpush.default, "sendNotification").mockImplementation(async (sub: any, payload: any) => {
+      capturedPayload = payload;
+      return { statusCode: 201, body: "", headers: {} } as any;
+    });
+
+    const contentNoAchievements: NotificationContent = {
+      ...sampleContent,
+      achievementsEarned: [],
+    };
+    await provider.send(validConfig, contentNoAchievements);
+    expect(capturedPayload).not.toBeNull();
+    const parsed = JSON.parse(capturedPayload!);
+    expect(parsed.body).not.toContain("badge");
+
+    sendSpy.mockRestore();
+  });
 });

--- a/server/notifications/webpush.test.ts
+++ b/server/notifications/webpush.test.ts
@@ -1,19 +1,6 @@
-import { describe, it, expect, beforeEach, afterEach, spyOn, mock } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { CONFIG } from "../config";
 import type { NotificationContent } from "./types";
-
-// Mock web-push module (include generateVAPIDKeys so the mock doesn't break
-// vapid.test.ts if it leaks across files in the same bun process)
-mock.module("web-push", () => ({
-  default: {
-    setVapidDetails: () => {},
-    sendNotification: async () => ({ statusCode: 201 }),
-    generateVAPIDKeys: () => ({
-      publicKey: "mock-generated-public",
-      privateKey: "mock-generated-private",
-    }),
-  },
-}));
 
 // Use CONFIG values so the real getVapidKeys() returns them without DB access.
 // This avoids mock.module("./vapid") which permanently poisons the module
@@ -26,6 +13,7 @@ CONFIG.VAPID_PUBLIC_KEY = "test-public-key";
 CONFIG.VAPID_PRIVATE_KEY = "test-private-key";
 CONFIG.VAPID_SUBJECT = "mailto:test@example.com";
 
+const webpush = await import("web-push");
 const { WebPushProvider, SubscriptionExpiredError } = await import("./webpush");
 const provider = new WebPushProvider();
 
@@ -57,13 +45,17 @@ const validConfig = {
   auth: "test-auth-key",
 };
 
+let setVapidDetailsSpy: ReturnType<typeof spyOn>;
+
 beforeEach(() => {
   CONFIG.VAPID_PUBLIC_KEY = "test-public-key";
   CONFIG.VAPID_PRIVATE_KEY = "test-private-key";
   CONFIG.VAPID_SUBJECT = "mailto:test@example.com";
+  setVapidDetailsSpy = spyOn(webpush.default, "setVapidDetails").mockImplementation(() => {});
 });
 
 afterEach(() => {
+  setVapidDetailsSpy.mockRestore();
   CONFIG.VAPID_PUBLIC_KEY = savedVapidPublicKey;
   CONFIG.VAPID_PRIVATE_KEY = savedVapidPrivateKey;
   CONFIG.VAPID_SUBJECT = savedVapidSubject;
@@ -96,7 +88,6 @@ describe("WebPushProvider.validateConfig", () => {
 
 describe("WebPushProvider.send", () => {
   it("sends push notification with correct payload", async () => {
-    const webpush = await import("web-push");
     let sentPayload: string | undefined;
     const sendSpy = spyOn(webpush.default, "sendNotification").mockImplementation(
       async (_sub: any, payload: any) => {
@@ -118,7 +109,6 @@ describe("WebPushProvider.send", () => {
   });
 
   it("skips sending when content is empty", async () => {
-    const webpush = await import("web-push");
     const sendSpy = spyOn(webpush.default, "sendNotification");
 
     await provider.send(validConfig, { date: "2026-03-15", episodes: [], movies: [] });
@@ -128,7 +118,6 @@ describe("WebPushProvider.send", () => {
   });
 
   it("throws SubscriptionExpiredError on 410", async () => {
-    const webpush = await import("web-push");
     const sendSpy = spyOn(webpush.default, "sendNotification").mockImplementation(async () => {
       const err: any = new Error("Gone");
       err.statusCode = 410;
@@ -143,7 +132,6 @@ describe("WebPushProvider.send", () => {
   });
 
   it("throws generic error on other failures", async () => {
-    const webpush = await import("web-push");
     const sendSpy = spyOn(webpush.default, "sendNotification").mockImplementation(async () => {
       const err: any = new Error("Server Error");
       err.statusCode = 500;
@@ -157,9 +145,8 @@ describe("WebPushProvider.send", () => {
   });
 
   it("includes achievement info in body when achievementsEarned is populated", async () => {
-    const webpush = await import("web-push");
     let capturedPayload: string | null = null;
-    const sendSpy = spyOn(webpush.default, "sendNotification").mockImplementation(async (sub: any, payload: any) => {
+    const sendSpy = spyOn(webpush.default, "sendNotification").mockImplementation(async (_sub: any, payload: any) => {
       capturedPayload = payload;
       return { statusCode: 201, body: "", headers: {} } as any;
     });
@@ -180,9 +167,8 @@ describe("WebPushProvider.send", () => {
   });
 
   it("does NOT include achievement info when achievementsEarned is empty", async () => {
-    const webpush = await import("web-push");
     let capturedPayload: string | null = null;
-    const sendSpy = spyOn(webpush.default, "sendNotification").mockImplementation(async (sub: any, payload: any) => {
+    const sendSpy = spyOn(webpush.default, "sendNotification").mockImplementation(async (_sub: any, payload: any) => {
       capturedPayload = payload;
       return { statusCode: 201, body: "", headers: {} } as any;
     });

--- a/server/notifications/webpush.ts
+++ b/server/notifications/webpush.ts
@@ -36,8 +36,8 @@ export class WebPushProvider implements NotificationProvider {
     config: Record<string, string>,
     content: NotificationContent
   ): Promise<void> {
-    const { episodes, movies, streamingAlerts = [] } = content;
-    if (episodes.length === 0 && movies.length === 0 && streamingAlerts.length === 0) return;
+    const { episodes, movies, streamingAlerts = [], achievementsEarned = [] } = content;
+    if (episodes.length === 0 && movies.length === 0 && streamingAlerts.length === 0 && achievementsEarned.length === 0) return;
 
     const vapid = await getVapidKeys();
     webpush.setVapidDetails(vapid.subject, vapid.publicKey, vapid.privateKey);
@@ -73,7 +73,7 @@ export class WebPushProvider implements NotificationProvider {
   }
 
   private buildPayload(content: NotificationContent) {
-    const { episodes, movies, streamingAlerts = [] } = content;
+    const { episodes, movies, streamingAlerts = [], achievementsEarned = [] } = content;
     const totalCount = episodes.length + movies.length + streamingAlerts.length;
 
     const lines: string[] = [];
@@ -100,8 +100,16 @@ export class WebPushProvider implements NotificationProvider {
       }
     }
 
+    if (achievementsEarned.length > 0) {
+      lines.push(`🏆 ${achievementsEarned.map((ae) => `${ae.title} +${ae.points} XP`).join(", ")}`);
+    }
+
+    const titleSuffix = achievementsEarned.length > 0 && totalCount === 0
+      ? `${achievementsEarned.length} new badge${achievementsEarned.length !== 1 ? "s" : ""}`
+      : `${totalCount} new release${totalCount !== 1 ? "s" : ""}`;
+
     return {
-      title: `Remindarr — ${totalCount} new release${totalCount !== 1 ? "s" : ""}`,
+      title: `Remindarr — ${titleSuffix}`,
       body: lines.join("\n"),
       icon: "/pwa-192x192.png",
       badge: "/pwa-192x192.png",

--- a/server/plex/sync.ts
+++ b/server/plex/sync.ts
@@ -11,6 +11,7 @@ import { watchTitle, watchEpisodesBulk, getEpisodeIdsBySE } from "../db/reposito
 import { updateIntegrationSyncStatus, disableIntegration } from "../db/repository";
 import type { PlexConfig } from "../db/repository/integrations";
 import { syncFailureTotal } from "../metrics";
+import { onWatchedTitle, onWatchedEpisodesBulk } from "../achievements/triggers";
 
 const log = logger.child({ module: "plex-sync" });
 
@@ -52,6 +53,7 @@ export async function syncPlexWatched(integration: IntegrationRow): Promise<Sync
             await watchTitle(titleId, userId);
             moviesMarked++;
             succeeded++;
+            await onWatchedTitle(userId, titleId, true);
           } catch (err) {
             log.warn("Plex title sync failed", { titleId, err });
             failed.push({ id: titleId, error: err instanceof Error ? err.message : String(err) });
@@ -95,6 +97,7 @@ export async function syncPlexWatched(integration: IntegrationRow): Promise<Sync
 
           await watchEpisodesBulk(episodeIds, userId);
           episodesMarked += episodeIds.length;
+          await onWatchedEpisodesBulk(userId, episodeIds.map(String), new Set([titleId]));
         }
       }
     }

--- a/server/routes/achievements.test.ts
+++ b/server/routes/achievements.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { Hono } from "hono";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { createUser, createSession, getSessionWithUser, upsertTitles } from "../db/repository";
+import { makeParsedTitle } from "../test-utils/fixtures";
+import { requireAuth, optionalAuth } from "../middleware/auth";
+import * as achievementsRepo from "../db/repository/achievements";
+import * as streaksRepo from "../db/repository/streaks";
+import { follow } from "../db/repository";
+import achievementsRoutes, { leaderboardApp, streakApp } from "./achievements";
+import type { AppEnv } from "../types";
+
+function createMockAuth() {
+  return {
+    api: {
+      getSession: async ({ headers }: { headers: Headers }) => {
+        const cookieHeader = headers.get("cookie") || "";
+        const match = cookieHeader.match(/better-auth\.session_token=([^;]+)/);
+        const token = match?.[1];
+        if (!token) return null;
+        const user = await getSessionWithUser(token);
+        if (!user) return null;
+        return {
+          session: { id: "session-id", userId: user.id },
+          user: {
+            id: user.id,
+            name: user.display_name,
+            username: user.username,
+            role: user.role || (user.is_admin ? "admin" : "user"),
+          },
+        };
+      },
+    },
+  };
+}
+
+let app: Hono<AppEnv>;
+let userAId: string;
+let userAToken: string;
+let userBId: string;
+let userBToken: string;
+
+beforeEach(async () => {
+  setupTestDb();
+
+  userAId = await createUser("alice", "hash", "Alice");
+  userAToken = await createSession(userAId);
+  userBId = await createUser("bob", "hash", "Bob");
+  userBToken = await createSession(userBId);
+
+  await upsertTitles([makeParsedTitle({ id: "movie-1", objectType: "MOVIE", title: "Test Movie" })]);
+
+  app = new Hono<AppEnv>();
+  app.use("*", async (c, next) => {
+    c.set("auth", createMockAuth() as any);
+    await next();
+  });
+  app.use("/achievements/*", optionalAuth);
+  app.use("/achievements", optionalAuth);
+  app.route("/achievements", achievementsRoutes);
+
+  app.use("/leaderboard/*", optionalAuth);
+  app.use("/leaderboard", optionalAuth);
+  app.route("/leaderboard", leaderboardApp);
+
+  app.use("/streak/*", optionalAuth);
+  app.use("/streak", optionalAuth);
+  app.route("/streak", streakApp);
+});
+
+afterEach(() => {
+  teardownTestDb();
+});
+
+function authHeaders(token: string) {
+  return { Cookie: `better-auth.session_token=${token}` };
+}
+
+describe("GET /achievements", () => {
+  it("returns full registry without auth", async () => {
+    const res = await app.request("/achievements");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.achievements)).toBe(true);
+    expect(body.achievements.length).toBeGreaterThan(0);
+    // Verify structure of registry entries
+    const first = body.achievements[0];
+    expect(first).toHaveProperty("key");
+    expect(first).toHaveProperty("kind");
+    expect(first).toHaveProperty("title");
+    expect(first).toHaveProperty("points");
+  });
+});
+
+describe("GET /achievements/me", () => {
+  it("returns merged progress for authed user", async () => {
+    const res = await app.request("/achievements/me", {
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.achievements)).toBe(true);
+    const first = body.achievements[0];
+    expect(first).toHaveProperty("progress");
+    expect(first).toHaveProperty("earned");
+    expect(first).toHaveProperty("earnedAt");
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await app.request("/achievements/me");
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /achievements/u/:username", () => {
+  it("returns 401 without auth", async () => {
+    const res = await app.request("/achievements/u/bob");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 for private profile (not found behavior)", async () => {
+    // bob has private visibility by default
+    const res = await app.request("/achievements/u/bob", {
+      headers: authHeaders(userAToken),
+    });
+    // private profiles return 404
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 for friends_only profile when not a follower", async () => {
+    // Set bob's profile to friends_only
+    const { getDb } = await import("../db/schema");
+    const { users } = await import("../db/schema");
+    const { eq } = await import("drizzle-orm");
+    const db = getDb();
+    await db.update(users).set({ profileVisibility: "friends_only" }).where(eq(users.id, userBId)).run();
+
+    const res = await app.request("/achievements/u/bob", {
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 200 for public profile", async () => {
+    // Set bob's profile to public
+    const { getDb } = await import("../db/schema");
+    const { users } = await import("../db/schema");
+    const { eq } = await import("drizzle-orm");
+    const db = getDb();
+    await db.update(users).set({ profileVisibility: "public" }).where(eq(users.id, userBId)).run();
+
+    const res = await app.request("/achievements/u/bob", {
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.achievements)).toBe(true);
+  });
+
+  it("validates param: empty username returns 400", async () => {
+    // Empty username after /u/ won't match the route — will 404
+    const res = await app.request("/achievements/u/", {
+      headers: authHeaders(userAToken),
+    });
+    // Route won't match — Hono returns 404
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /leaderboard", () => {
+  it("returns 401 without auth", async () => {
+    const res = await app.request("/leaderboard");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns leaderboard with self included, ordered by XP desc", async () => {
+    const res = await app.request("/leaderboard", {
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.entries)).toBe(true);
+    // Self (alice) should always be in the result
+    const selfEntry = body.entries.find((e: any) => e.userId === userAId);
+    expect(selfEntry).toBeDefined();
+    // Entries should have required fields
+    const first = body.entries[0];
+    expect(first).toHaveProperty("userId");
+    expect(first).toHaveProperty("username");
+    expect(first).toHaveProperty("xp");
+    expect(first).toHaveProperty("badgeCount");
+    expect(first).toHaveProperty("rank");
+  });
+
+  it("includes followed users in leaderboard", async () => {
+    await follow(userAId, userBId);
+    const res = await app.request("/leaderboard", {
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const bobEntry = body.entries.find((e: any) => e.userId === userBId);
+    expect(bobEntry).toBeDefined();
+  });
+});
+
+describe("GET /streak/me", () => {
+  it("returns 401 without auth", async () => {
+    const res = await app.request("/streak/me");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns streak shape for authed user", async () => {
+    const res = await app.request("/streak/me", {
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("currentStreak");
+    expect(body).toHaveProperty("longestStreak");
+    expect(body).toHaveProperty("lastWatchDate");
+    expect(typeof body.currentStreak).toBe("number");
+    expect(typeof body.longestStreak).toBe("number");
+  });
+
+  it("returns zeros when no watch history exists", async () => {
+    const res = await app.request("/streak/me", {
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.currentStreak).toBe(0);
+    expect(body.longestStreak).toBe(0);
+    expect(body.lastWatchDate).toBeNull();
+  });
+});

--- a/server/routes/achievements.ts
+++ b/server/routes/achievements.ts
@@ -1,0 +1,168 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { sql } from "drizzle-orm";
+import { getDb } from "../db/schema";
+import { ACHIEVEMENTS } from "../achievements/definitions";
+import { getUserAchievements } from "../db/repository/achievements";
+import { getStreak } from "../db/repository/streaks";
+import { getUserVisibilityByUsername } from "../db/repository/profile";
+import { isFollowing } from "../db/repository/follows";
+import type { AppEnv } from "../types";
+import { ok, err } from "./response";
+import { zValidator } from "../lib/validator";
+import { requireAuth } from "../middleware/auth";
+import { traceDbQuery } from "../tracing";
+
+// ─── Achievements sub-app (mounted at /api/achievements) ────────────────────
+
+const achievementsApp = new Hono<AppEnv>();
+
+const usernameSchema = z.object({
+  username: z.string().min(1).max(50),
+});
+
+// GET / — Public registry (no auth required)
+achievementsApp.get("/", (c) => {
+  return ok(c, { achievements: ACHIEVEMENTS });
+});
+
+// GET /me — User's merged progress (auth required)
+achievementsApp.get("/me", requireAuth, async (c) => {
+  const user = c.get("user")!;
+  const userRows = await getUserAchievements(user.id);
+
+  const progressMap = new Map(userRows.map((r) => [r.achievementKey, r]));
+
+  const result = ACHIEVEMENTS.map((a) => {
+    const row = progressMap.get(a.key);
+    return {
+      key: a.key,
+      kind: a.kind,
+      title: a.title,
+      description: a.description,
+      icon: a.icon,
+      threshold: a.threshold,
+      points: a.points,
+      genre: a.genre,
+      windowHours: a.windowHours,
+      progress: row?.progress ?? 0,
+      earned: row?.earnedAt != null,
+      earnedAt: row?.earnedAt ?? null,
+    };
+  });
+
+  return ok(c, { achievements: result });
+});
+
+// GET /u/:username — Another user's earned achievements (privacy gated)
+achievementsApp.get("/u/:username", requireAuth, zValidator("param", usernameSchema), async (c) => {
+  const requester = c.get("user")!;
+  const { username } = c.req.valid("param");
+
+  const profileUser = await getUserVisibilityByUsername(username);
+  if (!profileUser) {
+    return err(c, "User not found", 404);
+  }
+
+  // Privacy gate
+  if (profileUser.visibility === "private") {
+    return err(c, "User not found", 404);
+  }
+
+  if (profileUser.visibility === "friends_only") {
+    // Own profile passes the friends_only check
+    if (profileUser.id !== requester.id) {
+      const following = await isFollowing(requester.id, profileUser.id);
+      if (!following) {
+        return err(c, "Access denied", 403);
+      }
+    }
+  }
+
+  const userRows = await getUserAchievements(profileUser.id);
+  const earned = userRows
+    .filter((r) => r.earnedAt != null)
+    .map((r) => {
+      const def = ACHIEVEMENTS.find((a) => a.key === r.achievementKey);
+      return {
+        key: r.achievementKey,
+        kind: def?.kind ?? "count_movies",
+        title: def?.title ?? r.achievementKey,
+        description: def?.description ?? "",
+        icon: def?.icon ?? "",
+        threshold: def?.threshold ?? 0,
+        points: def?.points ?? 0,
+        genre: def?.genre,
+        windowHours: def?.windowHours,
+        // Progress hidden for other users — only earned status shown
+        earned: true,
+        earnedAt: r.earnedAt,
+      };
+    });
+
+  return ok(c, { achievements: earned });
+});
+
+export default achievementsApp;
+
+// ─── Leaderboard sub-app (mounted at /api/leaderboard) ──────────────────────
+
+export const leaderboardApp = new Hono<AppEnv>();
+
+leaderboardApp.get("/", requireAuth, async (c) => {
+  const user = c.get("user")!;
+
+  const entries = await traceDbQuery("leaderboard", async () => {
+    const db = getDb();
+    return await db.all<{
+      id: string;
+      username: string;
+      name: string | null;
+      image: string | null;
+      xp: number;
+      badge_count: number;
+    }>(sql`
+      WITH friend_set AS (
+        SELECT following_id AS id FROM follows WHERE follower_id = ${user.id}
+        UNION SELECT ${user.id}
+      )
+      SELECT u.id, u.username, u.name, u.image,
+        COALESCE(SUM(a.points), 0) AS xp,
+        COUNT(ua.achievement_key) AS badge_count
+      FROM friend_set fs
+      JOIN users u ON u.id = fs.id
+      LEFT JOIN user_achievements ua ON ua.user_id = u.id AND ua.earned_at IS NOT NULL
+      LEFT JOIN achievements a ON a.key = ua.achievement_key
+      GROUP BY u.id
+      ORDER BY xp DESC, badge_count DESC
+      LIMIT 50
+    `);
+  });
+
+  const leaderboard = entries.map((row, idx) => ({
+    userId: row.id,
+    username: row.username,
+    name: row.name,
+    image: row.image,
+    xp: Number(row.xp),
+    badgeCount: Number(row.badge_count),
+    rank: idx + 1,
+  }));
+
+  return ok(c, { entries: leaderboard });
+});
+
+// ─── Streak sub-app (mounted at /api/streak) ────────────────────────────────
+
+export const streakApp = new Hono<AppEnv>();
+
+streakApp.get("/me", requireAuth, async (c) => {
+  const user = c.get("user")!;
+  const streak = await getStreak(user.id);
+
+  return ok(c, {
+    currentStreak: streak?.currentStreak ?? 0,
+    longestStreak: streak?.longestStreak ?? 0,
+    lastWatchDate: streak?.lastWatchDate ?? null,
+  });
+});

--- a/server/routes/recommendations.ts
+++ b/server/routes/recommendations.ts
@@ -15,6 +15,7 @@ import type { AppEnv } from "../types";
 import { logger } from "../logger";
 import { ok, err } from "./response";
 import { zValidator } from "../lib/validator";
+import { onRecommendation } from "../achievements/triggers";
 
 const log = logger.child({ module: "recommendations" });
 
@@ -60,6 +61,7 @@ app.post("/", zValidator("json", createRecommendationSchema), async (c) => {
 
   const id = await createRecommendation(user.id, body.titleId, body.message, targetUserId);
   log.info("Recommendation created", { fromUserId: user.id, titleId: body.titleId, targetUserId: targetUserId ?? null });
+  await onRecommendation(user.id);
   return c.json({ success: true, id }, 201);
 });
 

--- a/server/routes/social.ts
+++ b/server/routes/social.ts
@@ -5,6 +5,7 @@ import type { AppEnv } from "../types";
 import { logger } from "../logger";
 import { ok, err } from "./response";
 import { zValidator } from "../lib/validator";
+import { onFollow } from "../achievements/triggers";
 
 const friendsLovedQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(50).optional().default(20),
@@ -30,6 +31,7 @@ app.post("/follow/:userId", async (c) => {
 
   await follow(currentUser.id, targetUserId);
   log.info("User followed", { followerId: currentUser.id, followingId: targetUserId });
+  await onFollow(currentUser.id);
   return ok(c, { success: true });
 });
 

--- a/server/routes/watched.ts
+++ b/server/routes/watched.ts
@@ -11,6 +11,7 @@ import { localDateForTimezone } from "../utils/timezone";
 import type { AppEnv } from "../types";
 import { ok, err } from "./response";
 import { zValidator } from "../lib/validator";
+import { onWatchedTitle, onWatchedEpisode, onWatchedEpisodesBulk } from "../achievements/triggers";
 
 const app = new Hono<AppEnv>();
 
@@ -62,7 +63,22 @@ app.post("/bulk", zValidator("json", bulkWatchedSchema), async (c) => {
         await logWatch(user.id, titleId, episodeId, watchedAtByEpisodeId?.get(episodeId));
       }
     }
+
+    // Trigger achievement evaluation for bulk episode watch
+    const distinctTitleIds = new Set(
+      releasedIds
+        .map((id) => titleIdMap.get(id))
+        .filter((id): id is string => id != null)
+    );
+    const watchedAt = watchedAtByEpisodeId?.get(releasedIds[0]);
+    await onWatchedEpisodesBulk(
+      user.id,
+      releasedIds.map(String),
+      distinctTitleIds,
+      watchedAt
+    );
   } else {
+    // Achievements are sticky — deletes do not undo progress or earned badges.
     await unwatchEpisodesBulk(episodeIds, user.id);
   }
 
@@ -107,10 +123,13 @@ app.post("/:episodeId", async (c) => {
     await logWatch(user.id, titleId, episodeId);
   }
 
+  await onWatchedEpisode(user.id, String(episodeId));
+
   return ok(c, {});
 });
 
 app.delete("/:episodeId", async (c) => {
+  // Achievements are sticky — deletes do not undo progress or earned badges.
   const user = c.get("user")!;
   const episodeId = Number(c.req.param("episodeId"));
   if (isNaN(episodeId)) return c.json({ error: "Invalid episodeId" }, 400);
@@ -125,10 +144,12 @@ app.post("/movies/:titleId", async (c) => {
   const titleId = c.req.param("titleId");
   await watchTitle(titleId, user.id);
   await logWatch(user.id, titleId);
+  await onWatchedTitle(user.id, titleId, true);
   return ok(c, {});
 });
 
 app.delete("/movies/:titleId", async (c) => {
+  // Achievements are sticky — deletes do not undo progress or earned badges.
   const user = c.get("user")!;
   const titleId = c.req.param("titleId");
   await unwatchTitle(titleId, user.id);

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -75,6 +75,7 @@ import shareRoutes from "./routes/share";
 import importRoutes from "./routes/import";
 import upNextRoutes from "./routes/up-next";
 import overlapRoutes from "./routes/overlap";
+import achievementsRoutes, { leaderboardApp, streakApp } from "./routes/achievements";
 import type { AppEnv } from "./types";
 import { logger, requestLogger, resetLogLevel } from "./logger";
 import { patchConfig, CONFIG } from "./config";
@@ -389,6 +390,21 @@ function createApp(env: Env) {
   app.use("/api/overlap/*", requireAuth);
   app.use("/api/overlap", requireAuth);
   app.route("/api/overlap", overlapRoutes);
+
+  // Achievements — GET /api/achievements is public; /me, /u/:username require auth (applied per-route)
+  app.use("/api/achievements/*", optionalAuth);
+  app.use("/api/achievements", optionalAuth);
+  app.route("/api/achievements", achievementsRoutes);
+
+  // Leaderboard — requireAuth applied per-route
+  app.use("/api/leaderboard/*", optionalAuth);
+  app.use("/api/leaderboard", optionalAuth);
+  app.route("/api/leaderboard", leaderboardApp);
+
+  // Streak — requireAuth applied per-route
+  app.use("/api/streak/*", optionalAuth);
+  app.use("/api/streak", optionalAuth);
+  app.route("/api/streak", streakApp);
 
   app.use("/api/user/settings/*", requireAuth);
   app.route("/api/user/settings", userSettingsRoutes);


### PR DESCRIPTION
## Summary

This is PR2 of 3 for #375 (Gamification: streaks, badges, achievements), building on the foundation from PR1 (#720).

- **Triggers** (`server/achievements/triggers.ts`): five functions (`onWatchedTitle`, `onWatchedEpisode`, `onWatchedEpisodesBulk`, `onFollow`, `onRecommendation`) wired into watched/social/recommendations/plex routes. Inline evaluation for cheap COUNT queries; deferred jobs for expensive ones. Wrapped in try/catch so achievement failures never block user-facing operations.
- **Job handlers**: `evaluate-achievements` (dispatches per-kind evaluators) and `backfill-achievements` (paginated 50-users-at-a-time cursor walk, sets `earnedNotified=1` to suppress notification burst)
- **API routes** (`server/routes/achievements.ts`): `GET /api/achievements` (public registry), `GET /api/achievements/me` (auth, with progress), `GET /api/achievements/u/:username` (privacy-gated), `GET /api/leaderboard` (friends+self, XP desc), `GET /api/streak/me`
- **Notifications**: all six providers (Discord, Telegram, Gotify, Ntfy, Webhook, WebPush) extended to render `achievementsEarned` when present; daily notification job fetches unnotified earned achievements and marks them notified after send

## Test plan

- [ ] All 2808 tests pass (`bun run check` — 0 failures)
- [ ] Trigger tests confirm inline + deferred split (mocked evaluators + enqueueJob spy)
- [ ] Route tests: auth gating, privacy gating on `/u/:username`, leaderboard shape
- [ ] Job handler tests: evaluate-achievements dispatches correct evaluators; backfill pages correctly and stops on `< 50` rows
- [ ] Notification provider tests: achievement section renders with `achievementsEarned`, absent when empty

Closes #375 (partial — PR3 will add the frontend UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)