### PR TITLE
fix(jobs): capture permanent job failures to Sentry with stable fingerprint

### DIFF
--- a/server/jobs/durable-object.test.ts
+++ b/server/jobs/durable-object.test.ts
@@ -10,11 +10,12 @@
  * idempotency, re-arm after processing) call alarm() and manipulate the
  * _actor_alarms table directly.
  */
-import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, afterAll, spyOn } from "bun:test";
 import { Database } from "bun:sqlite";
 import { JobQueueDO } from "./durable-object";
 import * as processorModule from "./processor";
 import * as repository from "../db/repository";
+import Sentry from "../sentry";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
 
 // ─── Fake CF storage ──────────────────────────────────────────────────────────
@@ -131,6 +132,7 @@ const fakeEnv = {
 // ─── Spy setup ────────────────────────────────────────────────────────────────
 
 const mockSyncTitles = spyOn(processorModule.handlers, "sync-titles" as any);
+const captureExceptionSpy = spyOn(Sentry, "captureException").mockReturnValue("test-event-id" as any);
 
 // Snapshot original handlers so afterEach can restore them (prevents mutation leaking to processor.test.ts)
 const originalHandlers: Record<string, (data: string | null) => Promise<void>> = { ...processorModule.handlers };
@@ -151,6 +153,7 @@ describe("JobQueueDO", () => {
   beforeEach(() => {
     setupTestDb(); // keep the shared DB fresh for processor imports
     ({ do_, state } = makeDO("sync-titles"));
+    captureExceptionSpy.mockClear();
 
     // Reset handler mocks
     for (const key of Object.keys(processorModule.handlers)) {
@@ -290,6 +293,35 @@ describe("JobQueueDO", () => {
     expect(rows[0].status).toBe("failed");
     expect(rows[0].error).toBe("fatal error");
     expect(rows[0].completed_at).not.toBeNull();
+  });
+
+  it("captures permanent failures to Sentry with stable fingerprint and tags", async () => {
+    const fatalError = new Error("fatal error");
+    processorModule.handlers["sync-titles"] = async () => { throw fatalError; };
+    await do_.enqueue("sync-titles", null, undefined, 1);
+    await do_.runJob(null);
+
+    expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+    const capturedErr = captureExceptionSpy.mock.calls[0]?.[0];
+    const capturedCtx = captureExceptionSpy.mock.calls[0]?.[1];
+    expect(capturedErr).toBe(fatalError);
+    expect(capturedCtx).toMatchObject({
+      level: "error",
+      tags: { jobName: "sync-titles", jobId: expect.any(String) },
+      extra: { attempts: 1, maxAttempts: 1, lastError: "fatal error" },
+      fingerprint: ["job-permanent-failure", "sync-titles"],
+    });
+  });
+
+  it("does NOT capture transient retry failures to Sentry", async () => {
+    processorModule.handlers["sync-titles"] = async () => {
+      throw new Error("transient error");
+    };
+    // maxAttempts=3 so first failure is a retry, not permanent
+    await do_.enqueue("sync-titles", null, undefined, 3);
+    await do_.runJob(null);
+
+    expect(captureExceptionSpy).not.toHaveBeenCalled();
   });
 
   // ── unknown handler ───────────────────────────────────────────────────────
@@ -605,6 +637,11 @@ describe("JobQueueDO", () => {
     deleteExpiredSessionsSpy.mockRestore();
     cleanupState.close();
   });
+});
+
+// Restore module-level spies after all tests so they don't leak into later test files on Linux CI.
+afterAll(() => {
+  captureExceptionSpy.mockRestore();
 });
 
 // Suppress unused-variable warning for the spy (it suppresses console output in tests)

--- a/server/jobs/durable-object.ts
+++ b/server/jobs/durable-object.ts
@@ -14,6 +14,7 @@ import { runWithCache } from "../cache";
 import { CloudflareKvCache } from "../cache/cloudflare-kv";
 import { MemoryCache } from "../cache/memory";
 import { logger } from "../logger";
+import Sentry from "../sentry";
 import { handlers } from "./processor";
 import type { DrizzleDb } from "../platform/types";
 
@@ -329,7 +330,7 @@ export class JobQueueDO {
           retryAt,
           job.id,
         );
-        log.warn("Job failed, will retry", { name: job.name, jobId: job.id, attempt: newAttempts, retryAt, err });
+        log.warn("Job failed, will retry", { name: job.name, jobId: job.id, attempt: newAttempts, retryAt, error: message });
       } else {
         this.ctx.storage.sql.exec(
           "UPDATE jobs SET status = 'failed', error = ?, completed_at = ? WHERE id = ?",
@@ -337,7 +338,20 @@ export class JobQueueDO {
           new Date().toISOString(),
           job.id,
         );
-        log.error("Job failed permanently", { name: job.name, jobId: job.id, attempts: newAttempts, err });
+        Sentry.captureException(err, {
+          level: "error",
+          tags: { jobName: job.name, jobId: String(job.id) },
+          extra: { attempts: newAttempts, maxAttempts: job.max_attempts, lastError: message },
+          fingerprint: ["job-permanent-failure", job.name],
+        });
+        log.error("Job failed permanently", {
+          name: job.name,
+          jobId: job.id,
+          attempts: newAttempts,
+          maxAttempts: job.max_attempts,
+          error: message,
+          stack: err instanceof Error ? err.stack : undefined,
+        });
       }
     }
 

--- a/server/sentry.ts
+++ b/server/sentry.ts
@@ -7,7 +7,7 @@
  */
 
 interface SentryLike {
-  captureException(err: unknown): string;
+  captureException(err: unknown, context?: Record<string, unknown>): string;
   startSpan<T>(opts: { name: string; op?: string; attributes?: Record<string, string> }, fn: () => T): T;
   withMonitor<T>(monitorSlug: string, fn: () => Promise<T>, config?: unknown): Promise<T>;
   flush(timeoutMs?: number): Promise<boolean>;
@@ -18,7 +18,7 @@ interface SentryLike {
 }
 
 const noopSentry: SentryLike = {
-  captureException: () => "",
+  captureException: (_err?: unknown, _ctx?: unknown) => "",
   startSpan: (_opts, fn) => fn(),
   withMonitor: (_slug, fn) => fn(),
   flush: () => Promise.resolve(true),


### PR DESCRIPTION
## Summary

- Adds `Sentry.captureException(err, ctx)` at the permanent-failure path in `JobQueueDO.runJob()` with `level`, `tags` (jobName, jobId), `extra` (attempts, maxAttempts, lastError), and a stable `fingerprint: ["job-permanent-failure", job.name]` that groups all failures for the same job type into one Sentry issue
- Enriches `log.error("Job failed permanently", ...)` with flat `error`, `stack`, and `maxAttempts` fields so the structured log is actionable even when Sentry is unreachable
- Fixes `log.warn("Job failed, will retry", ...)` to use `error: message` instead of `err` (same JSON serialisation issue — `err` objects log as `{}`)
- Extends `SentryLike` interface in `server/sentry.ts` to accept an optional context argument, matching the real SDK signature

## Root cause

The permanent-failure log line in the DO used the `err` field for the Error object. The project's structured JSON logger (pino-style) serialises unknown objects as `{}`, so the stack trace was silently dropped. There was no `Sentry.captureException` call, so dead-letter events never appeared in Sentry — the only signal was the single fingerprinted log message `"Job failed permanently"`.

## Test plan

- [ ] `bun run check` passes (2847 tests, 0 fail)
- [ ] New: `captures permanent failures to Sentry with stable fingerprint and tags` — asserts spy was called with the thrown Error and correct context shape
- [ ] New: `does NOT capture transient retry failures to Sentry` — regression guard
- [ ] Post-deploy: trigger a permanent job failure and verify a new Sentry issue appears in `remindarr-cf` with tags `jobName`/`jobId` and a full stack trace; verify the `"Job failed permanently"` log line now carries `error`, `stack`, and `maxAttempts` fields in CF Workers Observability

Closes #728

🤖 Generated with [Claude Code](https://claude.com/claude-code)