### PR TITLE
fix(ci): skip lefthook in dependabot lockfile sync workflow

### DIFF
--- a/.github/workflows/dependabot-bun-lockfile.yml
+++ b/.github/workflows/dependabot-bun-lockfile.yml
@@ -23,7 +23,7 @@ jobs:
           bun-version: 1.3.9
 
       - name: Regenerate lockfiles
-        run: bun install
+        run: bun install --ignore-scripts
 
       - name: Commit & push if lockfiles changed
         run: |


### PR DESCRIPTION
## Summary

- Changes `bun install` → `bun install --ignore-scripts` in the lockfile-sync workflow

## Why

`bun install` runs the `prepare` script (`lefthook install`), which wires up git hooks. When the workflow then does `git push`, the pre-push hook fires and runs the full `bun run check` suite — which fails on type errors introduced by the bumped packages (e.g. vite 8's breaking `manualChunks` type change).

Using `--ignore-scripts` prevents lefthook from installing, same pattern as the Dockerfile's production install (`fix(docker)` in #741 context).

## Test plan

- [ ] After merge, comment `@dependabot recreate` on a currently-failing Dependabot PR and confirm the lockfile commit is pushed without the pre-push hook blocking it