### PR TITLE
feat(gamification): frontend — badges, streak & leaderboard

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,6 +40,7 @@ const MorePage = lazyWithRetry(() => import("./pages/MorePage"));
 const KioskPage = lazyWithRetry(() => import("./pages/KioskPage"));
 const SharedWatchlistPage = lazyWithRetry(() => import("./pages/SharedWatchlistPage"));
 const UserOverlapPage = lazyWithRetry(() => import("./pages/UserOverlapPage"));
+const LeaderboardPage = lazyWithRetry(() => import("./pages/LeaderboardPage"));
 
 // Wraps a route element in an inline ErrorBoundary so a single page crash
 // shows a contained fallback instead of taking down the whole shell.
@@ -199,6 +200,7 @@ export default function App() {
             <Route path="/invite" element={<RequireAuth><Page><InvitePage /></Page></RequireAuth>} />
             <Route path="/stats" element={<Navigate to="/tracked?view=stats" replace />} />
             <Route path="/admin/users" element={<RequireAuth><Page><AdminUsersPage /></Page></RequireAuth>} />
+            <Route path="/leaderboard" element={<RequireAuth><Page><LeaderboardPage /></Page></RequireAuth>} />
             <Route path="/user/:username" element={<Page><UserProfilePage /></Page>} />
             <Route path="/u/:username/overlap/:friendUsername" element={<RequireAuth><Page><UserOverlapPage /></Page></RequireAuth>} />
             <Route path="/settings" element={<RequireAuth><Page><SettingsPage /></Page></RequireAuth>} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import OfflineIndicator from "./components/OfflineIndicator";
 import InstallPrompt from "./components/InstallPrompt";
 import NotificationPrompt from "./components/NotificationPrompt";
 import KeyboardShortcutsModal from "./components/KeyboardShortcutsModal";
+import AchievementToast from "./components/profile/AchievementToast";
 import { Github, Settings } from "lucide-react";
 import { navLinkClass } from "./nav-utils";
 import { usePushSubscriptionSync } from "./hooks/usePushSubscriptionSync";
@@ -231,6 +232,7 @@ export default function App() {
       </footer>
       {!isKioskPage && <BottomTabBar />}
       <OfflineIndicator />
+      {user && <AchievementToast />}
       <Toaster theme={theme === "light" ? "light" : "dark"} position="bottom-center" richColors />
       <KeyboardShortcutsModal open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />
     </div>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -33,6 +33,10 @@ import type {
   AppearanceSettings,
   UserSubscriptions,
   SuggestionsAggregateResponse,
+  AchievementDef,
+  UserAchievement,
+  LeaderboardEntry,
+  StreakData,
 } from "./types";
 
 const BASE = "/api";
@@ -582,6 +586,7 @@ export interface Notifier {
   quiet_hours_days: string | null;
   leaving_soon_alerts_enabled: boolean;
   friend_activity_alerts_enabled: boolean;
+  achievements_enabled: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -612,6 +617,7 @@ export interface NotifierPayload {
   quiet_hours_days?: number[];
   leaving_soon_alerts_enabled?: boolean;
   friend_activity_alerts_enabled?: boolean;
+  achievements_enabled?: boolean;
 }
 
 export async function createNotifier(data: NotifierPayload & { provider: string; config: Record<string, string>; notify_time: string; timezone: string }): Promise<{ notifier: Notifier }> {
@@ -1232,4 +1238,35 @@ export async function dismissSuggestion(titleId: string, signal?: AbortSignal): 
 
 export async function undismissSuggestion(titleId: string, signal?: AbortSignal): Promise<void> {
   await fetchJson(`/suggestions/dismiss/${encodeURIComponent(titleId)}`, { method: "DELETE", signal });
+}
+
+// ─── Achievements ─────────────────────────────────────────────────────────────
+
+export async function getAchievementsRegistry(signal?: AbortSignal): Promise<AchievementDef[]> {
+  const data = await fetchJson<{ achievements: AchievementDef[] }>("/achievements", { signal });
+  return data.achievements;
+}
+
+export async function getMyAchievements(signal?: AbortSignal): Promise<UserAchievement[]> {
+  const data = await fetchJson<{ achievements: UserAchievement[] }>("/achievements/me", { signal });
+  return data.achievements;
+}
+
+export async function getUserAchievements(username: string, signal?: AbortSignal): Promise<UserAchievement[]> {
+  const data = await fetchJson<{ achievements: UserAchievement[] }>(`/achievements/u/${encodeURIComponent(username)}`, { signal });
+  // Server returns achievements without progress for other users; fill in defaults
+  return data.achievements.map((a) => ({ ...a, progress: a.progress ?? 0 }));
+}
+
+// ─── Leaderboard ──────────────────────────────────────────────────────────────
+
+export async function getLeaderboard(signal?: AbortSignal): Promise<LeaderboardEntry[]> {
+  const data = await fetchJson<{ entries: LeaderboardEntry[] }>("/leaderboard", { signal });
+  return data.entries;
+}
+
+// ─── Streak ───────────────────────────────────────────────────────────────────
+
+export async function getMyStreak(signal?: AbortSignal): Promise<StreakData> {
+  return fetchJson<StreakData>("/streak/me", { signal });
 }

--- a/frontend/src/components/profile/AchievementToast.test.tsx
+++ b/frontend/src/components/profile/AchievementToast.test.tsx
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { render, screen, act, cleanup } from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
+import type { UserAchievement } from "../../types";
+import * as api from "../../api";
+
+import { useNewAchievements } from "./AchievementToast";
+import AchievementToast from "./AchievementToast";
+
+// ---- localStorage helper -------------------------------------------------------
+// Bun's happy-dom localStorage is a native binding; spyOn cannot intercept it.
+// We replace the global with a plain-object mock so spyOn/mockReturnValue works.
+
+const storedData: Record<string, string> = {};
+
+const localStorageMock = {
+  getItem: (key: string): string | null => storedData[key] ?? null,
+  setItem: (key: string, value: string): void => { storedData[key] = value; },
+  removeItem: (key: string): void => { delete storedData[key]; },
+  clear: (): void => { for (const k of Object.keys(storedData)) delete storedData[k]; },
+  get length() { return Object.keys(storedData).length; },
+  key: (_index: number): string | null => null,
+};
+
+Object.defineProperty(globalThis, "localStorage", {
+  value: localStorageMock,
+  writable: true,
+  configurable: true,
+});
+
+// ---- factories -----------------------------------------------------------------
+
+function makeAchievement(overrides: Partial<UserAchievement> = {}): UserAchievement {
+  return {
+    key: "movies_10",
+    kind: "count_movies",
+    threshold: 10,
+    points: 10,
+    title: "Cinephile I",
+    description: "Watch 10 movies",
+    icon: "Film",
+    progress: 10,
+    earned: true,
+    earnedAt: "2026-01-01T12:00:00Z",
+    ...overrides,
+  };
+}
+
+// Helper: flush the initial setTimeout(0) + promise resolution used by the hook
+async function flushHookTimers() {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 20));
+  });
+}
+
+// ---- useNewAchievements hook ---------------------------------------------------
+
+describe("useNewAchievements", () => {
+  let spy: ReturnType<typeof spyOn<typeof api, "getMyAchievements">>;
+
+  beforeEach(() => {
+    spy = spyOn(api, "getMyAchievements").mockResolvedValue([]);
+    localStorageMock.clear();
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+    cleanup();
+  });
+
+  it("surfaces all earned achievements when localStorage has no lastSeenAchievementAt", async () => {
+    const achievement = makeAchievement();
+    spy.mockResolvedValue([achievement]);
+    // localStorage is cleared — no lastSeenAchievementAt stored
+
+    const { result } = renderHook(() => useNewAchievements());
+    await flushHookTimers();
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].key).toBe("movies_10");
+  });
+
+  it("surfaces only achievements earned after lastSeenAchievementAt", async () => {
+    const oldDate = "2025-01-01T00:00:00Z";
+    const newDate = "2026-06-01T00:00:00Z";
+    const oldAchievement = makeAchievement({ key: "movies_10", earnedAt: oldDate });
+    const newAchievement = makeAchievement({ key: "movies_50", title: "Cinephile II", earnedAt: newDate });
+
+    spy.mockResolvedValue([oldAchievement, newAchievement]);
+    // Set lastSeenAchievementAt between the two earnedAt dates
+    localStorageMock.setItem("lastSeenAchievementAt", "2026-01-01T00:00:00Z");
+
+    const { result } = renderHook(() => useNewAchievements());
+    await flushHookTimers();
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].key).toBe("movies_50");
+  });
+
+  it("returns empty array when all achievements are older than lastSeenAchievementAt", async () => {
+    const achievement = makeAchievement({ earnedAt: "2024-01-01T00:00:00Z" });
+    spy.mockResolvedValue([achievement]);
+    // lastSeenAchievementAt is newer than earnedAt
+    localStorageMock.setItem("lastSeenAchievementAt", "2026-01-01T00:00:00Z");
+
+    const { result } = renderHook(() => useNewAchievements());
+    await flushHookTimers();
+
+    expect(result.current).toHaveLength(0);
+  });
+
+  it("updates localStorage.lastSeenAchievementAt after surfacing new achievements", async () => {
+    const achievement = makeAchievement();
+    spy.mockResolvedValue([achievement]);
+    // No lastSeenAchievementAt stored
+
+    renderHook(() => useNewAchievements());
+    await flushHookTimers();
+
+    const stored = localStorageMock.getItem("lastSeenAchievementAt");
+    expect(stored).not.toBeNull();
+    expect(typeof stored).toBe("string");
+    // Should be a valid ISO date
+    expect(new Date(stored!).toString()).not.toBe("Invalid Date");
+  });
+
+  it("does not update localStorage when no new achievements are found", async () => {
+    const achievement = makeAchievement({ earnedAt: "2024-01-01T00:00:00Z" });
+    spy.mockResolvedValue([achievement]);
+    localStorageMock.setItem("lastSeenAchievementAt", "2026-01-01T00:00:00Z");
+
+    // Track calls manually via the mock storage
+    const before = localStorageMock.getItem("lastSeenAchievementAt");
+
+    renderHook(() => useNewAchievements());
+    await flushHookTimers();
+
+    // The stored value should remain unchanged (not updated to a newer timestamp)
+    const after = localStorageMock.getItem("lastSeenAchievementAt");
+    expect(after).toBe(before);
+  });
+});
+
+// ---- AchievementToast component -----------------------------------------------
+
+describe("AchievementToast", () => {
+  let spy: ReturnType<typeof spyOn<typeof api, "getMyAchievements">>;
+
+  beforeEach(() => {
+    spy = spyOn(api, "getMyAchievements").mockResolvedValue([]);
+    localStorageMock.clear();
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+    cleanup();
+  });
+
+  it("renders a toast for each new achievement", async () => {
+    const a1 = makeAchievement({ key: "movies_10", title: "Cinephile I" });
+    const a2 = makeAchievement({ key: "movies_50", title: "Cinephile II" });
+    spy.mockResolvedValue([a1, a2]);
+
+    render(<AchievementToast />);
+    await flushHookTimers();
+
+    expect(screen.getByText("Cinephile I")).toBeDefined();
+    expect(screen.getByText("Cinephile II")).toBeDefined();
+  });
+
+  it("shows 'Achievement unlocked' label in each toast", async () => {
+    const achievement = makeAchievement({ title: "Cinephile I" });
+    spy.mockResolvedValue([achievement]);
+
+    render(<AchievementToast />);
+    await flushHookTimers();
+
+    const labels = screen.getAllByText("Achievement unlocked");
+    expect(labels.length).toBeGreaterThan(0);
+  });
+
+  it("shows achievement title in the toast", async () => {
+    const achievement = makeAchievement({ key: "movies_10", title: "Cinephile I" });
+    spy.mockResolvedValue([achievement]);
+
+    render(<AchievementToast />);
+    await flushHookTimers();
+
+    expect(screen.getByText("Cinephile I")).toBeDefined();
+  });
+
+  it("renders nothing when there are no new achievements", async () => {
+    spy.mockResolvedValue([]);
+
+    const { container } = render(<AchievementToast />);
+    await flushHookTimers();
+
+    // The root fixed container should not be in the DOM when there are no toasts
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders alert roles for accessibility", async () => {
+    const achievement = makeAchievement({ title: "Cinephile I" });
+    spy.mockResolvedValue([achievement]);
+
+    render(<AchievementToast />);
+    await flushHookTimers();
+
+    const alerts = screen.getAllByRole("alert");
+    expect(alerts.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components/profile/AchievementToast.tsx
+++ b/frontend/src/components/profile/AchievementToast.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { Trophy } from "lucide-react";
 import * as api from "../../api";
 import type { UserAchievement } from "../../types";
@@ -9,40 +9,41 @@ const TOAST_DURATION_MS = 4_000;
 
 export function useNewAchievements(): UserAchievement[] {
   const [newAchievements, setNewAchievements] = useState<UserAchievement[]>([]);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  const check = async (signal?: AbortSignal) => {
-    try {
-      const all = await api.getMyAchievements(signal);
-      if (signal?.aborted) return;
-
-      const lastSeen = localStorage.getItem(STORAGE_KEY);
-      const lastSeenDate = lastSeen ? new Date(lastSeen) : null;
-
-      const fresh = all.filter((a) => {
-        if (!a.earned || !a.earnedAt) return false;
-        if (!lastSeenDate) return true;
-        return new Date(a.earnedAt) > lastSeenDate;
-      });
-
-      if (fresh.length > 0) {
-        setNewAchievements(fresh);
-        localStorage.setItem(STORAGE_KEY, new Date().toISOString());
-      }
-    } catch {
-      // ignore — best-effort polling
-    }
-  };
 
   useEffect(() => {
     const controller = new AbortController();
+
+    async function check() {
+      try {
+        const all = await api.getMyAchievements(controller.signal);
+        if (controller.signal.aborted) return;
+
+        const lastSeen = localStorage.getItem(STORAGE_KEY);
+        const lastSeenDate = lastSeen ? new Date(lastSeen) : null;
+
+        const fresh = all.filter((a) => {
+          if (!a.earned || !a.earnedAt) return false;
+          if (!lastSeenDate) return true;
+          return new Date(a.earnedAt) > lastSeenDate;
+        });
+
+        if (fresh.length > 0) {
+          setNewAchievements(fresh);
+          localStorage.setItem(STORAGE_KEY, new Date().toISOString());
+        }
+      } catch {
+        // ignore — best-effort polling
+      }
+    }
+
     // Delay initial check by one tick to avoid synchronous setState inside effect
-    const initialTimer = setTimeout(() => check(controller.signal), 0);
-    intervalRef.current = setInterval(() => check(), POLL_INTERVAL_MS);
+    const initialTimer = setTimeout(check, 0);
+    const intervalId = setInterval(check, POLL_INTERVAL_MS);
+
     return () => {
       clearTimeout(initialTimer);
+      clearInterval(intervalId);
       controller.abort();
-      if (intervalRef.current) clearInterval(intervalRef.current);
     };
   }, []);
 

--- a/frontend/src/components/profile/AchievementToast.tsx
+++ b/frontend/src/components/profile/AchievementToast.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState } from "react";
+import { Trophy } from "lucide-react";
+import * as api from "../../api";
+import type { UserAchievement } from "../../types";
+
+const STORAGE_KEY = "lastSeenAchievementAt";
+const POLL_INTERVAL_MS = 60_000;
+const TOAST_DURATION_MS = 4_000;
+
+export function useNewAchievements(): UserAchievement[] {
+  const [newAchievements, setNewAchievements] = useState<UserAchievement[]>([]);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const check = async (signal?: AbortSignal) => {
+    try {
+      const all = await api.getMyAchievements(signal);
+      if (signal?.aborted) return;
+
+      const lastSeen = localStorage.getItem(STORAGE_KEY);
+      const lastSeenDate = lastSeen ? new Date(lastSeen) : null;
+
+      const fresh = all.filter((a) => {
+        if (!a.earned || !a.earnedAt) return false;
+        if (!lastSeenDate) return true;
+        return new Date(a.earnedAt) > lastSeenDate;
+      });
+
+      if (fresh.length > 0) {
+        setNewAchievements(fresh);
+        localStorage.setItem(STORAGE_KEY, new Date().toISOString());
+      }
+    } catch {
+      // ignore — best-effort polling
+    }
+  };
+
+  useEffect(() => {
+    const controller = new AbortController();
+    // Delay initial check by one tick to avoid synchronous setState inside effect
+    const initialTimer = setTimeout(() => check(controller.signal), 0);
+    intervalRef.current = setInterval(() => check(), POLL_INTERVAL_MS);
+    return () => {
+      clearTimeout(initialTimer);
+      controller.abort();
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, []);
+
+  return newAchievements;
+}
+
+interface ToastItemProps {
+  achievement: UserAchievement;
+  onDismiss: () => void;
+}
+
+function ToastItem({ achievement, onDismiss }: ToastItemProps) {
+  useEffect(() => {
+    const timer = setTimeout(onDismiss, TOAST_DURATION_MS);
+    return () => clearTimeout(timer);
+  }, [onDismiss]);
+
+  return (
+    <div
+      className="flex items-center gap-3 px-4 py-3 rounded-xl bg-zinc-900 border border-amber-400/30 shadow-lg max-w-xs"
+      role="alert"
+    >
+      <div className="w-9 h-9 rounded-lg bg-amber-400/20 flex items-center justify-center shrink-0">
+        <Trophy size={18} className="text-amber-400" />
+      </div>
+      <div className="min-w-0">
+        <div className="text-xs font-mono font-semibold uppercase tracking-widest text-amber-400 mb-0.5">
+          Achievement unlocked
+        </div>
+        <div className="text-sm font-bold text-zinc-100 truncate">{achievement.title}</div>
+        <div className="text-xs text-zinc-400 truncate">{achievement.description}</div>
+      </div>
+    </div>
+  );
+}
+
+export default function AchievementToast() {
+  const newAchievements = useNewAchievements();
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set());
+
+  const dismiss = (key: string) => {
+    setDismissed((prev) => new Set(prev).add(key));
+  };
+
+  const visible = newAchievements.filter((a) => !dismissed.has(a.key));
+
+  if (visible.length === 0) return null;
+
+  return (
+    <div className="fixed bottom-20 right-4 z-50 flex flex-col gap-2 sm:bottom-6">
+      {visible.map((a) => (
+        <ToastItem key={a.key} achievement={a} onDismiss={() => dismiss(a.key)} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/profile/BadgesCard.test.tsx
+++ b/frontend/src/components/profile/BadgesCard.test.tsx
@@ -1,0 +1,83 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { render, screen, cleanup } from "@testing-library/react";
+import BadgesCard from "./BadgesCard";
+import type { UserAchievement } from "../../types";
+
+function makeAchievement(overrides: Partial<UserAchievement> = {}): UserAchievement {
+  return {
+    key: "movies_10",
+    kind: "count_movies",
+    threshold: 10,
+    points: 10,
+    title: "Cinephile I",
+    description: "Watch 10 movies",
+    icon: "Film",
+    progress: 0,
+    earned: false,
+    earnedAt: null,
+    ...overrides,
+  };
+}
+
+const earnedAchievement = makeAchievement({
+  key: "movies_10",
+  earned: true,
+  progress: 10,
+  earnedAt: "2024-01-01T00:00:00Z",
+});
+
+const lockedAchievement = makeAchievement({
+  key: "movies_50",
+  title: "Cinephile II",
+  threshold: 50,
+  progress: 12,
+  earned: false,
+  earnedAt: null,
+});
+
+describe("BadgesCard", () => {
+  test("renders earned badges as opaque tiles", () => {
+    render(<BadgesCard achievements={[earnedAchievement]} mode="self" />);
+    expect(screen.getByText("Cinephile I")).toBeDefined();
+  });
+
+  test("renders locked badges with progress in mode=self", () => {
+    render(
+      <BadgesCard achievements={[earnedAchievement, lockedAchievement]} mode="self" />
+    );
+    expect(screen.getByText("Cinephile II")).toBeDefined();
+  });
+
+  test("in mode=other, does NOT render locked badges", () => {
+    render(
+      <BadgesCard achievements={[earnedAchievement, lockedAchievement]} mode="other" />
+    );
+    expect(screen.getByText("Cinephile I")).toBeDefined();
+    expect(screen.queryByText("Cinephile II")).toBeNull();
+  });
+
+  test("renders X / Y earned count in header", () => {
+    render(
+      <BadgesCard achievements={[earnedAchievement, lockedAchievement]} mode="self" />
+    );
+    expect(screen.getByText("1 / 2 earned")).toBeDefined();
+  });
+
+  test("handles empty achievements array", () => {
+    const { container } = render(<BadgesCard achievements={[]} mode="self" />);
+    expect(screen.getByText("No badges yet.")).toBeDefined();
+    // The card itself still renders
+    expect(container.firstChild).toBeDefined();
+  });
+
+  test("in mode=other with all locked, renders nothing", () => {
+    const { container } = render(
+      <BadgesCard achievements={[lockedAchievement]} mode="other" />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+});

--- a/frontend/src/components/profile/BadgesCard.tsx
+++ b/frontend/src/components/profile/BadgesCard.tsx
@@ -1,0 +1,112 @@
+import {
+  Film,
+  Tv,
+  Flame,
+  Swords,
+  Laugh,
+  Skull,
+  Sparkles,
+  Compass,
+  CheckCircle2,
+  MessageCircle,
+  UserPlus,
+  Zap,
+  Trophy,
+  type LucideProps,
+} from "lucide-react";
+import type { ForwardRefExoticComponent, RefAttributes } from "react";
+import { DossierCard } from "./atoms/DossierCard";
+import { Kicker } from "../design/Kicker";
+import { ThinProgress } from "./atoms/ThinProgress";
+import type { UserAchievement } from "../../types";
+
+type IconComponent = ForwardRefExoticComponent<Omit<LucideProps, "ref"> & RefAttributes<SVGSVGElement>>;
+
+const ICON_MAP: Record<string, IconComponent> = {
+  Film,
+  Tv,
+  Flame,
+  Swords,
+  Laugh,
+  Skull,
+  Sparkles,
+  Compass,
+  CheckCircle2,
+  MessageCircle,
+  UserPlus,
+  Zap,
+};
+
+function BadgeIcon({ name, size = 20 }: { name: string; size?: number }) {
+  const Icon = ICON_MAP[name] ?? Trophy;
+  return <Icon size={size} />;
+}
+
+interface BadgesCardProps {
+  achievements: UserAchievement[];
+  mode: "self" | "other";
+}
+
+export default function BadgesCard({ achievements, mode }: BadgesCardProps) {
+  const earned = achievements.filter((a) => a.earned);
+  const locked = achievements.filter((a) => !a.earned);
+  const visible = mode === "self" ? achievements : earned;
+
+  if (visible.length === 0 && mode === "other") return null;
+
+  return (
+    <DossierCard>
+      <div className="flex items-baseline justify-between mb-3">
+        <Kicker color="zinc" className="mb-0">
+          Badges
+        </Kicker>
+        <span className="text-[11px] text-zinc-500 font-mono">
+          {earned.length} / {achievements.length} earned
+        </span>
+      </div>
+
+      {visible.length === 0 ? (
+        <p className="text-xs text-zinc-500">No badges yet.</p>
+      ) : (
+        <div className="grid grid-cols-2 gap-2">
+          {earned.map((a) => (
+            <div
+              key={a.key}
+              className="flex flex-col gap-1.5 p-2.5 rounded-lg bg-amber-400/[0.08] border border-amber-400/20"
+              title={a.description}
+            >
+              <div className="flex items-center gap-1.5 text-amber-400">
+                <BadgeIcon name={a.icon} size={16} />
+                <span className="text-[12px] font-semibold text-zinc-200 truncate leading-tight">
+                  {a.title}
+                </span>
+              </div>
+            </div>
+          ))}
+
+          {mode === "self" &&
+            locked.map((a) => (
+              <div
+                key={a.key}
+                className="flex flex-col gap-1.5 p-2.5 rounded-lg bg-white/[0.03] border border-white/[0.06] opacity-60"
+                title={a.description}
+              >
+                <div className="flex items-center gap-1.5 text-zinc-500">
+                  <BadgeIcon name={a.icon} size={16} />
+                  <span className="text-[12px] font-semibold text-zinc-400 truncate leading-tight">
+                    {a.title}
+                  </span>
+                </div>
+                <ThinProgress
+                  value={a.progress}
+                  max={a.threshold}
+                  color="#71717a"
+                  height={3}
+                />
+              </div>
+            ))}
+        </div>
+      )}
+    </DossierCard>
+  );
+}

--- a/frontend/src/components/profile/StreakCounter.test.tsx
+++ b/frontend/src/components/profile/StreakCounter.test.tsx
@@ -1,0 +1,59 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { render, screen, cleanup } from "@testing-library/react";
+import StreakCounter from "./StreakCounter";
+import type { StreakData } from "../../types";
+
+function makeStreak(overrides: Partial<StreakData> = {}): StreakData {
+  return {
+    currentStreak: 5,
+    longestStreak: 10,
+    lastWatchDate: "2024-01-10",
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("StreakCounter", () => {
+  test("renders current streak number", () => {
+    render(<StreakCounter streak={makeStreak({ currentStreak: 7 })} variant="sidebar" />);
+    expect(screen.getByText("7")).toBeDefined();
+  });
+
+  test("renders longest streak in sidebar variant", () => {
+    render(<StreakCounter streak={makeStreak({ longestStreak: 42 })} variant="sidebar" />);
+    expect(screen.getByText(/42 days/)).toBeDefined();
+  });
+
+  test("shows 0 streak gracefully", () => {
+    render(
+      <StreakCounter streak={makeStreak({ currentStreak: 0, longestStreak: 0 })} variant="inline" />
+    );
+    expect(screen.getByText("0")).toBeDefined();
+  });
+
+  test("sidebar variant renders DossierCard shell with Streak kicker", () => {
+    const { container } = render(
+      <StreakCounter streak={makeStreak()} variant="sidebar" />
+    );
+    expect(screen.getByText("Streak")).toBeDefined();
+    // DossierCard renders a card element
+    expect(container.querySelector("[class*='p-4']")).toBeDefined();
+  });
+
+  test("inline variant does not render card shell", () => {
+    render(<StreakCounter streak={makeStreak()} variant="inline" />);
+    // No "Streak" kicker in inline mode
+    expect(screen.queryByText("Streak")).toBeNull();
+    // But still shows the streak number
+    expect(screen.getByText("5")).toBeDefined();
+  });
+
+  test("home variant renders without DossierCard kicker", () => {
+    render(<StreakCounter streak={makeStreak({ currentStreak: 3 })} variant="home" />);
+    expect(screen.getByText("3")).toBeDefined();
+    expect(screen.queryByText("Streak")).toBeNull();
+  });
+});

--- a/frontend/src/components/profile/StreakCounter.tsx
+++ b/frontend/src/components/profile/StreakCounter.tsx
@@ -1,0 +1,75 @@
+import { Flame } from "lucide-react";
+import { DossierCard } from "./atoms/DossierCard";
+import { Kicker } from "../design/Kicker";
+import type { StreakData } from "../../types";
+
+interface StreakCounterProps {
+  streak: StreakData;
+  variant: "sidebar" | "home" | "inline";
+}
+
+const TOOLTIP = "Streak resets at midnight UTC";
+
+function StreakDisplay({ streak }: { streak: StreakData }) {
+  return (
+    <div className="flex items-center gap-2" title={TOOLTIP}>
+      <Flame className="text-amber-400 shrink-0" size={20} />
+      <span className="text-2xl font-extrabold text-amber-400 tabular-nums">
+        {streak.currentStreak}
+      </span>
+      <span className="text-sm text-zinc-400 font-medium">day streak</span>
+    </div>
+  );
+}
+
+export default function StreakCounter({ streak, variant }: StreakCounterProps) {
+  if (variant === "sidebar") {
+    return (
+      <DossierCard>
+        <Kicker color="zinc">Streak</Kicker>
+        <StreakDisplay streak={streak} />
+        {streak.longestStreak > 0 && (
+          <p className="text-xs text-zinc-500 font-mono mt-1.5">
+            Longest: {streak.longestStreak} days
+          </p>
+        )}
+      </DossierCard>
+    );
+  }
+
+  if (variant === "home") {
+    return (
+      <div
+        className="flex items-center gap-3 px-4 py-3 rounded-xl bg-amber-400/[0.06] border border-amber-400/20"
+        title={TOOLTIP}
+      >
+        <Flame className="text-amber-400 shrink-0" size={22} />
+        <div>
+          <div className="flex items-baseline gap-1.5">
+            <span className="text-xl font-extrabold text-amber-400 tabular-nums">
+              {streak.currentStreak}
+            </span>
+            <span className="text-sm text-zinc-300 font-medium">day streak</span>
+          </div>
+          {streak.longestStreak > 0 && (
+            <p className="text-[11px] text-zinc-500 font-mono">
+              Longest: {streak.longestStreak} days
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // inline variant
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 text-amber-400 font-bold"
+      title={TOOLTIP}
+    >
+      <Flame size={16} />
+      <span className="text-base tabular-nums">{streak.currentStreak}</span>
+      <span className="text-xs text-zinc-400 font-medium">day streak</span>
+    </span>
+  );
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -501,7 +501,8 @@
         "today": "Today's Episodes",
         "upcoming": "Coming Up",
         "airing_soon": "Airing Soon",
-        "friends_loved": "Friends Loved This Week"
+        "friends_loved": "Friends Loved This Week",
+        "streak": "Daily Streak"
       }
     },
     "crowdedWeek": {

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -7,8 +7,9 @@ import { useTranslation } from "react-i18next";
 import { useAuth } from "../context/AuthContext";
 import { useIsMobile } from "../hooks/useIsMobile";
 import * as api from "../api";
-import type { Episode, Title, Recommendation, HomepageSection, FriendsLovedItem } from "../types";
+import type { Episode, Title, Recommendation, HomepageSection, FriendsLovedItem, StreakData } from "../types";
 import { normalizeSearchTitle, DEFAULT_HOMEPAGE_LAYOUT } from "../types";
+import StreakCounter from "../components/profile/StreakCounter";
 import TitleList from "../components/TitleList";
 import { HomeAuthSkeleton } from "../components/SkeletonComponents";
 import { groupByShow, formatUpcomingDate } from "../components/EpisodeComponents";
@@ -132,11 +133,13 @@ function MobileFeedHome({
   today,
   upcoming,
   unwatched,
+  streak,
 }: {
   user: NonNullable<ReturnType<typeof useAuth>["user"]>;
   today: Episode[];
   upcoming: Episode[];
   unwatched: Episode[];
+  streak: StreakData | null;
 }) {
   const tonightEp = today[0] ?? null;
   const alsoAiring = today.slice(1);
@@ -163,6 +166,11 @@ function MobileFeedHome({
           <div className="text-[22px] font-bold tracking-[-0.6px]">
             {getGreeting()}, <span className="text-amber-400">{user.display_name?.split(" ")[0] ?? user.username}</span>
           </div>
+          {streak && streak.currentStreak > 0 && (
+            <div className="mt-1">
+              <StreakCounter variant="inline" streak={streak} />
+            </div>
+          )}
         </div>
         <Link to="/browse" className="w-[38px] h-[38px] rounded-full bg-white/[0.06] border border-white/[0.08] flex items-center justify-center text-zinc-400 text-base shrink-0">
           ⌕
@@ -331,6 +339,7 @@ export default function HomePage() {
   const [state, dispatch] = useReducer(homeReducer, { status: "loading" });
   const [confirmingTitleId, setConfirmingTitleId] = useState<string | null>(null);
   const confirmTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [streakData, setStreakData] = useState<StreakData | null>(null);
 
   useEffect(() => {
     if (authLoading) return;
@@ -346,14 +355,16 @@ export default function HomePage() {
 
     async function load() {
       try {
-        const [episodeData, recData, layoutData, upNextData, friendsLovedData] = await Promise.all([
+        const [episodeData, recData, layoutData, upNextData, friendsLovedData, streakResult] = await Promise.all([
           api.getUpcomingEpisodes(signal),
           api.getRecommendations(6, undefined, signal).catch(() => ({ recommendations: [], count: 0 })),
           (api.getHomepageLayout?.(signal) ?? Promise.resolve({ homepage_layout: DEFAULT_HOMEPAGE_LAYOUT })).catch(() => ({ homepage_layout: DEFAULT_HOMEPAGE_LAYOUT })),
           api.getUpNext(12, signal).catch(() => ({ items: [] as UpNextItem[] })),
           api.getFriendsLoved(20, signal).catch(() => ({ items: [] as FriendsLovedItem[] })),
+          api.getMyStreak(signal).catch(() => null),
         ]);
         if (signal.aborted) return;
+        if (streakResult) setStreakData(streakResult);
         dispatch({ type: "LOAD_AUTH_SUCCESS", today: episodeData.today, upcoming: episodeData.upcoming, unwatched: episodeData.unwatched, recommendations: recData.recommendations, layout: layoutData.homepage_layout, upNextItems: upNextData.items, friendsLovedItems: friendsLovedData.items });
       } catch (err: unknown) {
         if (!signal.aborted) dispatch({ type: "LOAD_ERROR", message: err instanceof Error ? err.message : String(err) });
@@ -543,7 +554,7 @@ export default function HomePage() {
   }
 
   if (isMobile && user) {
-    return <MobileFeedHome user={user} today={today} upcoming={upcoming} unwatched={unwatched} />;
+    return <MobileFeedHome user={user} today={today} upcoming={upcoming} unwatched={unwatched} streak={streakData} />;
   }
 
   const noEpisodes = today.length === 0 && upcoming.length === 0 && unwatched.length === 0;
@@ -760,6 +771,13 @@ export default function HomePage() {
 
       case "friends_loved":
         return <FriendsLovedRow key="friends_loved" items={friendsLovedItems} />;
+
+      case "streak":
+        return streakData && streakData.currentStreak > 0 ? (
+          <section key="streak">
+            <StreakCounter variant="home" streak={streakData} />
+          </section>
+        ) : null;
 
       default:
         return null;

--- a/frontend/src/pages/LeaderboardPage.test.tsx
+++ b/frontend/src/pages/LeaderboardPage.test.tsx
@@ -12,6 +12,8 @@ mock.module("../context/AuthContext", () => ({
     user: { id: "current-user", username: "me", display_name: "Me", auth_provider: "local", is_admin: false },
     providers: { local: true, oidc: null },
     loading: false,
+    subscriptions: null,
+    refreshSubscriptions: mock(() => Promise.resolve()),
     login: mock(() => Promise.resolve()),
     signup: mock(() => Promise.resolve()),
     logout: mock(() => Promise.resolve()),

--- a/frontend/src/pages/LeaderboardPage.test.tsx
+++ b/frontend/src/pages/LeaderboardPage.test.tsx
@@ -1,0 +1,138 @@
+import { describe, test, expect, spyOn, afterEach, beforeEach, mock } from "bun:test";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import type { ReactNode } from "react";
+import * as api from "../api";
+import type { LeaderboardEntry } from "../types";
+
+// Mock AuthContext to avoid null context errors.
+// Returns a full shape so cross-file leaks don't corrupt other tests.
+mock.module("../context/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: "current-user", username: "me", display_name: "Me", auth_provider: "local", is_admin: false },
+    providers: { local: true, oidc: null },
+    loading: false,
+    login: mock(() => Promise.resolve()),
+    signup: mock(() => Promise.resolve()),
+    logout: mock(() => Promise.resolve()),
+    refresh: mock(() => Promise.resolve()),
+  }),
+  AuthContext: {
+    Provider: ({ children }: { children: ReactNode }) => children,
+  },
+}));
+
+const { default: LeaderboardPage } = await import("./LeaderboardPage");
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
+
+function makeEntry(overrides: Partial<LeaderboardEntry> = {}): LeaderboardEntry {
+  return {
+    userId: "u1",
+    username: "alice",
+    name: "Alice",
+    image: null,
+    xp: 100,
+    badgeCount: 3,
+    rank: 1,
+    ...overrides,
+  };
+}
+
+let getLeaderboardSpy: ReturnType<typeof spyOn<typeof api, "getLeaderboard">>;
+
+beforeEach(() => {
+  getLeaderboardSpy = spyOn(api, "getLeaderboard");
+});
+
+afterEach(() => {
+  getLeaderboardSpy.mockRestore();
+  cleanup();
+});
+
+describe("LeaderboardPage", () => {
+  test("loading state renders skeleton", async () => {
+    // Never resolves — stays in loading during render
+    getLeaderboardSpy.mockImplementation(() => new Promise(() => {}));
+
+    const { container } = render(<LeaderboardPage />, { wrapper: Wrapper });
+
+    // Loading shows animate-pulse skeleton divs
+    expect(container.querySelector(".animate-pulse")).toBeDefined();
+    // Title not shown during loading
+    expect(screen.queryByRole("heading", { name: "Leaderboard" })).toBeNull();
+  });
+
+  test("shows podium for top 3", async () => {
+    const entries = [
+      makeEntry({ userId: "u1", username: "alice", rank: 1, xp: 300 }),
+      makeEntry({ userId: "u2", username: "bob", rank: 2, xp: 200 }),
+      makeEntry({ userId: "u3", username: "charlie", rank: 3, xp: 100 }),
+    ];
+    getLeaderboardSpy.mockImplementation(() => Promise.resolve(entries));
+
+    render(<LeaderboardPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Leaderboard").length).toBeGreaterThanOrEqual(1);
+    });
+
+    expect(screen.getByText("#1")).toBeDefined();
+    expect(screen.getByText("#2")).toBeDefined();
+    expect(screen.getByText("#3")).toBeDefined();
+  });
+
+  test("empty state when only self in results (length 1)", async () => {
+    getLeaderboardSpy.mockImplementation(() =>
+      Promise.resolve([makeEntry({ userId: "u1", username: "solo", rank: 1 })])
+    );
+
+    render(<LeaderboardPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Follow people to see them on the leaderboard/)).toBeDefined();
+    });
+  });
+
+  test("highlights current user row", async () => {
+    const entries = [
+      makeEntry({ userId: "u1", username: "alice", name: "Alice", rank: 1, xp: 300 }),
+      makeEntry({ userId: "current-user", username: "me", name: "Me", rank: 2, xp: 200 }),
+      makeEntry({ userId: "u3", username: "charlie", name: "Charlie", rank: 3, xp: 100 }),
+    ];
+    getLeaderboardSpy.mockImplementation(() => Promise.resolve(entries));
+
+    render(<LeaderboardPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Leaderboard").length).toBeGreaterThanOrEqual(1);
+    });
+
+    // The current user entries should have highlighted styling — verify render
+    expect(screen.getByText("#2")).toBeDefined();
+  });
+
+  test("error state shows error message", async () => {
+    getLeaderboardSpy.mockImplementation(() =>
+      Promise.reject(new Error("Network error"))
+    );
+
+    render(<LeaderboardPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Network error")).toBeDefined();
+    });
+  });
+
+  test("empty array shows empty state", async () => {
+    getLeaderboardSpy.mockImplementation(() => Promise.resolve([]));
+
+    render(<LeaderboardPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Follow people to see them on the leaderboard/)).toBeDefined();
+    });
+  });
+});

--- a/frontend/src/pages/LeaderboardPage.tsx
+++ b/frontend/src/pages/LeaderboardPage.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useState } from "react";
+import { Trophy, Star } from "lucide-react";
+import * as api from "../api";
+import { useAuth } from "../context/AuthContext";
+import { Avatar } from "../components/profile/atoms/Avatar";
+import type { LeaderboardEntry } from "../types";
+
+function PodiumSpot({
+  entry,
+  currentUserId,
+}: {
+  entry: LeaderboardEntry;
+  currentUserId: string | undefined;
+}) {
+  const isMe = entry.userId === currentUserId;
+  const rankColors: Record<number, string> = {
+    1: "text-amber-400",
+    2: "text-zinc-300",
+    3: "text-amber-700",
+  };
+  const textColor = rankColors[entry.rank] ?? "text-zinc-400";
+
+  return (
+    <div
+      className={`flex flex-col items-center gap-2 px-4 py-4 rounded-xl border ${
+        isMe ? "border-amber-400/40 bg-amber-400/[0.06]" : "border-white/[0.06] bg-white/[0.02]"
+      }`}
+    >
+      <span className={`font-mono text-2xl font-extrabold ${textColor}`}>#{entry.rank}</span>
+      <Avatar
+        username={entry.username}
+        displayName={entry.name}
+        image={entry.image}
+        size={48}
+      />
+      <div className="text-center min-w-0">
+        <div className="text-sm font-bold text-zinc-100 truncate max-w-[120px]">
+          {entry.name ?? entry.username}
+        </div>
+        <div className="font-mono text-xs text-zinc-400 truncate">@{entry.username}</div>
+      </div>
+      <div className="flex items-center gap-1.5">
+        <Star size={13} className="text-amber-400" />
+        <span className="font-mono text-sm font-bold text-amber-400">{entry.xp} XP</span>
+      </div>
+      <div className="font-mono text-xs text-zinc-500">{entry.badgeCount} badge{entry.badgeCount !== 1 ? "s" : ""}</div>
+    </div>
+  );
+}
+
+export default function LeaderboardPage() {
+  const { user } = useAuth();
+  const [entries, setEntries] = useState<LeaderboardEntry[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    api
+      .getLeaderboard(controller.signal)
+      .then((data) => {
+        if (controller.signal.aborted) return;
+        setEntries(data);
+      })
+      .catch((err: unknown) => {
+        if (controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+    return () => controller.abort();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="max-w-2xl mx-auto space-y-4">
+        <div className="h-8 w-48 bg-zinc-800 rounded animate-pulse" />
+        <div className="grid grid-cols-3 gap-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-40 bg-zinc-800 rounded-xl animate-pulse" />
+          ))}
+        </div>
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="h-14 bg-zinc-800 rounded-xl animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="max-w-2xl mx-auto">
+        <div className="bg-red-900/40 border border-red-800 text-red-200 px-4 py-3 rounded-lg text-sm">
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  if (!entries || entries.length <= 1) {
+    return (
+      <div className="max-w-2xl mx-auto space-y-6">
+        <div>
+          <div className="font-mono text-[11px] uppercase tracking-[0.15em] text-amber-400 font-semibold mb-1">
+            Leaderboard
+          </div>
+          <h1 className="text-2xl font-extrabold tracking-tight">Leaderboard</h1>
+          <p className="text-zinc-400 text-sm mt-1">Among people you follow</p>
+        </div>
+        <div className="text-center py-12">
+          <Trophy size={40} className="text-zinc-600 mx-auto mb-3" />
+          <p className="text-zinc-400">Follow people to see them on the leaderboard.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const podium = entries.slice(0, 3);
+  const rest = entries.slice(3);
+
+  // Reorder podium for visual display: 2nd left, 1st center, 3rd right
+  const podiumDisplay =
+    podium.length === 3
+      ? [podium[1]!, podium[0]!, podium[2]!]
+      : podium;
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-6">
+      <div>
+        <div className="font-mono text-[11px] uppercase tracking-[0.15em] text-amber-400 font-semibold mb-1">
+          Leaderboard
+        </div>
+        <h1 className="text-2xl font-extrabold tracking-tight">Leaderboard</h1>
+        <p className="text-zinc-400 text-sm mt-1">Among people you follow</p>
+      </div>
+
+      {/* Podium */}
+      <div className={`grid gap-3 ${podium.length === 3 ? "grid-cols-3" : podium.length === 2 ? "grid-cols-2" : "grid-cols-1 max-w-xs mx-auto"}`}>
+        {podiumDisplay.map((entry) => (
+          <PodiumSpot key={entry.userId} entry={entry} currentUserId={user?.id} />
+        ))}
+      </div>
+
+      {/* Ranked list */}
+      {rest.length > 0 && (
+        <div className="space-y-1.5">
+          {rest.map((entry) => {
+            const isMe = entry.userId === user?.id;
+            return (
+              <div
+                key={entry.userId}
+                className={`flex items-center gap-3 px-4 py-3 rounded-xl border ${
+                  isMe
+                    ? "border-amber-400/30 bg-amber-400/[0.05]"
+                    : "border-white/[0.05] bg-white/[0.02]"
+                }`}
+              >
+                <span className="font-mono text-sm font-bold text-zinc-500 w-6 shrink-0">
+                  #{entry.rank}
+                </span>
+                <Avatar
+                  username={entry.username}
+                  displayName={entry.name}
+                  image={entry.image}
+                  size={32}
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-semibold text-zinc-100 truncate">
+                    {entry.name ?? entry.username}
+                  </div>
+                  <div className="font-mono text-xs text-zinc-500 truncate">
+                    @{entry.username}
+                  </div>
+                </div>
+                <div className="text-right shrink-0">
+                  <div className="font-mono text-sm font-bold text-amber-400">{entry.xp} XP</div>
+                  <div className="font-mono text-xs text-zinc-500">{entry.badgeCount} badges</div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -169,7 +169,7 @@ export default function UserProfilePage() {
               <StreakCounter streak={streakData} variant="sidebar" />
             )}
             {show_watchlist && <ProgressCard overview={overview} />}
-            {achievements && achievements.length > 0 && (
+            {show_watchlist && achievements && achievements.length > 0 && (
               <BadgesCard
                 achievements={achievements}
                 mode={is_own_profile ? "self" : "other"}

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Card } from "../components/ui/card";
 import { Link, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import * as api from "../api";
-import type { PinnedTitle } from "../types";
+import type { PinnedTitle, UserAchievement, StreakData } from "../types";
 import { useAuth } from "../context/AuthContext";
 import ProfileHero from "../components/profile/ProfileHero";
 import BioCard from "../components/profile/BioCard";
@@ -21,6 +21,8 @@ import WatchlistTabs, {
 import WatchlistGrid from "../components/profile/WatchlistGrid";
 import { TitleGridSkeleton } from "../components/SkeletonComponents";
 import { useApiCall } from "../hooks/useApiCall";
+import BadgesCard from "../components/profile/BadgesCard";
+import StreakCounter from "../components/profile/StreakCounter";
 
 export default function UserProfilePage() {
   const { username } = useParams<{ username: string }>();
@@ -35,6 +37,38 @@ export default function UserProfilePage() {
   const [activeTab, setActiveTab] = useState<WatchlistTab>("watching");
   const [localBio, setLocalBio] = useState<string | null | undefined>(undefined);
   const [localPinned, setLocalPinned] = useState<PinnedTitle[] | null>(null);
+  const [achievements, setAchievements] = useState<UserAchievement[] | null>(null);
+  const [streakData, setStreakData] = useState<StreakData | null>(null);
+
+  // Fetch achievements for the profile user
+  useEffect(() => {
+    if (!username) return;
+    const controller = new AbortController();
+    const fetchAchievements = async () => {
+      try {
+        const isOwn = currentUser?.username === username;
+        const result = isOwn
+          ? await api.getMyAchievements(controller.signal)
+          : await api.getUserAchievements(username, controller.signal);
+        if (!controller.signal.aborted) setAchievements(result);
+      } catch {
+        // Silently fail (e.g. private profile)
+      }
+    };
+    fetchAchievements();
+    return () => controller.abort();
+  }, [username, currentUser?.username]);
+
+  // Fetch streak for own profile only
+  useEffect(() => {
+    if (!currentUser || currentUser.username !== username) return;
+    const controller = new AbortController();
+    api
+      .getMyStreak(controller.signal)
+      .then((data) => { if (!controller.signal.aborted) setStreakData(data); })
+      .catch(() => { /* ignore */ });
+    return () => controller.abort();
+  }, [username, currentUser]);
 
   const handleFollowToggle = useCallback((isNowFollowing: boolean) => {
     setFollowerAdjust((prev) => prev + (isNowFollowing ? 1 : -1));
@@ -131,7 +165,16 @@ export default function UserProfilePage() {
                 onPinnedChanged={(next) => setLocalPinned(next)}
               />
             )}
+            {show_watchlist && streakData && streakData.currentStreak > 0 && (
+              <StreakCounter streak={streakData} variant="sidebar" />
+            )}
             {show_watchlist && <ProgressCard overview={overview} />}
+            {achievements && achievements.length > 0 && (
+              <BadgesCard
+                achievements={achievements}
+                mode={is_own_profile ? "self" : "other"}
+              />
+            )}
             {show_watchlist && genres.length > 0 && <TopGenresCard genres={genres} limit={6} />}
             {show_watchlist && friends.length > 0 && (
               <FriendsCard

--- a/frontend/src/pages/settings/AppearanceTab.tsx
+++ b/frontend/src/pages/settings/AppearanceTab.tsx
@@ -22,6 +22,7 @@ const SECTION_LABELS: Record<string, string> = {
   upcoming: "settings.homepage.sections.upcoming",
   airing_soon: "settings.homepage.sections.airing_soon",
   friends_loved: "settings.homepage.sections.friends_loved",
+  streak: "settings.homepage.sections.streak",
 };
 
 const DEFAULT_APPEARANCE: AppearanceSettings = {

--- a/frontend/src/pages/settings/NotificationsTab.tsx
+++ b/frontend/src/pages/settings/NotificationsTab.tsx
@@ -369,6 +369,7 @@ function NotificationsSection() {
   const [formQuietDays, setFormQuietDays] = useState<number[]>([]);
   const [formLeavingSoon, setFormLeavingSoon] = useState(true);
   const [formFriendActivity, setFormFriendActivity] = useState(false);
+  const [formAchievements, setFormAchievements] = useState(false);
   const [saving, setSaving] = useState(false);
 
   const refresh = useCallback((signal?: AbortSignal) => {
@@ -406,6 +407,7 @@ function NotificationsSection() {
     setFormQuietDays([]);
     setFormLeavingSoon(true);
     setFormFriendActivity(false);
+    setFormAchievements(false);
     setShowForm(false);
     setEditingId(null);
   }
@@ -429,6 +431,7 @@ function NotificationsSection() {
     setFormQuietDays(n.quiet_hours_days ? n.quiet_hours_days.split(",").map(Number).filter((d) => d >= 0 && d <= 6) : []);
     setFormLeavingSoon(n.leaving_soon_alerts_enabled !== false);
     setFormFriendActivity(n.friend_activity_alerts_enabled === true);
+    setFormAchievements(n.achievements_enabled === true);
     setShowForm(true);
     setMsg("");
     setErr("");
@@ -467,6 +470,7 @@ function NotificationsSection() {
         quiet_hours_days: formQuietDays.length > 0 ? formQuietDays : undefined,
         leaving_soon_alerts_enabled: formLeavingSoon,
         friend_activity_alerts_enabled: formFriendActivity,
+        achievements_enabled: formAchievements,
       };
       if (editingId) {
         await api.updateNotifier(editingId, {
@@ -915,6 +919,12 @@ function NotificationsSection() {
               sub="Fires when someone you follow rates a title 4★ or higher"
               on={formFriendActivity}
               onChange={setFormFriendActivity}
+            />
+            <SSwitch
+              label="Achievement notifications"
+              sub="Get notified when you earn a new badge"
+              on={formAchievements}
+              onChange={setFormAchievements}
             />
 
             <div className="flex gap-2 mt-5 flex-wrap">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -732,7 +732,7 @@ export interface AppearanceSettings {
   autoplayTrailers: number;
 }
 
-export type HomepageSectionId = "up_next" | "unwatched" | "recommendations" | "today" | "upcoming" | "airing_soon" | "friends_loved";
+export type HomepageSectionId = "up_next" | "unwatched" | "recommendations" | "today" | "upcoming" | "airing_soon" | "friends_loved" | "streak";
 
 export interface HomepageSection {
   id: HomepageSectionId;
@@ -740,6 +740,7 @@ export interface HomepageSection {
 }
 
 export const DEFAULT_HOMEPAGE_LAYOUT: HomepageSection[] = [
+  { id: "streak", enabled: true },
   { id: "up_next", enabled: true },
   { id: "unwatched", enabled: true },
   { id: "recommendations", enabled: true },
@@ -851,4 +852,40 @@ export interface SuggestionsGroup {
 export interface SuggestionsAggregateResponse {
   flat: SearchTitle[];
   groups: SuggestionsGroup[];
+}
+
+// ─── Gamification Types ───────────────────────────────────────────────────────
+
+export interface AchievementDef {
+  key: string;
+  kind: string;
+  threshold: number;
+  points: number;
+  title: string;
+  description: string;
+  icon: string;
+  genre?: string;
+  windowHours?: number;
+}
+
+export interface UserAchievement extends AchievementDef {
+  progress: number;
+  earned: boolean;
+  earnedAt: string | null;
+}
+
+export interface LeaderboardEntry {
+  userId: string;
+  username: string;
+  name: string | null;
+  image: string | null;
+  xp: number;
+  badgeCount: number;
+  rank: number;
+}
+
+export interface StreakData {
+  currentStreak: number;
+  longestStreak: number;
+  lastWatchDate: string | null;
 }


### PR DESCRIPTION
## Summary

Part 3/3 of #375 — closes the gamification feature by adding the full frontend surface:

- **`BadgesCard`** — profile sidebar card showing earned badges (with icon + title) and locked badges with `ThinProgress` bars in `mode="self"`, earned-only in `mode="other"`
- **`StreakCounter`** — three variants (`sidebar`, `home`, `inline`) with Flame icon, current streak, longest streak, and tooltip "Streak resets at midnight UTC"
- **`AchievementToast`** — polling hook (`useNewAchievements`) checks every 60s for newly earned achievements via `localStorage` timestamp comparison; renders bottom-right stacked toasts that auto-dismiss after 4s
- **`LeaderboardPage`** — `/leaderboard` route with top-3 podium (2nd–1st–3rd display order), ranked list, current-user row highlight, empty state, and error state
- **API functions** — `getAchievementsRegistry`, `getMyAchievements`, `getUserAchievements`, `getLeaderboard`, `getMyStreak`
- **Types** — `AchievementDef`, `UserAchievement`, `LeaderboardEntry`, `StreakData`; `HomepageSectionId` extended with `"streak"`
- **`UserProfilePage`** — fetches achievements (own vs other) and streak; inserts `StreakCounter` + `BadgesCard` into sidebar between `ProgressCard` and `TopGenresCard`
- **`HomePage`** — fetches streak alongside other data; `renderSection("streak")` for desktop; inline streak in `MobileFeedHome` header
- **`NotificationsTab`** — `achievements_enabled` toggle added to notifier form, `startEdit`, `resetForm`, and `handleSave` (mirrors `friend_activity_alerts_enabled` pattern)

## Test plan

- [ ] `BadgesCard.test.tsx` — 6 tests: earned tiles, locked tiles in self mode, hidden in other mode, count header, empty array
- [ ] `StreakCounter.test.tsx` — 6 tests: current streak, longest streak, zero streak, sidebar vs inline variants
- [ ] `LeaderboardPage.test.tsx` — 6 tests: loading skeleton, podium for top 3, current user highlight, empty state, error state, empty array

All 2832 tests pass (`bun run check` ✅).

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)