### PR TITLE
fix(docker): add --ignore-scripts to frontend-build bun install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM oven/bun:1.3.13 AS frontend-build
 WORKDIR /app
 COPY package.json bun.lock ./
 COPY frontend/package.json frontend/bun.lock ./frontend/
-RUN cd frontend && bun install --frozen-lockfile
+RUN cd frontend && bun install --frozen-lockfile --ignore-scripts
 COPY frontend/ ./frontend/
 RUN cd frontend && bun run build
 


### PR DESCRIPTION
## Summary

- The `frontend-build` stage in the `Dockerfile` runs `bun install --frozen-lockfile` without `--ignore-scripts`
- This triggers the root `prepare` script (`lefthook install`), which requires `git` — not present in the `oven/bun` base image
- Commit `f696e73` already applied this fix to the `server-build` stage; this mirrors it for `frontend-build`

## Test plan

- [ ] Merge and confirm the `Publish to GHCR` workflow passes (`gh run watch`)
- [ ] Verify `ghcr.io/MatijaMaric/remindarr:latest` and `:master-<sha>` are pushed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)