### PR TITLE
perf(track): batch bulk add_tag reads and writes to fix N+1

### DIFF
--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -75,7 +75,7 @@ export {
 } from "./tracked";
 export type { UserStatus, NotificationMode, SuggestionSourceTitle, SuggestionSeedReason } from "./tracked";
 
-export { getTagsForUser, getTagsForTitle, setTags } from "./tags";
+export { getTagsForUser, getTagsForTitle, setTags, getTagsForTitles, addTagToTitlesBulk } from "./tags";
 
 export {
   getUserPublicProfile,

--- a/server/db/repository/tags.test.ts
+++ b/server/db/repository/tags.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
+import { makeParsedTitle } from "../../test-utils/fixtures";
+import { createUser, upsertTitles, trackTitle } from "../repository";
+import { getTagsForTitles, addTagToTitlesBulk } from "./tags";
+
+let userId: string;
+
+beforeEach(async () => {
+  setupTestDb();
+  userId = await createUser("tagsuser", "hash");
+  await upsertTitles([
+    makeParsedTitle({ id: "title-1", title: "Title One" }),
+    makeParsedTitle({ id: "title-2", title: "Title Two" }),
+    makeParsedTitle({ id: "title-3", title: "Title Three" }),
+  ]);
+  await trackTitle("title-1", userId);
+  await trackTitle("title-2", userId);
+  await trackTitle("title-3", userId);
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+describe("getTagsForTitles", () => {
+  it("returns empty map for empty titleIds array", async () => {
+    const result = await getTagsForTitles(userId, []);
+    expect(result).toBeInstanceOf(Map);
+    expect(result.size).toBe(0);
+  });
+
+  it("returns map with correct tags grouped by titleId", async () => {
+    await addTagToTitlesBulk(userId, ["title-1", "title-2"], "action");
+    await addTagToTitlesBulk(userId, ["title-2"], "drama");
+
+    const result = await getTagsForTitles(userId, ["title-1", "title-2"]);
+
+    expect(result.get("title-1")).toEqual(["action"]);
+    const title2Tags = result.get("title-2") ?? [];
+    expect(title2Tags).toContain("action");
+    expect(title2Tags).toContain("drama");
+    expect(title2Tags).toHaveLength(2);
+  });
+
+  it("returns no entry for titleIds with no tags", async () => {
+    const result = await getTagsForTitles(userId, ["title-1"]);
+    expect(result.has("title-1")).toBe(false);
+  });
+});
+
+describe("addTagToTitlesBulk", () => {
+  it("inserts a tag for each titleId", async () => {
+    await addTagToTitlesBulk(userId, ["title-1", "title-2"], "favorite");
+
+    const result = await getTagsForTitles(userId, ["title-1", "title-2"]);
+    expect(result.get("title-1")).toEqual(["favorite"]);
+    expect(result.get("title-2")).toEqual(["favorite"]);
+  });
+
+  it("is idempotent — calling twice produces no duplicates", async () => {
+    await addTagToTitlesBulk(userId, ["title-1"], "favorite");
+    await addTagToTitlesBulk(userId, ["title-1"], "favorite");
+
+    const result = await getTagsForTitles(userId, ["title-1"]);
+    expect(result.get("title-1")).toEqual(["favorite"]);
+  });
+
+  it("handles more than 30 titleIds (chunking)", async () => {
+    const extraTitles = Array.from({ length: 35 }, (_, i) => ({
+      id: `bulk-title-${i}`,
+      title: `Bulk Title ${i}`,
+    }));
+    await upsertTitles(extraTitles.map(({ id, title }) => makeParsedTitle({ id, title })));
+    for (const { id } of extraTitles) {
+      await trackTitle(id, userId);
+    }
+
+    const ids = extraTitles.map((t) => t.id);
+    await addTagToTitlesBulk(userId, ids, "bulk");
+
+    const result = await getTagsForTitles(userId, ids);
+    for (const id of ids) {
+      expect(result.get(id)).toEqual(["bulk"]);
+    }
+  });
+});

--- a/server/db/repository/tags.ts
+++ b/server/db/repository/tags.ts
@@ -1,4 +1,4 @@
-import { eq, and, notInArray } from "drizzle-orm";
+import { eq, and, notInArray, inArray } from "drizzle-orm";
 import { getDb, titleTags } from "../schema";
 import { traceDbQuery } from "../../tracing";
 
@@ -35,6 +35,49 @@ export async function getTagsForTitle(userId: string, titleId: string): Promise<
       .where(and(eq(titleTags.userId, userId), eq(titleTags.titleId, titleId)))
       .all();
     return rows.map((r) => r.tag);
+  });
+}
+
+export async function getTagsForTitles(
+  userId: string,
+  titleIds: string[],
+): Promise<Map<string, string[]>> {
+  return traceDbQuery("getTagsForTitles", async () => {
+    if (titleIds.length === 0) return new Map();
+    const db = getDb();
+    const rows = await db
+      .select({ titleId: titleTags.titleId, tag: titleTags.tag })
+      .from(titleTags)
+      .where(and(eq(titleTags.userId, userId), inArray(titleTags.titleId, titleIds)))
+      .all();
+    const out = new Map<string, string[]>();
+    for (const r of rows) {
+      const list = out.get(r.titleId) ?? [];
+      list.push(r.tag);
+      out.set(r.titleId, list);
+    }
+    return out;
+  });
+}
+
+const BULK_TAG_CHUNK_SIZE = 30;
+
+export async function addTagToTitlesBulk(
+  userId: string,
+  titleIds: string[],
+  tag: string,
+): Promise<void> {
+  return traceDbQuery("addTagToTitlesBulk", async () => {
+    if (titleIds.length === 0) return;
+    const db = getDb();
+    for (let i = 0; i < titleIds.length; i += BULK_TAG_CHUNK_SIZE) {
+      const chunk = titleIds.slice(i, i + BULK_TAG_CHUNK_SIZE);
+      await db
+        .insert(titleTags)
+        .values(chunk.map((titleId) => ({ userId, titleId, tag })))
+        .onConflictDoNothing()
+        .run();
+    }
   });
 }
 

--- a/server/routes/track.test.ts
+++ b/server/routes/track.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterAll } from "bun:test";
 import { Hono } from "hono";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
 import { makeParsedTitle } from "../test-utils/fixtures";
-import { upsertTitles, upsertEpisodes, createUser, createSession, getSessionWithUser } from "../db/repository";
+import { upsertTitles, upsertEpisodes, createUser, createSession, getSessionWithUser, setTags, getTagsForTitle } from "../db/repository";
 import { requireAuth } from "../middleware/auth";
 import { getRawDb } from "../db/bun-db";
 import { CONFIG } from "../config";
@@ -1117,6 +1117,75 @@ describe("POST /track/bulk", () => {
     const listRes = await app.request("/track", { headers: headers() });
     const listBody = await listRes.json();
     expect(listBody.titles.every((t: any) => t.tags?.includes("favorite"))).toBe(true);
+  });
+
+  it("bulk add_tag enforces 10-tag cap per title", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-capped" })]);
+    await app.request("/track/movie-capped", {
+      method: "POST",
+      headers: { ...headers(), "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    const currentUser = await getSessionWithUser(userToken);
+    const existingTags = ["t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8", "t9", "t10"];
+    await setTags(currentUser!.id, "movie-capped", existingTags);
+
+    const res = await app.request("/track/bulk", {
+      method: "POST",
+      headers: { ...headers(), "Content-Type": "application/json" },
+      body: JSON.stringify({ titleIds: ["movie-capped"], action: "add_tag", payload: { tag: "eleventh" } }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.updated).toBe(1);
+
+    const tags = await getTagsForTitle(currentUser!.id, "movie-capped");
+    expect(tags).not.toContain("eleventh");
+    expect(tags).toHaveLength(10);
+  });
+
+  it("bulk add_tag is idempotent", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-idem" })]);
+    await app.request("/track/movie-idem", {
+      method: "POST",
+      headers: { ...headers(), "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    for (let i = 0; i < 2; i++) {
+      const res = await app.request("/track/bulk", {
+        method: "POST",
+        headers: { ...headers(), "Content-Type": "application/json" },
+        body: JSON.stringify({ titleIds: ["movie-idem"], action: "add_tag", payload: { tag: "unique" } }),
+      });
+      expect(res.status).toBe(200);
+    }
+
+    const idemUser = await getSessionWithUser(userToken);
+    const tags = await getTagsForTitle(idemUser!.id, "movie-idem");
+    expect(tags.filter((t) => t === "unique")).toHaveLength(1);
+  });
+
+  it("bulk add_tag normalises case and whitespace", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-norm" })]);
+    await app.request("/track/movie-norm", {
+      method: "POST",
+      headers: { ...headers(), "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    const res = await app.request("/track/bulk", {
+      method: "POST",
+      headers: { ...headers(), "Content-Type": "application/json" },
+      body: JSON.stringify({ titleIds: ["movie-norm"], action: "add_tag", payload: { tag: "  Favorite  " } }),
+    });
+    expect(res.status).toBe(200);
+
+    const normUser = await getSessionWithUser(userToken);
+    const tags = await getTagsForTitle(normUser!.id, "movie-norm");
+    expect(tags).toContain("favorite");
+    expect(tags).not.toContain("  Favorite  ");
   });
 
   it("bulk set_notification_mode updates all selected titles", async () => {

--- a/server/routes/track.ts
+++ b/server/routes/track.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { trackTitle, untrackTitle, getTrackedTitles, upsertTitles, getWatchedEpisodesForExport, getEpisodeIdsBySE, watchEpisodesBulk, getWatchedTitleIds, watchTitle, updateTrackedVisibility, updateAllTrackedVisibility, updateProfilePublic, getUserById, updateTrackedStatus, updateNotificationMode, updateTrackedNotes, setTags, getTagsForTitle, setSnooze, setRemindOnRelease, getTitleById } from "../db/repository";
+import { trackTitle, untrackTitle, getTrackedTitles, upsertTitles, getWatchedEpisodesForExport, getEpisodeIdsBySE, watchEpisodesBulk, getWatchedTitleIds, watchTitle, updateTrackedVisibility, updateAllTrackedVisibility, updateProfilePublic, getUserById, updateTrackedStatus, updateNotificationMode, updateTrackedNotes, setTags, getTagsForTitle, getTagsForTitles, addTagToTitlesBulk, setSnooze, setRemindOnRelease, getTitleById } from "../db/repository";
 import { getDb, jobs } from "../db/schema";
 import { and, eq, sql as dsql } from "drizzle-orm";
 import { getUserPace, computeEta } from "../db/repository/stats";
@@ -342,13 +342,18 @@ app.post("/bulk", zValidator("json", bulkActionSchema), async (c) => {
       return c.json({ error: "Validation failed", issues: [{ message: "Tag must be between 1 and 30 characters" }] }, 400);
     }
     const normalizedTag = tag.trim().toLowerCase();
-    for (const titleId of titleIds) {
-      const existing = await getTagsForTitle(user.id, titleId);
-      if (!existing.includes(normalizedTag) && existing.length < 10) {
-        await setTags(user.id, titleId, [...existing, normalizedTag]);
-      }
-      updated++;
+
+    const existingByTitle = await getTagsForTitles(user.id, titleIds);
+    const eligible = titleIds.filter((titleId) => {
+      const existing = existingByTitle.get(titleId) ?? [];
+      return !existing.includes(normalizedTag) && existing.length < 10;
+    });
+
+    if (eligible.length > 0) {
+      await addTagToTitlesBulk(user.id, eligible, normalizedTag);
     }
+
+    updated = titleIds.length;
   } else if (action === "set_notification_mode") {
     const mode = (payload?.mode ?? null) as NotificationMode | null;
     if (mode !== null && !VALID_NOTIFICATION_MODES.includes(mode as (typeof VALID_NOTIFICATION_MODES)[number])) {


### PR DESCRIPTION
## Summary

- Replace the N+1 DB query loop in `POST /api/track/bulk` (`action: "add_tag"`) with a single batch read (`getTagsForTitles`) and a chunked bulk insert (`addTagToTitlesBulk`)
- The 10-tag-per-title cap is now enforced in-process after the single batch read, so eligible title IDs are filtered before any write
- Two new exported functions added to `server/db/repository/tags.ts`; existing `getTagsForTitle` and `setTags` are untouched (used by single-title PATCH handlers)

## Test plan

- [ ] `bun test server/db/repository/tags.test.ts` — 6 new unit tests for `getTagsForTitles` and `addTagToTitlesBulk` (empty input, grouping, idempotency, chunking >30 IDs)
- [ ] `bun test server/routes/track.test.ts` — 3 new regression tests: 10-tag cap enforcement, idempotency, case/whitespace normalisation
- [ ] `bun run check` — full CI pipeline passes

Closes #780

🤖 Generated with [Claude Code](https://claude.com/claude-code)