### PR TITLE
fix(ci): move happy-dom preload to frontend/bunfig.toml for Windows compatibility

### DIFF
--- a/frontend/bunfig.toml
+++ b/frontend/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./src/test-utils/setup.ts"]

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "cd frontend && bun run lint",
     "test": "bun run test:server && bun run test:frontend",
     "test:server": "bun test server/",
-    "test:frontend": "bun test --preload ./frontend/src/test-utils/setup.ts frontend/src/",
+    "test:frontend": "cd frontend && bun test src/",
     "test:e2e": "playwright test",
     "eval": "bun test evals/",
     "eval:notifications": "bun test evals/notifications/",


### PR DESCRIPTION
## Summary

- Creates `frontend/bunfig.toml` with `[test] preload = ["./src/test-utils/setup.ts"]` so happy-dom global registration is declared via config rather than a CLI flag
- Updates the root `test:frontend` script from `bun test --preload ./frontend/src/test-utils/setup.ts frontend/src/` to `cd frontend && bun test src/`, eliminating the cross-platform path resolution issue on Windows that caused "document is not defined" failures

## Test plan

- [ ] `bun run test:frontend` passes (955 tests, 0 failures) on Windows
- [ ] `bun run test:frontend` passes on Linux/macOS CI
- [ ] `bun run check` (full CI pipeline) passes

Closes #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)