### PR TITLE
fix(docker): skip prepare script in production install to unblock GHCR builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM oven/bun:1.3.9 AS server-build
 WORKDIR /app
 COPY package.json bun.lock ./
 COPY frontend/package.json ./frontend/
-RUN bun install --frozen-lockfile --production
+RUN bun install --frozen-lockfile --production --ignore-scripts
 COPY server/ ./server/
 COPY drizzle/ ./drizzle/
 COPY tsconfig.json ./


### PR DESCRIPTION
## Summary

- `bun install --production` in the `server-build` Docker stage omits `devDependencies` (including `lefthook`) but still runs the `prepare` lifecycle script, which calls `lefthook install` → exits 127
- This broke the `Publish to GHCR` workflow in every run since PR #719 added `lefthook` + the `prepare` script
- Fix: add `--ignore-scripts` to that single `bun install` call — lefthook git hooks have no purpose inside a Docker image anyway

## Test plan

- [ ] Verify `docker build -t remindarr-local .` completes locally without error
- [ ] After merge: confirm the next `Publish to GHCR` workflow run on master succeeds (`gh run list --workflow="Publish to GHCR" --limit 3`)
- [ ] Confirm `ghcr.io/MatijaMaric/remindarr:latest` is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)