### PR TITLE
fix(jobs): hasActiveJob always returned true (Drizzle .get() returns undefined not null)

### DIFF
--- a/server/jobs/enqueue.ts
+++ b/server/jobs/enqueue.ts
@@ -30,5 +30,5 @@ export async function hasActiveJob(name: string): Promise<boolean> {
     .from(jobs)
     .where(and(eq(jobs.name, name), inArray(jobs.status, ["pending", "running", "completed"])))
     .get();
-  return row !== null;
+  return row != null;
 }


### PR DESCRIPTION
## Summary

- `hasActiveJob()` in `server/jobs/enqueue.ts` used `row !== null` to check whether Drizzle found a matching row, but Drizzle's `.get()` returns `undefined` when no row matches — not `null`
- `undefined !== null` is always `true`, so the guard in `syncAchievementRegistry()` always skipped enqueuing the achievements backfill job
- Result: `achievements_backfill_done` was never set, `user_achievements` remained empty, but no error was logged

## Root cause spotted via

Querying the CF D1 prod DB: the `achievements` table had 20 definition rows (sync ran fine) but zero `backfill-achievements` jobs had ever been inserted and zero `user_achievements` rows existed.

## Fix

`row !== null` → `row != null` (loose equality catches both `null` and `undefined`)

## Immediate mitigation

Inserted a `backfill-achievements` job directly into D1 prod so the 4 existing users get their achievements backfilled immediately without waiting for this deploy.

## Test plan
- [x] `bun run check` passes (all phases green)
- [x] Manually verified D1 prod had 0 `backfill-achievements` jobs and 0 `user_achievements` rows before fix
- [x] Manually inserted backfill job into D1 prod to unblock existing users

Closes #725

🤖 Generated with [Claude Code](https://claude.com/claude-code)