### PR TITLE
fix(jobs): move DO cleanup work out of alarm to avoid 30s timeout

### DIFF
--- a/server/jobs/backend.test.ts
+++ b/server/jobs/backend.test.ts
@@ -17,6 +17,7 @@ import { runWithDb } from "../db/schema";
 import * as processorModule from "./processor";
 import {
   armCron,
+  cleanupOld,
   enqueueAdhoc,
   enqueueOnce,
   processPending,
@@ -32,6 +33,7 @@ const mockEnqueueCronJob = spyOn(processorModule, "enqueueCronJob").mockResolved
 const mockProcessPendingJobs = spyOn(processorModule, "processPendingJobs").mockResolvedValue(0);
 const mockRecoverStaleJobs = spyOn(processorModule, "recoverStaleJobs").mockResolvedValue(0);
 const mockEnqueueOneTimeMigration = spyOn(processorModule, "enqueueOneTimeMigration").mockResolvedValue(undefined);
+const mockCleanupOldJobs = spyOn(processorModule, "cleanupOldJobs").mockResolvedValue(0);
 
 // ─── DO stub factory ──────────────────────────────────────────────────────────
 
@@ -73,6 +75,7 @@ beforeEach(() => {
   mockProcessPendingJobs.mockClear();
   mockRecoverStaleJobs.mockClear();
   mockEnqueueOneTimeMigration.mockClear();
+  mockCleanupOldJobs.mockClear();
 });
 
 afterAll(() => {
@@ -82,6 +85,7 @@ afterAll(() => {
   mockProcessPendingJobs.mockRestore();
   mockRecoverStaleJobs.mockRestore();
   mockEnqueueOneTimeMigration.mockRestore();
+  mockCleanupOldJobs.mockRestore();
 });
 
 const d1Env = {
@@ -309,5 +313,62 @@ describe("runWithEnv", () => {
       await enqueueAdhoc("sync-plex-library");
     });
     expect(ns.calls).toHaveLength(1);
+  });
+});
+
+// ─── cleanupOld ──────────────────────────────────────────────────────────────
+
+describe("cleanupOld (D1 mode)", () => {
+  it("delegates to cleanupOldJobs with the given retention days", async () => {
+    mockCleanupOldJobs.mockResolvedValueOnce(7);
+    const count = await cleanupOld(d1Env, 14);
+    expect(count).toBe(7);
+    expect(mockCleanupOldJobs).toHaveBeenCalledWith(14);
+  });
+});
+
+describe("cleanupOld (DO mode)", () => {
+  it("fans out POST /cleanup to all 5 cron DOs and sums counts", async () => {
+    CONFIG.JOB_QUEUE_BACKEND = "durable-object";
+    const ns = makeFakeDoNamespace(() => ({ count: 2 }));
+    const env = { ...d1Env, JOB_QUEUE_DO: ns as unknown as DurableObjectNamespace };
+
+    const total = await cleanupOld(env, 30);
+
+    // 4 CRON_JOB_NAMES + "cleanup" = 5 DOs
+    expect(ns.calls).toHaveLength(5);
+    expect(ns.calls.every((c) => c.path === "/cleanup" && c.method === "POST")).toBe(true);
+    expect(ns.calls.every((c) => (c.body as any).retentionDays === 30)).toBe(true);
+    expect(total).toBe(10); // 5 × 2
+    expect(mockCleanupOldJobs).not.toHaveBeenCalled();
+  });
+
+  it("continues and sums fulfilled counts when one peer DO rejects", async () => {
+    CONFIG.JOB_QUEUE_BACKEND = "durable-object";
+    const attempted: string[] = [];
+    // Use name-aware stub so each DO call can be routed by the captured id
+    const failingNs = {
+      idFromName: (name: string) => ({ name, toString: () => name }),
+      get: (id: any) => ({
+        fetch: async () => {
+          const name: string = id.name ?? id.toString();
+          attempted.push(name);
+          if (name === "send-notifications") throw new Error("DO unavailable");
+          return new Response(JSON.stringify({ count: 3 }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      }),
+    };
+    const env = { ...d1Env, JOB_QUEUE_DO: failingNs as unknown as DurableObjectNamespace };
+
+    const total = await cleanupOld(env, 30);
+
+    // All 5 DOs were attempted despite one failure
+    expect(attempted).toHaveLength(5);
+    expect(attempted).toContain("send-notifications");
+    // Only 4 fulfilled × 3 = 12 (send-notifications rejected, excluded)
+    expect(total).toBe(12);
   });
 });

--- a/server/jobs/backend.ts
+++ b/server/jobs/backend.ts
@@ -184,17 +184,28 @@ export async function recoverStale(env: CFEnv, staleMinutes = 15): Promise<numbe
 /**
  * Clean up old completed/failed jobs.
  * D1 mode: DELETE from shared jobs table.
- * DO mode: fan out to each cron DO (cleanup DO fans out further internally).
+ * DO mode: fan out POST /cleanup to all 5 cron DOs. Uses allSettled so one
+ * unresponsive DO cannot abort the rest of the sweep.
  */
 export async function cleanupOld(env: CFEnv, retentionDays = 30): Promise<number> {
   if (CONFIG.JOB_QUEUE_BACKEND === "durable-object") {
     if (!env.JOB_QUEUE_DO) return 0;
-    const results = await Promise.all(
-      [...CRON_JOB_NAMES, "cleanup"].map((name) =>
+    const names = [...CRON_JOB_NAMES, "cleanup"];
+    const results = await Promise.allSettled(
+      names.map((name) =>
         doFetch<{ count: number }>(env, name, "/cleanup", "POST", { retentionDays }),
       ),
     );
-    return results.reduce((sum, r) => sum + (r.count ?? 0), 0);
+    let total = 0;
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      if (result.status === "fulfilled") {
+        total += result.value.count ?? 0;
+      } else {
+        log.warn("DO cleanup peer failed", { name: names[i], error: result.reason instanceof Error ? result.reason.message : String(result.reason) });
+      }
+    }
+    return total;
   }
   return cleanupOldJobs(retentionDays);
 }

--- a/server/jobs/durable-object.test.ts
+++ b/server/jobs/durable-object.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { Database } from "bun:sqlite";
 import { JobQueueDO } from "./durable-object";
 import * as processorModule from "./processor";
+import * as repository from "../db/repository";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
 
 // ─── Fake CF storage ──────────────────────────────────────────────────────────
@@ -563,6 +564,46 @@ describe("JobQueueDO", () => {
   it("returns 404 for unknown paths", async () => {
     const resp = await do_.fetch(new Request("https://do/unknown-path"));
     expect(resp.status).toBe(404);
+  });
+
+  // ── runCleanup (cleanup DO alarm) ─────────────────────────────────────────
+
+  it("runCleanup() only prunes the DO's own jobs table — no D1 call or peer-DO fan-out", async () => {
+    const deleteExpiredSessionsSpy = spyOn(repository, "deleteExpiredSessions").mockResolvedValue(undefined);
+    const peerFetchCalls: { path: string }[] = [];
+    const fakeNs = {
+      idFromName: (_name: string) => ({ toString: () => _name }),
+      get: () => ({
+        fetch: async (req: Request) => {
+          peerFetchCalls.push({ path: new URL(req.url).pathname });
+          return new Response(JSON.stringify({ count: 0 }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      }),
+    };
+
+    const cleanupState = new FakeDurableObjectState("cleanup");
+    const cleanupDO = new JobQueueDO(
+      cleanupState as any,
+      { ...fakeEnv, JOB_QUEUE_DO: fakeNs as any } as any,
+    );
+
+    // Arm the cleanup cron (sets the "cron" key in storage so runJob auto-inserts a tick row)
+    await cleanupDO.armCron("cleanup", "0 0 * * *");
+    await cleanupDO.runJob(null);
+
+    // No peer-DO fetch calls
+    expect(peerFetchCalls).toHaveLength(0);
+    // No D1 deleteExpiredSessions call
+    expect(deleteExpiredSessionsSpy).not.toHaveBeenCalled();
+    // Own jobs table has a completed row
+    const rows = cleanupState.rawDb.prepare("SELECT status FROM jobs ORDER BY id DESC LIMIT 1").all() as Array<{ status: string }>;
+    expect(rows[0]?.status).toBe("completed");
+
+    deleteExpiredSessionsSpy.mockRestore();
+    cleanupState.close();
   });
 });
 

--- a/server/jobs/durable-object.ts
+++ b/server/jobs/durable-object.ts
@@ -14,7 +14,6 @@ import { runWithCache } from "../cache";
 import { CloudflareKvCache } from "../cache/cloudflare-kv";
 import { MemoryCache } from "../cache/memory";
 import { logger } from "../logger";
-import { deleteExpiredSessions } from "../db/repository";
 import { handlers } from "./processor";
 import type { DrizzleDb } from "../platform/types";
 
@@ -495,29 +494,10 @@ export class JobQueueDO {
     }
   }
 
-  /** Cleanup handler: delete expired sessions + fan out per-DO cleanup. */
-  private async runCleanup(): Promise<void> {
-    // deleteExpiredSessions() uses getDb() which is bound via runWithDb above
-    await deleteExpiredSessions();
-
-    // Fan out cleanup to the four cron-singleton DOs
-    if (this.env.JOB_QUEUE_DO) {
-      await Promise.all(
-        CRON_JOB_NAMES.map((cronName) => {
-          const id = this.env.JOB_QUEUE_DO!.idFromName(cronName);
-          const stub = this.env.JOB_QUEUE_DO!.get(id);
-          return stub.fetch(
-            new Request("https://do/cleanup", {
-              method: "POST",
-              body: JSON.stringify({ retentionDays: 30 }),
-              headers: { "content-type": "application/json" },
-            }),
-          );
-        }),
-      );
-    }
-
-    // Also clean our own jobs table
+  /** Cleanup handler: prune this DO's own old jobs. */
+  private runCleanup(): void {
+    // D1 cleanup + peer-DO fan-out moved to Worker scheduled() to avoid the
+    // 30-second DO alarm hard limit (#726). Only local SQLite work stays here.
     this.cleanup(30);
   }
 }

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -40,7 +40,7 @@ import { cors } from "hono/cors";
 import { HTTPException } from "hono/http-exception";
 import { drizzle } from "drizzle-orm/d1";
 import { getDb, runWithDb, schemaExports } from "./db/schema";
-import { getUserCount, createUser, isOidcConfigured, getOidcConfig, getUserByWatchlistShareToken, getTrackedTitles } from "./db/repository";
+import { getUserCount, createUser, isOidcConfigured, getOidcConfig, getUserByWatchlistShareToken, getTrackedTitles, deleteExpiredSessions } from "./db/repository";
 import { optionalAuth, requireAuth, requireAdmin } from "./middleware/auth";
 import { rateLimiter, MemoryRateLimitStore, KvRateLimitStore } from "./middleware/rate-limit";
 import syncRoutes from "./routes/sync";
@@ -82,7 +82,7 @@ import { patchConfig, CONFIG } from "./config";
 import Sentry from "./sentry";
 import { withSentry } from "@sentry/cloudflare";
 import { CloudflarePlatform } from "./platform/cloudflare";
-import { armCron, enqueueOnce, processPending, recoverStale, runWithEnv, CRON_JOBS } from "./jobs/backend";
+import { armCron, cleanupOld, enqueueOnce, processPending, recoverStale, runWithEnv, CRON_JOBS } from "./jobs/backend";
 export { JobQueueDO } from "./jobs/durable-object";
 import { createAuth } from "./auth/better-auth";
 import { migrateAuthData } from "./db/migrate-auth";
@@ -627,6 +627,14 @@ const handler = {
         const processed = await processPending();
         if (processed > 0) {
           logger.info("Processed jobs", { count: processed });
+        }
+
+        // Daily cleanup — moved out of JobQueueDO alarm to avoid the 30-second
+        // DO alarm hard limit (#726). This handler has no such limit.
+        await deleteExpiredSessions();
+        const cleaned = await cleanupOld(cfEnv, 30);
+        if (cleaned > 0) {
+          logger.info("Daily cleanup pruned old jobs", { cleaned });
         }
       })));
     } catch (err) {


### PR DESCRIPTION
## Summary

- Moves `deleteExpiredSessions()` (cross-boundary D1 RPC) and the 4-DO fan-out cleanup (`Promise.all` of `stub.fetch()`) out of `JobQueueDO.runCleanup()` and into the Worker `scheduled()` handler, which has no 30-second hard limit
- Slims `runCleanup()` to only `this.cleanup(30)` — purely local SQLite (~ms)
- Switches `cleanupOld()` from `Promise.all` to `Promise.allSettled` so one unresponsive peer DO cannot abort the remaining sweep; logs per-peer rejections via `log.warn`

## Root cause

The cleanup DO alarm was calling `deleteExpiredSessions()` (D1 cross-boundary RPC, 5–15 s) plus `Promise.all` over 4 inter-DO `stub.fetch()` calls (each waking a cold DO), pushing wall time to 31–33 s against the 30 s CF DO alarm hard limit. Storage timeout reset the DO mid-job, silently dropping the job and potentially losing the re-arm.

## Test plan

- [ ] `bun run check` passes (2849 tests, 0 fail)
- [ ] New: `cleanupOld (DO mode)` tests in `backend.test.ts` — fan-out to 5 DOs, `Promise.allSettled` continues on partial failure
- [ ] New: `runCleanup() only prunes the DO's own jobs table` in `durable-object.test.ts`
- [ ] Post-deploy: next 0:00 UTC alarm invocation for cleanup DO should show `wallTimeMs < 1000` in CF Workers Observability (was 31–33 s)

Closes #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)