### PR TITLE
fix(ci): use PAT for lockfile commit push so test.yml re-runs

### DIFF
--- a/.github/workflows/dependabot-bun-lockfile.yml
+++ b/.github/workflows/dependabot-bun-lockfile.yml
@@ -16,7 +16,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # PAT required: GITHUB_TOKEN pushes don't trigger downstream workflow runs,
+          # so all-passed would wait forever on the lockfile commit.
+          token: ${{ secrets.WORKFLOW_PAT }}
 
       - uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Summary

- Switches the checkout `token` in the lockfile-sync workflow from `GITHUB_TOKEN` to `WORKFLOW_PAT`

## Why

`GITHUB_TOKEN` pushes are a GitHub limitation: they don't trigger downstream workflow runs. So after the lockfile-sync workflow commits `chore(deps): regenerate bun.lock` and pushes it, that commit becomes the new PR HEAD but `test.yml` never fires for it — leaving `all-passed` waiting forever.

A PAT push is treated as a human push and correctly triggers `test.yml` on the lockfile commit.

## Required setup before merging

Add a repo secret named **`WORKFLOW_PAT`**:

1. **Settings → Developer settings → Personal access tokens → Fine-grained tokens → Generate new token**
   - Repository access: `remindarr` only
   - Permissions: **Contents** = Read and write, **Pull requests** = Read-only
2. **Settings → Secrets and variables → Actions → New repository secret** → name `WORKFLOW_PAT`, paste the token

## Test plan

- [ ] Secret `WORKFLOW_PAT` added to repo
- [ ] After merge, comment `@dependabot recreate` on one open Dependabot PR
- [ ] Confirm lockfile-sync workflow runs, pushes lockfile commit, and `test.yml` triggers a new run on that commit
- [ ] `all-passed` goes green