### PR TITLE
feat(achievements): PR1 — discovery skeleton

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,6 +42,7 @@ const KioskPage = lazyWithRetry(() => import("./pages/KioskPage"));
 const SharedWatchlistPage = lazyWithRetry(() => import("./pages/SharedWatchlistPage"));
 const UserOverlapPage = lazyWithRetry(() => import("./pages/UserOverlapPage"));
 const LeaderboardPage = lazyWithRetry(() => import("./pages/LeaderboardPage"));
+const AchievementsPage = lazyWithRetry(() => import("./pages/AchievementsPage"));
 
 // Wraps a route element in an inline ErrorBoundary so a single page crash
 // shows a contained fallback instead of taking down the whole shell.
@@ -204,6 +205,8 @@ export default function App() {
             <Route path="/leaderboard" element={<RequireAuth><Page><LeaderboardPage /></Page></RequireAuth>} />
             <Route path="/user/:username" element={<Page><UserProfilePage /></Page>} />
             <Route path="/u/:username/overlap/:friendUsername" element={<RequireAuth><Page><UserOverlapPage /></Page></RequireAuth>} />
+            <Route path="/u/:username/achievements" element={<Page><AchievementsPage /></Page>} />
+            <Route path="/achievements" element={<RequireAuth><Page><AchievementsPage /></Page></RequireAuth>} />
             <Route path="/settings" element={<RequireAuth><Page><SettingsPage /></Page></RequireAuth>} />
             <Route path="/profile" element={<Page><ProfilePage /></Page>} />
             <Route path="/title/:id" element={<Page><TitleDetailPage /></Page>} />

--- a/frontend/src/components/achievements/BadgeGrid.tsx
+++ b/frontend/src/components/achievements/BadgeGrid.tsx
@@ -1,0 +1,18 @@
+import { BadgeTile } from "./BadgeTile";
+import type { UserAchievement } from "../../types";
+
+export interface BadgeGridProps {
+  achievements: UserAchievement[];
+  mode: "self" | "other";
+  baseHref?: string;
+}
+
+export function BadgeGrid({ achievements, mode, baseHref }: BadgeGridProps) {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+      {achievements.map((a) => (
+        <BadgeTile key={a.key} achievement={a} mode={mode} baseHref={baseHref} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/achievements/BadgeTile.test.tsx
+++ b/frontend/src/components/achievements/BadgeTile.test.tsx
@@ -1,0 +1,85 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { render, screen, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { BadgeTile } from "./BadgeTile";
+import type { UserAchievement } from "../../types";
+
+function makeAchievement(overrides: Partial<UserAchievement> = {}): UserAchievement {
+  return {
+    key: "movies_10",
+    kind: "count_movies",
+    threshold: 10,
+    points: 10,
+    title: "Cinephile I",
+    description: "Watch 10 movies",
+    icon: "Film",
+    category: "watching",
+    tier: "ladder",
+    repeatable: false,
+    family: "cinephile",
+    rungIndex: 0,
+    progress: 0,
+    earned: false,
+    earnedAt: null,
+    earnedCount: 0,
+    lastEarnedAt: null,
+    nextRung: null,
+    rarity: null,
+    ...overrides,
+  };
+}
+
+function renderTile(achievement: UserAchievement, mode: "self" | "other" = "self") {
+  return render(
+    <MemoryRouter>
+      <BadgeTile achievement={achievement} mode={mode} />
+    </MemoryRouter>
+  );
+}
+
+describe("BadgeTile", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("earned tile renders tier ring class for bronze (rungIndex=0)", () => {
+    const { container } = renderTile(
+      makeAchievement({ earned: true, earnedAt: "2024-01-01T00:00:00Z", earnedCount: 1, progress: 10 })
+    );
+    // rungIndex=0 → bronze → ring-2 ring-amber-700/40
+    const link = container.querySelector("a");
+    expect(link).toBeDefined();
+    expect(link?.className).toContain("ring-2");
+    expect(link?.className).toContain("ring-amber-700/40");
+  });
+
+  test("locked tile in mode=self renders at 60% opacity", () => {
+    const { container } = renderTile(
+      makeAchievement({ earned: false, progress: 5 }),
+      "self"
+    );
+    const link = container.querySelector("a");
+    expect(link).toBeDefined();
+    expect(link?.className).toContain("opacity-60");
+  });
+
+  test("locked tile in mode=other renders nothing", () => {
+    const { container } = renderTile(
+      makeAchievement({ earned: false, progress: 0 }),
+      "other"
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("earnedCount > 1 shows a count chip with ×2", () => {
+    renderTile(
+      makeAchievement({
+        earned: true,
+        earnedAt: "2024-01-01T00:00:00Z",
+        earnedCount: 2,
+        progress: 10,
+      })
+    );
+    expect(screen.getByText("×2")).toBeDefined();
+  });
+});

--- a/frontend/src/components/achievements/BadgeTile.tsx
+++ b/frontend/src/components/achievements/BadgeTile.tsx
@@ -1,0 +1,128 @@
+import { Link } from "react-router";
+import {
+  Film,
+  Tv,
+  Flame,
+  Swords,
+  Laugh,
+  Skull,
+  Sparkles,
+  Compass,
+  CheckCircle2,
+  MessageCircle,
+  UserPlus,
+  Zap,
+  Trophy,
+  type LucideProps,
+} from "lucide-react";
+import type { ForwardRefExoticComponent, RefAttributes } from "react";
+import { cn } from "@/lib/utils";
+import { ThinProgress } from "../profile/atoms/ThinProgress";
+import { tierFromRung, TIER_COLORS } from "./tier";
+import type { UserAchievement } from "../../types";
+
+type IconComponent = ForwardRefExoticComponent<Omit<LucideProps, "ref"> & RefAttributes<SVGSVGElement>>;
+
+const ICON_MAP: Record<string, IconComponent> = {
+  Film,
+  Tv,
+  Flame,
+  Swords,
+  Laugh,
+  Skull,
+  Sparkles,
+  Compass,
+  CheckCircle2,
+  MessageCircle,
+  UserPlus,
+  Zap,
+};
+
+function BadgeIcon({ name, size = 20 }: { name: string; size?: number }) {
+  const Icon = ICON_MAP[name] ?? Trophy;
+  return <Icon size={size} />;
+}
+
+export interface BadgeTileProps {
+  achievement: UserAchievement;
+  mode: "self" | "other";
+  compact?: boolean;
+  baseHref?: string;
+}
+
+export function BadgeTile({ achievement, mode, compact = false, baseHref = "/achievements" }: BadgeTileProps) {
+  const { key, icon, title, earned, progress, threshold, earnedCount, rungIndex, tier } = achievement;
+
+  // Other users only see earned badges
+  if (!earned && mode === "other") {
+    return null;
+  }
+
+  // Determine tier styling
+  let ringClass = "";
+  let bgClass = "";
+  let iconColorClass = "";
+  let textColorClass = "";
+
+  if (earned) {
+    if (tier === "ladder" && rungIndex !== null) {
+      const { tier: t } = tierFromRung(rungIndex);
+      const style = TIER_COLORS[t];
+      ringClass = style.ring;
+      bgClass = style.bg;
+      iconColorClass = style.icon;
+      textColorClass = style.text;
+    } else {
+      // one-shot: amber-400 fallback
+      ringClass = "ring-2 ring-amber-400/50";
+      bgClass = "bg-amber-400/10";
+      iconColorClass = "text-amber-400";
+      textColorClass = "text-amber-400";
+    }
+  }
+
+  const iconSize = compact ? 14 : 18;
+  const href = `${baseHref}/${key}`;
+
+  return (
+    <Link
+      to={href}
+      className={cn(
+        "relative flex flex-col gap-1.5 rounded-lg border transition-opacity",
+        compact ? "p-2" : "p-3",
+        earned
+          ? cn("border-white/10", bgClass, ringClass)
+          : "bg-white/[0.03] border-white/[0.06] opacity-60"
+      )}
+      title={achievement.description}
+    >
+      {/* earnedCount chip — shown when earned more than once */}
+      {earnedCount > 1 && (
+        <span className="absolute top-1 right-1 text-[9px] font-mono font-semibold bg-white/10 text-zinc-300 rounded px-1 leading-4">
+          ×{earnedCount}
+        </span>
+      )}
+
+      {/* Icon */}
+      <div className={cn(earned ? iconColorClass : "text-zinc-500")}>
+        <BadgeIcon name={icon} size={iconSize} />
+      </div>
+
+      {/* Title */}
+      <span
+        className={cn(
+          "font-semibold leading-tight truncate",
+          compact ? "text-[10px]" : "text-[12px]",
+          earned ? (textColorClass || "text-zinc-200") : "text-zinc-400"
+        )}
+      >
+        {title}
+      </span>
+
+      {/* Progress bar for locked self-view */}
+      {!earned && mode === "self" && (
+        <ThinProgress value={progress} max={threshold} color="#71717a" height={3} />
+      )}
+    </Link>
+  );
+}

--- a/frontend/src/components/achievements/CategoryFilter.tsx
+++ b/frontend/src/components/achievements/CategoryFilter.tsx
@@ -1,0 +1,70 @@
+import { useSearchParams } from "react-router";
+import { cn } from "@/lib/utils";
+import type { Category } from "../../types";
+
+export interface CategoryFilterProps {
+  categories: Category[];
+  className?: string;
+}
+
+const CATEGORY_LABELS: Record<Category, string> = {
+  watching: "Watching",
+  streaks: "Streaks",
+  genres: "Genres",
+  social: "Social",
+  special: "Special",
+  explorer: "Explorer",
+  habit: "Habit",
+  "long-haul": "Long Haul",
+};
+
+export function CategoryFilter({ categories, className }: CategoryFilterProps) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeCat = searchParams.get("cat");
+
+  function selectAll() {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.delete("cat");
+      return next;
+    });
+  }
+
+  function selectCategory(cat: Category) {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.set("cat", cat);
+      return next;
+    });
+  }
+
+  return (
+    <div className={cn("flex flex-wrap gap-1.5", className)}>
+      <button
+        onClick={selectAll}
+        className={cn(
+          "px-3 py-1 rounded-full text-xs font-semibold transition-colors",
+          activeCat === null
+            ? "bg-white/10 text-white"
+            : "text-zinc-400 hover:text-white hover:bg-white/5"
+        )}
+      >
+        All
+      </button>
+      {categories.map((cat) => (
+        <button
+          key={cat}
+          onClick={() => selectCategory(cat)}
+          className={cn(
+            "px-3 py-1 rounded-full text-xs font-semibold transition-colors",
+            activeCat === cat
+              ? "bg-white/10 text-white"
+              : "text-zinc-400 hover:text-white hover:bg-white/5"
+          )}
+        >
+          {CATEGORY_LABELS[cat]}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/achievements/NextUpStrip.tsx
+++ b/frontend/src/components/achievements/NextUpStrip.tsx
@@ -1,0 +1,30 @@
+import ScrollableRow from "../ScrollableRow";
+import { BadgeTile } from "./BadgeTile";
+import type { UserAchievement } from "../../types";
+
+export interface NextUpStripProps {
+  achievements: UserAchievement[];
+  mode: "self" | "other";
+  baseHref?: string;
+}
+
+export function NextUpStrip({ achievements, mode, baseHref }: NextUpStripProps) {
+  const inProgress = achievements
+    .filter((a) => !a.earned && a.progress > 0)
+    .sort((a, b) => b.progress / b.threshold - a.progress / a.threshold)
+    .slice(0, 6);
+
+  if (inProgress.length === 0) {
+    return null;
+  }
+
+  return (
+    <ScrollableRow className="gap-2 pb-1">
+      {inProgress.map((a) => (
+        <div key={a.key} className="flex-none w-28">
+          <BadgeTile achievement={a} mode={mode} compact baseHref={baseHref} />
+        </div>
+      ))}
+    </ScrollableRow>
+  );
+}

--- a/frontend/src/components/achievements/RecentlyEarnedStrip.tsx
+++ b/frontend/src/components/achievements/RecentlyEarnedStrip.tsx
@@ -1,0 +1,55 @@
+import ScrollableRow from "../ScrollableRow";
+import { BadgeTile } from "./BadgeTile";
+import type { UserAchievement } from "../../types";
+
+/** Format an ISO date string as a relative label like "3d ago" or "just now". */
+function formatRelative(dateStr: string): string {
+  const diffMs = Date.now() - new Date(dateStr).getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 60) return "just now";
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 30) return `${diffDay}d ago`;
+  const diffMo = Math.floor(diffDay / 30);
+  if (diffMo < 12) return `${diffMo}mo ago`;
+  return `${Math.floor(diffMo / 12)}y ago`;
+}
+
+export interface RecentlyEarnedStripProps {
+  achievements: UserAchievement[];
+  mode: "self" | "other";
+  baseHref?: string;
+}
+
+export function RecentlyEarnedStrip({ achievements, mode, baseHref }: RecentlyEarnedStripProps) {
+  const recent = achievements
+    .filter((a) => a.earned)
+    .sort((a, b) => {
+      const aTime = a.earnedAt ? new Date(a.earnedAt).getTime() : 0;
+      const bTime = b.earnedAt ? new Date(b.earnedAt).getTime() : 0;
+      return bTime - aTime;
+    })
+    .slice(0, 8);
+
+  if (recent.length === 0) {
+    return null;
+  }
+
+  return (
+    <ScrollableRow className="gap-2 pb-1">
+      {recent.map((a) => (
+        <div key={a.key} className="flex-none w-28 flex flex-col gap-1">
+          <BadgeTile achievement={a} mode={mode} compact baseHref={baseHref} />
+          {a.earnedAt && (
+            <span className="text-[10px] text-zinc-500 text-center font-mono">
+              {formatRelative(a.earnedAt)}
+            </span>
+          )}
+        </div>
+      ))}
+    </ScrollableRow>
+  );
+}

--- a/frontend/src/components/achievements/tier.test.ts
+++ b/frontend/src/components/achievements/tier.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect } from 'bun:test';
+import { tierFromRung, TIER_COLORS } from './tier';
+
+describe('tierFromRung', () => {
+  test('rungIndex=0 → bronze (no suffix)', () => {
+    expect(tierFromRung(0)).toEqual({ tier: 'bronze' });
+  });
+
+  test('rungIndex=1 → silver (no suffix)', () => {
+    expect(tierFromRung(1)).toEqual({ tier: 'silver' });
+  });
+
+  test('rungIndex=4 → diamond (no suffix)', () => {
+    expect(tierFromRung(4)).toEqual({ tier: 'diamond' });
+  });
+
+  test('rungIndex=5 → diamond II (overflow=1)', () => {
+    expect(tierFromRung(5)).toEqual({ tier: 'diamond', suffix: 'II' });
+  });
+
+  test('rungIndex=8 → diamond V (overflow=4 → NUMERALS[4]="V")', () => {
+    expect(tierFromRung(8)).toEqual({ tier: 'diamond', suffix: 'V' });
+  });
+
+  test('rungIndex=14 → diamond X (overflow=10 → capped at index 9 → NUMERALS[9]="X")', () => {
+    expect(tierFromRung(14)).toEqual({ tier: 'diamond', suffix: 'X' });
+  });
+
+  test('rungIndex=100 → diamond X (capped)', () => {
+    expect(tierFromRung(100)).toEqual({ tier: 'diamond', suffix: 'X' });
+  });
+});
+
+describe('TIER_COLORS', () => {
+  test('has all 5 tier keys', () => {
+    const keys = Object.keys(TIER_COLORS);
+    expect(keys).toContain('bronze');
+    expect(keys).toContain('silver');
+    expect(keys).toContain('gold');
+    expect(keys).toContain('platinum');
+    expect(keys).toContain('diamond');
+    expect(keys).toHaveLength(5);
+  });
+
+  test('each tier has ring, bg, text, and icon properties', () => {
+    const tiers = ['bronze', 'silver', 'gold', 'platinum', 'diamond'] as const;
+    for (const tier of tiers) {
+      const style = TIER_COLORS[tier];
+      expect(typeof style.ring).toBe('string');
+      expect(typeof style.bg).toBe('string');
+      expect(typeof style.text).toBe('string');
+      expect(typeof style.icon).toBe('string');
+    }
+  });
+});

--- a/frontend/src/components/achievements/tier.ts
+++ b/frontend/src/components/achievements/tier.ts
@@ -1,0 +1,32 @@
+export type Tier = 'bronze' | 'silver' | 'gold' | 'platinum' | 'diamond';
+
+// Maps a 0-based rung index to a tier name + optional overflow suffix
+export function tierFromRung(rungIndex: number): { tier: Tier; suffix?: string } {
+  const TIERS: Tier[] = ['bronze', 'silver', 'gold', 'platinum', 'diamond'];
+  if (rungIndex < TIERS.length) {
+    return { tier: TIERS[rungIndex] };
+  }
+  // Diamond overflow: Diamond II, III, IV … capped at X
+  const NUMERALS = ['', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII', 'IX', 'X'];
+  const overflow = rungIndex - TIERS.length + 1; // 1 for rungIndex=5, 2 for rungIndex=6, …
+  return {
+    tier: 'diamond',
+    suffix: NUMERALS[Math.min(overflow, NUMERALS.length - 1)],
+  };
+}
+
+// Tailwind classes for each tier — all use ring + bg + text tokens
+export interface TierStyle {
+  ring: string;  // e.g. "ring-2 ring-amber-700/40"
+  bg: string;    // e.g. "bg-amber-900/10"
+  text: string;  // e.g. "text-amber-700"
+  icon: string;  // icon color class
+}
+
+export const TIER_COLORS: Record<Tier, TierStyle> = {
+  bronze:   { ring: 'ring-2 ring-amber-700/40',  bg: 'bg-amber-900/10',   text: 'text-amber-600',  icon: 'text-amber-600' },
+  silver:   { ring: 'ring-2 ring-zinc-300/40',   bg: 'bg-zinc-700/10',    text: 'text-zinc-300',   icon: 'text-zinc-300' },
+  gold:     { ring: 'ring-2 ring-amber-400/50',  bg: 'bg-amber-400/10',   text: 'text-amber-400',  icon: 'text-amber-400' },
+  platinum: { ring: 'ring-2 ring-sky-200/50',    bg: 'bg-sky-900/10',     text: 'text-sky-200',    icon: 'text-sky-200' },
+  diamond:  { ring: 'ring-2 ring-cyan-300/50',   bg: 'bg-cyan-900/10',    text: 'text-cyan-300',   icon: 'text-cyan-300' },
+};

--- a/frontend/src/components/profile/ProfileBadgesSummary.test.tsx
+++ b/frontend/src/components/profile/ProfileBadgesSummary.test.tsx
@@ -1,0 +1,166 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { render, screen, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import ProfileBadgesSummary from "./ProfileBadgesSummary";
+import type { UserAchievement } from "../../types";
+
+function makeAchievement(overrides: Partial<UserAchievement> = {}): UserAchievement {
+  return {
+    key: "movies_10",
+    kind: "count_movies",
+    threshold: 10,
+    points: 10,
+    title: "Cinephile I",
+    description: "Watch 10 movies",
+    icon: "Film",
+    category: "watching",
+    tier: "ladder",
+    repeatable: false,
+    family: "cinephile",
+    rungIndex: 0,
+    progress: 0,
+    earned: false,
+    earnedAt: null,
+    earnedCount: 0,
+    lastEarnedAt: null,
+    nextRung: null,
+    rarity: null,
+    ...overrides,
+  };
+}
+
+function renderSummary(
+  achievements: UserAchievement[],
+  mode: "self" | "other" = "self",
+  viewAllHref = "/achievements"
+) {
+  return render(
+    <MemoryRouter>
+      <ProfileBadgesSummary
+        achievements={achievements}
+        mode={mode}
+        viewAllHref={viewAllHref}
+      />
+    </MemoryRouter>
+  );
+}
+
+const earned1 = makeAchievement({
+  key: "movies_10",
+  title: "Cinephile I",
+  points: 10,
+  earned: true,
+  earnedAt: "2024-03-01T00:00:00Z",
+  earnedCount: 1,
+  progress: 10,
+});
+
+const earned2 = makeAchievement({
+  key: "movies_50",
+  title: "Cinephile II",
+  points: 25,
+  earned: true,
+  earnedAt: "2024-04-01T00:00:00Z",
+  earnedCount: 1,
+  progress: 50,
+  threshold: 50,
+  rungIndex: 1,
+});
+
+const earned3 = makeAchievement({
+  key: "movies_100",
+  title: "Cinephile III",
+  points: 50,
+  earned: true,
+  earnedAt: "2024-05-01T00:00:00Z",
+  earnedCount: 1,
+  progress: 100,
+  threshold: 100,
+  rungIndex: 2,
+});
+
+const locked = makeAchievement({
+  key: "tv_10",
+  title: "Binge Watcher I",
+  points: 10,
+  earned: false,
+  earnedAt: null,
+  earnedCount: 0,
+  progress: 5,
+});
+
+describe("ProfileBadgesSummary", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("renders the Achievements kicker", () => {
+    renderSummary([earned1]);
+    expect(screen.getByText("Achievements")).toBeDefined();
+  });
+
+  test("shows N/M · X XP chip with correct counts", () => {
+    renderSummary([earned1, earned2, locked]);
+    // earned1.points=10, earned2.points=25 → totalXp=35; earned=2, total=3
+    expect(screen.getByText("2/3 · 35 XP")).toBeDefined();
+  });
+
+  test("shows up to 3 earned badges sorted by earnedAt desc", () => {
+    // earned3 is most recent (2024-05-01), then earned2 (2024-04-01), then earned1 (2024-03-01)
+    renderSummary([earned1, earned2, earned3]);
+    const tiles = screen.getAllByRole("link");
+    // The 3 badge tiles + the view all link
+    // Filter out the view all link (it has text content)
+    const badgeTiles = tiles.filter((el) => !el.textContent?.includes("View all"));
+    expect(badgeTiles).toHaveLength(3);
+    // First tile should be the most recently earned (earned3 — Cinephile III)
+    expect(screen.getByText("Cinephile III")).toBeDefined();
+    expect(screen.getByText("Cinephile II")).toBeDefined();
+    expect(screen.getByText("Cinephile I")).toBeDefined();
+  });
+
+  test("shows the View all link with correct href", () => {
+    renderSummary([earned1], "self", "/achievements");
+    const link = screen.getByText("View all achievements →");
+    expect(link).toBeDefined();
+    expect(link.closest("a")?.getAttribute("href")).toBe("/achievements");
+  });
+
+  test("shows View all link with other user href", () => {
+    renderSummary([earned1], "other", "/u/alice/achievements");
+    const link = screen.getByText("View all achievements →");
+    expect(link.closest("a")?.getAttribute("href")).toBe("/u/alice/achievements");
+  });
+
+  test("returns null when achievements array is empty", () => {
+    const { container } = renderSummary([]);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("returns null when mode=other and no badges are earned", () => {
+    const { container } = renderSummary([locked], "other");
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders card (not null) when mode=other and some badges are earned", () => {
+    const { container } = renderSummary([earned1, locked], "other");
+    expect(container.firstChild).not.toBeNull();
+  });
+
+  test("shows only up to 3 tiles even with more earned badges", () => {
+    const extra = makeAchievement({
+      key: "social_1",
+      title: "Social Butterfly",
+      points: 5,
+      earned: true,
+      earnedAt: "2024-01-01T00:00:00Z",
+      earnedCount: 1,
+      progress: 1,
+    });
+    renderSummary([earned1, earned2, earned3, extra]);
+    // 4 earned, but only top 3 shown → earned3, earned2, earned1 by earnedAt desc
+    // "Social Butterfly" earned earliest (2024-01-01) so it should NOT appear
+    expect(screen.queryByText("Social Butterfly")).toBeNull();
+    expect(screen.getByText("Cinephile III")).toBeDefined();
+  });
+});

--- a/frontend/src/components/profile/ProfileBadgesSummary.tsx
+++ b/frontend/src/components/profile/ProfileBadgesSummary.tsx
@@ -1,0 +1,67 @@
+import { Link } from "react-router";
+import { DossierCard } from "./atoms/DossierCard";
+import { Kicker } from "../design/Kicker";
+import { BadgeTile } from "../achievements/BadgeTile";
+import type { UserAchievement } from "../../types";
+
+interface ProfileBadgesSummaryProps {
+  achievements: UserAchievement[];
+  mode: "self" | "other";
+  viewAllHref: string;
+}
+
+export default function ProfileBadgesSummary({
+  achievements,
+  mode,
+  viewAllHref,
+}: ProfileBadgesSummaryProps) {
+  if (achievements.length === 0) return null;
+
+  const earned = achievements.filter((a) => a.earned);
+
+  if (mode === "other" && earned.length === 0) return null;
+
+  const totalXp = earned.reduce((sum, a) => sum + a.points, 0);
+
+  const top3 = [...earned]
+    .sort((a, b) => {
+      const aTime = a.earnedAt ? new Date(a.earnedAt).getTime() : 0;
+      const bTime = b.earnedAt ? new Date(b.earnedAt).getTime() : 0;
+      return bTime - aTime;
+    })
+    .slice(0, 3);
+
+  return (
+    <DossierCard>
+      <div className="flex items-baseline justify-between mb-3">
+        <Kicker color="zinc" className="mb-0">
+          Achievements
+        </Kicker>
+        <span className="text-[11px] text-zinc-500 font-mono">
+          {earned.length}/{achievements.length} · {totalXp} XP
+        </span>
+      </div>
+
+      {top3.length > 0 && (
+        <div className="grid grid-cols-3 gap-2 mb-3">
+          {top3.map((a) => (
+            <BadgeTile
+              key={a.key}
+              achievement={a}
+              mode={mode}
+              compact
+              baseHref={viewAllHref}
+            />
+          ))}
+        </div>
+      )}
+
+      <Link
+        to={viewAllHref}
+        className="text-xs text-zinc-400 hover:text-white transition-colors"
+      >
+        View all achievements →
+      </Link>
+    </DossierCard>
+  );
+}

--- a/frontend/src/pages/AchievementsPage.test.tsx
+++ b/frontend/src/pages/AchievementsPage.test.tsx
@@ -162,6 +162,20 @@ describe("AchievementsPage — own profile", () => {
 
     expect(screen.getByText("Streaks")).toBeDefined();
   });
+
+  test("hides 'recently earned' section when no achievements are earned", async () => {
+    getMyAchievementsSpy.mockImplementation(() =>
+      Promise.resolve([inProgressWatching])
+    );
+
+    render(<AchievementsPage />, { wrapper: OwnWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Achievements")).toBeDefined();
+    });
+
+    expect(screen.queryByText("Recently earned")).toBeNull();
+  });
 });
 
 describe("AchievementsPage — other user profile", () => {

--- a/frontend/src/pages/AchievementsPage.test.tsx
+++ b/frontend/src/pages/AchievementsPage.test.tsx
@@ -1,0 +1,183 @@
+import { describe, test, expect, spyOn, afterEach, beforeEach, mock } from "bun:test";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import type { ReactNode } from "react";
+import * as api from "../api";
+import type { UserAchievement } from "../types";
+
+// Mock AuthContext to avoid null context errors.
+// Returns a full shape so cross-file leaks don't corrupt other tests.
+mock.module("../context/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: "current-user", username: "me", display_name: "Me", auth_provider: "local", is_admin: false },
+    providers: { local: true, oidc: null },
+    loading: false,
+    subscriptions: null,
+    refreshSubscriptions: mock(() => Promise.resolve()),
+    login: mock(() => Promise.resolve()),
+    signup: mock(() => Promise.resolve()),
+    logout: mock(() => Promise.resolve()),
+    refresh: mock(() => Promise.resolve()),
+  }),
+  AuthContext: {
+    Provider: ({ children }: { children: ReactNode }) => children,
+  },
+}));
+
+const { default: AchievementsPage } = await import("./AchievementsPage");
+
+// Renders the page as the current user (own profile — /achievements)
+function OwnWrapper({ children }: { children: ReactNode }) {
+  return <MemoryRouter initialEntries={["/achievements"]}>{children}</MemoryRouter>;
+}
+
+// Renders the page as another user (/u/alice/achievements)
+function OtherWrapper({ children }: { children: ReactNode }) {
+  return (
+    <MemoryRouter initialEntries={["/u/alice/achievements"]}>
+      {children}
+    </MemoryRouter>
+  );
+}
+
+function makeAchievement(overrides: Partial<UserAchievement> = {}): UserAchievement {
+  return {
+    key: "watch-1",
+    kind: "watch_count",
+    threshold: 10,
+    points: 50,
+    title: "First Watch",
+    description: "Watch 10 titles",
+    icon: "🎬",
+    category: "watching",
+    tier: "ladder",
+    repeatable: false,
+    family: "watch",
+    rungIndex: 0,
+    progress: 10,
+    earned: true,
+    earnedAt: "2025-01-01T00:00:00.000Z",
+    earnedCount: 1,
+    lastEarnedAt: "2025-01-01T00:00:00.000Z",
+    nextRung: null,
+    rarity: { pct: 60, bucket: "common" },
+    ...overrides,
+  };
+}
+
+let getMyAchievementsSpy: ReturnType<typeof spyOn<typeof api, "getMyAchievements">>;
+let getUserAchievementsSpy: ReturnType<typeof spyOn<typeof api, "getUserAchievements">>;
+
+beforeEach(() => {
+  getMyAchievementsSpy = spyOn(api, "getMyAchievements");
+  getUserAchievementsSpy = spyOn(api, "getUserAchievements");
+});
+
+afterEach(() => {
+  getMyAchievementsSpy.mockRestore();
+  getUserAchievementsSpy.mockRestore();
+  cleanup();
+});
+
+const earnedWatching = makeAchievement({ key: "watch-1", category: "watching", earned: true, points: 50 });
+const earnedStreaks = makeAchievement({ key: "streak-1", category: "streaks", earned: true, points: 30, earnedAt: "2025-02-01T00:00:00.000Z" });
+const inProgressWatching = makeAchievement({
+  key: "watch-2",
+  category: "watching",
+  earned: false,
+  earnedAt: null,
+  earnedCount: 0,
+  lastEarnedAt: null,
+  progress: 5,
+  threshold: 10,
+  points: 100,
+  rarity: null,
+});
+
+describe("AchievementsPage — own profile", () => {
+  test("renders 'Achievements' kicker", async () => {
+    getMyAchievementsSpy.mockImplementation(() => Promise.resolve([earnedWatching]));
+
+    render(<AchievementsPage />, { wrapper: OwnWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Achievements")).toBeDefined();
+    });
+  });
+
+  test("shows earned/total/XP summary chip", async () => {
+    getMyAchievementsSpy.mockImplementation(() =>
+      Promise.resolve([earnedWatching, inProgressWatching])
+    );
+
+    render(<AchievementsPage />, { wrapper: OwnWrapper });
+
+    await waitFor(() => {
+      // 1 earned out of 2 total, 50 XP
+      expect(screen.getByText("1/2 earned · 50 XP")).toBeDefined();
+    });
+  });
+
+  test("NextUpStrip section is visible for own profile when in-progress badges exist", async () => {
+    getMyAchievementsSpy.mockImplementation(() =>
+      Promise.resolve([earnedWatching, inProgressWatching])
+    );
+
+    render(<AchievementsPage />, { wrapper: OwnWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Next up")).toBeDefined();
+    });
+  });
+
+  test("category filter chip 'Watching' filters grid to only watching category", async () => {
+    getMyAchievementsSpy.mockImplementation(() =>
+      Promise.resolve([earnedWatching, earnedStreaks])
+    );
+
+    render(<AchievementsPage />, {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <MemoryRouter initialEntries={["/achievements?cat=watching"]}>{children}</MemoryRouter>
+      ),
+    });
+
+    await waitFor(() => {
+      // "Watching" category kicker should appear but not "Streaks"
+      expect(screen.getByText("Watching")).toBeDefined();
+    });
+
+    expect(screen.queryByText("Streaks")).toBeNull();
+  });
+
+  test("'All' filter (no cat param) shows all categories", async () => {
+    getMyAchievementsSpy.mockImplementation(() =>
+      Promise.resolve([earnedWatching, earnedStreaks])
+    );
+
+    render(<AchievementsPage />, { wrapper: OwnWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Watching")).toBeDefined();
+    });
+
+    expect(screen.getByText("Streaks")).toBeDefined();
+  });
+});
+
+describe("AchievementsPage — other user profile", () => {
+  test("NextUpStrip section is hidden for other user profiles", async () => {
+    getUserAchievementsSpy.mockImplementation(() =>
+      Promise.resolve([earnedWatching, inProgressWatching])
+    );
+
+    // Render as the "alice" profile view (other user)
+    render(<AchievementsPage />, { wrapper: OtherWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Achievements")).toBeDefined();
+    });
+
+    // "Next up" section must not appear for other profiles
+    expect(screen.queryByText("Next up")).toBeNull();
+  });
+});

--- a/frontend/src/pages/AchievementsPage.test.tsx
+++ b/frontend/src/pages/AchievementsPage.test.tsx
@@ -1,6 +1,6 @@
 import { describe, test, expect, spyOn, afterEach, beforeEach, mock } from "bun:test";
 import { render, screen, waitFor, cleanup } from "@testing-library/react";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, Routes, Route } from "react-router";
 import type { ReactNode } from "react";
 import * as api from "../api";
 import type { UserAchievement } from "../types";
@@ -28,14 +28,22 @@ const { default: AchievementsPage } = await import("./AchievementsPage");
 
 // Renders the page as the current user (own profile — /achievements)
 function OwnWrapper({ children }: { children: ReactNode }) {
-  return <MemoryRouter initialEntries={["/achievements"]}>{children}</MemoryRouter>;
+  return (
+    <MemoryRouter initialEntries={["/achievements"]}>
+      <Routes>
+        <Route path="/achievements" element={<>{children}</>} />
+      </Routes>
+    </MemoryRouter>
+  );
 }
 
 // Renders the page as another user (/u/alice/achievements)
 function OtherWrapper({ children }: { children: ReactNode }) {
   return (
     <MemoryRouter initialEntries={["/u/alice/achievements"]}>
-      {children}
+      <Routes>
+        <Route path="/u/:username/achievements" element={<>{children}</>} />
+      </Routes>
     </MemoryRouter>
   );
 }
@@ -137,16 +145,25 @@ describe("AchievementsPage — own profile", () => {
 
     render(<AchievementsPage />, {
       wrapper: ({ children }: { children: ReactNode }) => (
-        <MemoryRouter initialEntries={["/achievements?cat=watching"]}>{children}</MemoryRouter>
+        <MemoryRouter initialEntries={["/achievements?cat=watching"]}>
+          <Routes>
+            <Route path="/achievements" element={<>{children}</>} />
+          </Routes>
+        </MemoryRouter>
       ),
     });
 
     await waitFor(() => {
-      // "Watching" category kicker should appear but not "Streaks"
-      expect(screen.getByText("Watching")).toBeDefined();
+      expect(screen.getByText("Achievements")).toBeDefined();
     });
 
-    expect(screen.queryByText("Streaks")).toBeNull();
+    // "Watching" appears in both the filter chip and the section heading (2+)
+    const watchingEls = screen.getAllByText("Watching");
+    expect(watchingEls.length).toBeGreaterThanOrEqual(2);
+
+    // "Streaks" appears only in the filter chip (section heading is hidden) = 1
+    const streaksEls = screen.getAllByText("Streaks");
+    expect(streaksEls.length).toBe(1);
   });
 
   test("'All' filter (no cat param) shows all categories", async () => {
@@ -157,10 +174,12 @@ describe("AchievementsPage — own profile", () => {
     render(<AchievementsPage />, { wrapper: OwnWrapper });
 
     await waitFor(() => {
-      expect(screen.getByText("Watching")).toBeDefined();
+      expect(screen.getByText("Achievements")).toBeDefined();
     });
 
-    expect(screen.getByText("Streaks")).toBeDefined();
+    // Both categories appear in chip + section heading = at least 2 each
+    expect(screen.getAllByText("Watching").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("Streaks").length).toBeGreaterThanOrEqual(2);
   });
 
   test("hides 'recently earned' section when no achievements are earned", async () => {

--- a/frontend/src/pages/AchievementsPage.tsx
+++ b/frontend/src/pages/AchievementsPage.tsx
@@ -117,10 +117,12 @@ export default function AchievementsPage() {
       )}
 
       {/* Recently earned */}
-      <section>
-        <Kicker color="zinc" className="mb-2">Recently earned</Kicker>
-        <RecentlyEarnedStrip achievements={achievements} mode={mode} baseHref={baseHref} />
-      </section>
+      {earned.length > 0 && (
+        <section>
+          <Kicker color="zinc" className="mb-2">Recently earned</Kicker>
+          <RecentlyEarnedStrip achievements={achievements} mode={mode} baseHref={baseHref} />
+        </section>
+      )}
 
       {/* Category filter */}
       <CategoryFilter categories={presentCategories} />

--- a/frontend/src/pages/AchievementsPage.tsx
+++ b/frontend/src/pages/AchievementsPage.tsx
@@ -1,0 +1,141 @@
+import { useParams, useSearchParams } from "react-router";
+import { useAuth } from "../context/AuthContext";
+import { useApiCall } from "../hooks/useApiCall";
+import * as api from "../api";
+import type { Category, UserAchievement } from "../types";
+import { Kicker } from "../components/design/Kicker";
+import { NextUpStrip } from "../components/achievements/NextUpStrip";
+import { RecentlyEarnedStrip } from "../components/achievements/RecentlyEarnedStrip";
+import { CategoryFilter } from "../components/achievements/CategoryFilter";
+import { BadgeGrid } from "../components/achievements/BadgeGrid";
+
+const DISPLAY_ORDER: Category[] = [
+  "watching",
+  "streaks",
+  "genres",
+  "social",
+  "special",
+  "explorer",
+  "habit",
+  "long-haul",
+];
+
+const CATEGORY_LABELS: Record<Category, string> = {
+  watching: "Watching",
+  streaks: "Streaks",
+  genres: "Genres",
+  social: "Social",
+  special: "Special",
+  explorer: "Explorer",
+  habit: "Habit",
+  "long-haul": "Long Haul",
+};
+
+export default function AchievementsPage() {
+  const { user } = useAuth();
+  const { username } = useParams<{ username?: string }>();
+  const [searchParams] = useSearchParams();
+
+  const isOwnProfile = !username || user?.username === username;
+  const mode: "self" | "other" = isOwnProfile ? "self" : "other";
+  const baseHref = isOwnProfile ? "/achievements" : `/u/${username}/achievements`;
+  const activeCategory = searchParams.get("cat") as Category | null;
+
+  const { data, loading, error } = useApiCall(
+    (signal) =>
+      isOwnProfile
+        ? api.getMyAchievements(signal)
+        : api.getUserAchievements(username!, signal),
+    [isOwnProfile, username],
+  );
+
+  if (loading) {
+    return (
+      <div className="max-w-4xl mx-auto px-4 py-6">
+        <div className="text-zinc-500 text-sm">Loading…</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="max-w-4xl mx-auto px-4 py-6">
+        <div className="text-zinc-500 text-sm">Failed to load achievements.</div>
+      </div>
+    );
+  }
+
+  const achievements: UserAchievement[] = data ?? [];
+
+  if (achievements.length === 0) {
+    return (
+      <div className="max-w-4xl mx-auto px-4 py-6 flex flex-col gap-6">
+        <div className="flex items-baseline justify-between">
+          <Kicker color="zinc">Achievements</Kicker>
+        </div>
+        <div className="text-zinc-500 text-sm">No achievements yet.</div>
+      </div>
+    );
+  }
+
+  const earned = achievements.filter((a) => a.earned);
+  const totalXp = earned.reduce((sum, a) => sum + a.points, 0);
+
+  // Collect unique categories present in the data, in display order
+  const presentCategorySet = new Set(achievements.map((a) => a.category));
+  const presentCategories = DISPLAY_ORDER.filter((cat) => presentCategorySet.has(cat));
+
+  // Categories to render: all or filtered
+  const visibleCategories =
+    activeCategory !== null
+      ? presentCategories.filter((cat) => cat === activeCategory)
+      : presentCategories;
+
+  // Group achievements by category
+  const byCategory = achievements.reduce<Record<string, UserAchievement[]>>((acc, a) => {
+    if (!acc[a.category]) acc[a.category] = [];
+    acc[a.category].push(a);
+    return acc;
+  }, {});
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-6 flex flex-col gap-6">
+      {/* Header */}
+      <div className="flex items-baseline justify-between">
+        <Kicker color="zinc">Achievements</Kicker>
+        <span className="text-[11px] text-zinc-500 font-mono">
+          {earned.length}/{achievements.length} earned · {totalXp} XP
+        </span>
+      </div>
+
+      {/* Next up (self only) */}
+      {isOwnProfile && (
+        <section>
+          <Kicker color="zinc" className="mb-2">Next up</Kicker>
+          <NextUpStrip achievements={achievements} mode="self" baseHref={baseHref} />
+        </section>
+      )}
+
+      {/* Recently earned */}
+      <section>
+        <Kicker color="zinc" className="mb-2">Recently earned</Kicker>
+        <RecentlyEarnedStrip achievements={achievements} mode={mode} baseHref={baseHref} />
+      </section>
+
+      {/* Category filter */}
+      <CategoryFilter categories={presentCategories} />
+
+      {/* Category-grouped grids */}
+      {DISPLAY_ORDER.filter((cat) => visibleCategories.includes(cat)).map((cat) => {
+        const catAchievements = byCategory[cat];
+        if (!catAchievements || catAchievements.length === 0) return null;
+        return (
+          <section key={cat}>
+            <Kicker color="zinc" className="mb-2">{CATEGORY_LABELS[cat]}</Kicker>
+            <BadgeGrid achievements={catAchievements} mode={mode} baseHref={baseHref} />
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -21,7 +21,7 @@ import WatchlistTabs, {
 import WatchlistGrid from "../components/profile/WatchlistGrid";
 import { TitleGridSkeleton } from "../components/SkeletonComponents";
 import { useApiCall } from "../hooks/useApiCall";
-import BadgesCard from "../components/profile/BadgesCard";
+import ProfileBadgesSummary from "../components/profile/ProfileBadgesSummary";
 import StreakCounter from "../components/profile/StreakCounter";
 
 export default function UserProfilePage() {
@@ -170,9 +170,13 @@ export default function UserProfilePage() {
             )}
             {show_watchlist && <ProgressCard overview={overview} />}
             {show_watchlist && achievements && achievements.length > 0 && (
-              <BadgesCard
+              <ProfileBadgesSummary
                 achievements={achievements}
                 mode={is_own_profile ? "self" : "other"}
+                viewAllHref={is_own_profile
+                  ? "/achievements"
+                  : `/u/${user.username}/achievements`
+                }
               />
             )}
             {show_watchlist && genres.length > 0 && <TopGenresCard genres={genres} limit={6} />}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -856,6 +856,8 @@ export interface SuggestionsAggregateResponse {
 
 // ─── Gamification Types ───────────────────────────────────────────────────────
 
+export type Category = 'watching' | 'streaks' | 'genres' | 'social' | 'special' | 'explorer' | 'habit' | 'long-haul';
+
 export interface AchievementDef {
   key: string;
   kind: string;
@@ -866,12 +868,23 @@ export interface AchievementDef {
   icon: string;
   genre?: string;
   windowHours?: number;
+  // PR1 additions (computed server-side from registry)
+  category: Category;
+  tier: 'ladder' | 'one-shot';
+  repeatable: boolean;
+  family: string | null;
+  rungIndex: number | null;
 }
 
 export interface UserAchievement extends AchievementDef {
   progress: number;
   earned: boolean;
   earnedAt: string | null;
+  // PR1 additions
+  earnedCount: number;
+  lastEarnedAt: string | null;
+  nextRung: { key: string; threshold: number; rungIndex: number; points: number } | null;
+  rarity: { pct: number; bucket: 'common' | 'rare' | 'epic' | 'legendary' } | null;
 }
 
 export interface LeaderboardEntry {

--- a/server/achievements/definitions.ts
+++ b/server/achievements/definitions.ts
@@ -8,6 +8,16 @@ export type AchievementKind =
   | "social_first_follow"
   | "speed_binge_season";
 
+export type Category =
+  | "watching"
+  | "streaks"
+  | "genres"
+  | "social"
+  | "special"
+  | "explorer"
+  | "habit"
+  | "long-haul";
+
 export interface Achievement {
   key: string;           // immutable PK — NEVER reused (orphan rows in user_achievements if renamed)
   kind: AchievementKind;
@@ -50,3 +60,95 @@ export const ACHIEVEMENTS: readonly Achievement[] = [
   // Speed
   { key: "binge_season_24h", kind: "speed_binge_season", threshold: 8, windowHours: 24, points: 50, title: "Speedrun", description: "Watch 8 episodes of one season in 24 hours", icon: "Zap" },
 ];
+
+export interface AchievementMeta {
+  category: Category;
+  family: string | null;
+  rungIndex: number | null;
+  tier: "ladder" | "one-shot";
+  repeatable: boolean;
+}
+
+function deriveCategory(kind: AchievementKind): Category {
+  switch (kind) {
+    case "count_movies":
+    case "count_episodes":
+      return "watching";
+    case "streak_days":
+      return "streaks";
+    case "genre_count":
+      return "genres";
+    case "social_first_recommendation":
+    case "social_first_follow":
+      return "social";
+    case "completionist":
+    case "speed_binge_season":
+      return "special";
+  }
+}
+
+function deriveFamily(achievement: Achievement): string | null {
+  switch (achievement.kind) {
+    case "count_movies":
+      return "movies";
+    case "count_episodes":
+      return "episodes";
+    case "streak_days":
+      return "streaks";
+    case "genre_count":
+      if (achievement.genre && achievement.genre !== "__any__") {
+        return "genre_" + achievement.genre.toLowerCase();
+      }
+      return null;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Pre-computes category, family, rungIndex, tier, and repeatable for each
+ * achievement in the registry. Call once at module load; use the returned Map
+ * in route handlers.
+ */
+export function computeAchievementMeta(
+  achievements: readonly Achievement[],
+): Map<string, AchievementMeta> {
+  // Build family → sorted entries (by threshold asc) to assign rungIndex
+  const familyBuckets = new Map<string, Achievement[]>();
+  for (const a of achievements) {
+    const family = deriveFamily(a);
+    if (family !== null) {
+      const bucket = familyBuckets.get(family) ?? [];
+      bucket.push(a);
+      familyBuckets.set(family, bucket);
+    }
+  }
+  // Sort each bucket by threshold ascending
+  for (const bucket of familyBuckets.values()) {
+    bucket.sort((a, b) => a.threshold - b.threshold);
+  }
+  // Build rungIndex lookup: key → index within its family bucket
+  const rungIndexByKey = new Map<string, number>();
+  for (const bucket of familyBuckets.values()) {
+    bucket.forEach((a, idx) => {
+      rungIndexByKey.set(a.key, idx);
+    });
+  }
+
+  const result = new Map<string, AchievementMeta>();
+  for (const a of achievements) {
+    const family = deriveFamily(a);
+    const rungIndex = family !== null ? (rungIndexByKey.get(a.key) ?? null) : null;
+    result.set(a.key, {
+      category: deriveCategory(a.kind),
+      family,
+      rungIndex,
+      tier: family !== null ? "ladder" : "one-shot",
+      repeatable: false,
+    });
+  }
+  return result;
+}
+
+/** Pre-computed meta map — computed once at module load. */
+export const ACHIEVEMENT_META: Map<string, AchievementMeta> = computeAchievementMeta(ACHIEVEMENTS);

--- a/server/routes/achievements.test.ts
+++ b/server/routes/achievements.test.ts
@@ -1,12 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { Hono } from "hono";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
 import { createUser, createSession, getSessionWithUser, upsertTitles } from "../db/repository";
 import { makeParsedTitle } from "../test-utils/fixtures";
-import { requireAuth, optionalAuth } from "../middleware/auth";
-import * as achievementsRepo from "../db/repository/achievements";
+import { optionalAuth } from "../middleware/auth";
 import { upsertAchievementDef } from "../db/repository/achievements";
-import * as streaksRepo from "../db/repository/streaks";
 import { follow } from "../db/repository";
 import achievementsRoutes, { leaderboardApp, streakApp } from "./achievements";
 import { ACHIEVEMENTS } from "../achievements/definitions";

--- a/server/routes/achievements.test.ts
+++ b/server/routes/achievements.test.ts
@@ -5,9 +5,11 @@ import { createUser, createSession, getSessionWithUser, upsertTitles } from "../
 import { makeParsedTitle } from "../test-utils/fixtures";
 import { requireAuth, optionalAuth } from "../middleware/auth";
 import * as achievementsRepo from "../db/repository/achievements";
+import { upsertAchievementDef } from "../db/repository/achievements";
 import * as streaksRepo from "../db/repository/streaks";
 import { follow } from "../db/repository";
 import achievementsRoutes, { leaderboardApp, streakApp } from "./achievements";
+import { ACHIEVEMENTS } from "../achievements/definitions";
 import type { AppEnv } from "../types";
 
 function createMockAuth() {
@@ -83,12 +85,74 @@ describe("GET /achievements", () => {
     const body = await res.json();
     expect(Array.isArray(body.achievements)).toBe(true);
     expect(body.achievements.length).toBeGreaterThan(0);
-    // Verify structure of registry entries
+    // Verify base structure of registry entries
     const first = body.achievements[0];
     expect(first).toHaveProperty("key");
     expect(first).toHaveProperty("kind");
     expect(first).toHaveProperty("title");
     expect(first).toHaveProperty("points");
+    // Verify enriched meta fields are present on every row
+    for (const row of body.achievements) {
+      expect(row).toHaveProperty("category");
+      expect(row).toHaveProperty("family");
+      expect(row).toHaveProperty("rungIndex");
+      expect(row).toHaveProperty("tier");
+      expect(row).toHaveProperty("repeatable");
+      expect(typeof row.category).toBe("string");
+      expect(["ladder", "one-shot"]).toContain(row.tier);
+      expect(typeof row.repeatable).toBe("boolean");
+    }
+  });
+
+  it("computes correct category for count_movies kind", async () => {
+    const res = await app.request("/achievements");
+    const body = await res.json();
+    const movieRow = body.achievements.find((a: any) => a.key === "movies_10");
+    expect(movieRow.category).toBe("watching");
+    expect(movieRow.family).toBe("movies");
+    expect(movieRow.tier).toBe("ladder");
+    expect(movieRow.rungIndex).toBe(0);
+  });
+
+  it("computes correct rungIndex for ladder family", async () => {
+    const res = await app.request("/achievements");
+    const body = await res.json();
+    const movies = body.achievements
+      .filter((a: any) => a.family === "movies")
+      .sort((a: any, b: any) => a.threshold - b.threshold);
+    movies.forEach((row: any, idx: number) => {
+      expect(row.rungIndex).toBe(idx);
+    });
+  });
+
+  it("computes one-shot tier and null family for social achievements", async () => {
+    const res = await app.request("/achievements");
+    const body = await res.json();
+    const socialRow = body.achievements.find((a: any) => a.key === "first_recommendation");
+    expect(socialRow.category).toBe("social");
+    expect(socialRow.family).toBeNull();
+    expect(socialRow.tier).toBe("one-shot");
+    expect(socialRow.rungIndex).toBeNull();
+  });
+
+  it("genre_explorer has null family and one-shot tier", async () => {
+    const res = await app.request("/achievements");
+    const body = await res.json();
+    const explorerRow = body.achievements.find((a: any) => a.key === "genre_explorer");
+    expect(explorerRow.category).toBe("genres");
+    expect(explorerRow.family).toBeNull();
+    expect(explorerRow.tier).toBe("one-shot");
+    expect(explorerRow.rungIndex).toBeNull();
+  });
+
+  it("specific genre achievements have family and ladder tier", async () => {
+    const res = await app.request("/achievements");
+    const body = await res.json();
+    const actionRow = body.achievements.find((a: any) => a.key === "genre_action_25");
+    expect(actionRow.category).toBe("genres");
+    expect(actionRow.family).toBe("genre_action");
+    expect(actionRow.tier).toBe("ladder");
+    expect(actionRow.rungIndex).toBe(0);
   });
 });
 
@@ -104,6 +168,49 @@ describe("GET /achievements/me", () => {
     expect(first).toHaveProperty("progress");
     expect(first).toHaveProperty("earned");
     expect(first).toHaveProperty("earnedAt");
+    // Verify enriched meta fields are present on every row
+    for (const row of body.achievements) {
+      expect(row).toHaveProperty("category");
+      expect(row).toHaveProperty("family");
+      expect(row).toHaveProperty("rungIndex");
+      expect(row).toHaveProperty("tier");
+      expect(row).toHaveProperty("repeatable");
+      // /me-only extra fields
+      expect(row).toHaveProperty("earnedCount");
+      expect(row).toHaveProperty("lastEarnedAt");
+      expect(row).toHaveProperty("nextRung");
+      expect(row).toHaveProperty("rarity");
+      expect(typeof row.earnedCount).toBe("number");
+      expect(row.nextRung).toBeNull();
+      expect(row.rarity).toBeNull();
+    }
+  });
+
+  it("earnedCount is 0 when not earned, 1 when earned", async () => {
+    // Seed the achievement definition (FK parent) then insert user row
+    const moviesDef = ACHIEVEMENTS.find((a) => a.key === "movies_10")!;
+    await upsertAchievementDef(moviesDef);
+
+    const { getDb } = await import("../db/schema");
+    const { userAchievements } = await import("../db/schema");
+    const db = getDb();
+    await db.insert(userAchievements).values({
+      userId: userAId,
+      achievementKey: "movies_10",
+      progress: 10,
+      earnedAt: new Date().toISOString(),
+    }).run();
+
+    const res = await app.request("/achievements/me", {
+      headers: authHeaders(userAToken),
+    });
+    const body = await res.json();
+    const earnedRow = body.achievements.find((a: any) => a.key === "movies_10");
+    const unearnedRow = body.achievements.find((a: any) => a.key === "movies_50");
+    expect(earnedRow.earnedCount).toBe(1);
+    expect(earnedRow.lastEarnedAt).not.toBeNull();
+    expect(unearnedRow.earnedCount).toBe(0);
+    expect(unearnedRow.lastEarnedAt).toBeNull();
   });
 
   it("returns 401 without auth", async () => {
@@ -155,6 +262,43 @@ describe("GET /achievements/u/:username", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(Array.isArray(body.achievements)).toBe(true);
+  });
+
+  it("returns meta fields on earned rows for public profile", async () => {
+    const { getDb } = await import("../db/schema");
+    const { users, userAchievements } = await import("../db/schema");
+    const { eq } = await import("drizzle-orm");
+    const db = getDb();
+    await db.update(users).set({ profileVisibility: "public" }).where(eq(users.id, userBId)).run();
+
+    // Seed the achievement definition (FK parent) then insert user row
+    const streakDef = ACHIEVEMENTS.find((a) => a.key === "streak_7")!;
+    await upsertAchievementDef(streakDef);
+
+    // Give bob an earned achievement
+    await db.insert(userAchievements).values({
+      userId: userBId,
+      achievementKey: "streak_7",
+      progress: 7,
+      earnedAt: new Date().toISOString(),
+    }).run();
+
+    const res = await app.request("/achievements/u/bob", {
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.achievements.length).toBe(1);
+    const row = body.achievements[0];
+    expect(row.category).toBe("streaks");
+    expect(row.family).toBe("streaks");
+    expect(row.tier).toBe("ladder");
+    expect(typeof row.rungIndex).toBe("number");
+    expect(row.repeatable).toBe(false);
+    // /u/:username should NOT expose /me-only fields
+    expect(row.earnedCount).toBeUndefined();
+    expect(row.nextRung).toBeUndefined();
+    expect(row.rarity).toBeUndefined();
   });
 
   it("validates param: empty username returns 400", async () => {

--- a/server/routes/achievements.ts
+++ b/server/routes/achievements.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { sql } from "drizzle-orm";
 import { getDb } from "../db/schema";
 import { ACHIEVEMENTS, ACHIEVEMENT_META } from "../achievements/definitions";
+import type { Achievement, AchievementMeta } from "../achievements/definitions";
 import { getUserAchievements } from "../db/repository/achievements";
 import { getStreak } from "../db/repository/streaks";
 import { getUserVisibilityByUsername } from "../db/repository/profile";
@@ -12,6 +13,16 @@ import { ok, err } from "./response";
 import { zValidator } from "../lib/validator";
 import { requireAuth } from "../middleware/auth";
 import { traceDbQuery } from "../tracing";
+
+function enrichWithMeta(_a: Achievement | undefined, meta: AchievementMeta | undefined) {
+  return {
+    category: meta?.category ?? "watching",
+    family: meta?.family ?? null,
+    rungIndex: meta?.rungIndex ?? null,
+    tier: meta?.tier ?? "one-shot" as const,
+    repeatable: meta?.repeatable ?? false,
+  };
+}
 
 // ─── Achievements sub-app (mounted at /api/achievements) ────────────────────
 
@@ -23,17 +34,10 @@ const usernameSchema = z.object({
 
 // GET / — Public registry (no auth required)
 achievementsApp.get("/", (c) => {
-  const achievements = ACHIEVEMENTS.map((a) => {
-    const meta = ACHIEVEMENT_META.get(a.key);
-    return {
-      ...a,
-      category: meta?.category ?? "watching",
-      family: meta?.family ?? null,
-      rungIndex: meta?.rungIndex ?? null,
-      tier: meta?.tier ?? "one-shot",
-      repeatable: meta?.repeatable ?? false,
-    };
-  });
+  const achievements = ACHIEVEMENTS.map((a) => ({
+    ...a,
+    ...enrichWithMeta(a, ACHIEVEMENT_META.get(a.key)),
+  }));
   return ok(c, { achievements });
 });
 
@@ -46,7 +50,6 @@ achievementsApp.get("/me", requireAuth, async (c) => {
 
   const result = ACHIEVEMENTS.map((a) => {
     const row = progressMap.get(a.key);
-    const meta = ACHIEVEMENT_META.get(a.key);
     const earnedAt = row?.earnedAt ?? null;
     return {
       key: a.key,
@@ -61,11 +64,7 @@ achievementsApp.get("/me", requireAuth, async (c) => {
       progress: row?.progress ?? 0,
       earned: earnedAt != null,
       earnedAt,
-      category: meta?.category ?? "watching",
-      family: meta?.family ?? null,
-      rungIndex: meta?.rungIndex ?? null,
-      tier: meta?.tier ?? "one-shot",
-      repeatable: meta?.repeatable ?? false,
+      ...enrichWithMeta(a, ACHIEVEMENT_META.get(a.key)),
       earnedCount: earnedAt != null ? 1 : 0,
       lastEarnedAt: earnedAt,
       nextRung: null,
@@ -106,7 +105,6 @@ achievementsApp.get("/u/:username", requireAuth, zValidator("param", usernameSch
     .filter((r) => r.earnedAt != null)
     .map((r) => {
       const def = ACHIEVEMENTS.find((a) => a.key === r.achievementKey);
-      const meta = ACHIEVEMENT_META.get(r.achievementKey);
       return {
         key: r.achievementKey,
         kind: def?.kind ?? "count_movies",
@@ -120,11 +118,7 @@ achievementsApp.get("/u/:username", requireAuth, zValidator("param", usernameSch
         // Progress hidden for other users — only earned status shown
         earned: true,
         earnedAt: r.earnedAt,
-        category: meta?.category ?? "watching",
-        family: meta?.family ?? null,
-        rungIndex: meta?.rungIndex ?? null,
-        tier: meta?.tier ?? "one-shot",
-        repeatable: meta?.repeatable ?? false,
+        ...enrichWithMeta(def, ACHIEVEMENT_META.get(r.achievementKey)),
       };
     });
 

--- a/server/routes/achievements.ts
+++ b/server/routes/achievements.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { sql } from "drizzle-orm";
 import { getDb } from "../db/schema";
-import { ACHIEVEMENTS } from "../achievements/definitions";
+import { ACHIEVEMENTS, ACHIEVEMENT_META } from "../achievements/definitions";
 import { getUserAchievements } from "../db/repository/achievements";
 import { getStreak } from "../db/repository/streaks";
 import { getUserVisibilityByUsername } from "../db/repository/profile";
@@ -23,7 +23,18 @@ const usernameSchema = z.object({
 
 // GET / — Public registry (no auth required)
 achievementsApp.get("/", (c) => {
-  return ok(c, { achievements: ACHIEVEMENTS });
+  const achievements = ACHIEVEMENTS.map((a) => {
+    const meta = ACHIEVEMENT_META.get(a.key);
+    return {
+      ...a,
+      category: meta?.category ?? "watching",
+      family: meta?.family ?? null,
+      rungIndex: meta?.rungIndex ?? null,
+      tier: meta?.tier ?? "one-shot",
+      repeatable: meta?.repeatable ?? false,
+    };
+  });
+  return ok(c, { achievements });
 });
 
 // GET /me — User's merged progress (auth required)
@@ -35,6 +46,8 @@ achievementsApp.get("/me", requireAuth, async (c) => {
 
   const result = ACHIEVEMENTS.map((a) => {
     const row = progressMap.get(a.key);
+    const meta = ACHIEVEMENT_META.get(a.key);
+    const earnedAt = row?.earnedAt ?? null;
     return {
       key: a.key,
       kind: a.kind,
@@ -46,8 +59,17 @@ achievementsApp.get("/me", requireAuth, async (c) => {
       genre: a.genre,
       windowHours: a.windowHours,
       progress: row?.progress ?? 0,
-      earned: row?.earnedAt != null,
-      earnedAt: row?.earnedAt ?? null,
+      earned: earnedAt != null,
+      earnedAt,
+      category: meta?.category ?? "watching",
+      family: meta?.family ?? null,
+      rungIndex: meta?.rungIndex ?? null,
+      tier: meta?.tier ?? "one-shot",
+      repeatable: meta?.repeatable ?? false,
+      earnedCount: earnedAt != null ? 1 : 0,
+      lastEarnedAt: earnedAt,
+      nextRung: null,
+      rarity: null,
     };
   });
 
@@ -84,6 +106,7 @@ achievementsApp.get("/u/:username", requireAuth, zValidator("param", usernameSch
     .filter((r) => r.earnedAt != null)
     .map((r) => {
       const def = ACHIEVEMENTS.find((a) => a.key === r.achievementKey);
+      const meta = ACHIEVEMENT_META.get(r.achievementKey);
       return {
         key: r.achievementKey,
         kind: def?.kind ?? "count_movies",
@@ -97,6 +120,11 @@ achievementsApp.get("/u/:username", requireAuth, zValidator("param", usernameSch
         // Progress hidden for other users — only earned status shown
         earned: true,
         earnedAt: r.earnedAt,
+        category: meta?.category ?? "watching",
+        family: meta?.family ?? null,
+        rungIndex: meta?.rungIndex ?? null,
+        tier: meta?.tier ?? "one-shot",
+        repeatable: meta?.repeatable ?? false,
       };
     });
 


### PR DESCRIPTION
Closes #734

## Summary

First of three PRs for the achievements/badges redesign. Ships a new dedicated `/achievements` screen using the existing 19 badges — no schema changes.

- **New `/achievements` page** — hybrid layout: "Next up" strip (in-progress badges sorted by % complete), "Recently earned" strip, URL-synced category filter chips (`?cat=`), and a category-grouped badge grid
- **`/u/:username/achievements`** — same page, earned-only view for other users
- **Tier visuals** — Bronze → Silver → Gold → Platinum → Diamond ring colors derived from ladder rung index; Diamond overflow suffix (II, III … X); amber fallback for one-shot specials
- **`ProfileBadgesSummary`** replaces `BadgesCard` on profile — slim card showing XP, earned/total, top 3 recent badges, "View all →" link
- **Backend enrichment** — `GET /api/achievements` and `/me` now return `category`, `family`, `rungIndex`, `tier`, `repeatable` computed from the registry (no DB changes)

## New files

- `frontend/src/components/achievements/tier.ts` — `tierFromRung()` + `TIER_COLORS`
- `frontend/src/components/achievements/{BadgeTile,NextUpStrip,RecentlyEarnedStrip,CategoryFilter,BadgeGrid}.tsx`
- `frontend/src/components/profile/ProfileBadgesSummary.tsx`
- `frontend/src/pages/AchievementsPage.tsx`

## Test plan

- [ ] `bun test server/routes/achievements.test.ts` — all pass; every row has `category`/`family`/`rungIndex`/`tier`/`repeatable`
- [ ] `bun test frontend/src/components/achievements/` — tier mapping, BadgeTile locked/earned/count-chip
- [ ] `bun test frontend/src/components/profile/ProfileBadgesSummary.test.tsx` — XP chip, top-3 sort, view-all link
- [ ] Visit `/achievements` — Next up strip sorts by % complete, filter chip syncs to URL, locked tiles at 60% opacity with progress bar, earned tiles show tier ring
- [ ] Visit `/profile` — slim `ProfileBadgesSummary` card with "View all →" link
- [ ] Visit `/u/:username/achievements` — earned-only view for another user
- [ ] `?cat=watching` URL survives a page refresh

Note: Frontend tests fail on Windows (pre-existing happy-dom issue, tracked in #735). Linux CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)