### PR TITLE
fix(jobs): route achievements enqueues through DO backend dispatcher

### DIFF
--- a/server/achievements/sync.test.ts
+++ b/server/achievements/sync.test.ts
@@ -1,11 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { eq } from "drizzle-orm";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
 import { ACHIEVEMENTS } from "./definitions";
 import { syncAchievementRegistry } from "./sync";
 import { listAchievementDefs } from "../db/repository/achievements";
 import { getDb } from "../db/schema";
-import { achievements } from "../db/schema";
+import { achievements, settings } from "../db/schema";
+import * as backend from "../jobs/backend";
 
 beforeEach(() => setupTestDb());
 afterEach(() => teardownTestDb());
@@ -51,6 +52,22 @@ describe("syncAchievementRegistry", () => {
     expect(orphan).toBeDefined();
     // Plus all registry entries
     expect(all.length).toBe(ACHIEVEMENTS.length + 1);
+  });
+
+  it("enqueues backfill-achievements job when not yet done", async () => {
+    const spy = spyOn(backend, "enqueueOnce").mockResolvedValue(undefined);
+    await syncAchievementRegistry();
+    expect(spy).toHaveBeenCalledWith("backfill-achievements");
+    spy.mockRestore();
+  });
+
+  it("does not enqueue backfill when achievements_backfill_done is set", async () => {
+    const db = getDb();
+    await db.insert(settings).values({ key: "achievements_backfill_done", value: "1" });
+    const spy = spyOn(backend, "enqueueOnce").mockResolvedValue(undefined);
+    await syncAchievementRegistry();
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
   });
 
   it("updates stale rows with new values on re-sync", async () => {

--- a/server/achievements/sync.ts
+++ b/server/achievements/sync.ts
@@ -1,7 +1,7 @@
 import { ACHIEVEMENTS } from "./definitions";
 import { upsertAchievementDef } from "../db/repository/achievements";
 import { getSetting } from "../db/repository/settings";
-import { enqueueJob, hasActiveJob } from "../jobs/enqueue";
+import { enqueueOnce } from "../jobs/backend";
 import { logger } from "../logger";
 
 const log = logger.child({ module: "achievements-sync" });
@@ -20,10 +20,11 @@ export async function syncAchievementRegistry(): Promise<void> {
 
   log.info("Achievement registry sync complete");
 
-  // Auto-trigger backfill once (idempotent via hasActiveJob guard)
+  // Auto-trigger backfill once — idempotent via the backend dispatcher's
+  // dedup logic (DO: idempotent flag; D1: enqueueOneTimeMigration sentinel row)
   const done = await getSetting("achievements_backfill_done");
-  if (!done && !(await hasActiveJob("backfill-achievements"))) {
-    await enqueueJob("backfill-achievements", {});
+  if (!done) {
+    await enqueueOnce("backfill-achievements");
     log.info("Enqueued achievements backfill job");
   }
 }

--- a/server/achievements/triggers.test.ts
+++ b/server/achievements/triggers.test.ts
@@ -3,7 +3,7 @@ import { Hono } from "hono";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
 import { createUser, upsertTitles, upsertEpisodes } from "../db/repository";
 import { makeParsedTitle } from "../test-utils/fixtures";
-import * as enqueue from "../jobs/enqueue";
+import * as backend from "../jobs/backend";
 import * as achievementsRepo from "../db/repository/achievements";
 import * as streaksRepo from "../db/repository/streaks";
 import * as evaluate from "./evaluate";
@@ -67,7 +67,7 @@ describe("onWatchedTitle", () => {
       updatedAt: new Date().toISOString(),
     });
     const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: false });
-    const enqueueSpy = spyOn(enqueue, "enqueueJob").mockResolvedValue(undefined);
+    const enqueueSpy = spyOn(backend, "enqueueAdhoc").mockResolvedValue(undefined);
     const evalMoviesSpy = spyOn(evaluate, "evaluateCountMovies").mockResolvedValue({ progress: 1, earned: false });
     const evalStreakSpy = spyOn(evaluate, "evaluateStreak").mockResolvedValue({ progress: 1, earned: false });
 
@@ -99,7 +99,7 @@ describe("onWatchedTitle", () => {
       updatedAt: new Date().toISOString(),
     });
     const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: false });
-    const enqueueSpy = spyOn(enqueue, "enqueueJob").mockResolvedValue(undefined);
+    const enqueueSpy = spyOn(backend, "enqueueAdhoc").mockResolvedValue(undefined);
     const evalMoviesSpy = spyOn(evaluate, "evaluateCountMovies").mockResolvedValue({ progress: 1, earned: false });
     const evalStreakSpy = spyOn(evaluate, "evaluateStreak").mockResolvedValue({ progress: 1, earned: false });
 
@@ -130,7 +130,7 @@ describe("onWatchedEpisode", () => {
       updatedAt: new Date().toISOString(),
     });
     const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: false });
-    const enqueueSpy = spyOn(enqueue, "enqueueJob").mockResolvedValue(undefined);
+    const enqueueSpy = spyOn(backend, "enqueueAdhoc").mockResolvedValue(undefined);
     const evalEpsSpy = spyOn(evaluate, "evaluateCountEpisodes").mockResolvedValue({ progress: 1, earned: false });
     const evalStreakSpy = spyOn(evaluate, "evaluateStreak").mockResolvedValue({ progress: 1, earned: false });
 
@@ -167,7 +167,7 @@ describe("onWatchedEpisodesBulk", () => {
       updatedAt: new Date().toISOString(),
     });
     const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: false });
-    const enqueueSpy = spyOn(enqueue, "enqueueJob").mockResolvedValue(undefined);
+    const enqueueSpy = spyOn(backend, "enqueueAdhoc").mockResolvedValue(undefined);
     const evalEpsSpy = spyOn(evaluate, "evaluateCountEpisodes").mockResolvedValue({ progress: 5, earned: false });
     const evalStreakSpy = spyOn(evaluate, "evaluateStreak").mockResolvedValue({ progress: 1, earned: false });
 
@@ -192,7 +192,7 @@ describe("onFollow", () => {
     const { onFollow } = await import("./triggers");
 
     const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: true });
-    const enqueueSpy = spyOn(enqueue, "enqueueJob").mockResolvedValue(undefined);
+    const enqueueSpy = spyOn(backend, "enqueueAdhoc").mockResolvedValue(undefined);
     const evalFollowSpy = spyOn(evaluate, "evaluateSocialFirstFollow").mockResolvedValue({ progress: 1, earned: true });
 
     await onFollow(userId);
@@ -212,7 +212,7 @@ describe("onRecommendation", () => {
     const { onRecommendation } = await import("./triggers");
 
     const upsertSpy = spyOn(achievementsRepo, "upsertUserAchievement").mockResolvedValue({ newlyEarned: true });
-    const enqueueSpy = spyOn(enqueue, "enqueueJob").mockResolvedValue(undefined);
+    const enqueueSpy = spyOn(backend, "enqueueAdhoc").mockResolvedValue(undefined);
     const evalRecSpy = spyOn(evaluate, "evaluateSocialFirstRecommendation").mockResolvedValue({ progress: 1, earned: true });
 
     await onRecommendation(userId);
@@ -252,7 +252,7 @@ describe("DELETE /watched/:episodeId — no trigger fired", () => {
       lastWatchDate: null,
       updatedAt: new Date().toISOString(),
     });
-    const enqueueSpy = spyOn(enqueue, "enqueueJob").mockResolvedValue(undefined);
+    const enqueueSpy = spyOn(backend, "enqueueAdhoc").mockResolvedValue(undefined);
 
     const watchedApp = (await import("../routes/watched")).default;
     const app = new Hono<AppEnv>();
@@ -280,7 +280,7 @@ describe("DELETE /watched/movies/:titleId — no trigger fired", () => {
     await upsertTitles([makeParsedTitle({ id: "movie-del-1", objectType: "MOVIE", title: "Delete Me" })]);
 
     const onWatchedTitleSpy = spyOn(triggers, "onWatchedTitle").mockResolvedValue(undefined);
-    const enqueueSpy = spyOn(enqueue, "enqueueJob").mockResolvedValue(undefined);
+    const enqueueSpy = spyOn(backend, "enqueueAdhoc").mockResolvedValue(undefined);
 
     const watchedApp = (await import("../routes/watched")).default;
     const app = new Hono<AppEnv>();
@@ -306,7 +306,7 @@ describe("DELETE /social/follow/:userId — no trigger fired", () => {
     const targetUserId = await createUser("targetuser", "hash2", "Target User");
 
     const onFollowSpy = spyOn(triggers, "onFollow").mockResolvedValue(undefined);
-    const enqueueSpy = spyOn(enqueue, "enqueueJob").mockResolvedValue(undefined);
+    const enqueueSpy = spyOn(backend, "enqueueAdhoc").mockResolvedValue(undefined);
 
     const socialApp = (await import("../routes/social")).default;
     const app = new Hono<AppEnv>();

--- a/server/achievements/triggers.ts
+++ b/server/achievements/triggers.ts
@@ -9,7 +9,7 @@ import {
 import { upsertUserAchievement } from "../db/repository/achievements";
 import { bumpStreak } from "../db/repository/streaks";
 import { getEpisodeTitleId } from "../db/repository";
-import { enqueueJob } from "../jobs/enqueue";
+import { enqueueAdhoc } from "../jobs/backend";
 import { logger } from "../logger";
 
 const log = logger.child({ module: "achievement-triggers" });
@@ -52,7 +52,7 @@ export async function onWatchedTitle(userId: string, titleId: string, isMovie?: 
     }
 
     // Deferred: completionist + genre_count
-    await enqueueJob("evaluate-achievements", { userId, kinds: ["completionist", "genre_count"] as AchievementKind[], titleId });
+    await enqueueAdhoc("evaluate-achievements", { userId, kinds: ["completionist", "genre_count"] as AchievementKind[], titleId });
   } catch (err) {
     log.error("onWatchedTitle trigger failed", { userId, titleId, err });
   }
@@ -82,7 +82,7 @@ export async function onWatchedEpisode(userId: string, episodeId: string, watche
     // Deferred: look up titleId then enqueue completionist + genre_count + speed_binge_season
     const titleId = await getEpisodeTitleId(parseInt(episodeId, 10));
     if (titleId) {
-      await enqueueJob("evaluate-achievements", {
+      await enqueueAdhoc("evaluate-achievements", {
         userId,
         kinds: ["completionist", "genre_count", "speed_binge_season"] as AchievementKind[],
         titleId,
@@ -121,7 +121,7 @@ export async function onWatchedEpisodesBulk(
 
     // Deferred: one job per distinct titleId
     for (const titleId of titleIds) {
-      await enqueueJob("evaluate-achievements", {
+      await enqueueAdhoc("evaluate-achievements", {
         userId,
         kinds: ["completionist", "genre_count", "speed_binge_season"] as AchievementKind[],
         titleId,

--- a/server/jobs/backend.ts
+++ b/server/jobs/backend.ts
@@ -66,6 +66,7 @@ export const CRON_BY_EXPRESSION: Record<string, CronJobName> = Object.fromEntrie
 function getPartitionKey(name: string, data?: Record<string, unknown>): string | null {
   if (name === "sync-show-episodes" && data?.titleId != null) return String(data.titleId);
   if (name === "backfill-title-offers" && data?.tmdbId != null) return String(data.tmdbId);
+  if (name === "evaluate-achievements" && data?.userId != null) return String(data.userId);
   return null;
 }
 

--- a/server/jobs/durable-object.ts
+++ b/server/jobs/durable-object.ts
@@ -9,7 +9,7 @@
 import { Alarms } from "@cloudflare/actors/alarms";
 import { drizzle } from "drizzle-orm/d1";
 import { eq, sql } from "drizzle-orm";
-import { runWithDb, schemaExports, titles } from "../db/schema";
+import { runWithDb, schemaExports, titles, settings } from "../db/schema";
 import { runWithCache } from "../cache";
 import { CloudflareKvCache } from "../cache/cloudflare-kv";
 import { MemoryCache } from "../cache/memory";
@@ -294,6 +294,26 @@ export class JobQueueDO {
           log.info("migrate-offers batch done, re-queued in DO", { remaining: remaining.count });
         } else {
           log.info("migrate-offers migration complete");
+        }
+      }
+
+      // backfill-achievements: re-enqueue next page unless the handler marked it done.
+      // The handler writes achievements_backfill_done=1 to D1 settings on last page;
+      // processor.ts skips the D1 re-enqueue in DO mode, so we do it here instead.
+      if (job.name === "backfill-achievements") {
+        const doneSetting = await db
+          .select({ value: settings.value })
+          .from(settings)
+          .where(eq(settings.key, "achievements_backfill_done"))
+          .get();
+        if (!doneSetting) {
+          this.ctx.storage.sql.exec(
+            "INSERT INTO jobs (name, run_at, max_attempts) VALUES ('backfill-achievements', ?, 1)",
+            new Date(Date.now() + 5000).toISOString(),
+          );
+          log.info("Backfill: enqueued next batch in DO");
+        } else {
+          log.info("Backfill: complete");
         }
       }
     } catch (err) {

--- a/server/jobs/processor.ts
+++ b/server/jobs/processor.ts
@@ -414,8 +414,11 @@ async function handleBackfillAchievements(_data?: string | null): Promise<void> 
   await setSetting("achievements_backfill_cursor", lastUserId);
 
   if (rows.length === BACKFILL_PAGE_SIZE) {
-    // Direct insert is CF-safe (no bun:sqlite); mirrors handleMigrateOffers pattern
-    await db.insert(jobs).values({ name: "backfill-achievements", runAt: new Date(Date.now() + 5000).toISOString() });
+    // In DO mode the DO re-enqueues into its own SQLite after the handler returns.
+    // In D1/Bun mode insert directly so the polling worker picks up the next page.
+    if (CONFIG.JOB_QUEUE_BACKEND !== "durable-object") {
+      await db.insert(jobs).values({ name: "backfill-achievements", runAt: new Date(Date.now() + 5000).toISOString() });
+    }
     log.info("Backfill: enqueued next batch", { nextCursor: lastUserId });
   } else {
     await setSetting("achievements_backfill_done", "1");


### PR DESCRIPTION
## Summary

- `sync.ts` / `triggers.ts` called `enqueueJob`/`hasActiveJob` from `jobs/enqueue.ts`, which unconditionally writes to the D1 `jobs` table — but production runs `JOB_QUEUE_BACKEND=durable-object` where the DO processor never reads D1. Every `backfill-achievements` and `evaluate-achievements` job enqueue has been silently dropped since gamification shipped.
- Rerouted both call sites through the backend dispatcher (`enqueueOnce` for the one-time backfill, `enqueueAdhoc` for per-event triggers), which correctly targets DO or D1 based on `JOB_QUEUE_BACKEND`.
- Added `backfill-achievements` re-enqueue into DO-local SQLite (mirrors `migrate-offers` pattern) so page 2…N of the paginated backfill stay in the right store.
- Partitioned `evaluate-achievements` by `userId` in the DO dispatcher so per-user evaluations don't serialize through one global DO instance.

## Root cause evidence (prod D1)

- `jobs` id 10346: `backfill-achievements`, status `pending`, attempts 0 — enqueued 2026-05-09 20:57, never picked up.
- `user_achievements`: 0 rows. `user_streaks`: 0 rows. `achievements`: 20 rows (registry sync ran; that path bypasses the queue).
- All D1 job completions stopped 2026-04-27 — the day DO mode was enabled.

## After deploy

Delete orphan D1 rows:
```sql
DELETE FROM jobs WHERE id IN (10132, 10346);
```

Then verify in CF logs: `"Backfill: processing page"` cycling at 5s intervals until `"Backfill: complete"`.

## Test plan

- [x] `bun run check` — 2845 pass, 0 fail, no TS/lint errors
- [ ] Deploy to prod; confirm CF logs show `"Enqueued achievements backfill job"` on first isolate spin-up
- [ ] `SELECT COUNT(*) FROM user_achievements` and `user_streaks` grow after backfill completes
- [ ] Mark a movie watched → CF logs show `"Running job"` for `evaluate-achievements` within seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)