### PR TITLE
fix: surface init errors and guard onlyMine provider lookup in browse

### DIFF
--- a/server/routes/browse.test.ts
+++ b/server/routes/browse.test.ts
@@ -7,6 +7,7 @@ import { setupTestDb, teardownTestDb } from "../test-utils/setup";
 import { upsertTitles, trackTitle, createUser, getOffersForTitle } from "../db/repository";
 import { makeParsedTitle, makeTmdbDiscoverMovie, makeTmdbDiscoverTv, makeTmdbMovieDetails, makeTmdbTvDetails } from "../test-utils/fixtures";
 import * as tmdbClient from "../tmdb/client";
+import * as repository from "../db/repository";
 
 const browseApp = (await import("./browse")).default;
 
@@ -575,6 +576,50 @@ describe("GET /browse", () => {
     it("happy-path: category + year filters + min_rating", async () => {
       const res = await app.request("/browse?category=popular&year_min=2000&min_rating=7.5");
       expect(res.status).toBe(200);
+    });
+  });
+
+  describe("onlyMine filtering", () => {
+    it("returns 500 via route catch when getSubscribedProviderIds throws", async () => {
+      spies.push(
+        spyOn(repository, "getSubscribedProviderIds").mockRejectedValueOnce(new Error("D1 connection lost"))
+      );
+
+      const userId = await createUser("onlymine-err-user", "hash");
+      const authedApp = new Hono<AppEnv>();
+      authedApp.use("/browse/*", async (c, next) => {
+        c.set("user", { id: userId, username: "onlymine-err-user", name: null, role: null, is_admin: false });
+        await next();
+      });
+      authedApp.route("/browse", browseApp);
+
+      const res = await authedApp.request("/browse?category=popular&onlyMine=true");
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBeDefined();
+    });
+
+    it("happy-path: onlyMine=true passes subscribed providers to discover filters", async () => {
+      spies.push(
+        spyOn(repository, "getSubscribedProviderIds").mockResolvedValueOnce([8])
+      );
+
+      const userId = await createUser("onlymine-ok-user", "hash");
+      const authedApp = new Hono<AppEnv>();
+      authedApp.use("/browse/*", async (c, next) => {
+        c.set("user", { id: userId, username: "onlymine-ok-user", name: null, role: null, is_admin: false });
+        await next();
+      });
+      authedApp.route("/browse", browseApp);
+
+      const res = await authedApp.request("/browse?category=popular&onlyMine=true");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.titles).toBeDefined();
+      expect(tmdbClient.discoverMovies).toHaveBeenCalled();
+      const movieCallFilters = ((tmdbClient.discoverMovies as any).mock.calls[0] as unknown[])[0] as Record<string, unknown>;
+      const filters = movieCallFilters.filters as Record<string, string>;
+      expect(filters.withProviders).toBe("8");
     });
   });
 });

--- a/server/routes/browse.ts
+++ b/server/routes/browse.ts
@@ -112,21 +112,22 @@ app.get("/", zValidator("query", browseQuerySchema), async (c) => {
   const typeValues = type ? type.split(",").filter(Boolean) : [];
 
   const user = c.get("user");
-  if (onlyMine && user) {
-    const subscribedIds = await getSubscribedProviderIds(user.id);
-    if (subscribedIds.length === 0) {
-      return ok(c, { titles: [], page, totalPages: 0, totalResults: 0, availableGenres: [], availableProviders: [], availableLanguages: [], regionProviderIds: [], priorityLanguageCodes: [] });
-    }
-    const subscribedStrings = subscribedIds.map(String);
-    providerValues = providerValues.length > 0
-      ? providerValues.filter((p) => subscribedStrings.includes(p))
-      : subscribedStrings;
-    if (providerValues.length === 0) {
-      return ok(c, { titles: [], page, totalPages: 0, totalResults: 0, availableGenres: [], availableProviders: [], availableLanguages: [], regionProviderIds: [], priorityLanguageCodes: [] });
-    }
-  }
 
   try {
+    if (onlyMine && user) {
+      const subscribedIds = await getSubscribedProviderIds(user.id);
+      if (subscribedIds.length === 0) {
+        return ok(c, { titles: [], page, totalPages: 0, totalResults: 0, availableGenres: [], availableProviders: [], availableLanguages: [], regionProviderIds: [], priorityLanguageCodes: [] });
+      }
+      const subscribedStrings = subscribedIds.map(String);
+      providerValues = providerValues.length > 0
+        ? providerValues.filter((p) => subscribedStrings.includes(p))
+        : subscribedStrings;
+      if (providerValues.length === 0) {
+        return ok(c, { titles: [], page, totalPages: 0, totalResults: 0, availableGenres: [], availableProviders: [], availableLanguages: [], regionProviderIds: [], priorityLanguageCodes: [] });
+      }
+    }
+
     const [movieGenreMap, tvGenreMap, movieProviders, tvProviders, tmdbLanguages] = await Promise.all([
       getMovieGenres(),
       getTvGenres(),

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -85,7 +85,7 @@ import { CloudflarePlatform } from "./platform/cloudflare";
 import { armCron, cleanupOld, enqueueOnce, processPending, recoverStale, runWithEnv, CRON_JOBS } from "./jobs/backend";
 export { JobQueueDO } from "./jobs/durable-object";
 import { createAuth } from "./auth/better-auth";
-import { migrateAuthData } from "./db/migrate-auth";
+import { migrateAuthData, resetMigrationState } from "./db/migrate-auth";
 import { syncAchievementRegistry } from "./achievements";
 import type { DrizzleDb } from "./platform/types";
 import { runWithCache } from "./cache";
@@ -209,40 +209,78 @@ function createApp(env: Env) {
   // Per-request setup: inject platform and auth into context.
   // One-time initialization (migration, admin creation, OIDC config) is
   // guarded by module-level flags so it only runs on the first request.
+  // Each init step is wrapped in its own try/catch so a transient failure
+  // doesn't 500 the request — the step retries on the next request (flags
+  // are reset on error), and the error message is captured in CF logs even
+  // when Sentry is unconfigured.
   app.use("*", async (c, next) => {
     c.set("platform", platform);
 
     // One-time data migration (skipped after first successful check)
-    await migrateAuthData();
+    try {
+      await migrateAuthData();
+    } catch (err) {
+      resetMigrationState();
+      logger.error("Auth data migration failed", {
+        error: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
+      });
+    }
 
     // Sync achievement registry once per isolate (idempotent UPSERT)
     if (!achievementRegistrySynced) {
       achievementRegistrySynced = true;
-      await syncAchievementRegistry();
+      try {
+        await syncAchievementRegistry();
+      } catch (err) {
+        achievementRegistrySynced = false;
+        logger.error("Achievement registry sync failed", {
+          error: err instanceof Error ? err.message : String(err),
+          stack: err instanceof Error ? err.stack : undefined,
+        });
+      }
     }
 
     // Create admin on first request if no users exist
     if (!adminChecked) {
       adminChecked = true;
-      const userCount = await getUserCount();
-      if (userCount === 0) {
-        const password = crypto.randomUUID().slice(0, 16);
-        const hash = await platform.hashPassword(password);
-        await createUser("admin", hash, "Admin", "local", undefined, true);
-        // Keep the password inline in the human-readable message only —
-        // do NOT pass it as a structured field so it isn't indexed by log
-        // aggregators. The operator still sees it once in dev/server logs.
-        const bootstrapLog = logger.child({ module: "worker-bootstrap" });
-        bootstrapLog.warn(
-          `Admin account created — default password: ${password} (change it after first login)`,
-          { username: "admin" }
-        );
+      try {
+        const userCount = await getUserCount();
+        if (userCount === 0) {
+          const password = crypto.randomUUID().slice(0, 16);
+          const hash = await platform.hashPassword(password);
+          await createUser("admin", hash, "Admin", "local", undefined, true);
+          // Keep the password inline in the human-readable message only —
+          // do NOT pass it as a structured field so it isn't indexed by log
+          // aggregators. The operator still sees it once in dev/server logs.
+          const bootstrapLog = logger.child({ module: "worker-bootstrap" });
+          bootstrapLog.warn(
+            `Admin account created — default password: ${password} (change it after first login)`,
+            { username: "admin" }
+          );
+        }
+      } catch (err) {
+        adminChecked = false;
+        logger.error("Admin bootstrap check failed", {
+          error: err instanceof Error ? err.message : String(err),
+          stack: err instanceof Error ? err.stack : undefined,
+        });
       }
     }
 
     // Create auth instance per-request (D1 binding is per-request),
     // but reuse cached OIDC config to avoid DB queries every time.
-    const oidcConfig = await resolveOidcConfig();
+    let oidcConfig: Awaited<ReturnType<typeof resolveOidcConfig>>;
+    try {
+      oidcConfig = await resolveOidcConfig();
+    } catch (err) {
+      invalidateOidcConfig();
+      oidcConfig = undefined;
+      logger.error("OIDC config resolve failed", {
+        error: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
+      });
+    }
     const db = getDb();
     c.set("auth", createAuth(db, platform, oidcConfig));
 


### PR DESCRIPTION
## Summary

- **`server/worker.ts`**: Wrap each one-time per-isolate init step (`migrateAuthData`, `syncAchievementRegistry`, admin bootstrap, `resolveOidcConfig`) in its own `try/catch`. Each catch logs a distinct, searchable message with `error` and `stack` fields — surfacing the actual exception message in CF Workers observability even when Sentry is unconfigured. Per-isolate flags are reset on failure so operations retry on the next request. Auth setup and `await next()` now run unconditionally, so a transient init failure no longer 500s the whole request.
- **`server/routes/browse.ts`**: Move the `onlyMine`/`getSubscribedProviderIds` block inside the route's existing `try/catch` so DB errors on that path are caught and returned as 500 via the route handler instead of escaping to `app.onError` with no message context.
- **`server/routes/browse.test.ts`**: Add regression test (`getSubscribedProviderIds` throws → route catch returns 500) and happy-path test (`onlyMine=true` passes subscribed providers to discover filters).

## Operator follow-up required

`SENTRY_DSN` appears to not be set in the CF Workers environment — `withSentry` silently no-ops without a DSN, which is why the original 500 produced no Sentry event. Verify with `wrangler secret list` and set if missing: `wrangler secret put SENTRY_DSN`. Without this, future unhandled exceptions still won't reach Sentry.

## Test plan

- [x] `bun test server/routes/browse.test.ts` — 40 tests pass (2 new)
- [x] `bun run check` — full CI gate: server tsc + frontend tsc + ESLint + 1991 server tests + 955 frontend tests — all green

Closes #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)