### PR TITLE
ci(e2e): switch to nightly schedule with Claude failure triage

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,12 +1,9 @@
 name: e2e
 
 on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
-  merge_group:
-    branches: [master]
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
 
 concurrency:
   group: e2e-${{ github.ref }}
@@ -55,3 +52,67 @@ jobs:
           path: |
             playwright-report/
             test-results/
+
+  triage:
+    needs: e2e
+    if: always() && needs.e2e.result == 'failure' && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: write
+      actions: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.9"
+
+      - name: Download Playwright artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: playwright-report
+          path: e2e-artifacts/
+
+      - name: Ensure e2e-failure label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create e2e-failure \
+            --color B60205 \
+            --description "Auto-filed e2e test failure" || true
+
+      - name: Triage with Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          claude_args: >-
+            --allowed-tools "Bash(gh *),Read,Glob,Grep"
+          prompt: |
+            The nightly e2e workflow failed (run ${{ github.run_id }}, ref ${{ github.ref }}).
+            Artifacts are downloaded under ./e2e-artifacts/. Job logs are available via
+            `gh run view ${{ github.run_id }} --log-failed`.
+
+            Your job:
+            1. Identify each failing test (spec file + test name) and a one-line
+               cause from the error message. Prefer reading the gh logs over the
+               artifact for the actual error text; use the artifact for screenshots
+               and trace context if needed.
+            2. For each failure, build a stable signature: `<spec-file>::<test-name>`.
+            3. Look for existing open issues with label `e2e-failure` via
+               `gh issue list --label e2e-failure --state open --json number,title,body`.
+               If a signature already matches an open issue, add a comment with
+               a link to this run (https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+               and the latest error excerpt.
+            4. If no match, file a new issue:
+               - title: `[e2e] <spec>::<test name> failing`
+               - labels: e2e-failure
+               - body: link to this run, the failing assertion / error excerpt,
+                 and a note that this was auto-filed by the nightly triage.
+            5. Do not modify any code; this is a read-and-file job only.


### PR DESCRIPTION
## Summary

- Drops `push`/`pull_request`/`merge_group` triggers — e2e no longer gates every PR or re-runs on every post-merge push
- Adds `schedule` (04:00 UTC daily) + `workflow_dispatch` as the only triggers
- Adds a `triage` job that fires on scheduled-run failures: downloads the Playwright artifact, bootstraps an `e2e-failure` label, then invokes Claude Code to inspect the failure, dedupe against existing open issues by `<spec>::<test>` signature, and comment on or file a new issue

## Test plan

- [ ] Push this branch → confirm `test.yml` CI passes (no e2e job runs on PR)
- [ ] Actions → e2e → Run workflow → confirm `triage` job is skipped (manual dispatch excluded by `if` condition)
- [ ] To validate triage: temporarily remove the `github.event_name == 'schedule'` guard on a test branch, break a spec, dispatch — confirm Claude files a new `e2e-failure` issue
- [ ] Run the dispatch a second time with the same broken spec — confirm Claude comments on the existing issue instead of filing a new one

🤖 Generated with [Claude Code](https://claude.com/claude-code)