### PR TITLE
fix(ci): pin Bun to 1.3.9 for CF builds and auto-sync bun.lock on Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-bun-lockfile.yml
+++ b/.github/workflows/dependabot-bun-lockfile.yml
@@ -1,0 +1,38 @@
+name: Sync bun.lock on Dependabot PRs
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  sync-lockfile:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Regenerate lockfiles
+        run: bun install
+
+      - name: Commit & push if lockfiles changed
+        run: |
+          if [[ -n "$(git status --porcelain bun.lock frontend/bun.lock)" ]]; then
+            git config user.name 'dependabot[bot]'
+            git config user.email '49699333+dependabot[bot]@users.noreply.github.com'
+            git add bun.lock frontend/bun.lock
+            git commit -m "chore(deps): regenerate bun.lock"
+            git push
+          else
+            echo "Lockfiles already in sync."
+          fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "remindarr",
   "version": "1.0.0",
+  "packageManager": "bun@1.3.9",
   "workspaces": ["frontend"],
   "scripts": {
     "dev": "concurrently \"bun run dev:server\" \"bun run dev:frontend\"",


### PR DESCRIPTION
## Summary

- Adds `"packageManager": "bun@1.3.9"` to root `package.json` so Cloudflare Workers Builds detects the correct Bun version (was defaulting to 1.2.15; everything else — Dockerfile, GH Actions — uses 1.3.9)
- Adds `.github/workflows/dependabot-bun-lockfile.yml`: runs `bun install` on Dependabot PRs and commits updated lockfiles as a follow-up commit, since Dependabot's `npm` ecosystem doesn't regenerate `bun.lock`

## Why it's needed

Every Dependabot PR opened after #741 fails CF Workers Builds with:
```
error: lockfile had changes, but lockfile is frozen
```

Two root causes: wrong Bun version in CF, and stale `bun.lock` after Dependabot bumps `package.json`.

## Repo setting required

For the lockfile-sync workflow to push the follow-up commit, check that:
**Settings → Actions → General → Workflow permissions** = "Read and write permissions" ✅

If it's currently read-only, the workflow's `git push` will 403.

## After merging

Comment `@dependabot recreate` on each open Dependabot PR to trigger a fresh run that picks up the new workflow.

## Test plan

- [ ] Cloudflare Workers Builds on this PR passes (no `bun.lock` drift here, and CF should now detect `bun@1.3.9` from `packageManager`)
- [ ] After merge: comment `@dependabot recreate` on one failing Dependabot PR → confirm the lockfile-sync workflow runs, a `chore(deps): regenerate bun.lock` commit appears, and CF Workers Builds goes green

Closes #734