### PR TITLE
fix(test): bump waitFor timeout and flush microtasks in AuthContext test

### DIFF
--- a/frontend/src/context/AuthContext.test.tsx
+++ b/frontend/src/context/AuthContext.test.tsx
@@ -59,10 +59,13 @@ describe("AuthContext", () => {
     try {
       render(<LoginPage />, { wrapper: Wrapper });
 
+      // Drain the Promise.allSettled microtask chain before waitFor starts polling
+      await new Promise(resolve => setTimeout(resolve, 0));
+
       // The OIDC button should appear even though session check failed
       await waitFor(() => {
         expect(screen.getByText(/PocketID/)).toBeDefined();
-      });
+      }, { timeout: 3000 });
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -97,10 +100,13 @@ describe("AuthContext", () => {
     try {
       render(<LoginPage />, { wrapper: Wrapper });
 
+      // Drain the Promise.allSettled microtask chain before waitFor starts polling
+      await new Promise(resolve => setTimeout(resolve, 0));
+
       // With a valid session and no OIDC, local login form should render
       await waitFor(() => {
         expect(screen.getByLabelText(/username/i)).toBeDefined();
-      });
+      }, { timeout: 3000 });
     } finally {
       globalThis.fetch = originalFetch;
     }


### PR DESCRIPTION
## Summary

- Adds a zero-delay `setTimeout` after each `render()` call to drain the `Promise.allSettled` microtask chain before `waitFor` starts polling
- Raises the `waitFor` timeout from the default 1000ms to 3000ms on both tests
- Fixes a CI flake where `loads providers even when getSession rejects` consistently timed out at ~1004ms on Linux — the provider button was appearing, just 4ms too late

## Test plan

- [ ] `bun test --preload ./frontend/src/test-utils/setup.ts frontend/src/context/AuthContext.test.tsx` passes (run 3× to confirm no flaking)
- [ ] Only `frontend/src/context/AuthContext.test.tsx` is modified — no production code changed

Closes #779

🤖 Generated with [Claude Code](https://claude.com/claude-code)