### PR TITLE
feat(watched): allow editing watched-at timestamps on history entries

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -429,6 +429,17 @@ export async function getWatchHistory(titleId: string, signal?: AbortSignal): Pr
   return fetchJson(`/watched/history/${encodeURIComponent(titleId)}`, { signal });
 }
 
+export async function patchWatchHistoryEntry(
+  id: string,
+  watchedAt: string,
+): Promise<{ id: string; watchedAt: string }> {
+  return fetchJson(`/watched/history/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ watched_at: watchedAt }),
+  });
+}
+
 // ─── Details ────────────────────────────────────────────────────────────────
 
 export async function getMovieDetails(titleId: string, signal?: AbortSignal): Promise<MovieDetailsResponse> {

--- a/frontend/src/components/EditWatchedAtDialog.test.tsx
+++ b/frontend/src/components/EditWatchedAtDialog.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import "../i18n";
+import EditWatchedAtDialog from "./EditWatchedAtDialog";
+import * as api from "../api";
+
+let spies: ReturnType<typeof spyOn>[] = [];
+
+beforeEach(() => {
+  spies = [
+    spyOn(api, "patchWatchHistoryEntry").mockResolvedValue({ id: "hist-1", watchedAt: "2024-06-01 00:00:00" }),
+  ];
+});
+
+afterEach(() => {
+  cleanup();
+  for (const spy of spies) spy.mockRestore();
+  spies = [];
+});
+
+function renderDialog(overrides: Partial<Parameters<typeof EditWatchedAtDialog>[0]> = {}) {
+  const defaults = {
+    open: true,
+    onClose: mock(() => {}),
+    entryId: "hist-1",
+    currentWatchedAt: "2024-05-01 10:00:00",
+    anchorDate: null as string | null,
+    onUpdated: mock((_: string) => {}),
+  };
+  const props = { ...defaults, ...overrides };
+  return { result: render(<EditWatchedAtDialog {...props} />), props };
+}
+
+describe("EditWatchedAtDialog", () => {
+  it("renders the dialog title", () => {
+    renderDialog();
+    expect(screen.getByText("Edit watched date")).toBeDefined();
+  });
+
+  it("renders Today, Yesterday, and Last week chips", () => {
+    renderDialog();
+    expect(screen.getByText("Today")).toBeDefined();
+    expect(screen.getByText("Yesterday")).toBeDefined();
+    expect(screen.getByText("Last week")).toBeDefined();
+  });
+
+  it("does not render On release chip when anchorDate is null", () => {
+    renderDialog({ anchorDate: null });
+    expect(screen.queryByText("On release")).toBeNull();
+  });
+
+  it("renders On release chip when anchorDate is provided", () => {
+    renderDialog({ anchorDate: "2024-01-15" });
+    expect(screen.getByText("On release")).toBeDefined();
+  });
+
+  it("clicking Cancel does not call patchWatchHistoryEntry", () => {
+    renderDialog();
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(api.patchWatchHistoryEntry).not.toHaveBeenCalled();
+  });
+
+  it("clicking Save calls patchWatchHistoryEntry with the entry id", async () => {
+    renderDialog({ entryId: "hist-42" });
+    fireEvent.click(screen.getByText("Save"));
+    await waitFor(() => {
+      expect(api.patchWatchHistoryEntry).toHaveBeenCalled();
+      const [id] = (api.patchWatchHistoryEntry as ReturnType<typeof spyOn>).mock.calls[0] as [string, string];
+      expect(id).toBe("hist-42");
+    });
+  });
+
+  it("dispatches watch-history:updated event on successful save", async () => {
+    const events: Event[] = [];
+    const handler = (e: Event) => events.push(e);
+    window.addEventListener("watch-history:updated", handler);
+
+    const onClose = mock(() => {});
+    renderDialog({ onClose });
+
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(api.patchWatchHistoryEntry).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(events.length).toBeGreaterThan(0);
+    });
+
+    window.removeEventListener("watch-history:updated", handler);
+  });
+});

--- a/frontend/src/components/EditWatchedAtDialog.tsx
+++ b/frontend/src/components/EditWatchedAtDialog.tsx
@@ -1,0 +1,125 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  AlertDialog,
+  AlertDialogPopup,
+  AlertDialogTitle,
+  AlertDialogClose,
+} from "./ui/alert-dialog";
+import { Calendar } from "./ui/calendar";
+import { Button } from "./ui/button";
+import * as api from "../api";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  entryId: string;
+  currentWatchedAt: string;
+  anchorDate?: string | null;
+  onUpdated: (newWatchedAt: string) => void;
+}
+
+function toDate(watchedAt: string): Date {
+  return new Date(watchedAt.slice(0, 10) + "T00:00:00");
+}
+
+function toYMD(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export default function EditWatchedAtDialog({ open, onClose, entryId, currentWatchedAt, anchorDate, onUpdated }: Props) {
+  const { t } = useTranslation();
+  const [selected, setSelected] = useState<Date | undefined>(toDate(currentWatchedAt));
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  function pickQuick(offsetDays: number) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - offsetDays);
+    setSelected(d);
+  }
+
+  function pickAnchor() {
+    if (!anchorDate) return;
+    setSelected(new Date(anchorDate + "T00:00:00"));
+  }
+
+  async function handleSave() {
+    if (!selected) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const result = await api.patchWatchHistoryEntry(entryId, toYMD(selected));
+      onUpdated(result.watchedAt);
+      window.dispatchEvent(new CustomEvent("watch-history:updated"));
+      onClose();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Failed to save";
+      setError(msg);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <AlertDialogPopup className="max-w-sm space-y-4">
+        <AlertDialogTitle>{t("watchedAt.editTitle", "Edit watched date")}</AlertDialogTitle>
+
+        <div className="flex flex-wrap gap-2">
+          <button
+            onClick={() => pickQuick(0)}
+            className="min-h-7 px-3 py-1 rounded-md text-xs font-medium bg-zinc-800 text-zinc-300 hover:bg-zinc-700 transition-colors cursor-pointer"
+          >
+            {t("watchedAt.today", "Today")}
+          </button>
+          <button
+            onClick={() => pickQuick(1)}
+            className="min-h-7 px-3 py-1 rounded-md text-xs font-medium bg-zinc-800 text-zinc-300 hover:bg-zinc-700 transition-colors cursor-pointer"
+          >
+            {t("watchedAt.yesterday", "Yesterday")}
+          </button>
+          <button
+            onClick={() => pickQuick(7)}
+            className="min-h-7 px-3 py-1 rounded-md text-xs font-medium bg-zinc-800 text-zinc-300 hover:bg-zinc-700 transition-colors cursor-pointer"
+          >
+            {t("watchedAt.lastWeek", "Last week")}
+          </button>
+          {anchorDate && (
+            <button
+              onClick={pickAnchor}
+              className="min-h-7 px-3 py-1 rounded-md text-xs font-medium bg-zinc-800 text-zinc-300 hover:bg-zinc-700 transition-colors cursor-pointer"
+            >
+              {t("watchedAt.onRelease", "On release")}
+            </button>
+          )}
+        </div>
+
+        <Calendar
+          mode="single"
+          selected={selected}
+          onSelect={setSelected}
+          disabled={{ after: today }}
+          className="rounded-md"
+        />
+
+        {error && <p className="text-xs text-red-400">{error}</p>}
+
+        <div className="flex justify-end gap-2">
+          <AlertDialogClose
+            onClick={onClose}
+            className="min-h-8 px-3 py-1.5 rounded-md text-sm font-medium bg-zinc-800 text-zinc-300 hover:bg-zinc-700 transition-colors cursor-pointer"
+          >
+            {t("watchedAt.cancel", "Cancel")}
+          </AlertDialogClose>
+          <Button onClick={handleSave} disabled={!selected || saving} size="sm">
+            {saving ? "…" : t("watchedAt.save", "Save")}
+          </Button>
+        </div>
+      </AlertDialogPopup>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/components/profile/RecentActivityCard.tsx
+++ b/frontend/src/components/profile/RecentActivityCard.tsx
@@ -286,6 +286,13 @@ function ActivityFeed({ username, isOwnProfile, pageSize, fetcher }: ActivityFee
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState(false);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    const handler = () => setTick((t) => t + 1);
+    window.addEventListener("watch-history:updated", handler);
+    return () => window.removeEventListener("watch-history:updated", handler);
+  }, []);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -303,7 +310,7 @@ function ActivityFeed({ username, isOwnProfile, pageSize, fetcher }: ActivityFee
         setLoading(false);
       });
     return () => controller.abort();
-  }, [username, pageSize, fetcher]);
+  }, [username, pageSize, fetcher, tick]);
 
   const handleHide = useCallback((event: ActivityEvent) => {
     setEvents((prev) => prev.filter((e) => e.id !== event.id));

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,4 +1,13 @@
 {
+  "watchedAt": {
+    "editTitle": "Edit watched date",
+    "today": "Today",
+    "yesterday": "Yesterday",
+    "lastWeek": "Last week",
+    "onRelease": "On release",
+    "save": "Save",
+    "cancel": "Cancel"
+  },
   "admin": {
     "accessDenied": "Access denied",
     "backToSettings": "Back to Settings",

--- a/frontend/src/pages/EpisodeDetailPage.tsx
+++ b/frontend/src/pages/EpisodeDetailPage.tsx
@@ -1,10 +1,10 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import ScrollableRow from "../components/ScrollableRow";
 import * as api from "../api";
-import type { EpisodeDetailsResponse, CastMember, CrewMember } from "../types";
+import type { EpisodeDetailsResponse, CastMember, CrewMember, WatchHistoryEntry } from "../types";
 import PersonCard from "../components/PersonCard";
 import { DetailPageSkeleton } from "../components/SkeletonComponents";
 import { useApiCall } from "../hooks/useApiCall";
@@ -14,6 +14,7 @@ import ShareButton from "../components/ShareButton";
 import EpisodeRatingButtons from "../components/EpisodeRatingButtons";
 import { stillUrl as mkStillUrl } from "../lib/tmdb-images";
 import SectionErrorBoundary from "../components/SectionErrorBoundary";
+import EditWatchedAtDialog from "../components/EditWatchedAtDialog";
 
 function formatDate(dateStr: string | null | undefined): string {
   if (!dateStr) return "—";
@@ -39,6 +40,8 @@ export default function EpisodeDetailPage() {
   );
 
   const [episodeStatus, setEpisodeStatus] = useState<{ id: number; is_watched: boolean } | null>(null);
+  const [watchHistoryEntries, setWatchHistoryEntries] = useState<WatchHistoryEntry[]>([]);
+  const [editHistoryEntry, setEditHistoryEntry] = useState<string | null>(null);
 
   useApiCall(
     (signal) => user && id && season
@@ -52,6 +55,14 @@ export default function EpisodeDetailPage() {
       },
     },
   );
+
+  useEffect(() => {
+    if (episodeStatus?.is_watched && id) {
+      api.getWatchHistory(id).then(({ history }) => {
+        setWatchHistoryEntries(history.filter(e => e.episodeId === episodeStatus.id));
+      }).catch(() => {});
+    }
+  }, [episodeStatus?.is_watched, episodeStatus?.id, id]);
 
   const toggleWatched = async () => {
     if (!episodeStatus) return;
@@ -165,6 +176,15 @@ export default function EpisodeDetailPage() {
             </>
           ) : null}
         </div>
+
+        {episodeStatus?.is_watched && watchHistoryEntries.length > 0 && (
+          <button
+            onClick={() => setEditHistoryEntry(watchHistoryEntries[0].id)}
+            className="text-xs text-emerald-400 hover:text-emerald-300 transition-colors underline-offset-2 hover:underline cursor-pointer"
+          >
+            Watched {new Date(watchHistoryEntries[0].watchedAt.replace(" ", "T") + "Z").toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" })}
+          </button>
+        )}
       </div>
 
       {/* Rating */}
@@ -220,6 +240,20 @@ export default function EpisodeDetailPage() {
             </ScrollableRow>
           </section>
         </SectionErrorBoundary>
+      )}
+
+      {editHistoryEntry && (
+        <EditWatchedAtDialog
+          open={true}
+          onClose={() => setEditHistoryEntry(null)}
+          entryId={editHistoryEntry}
+          currentWatchedAt={watchHistoryEntries.find(e => e.id === editHistoryEntry)?.watchedAt ?? ""}
+          anchorDate={data?.tmdb?.air_date ?? null}
+          onUpdated={(newWatchedAt) => {
+            setWatchHistoryEntries(prev => prev.map(e => e.id === editHistoryEntry ? { ...e, watchedAt: newWatchedAt } : e));
+            setEditHistoryEntry(null);
+          }}
+        />
       )}
     </div>
   );

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import * as api from "../api";
 import type { StatsResponse } from "../types";
 import { useApiCall } from "../hooks/useApiCall";
@@ -121,7 +122,13 @@ const LANGUAGE_NAMES: Record<string, string> = {
 };
 
 export function StatsView() {
-  const { data, loading } = useApiCall((signal) => api.getStats(signal), []);
+  const { data, loading, refetch } = useApiCall((signal) => api.getStats(signal), []);
+
+  useEffect(() => {
+    const handler = () => refetch();
+    window.addEventListener("watch-history:updated", handler);
+    return () => window.removeEventListener("watch-history:updated", handler);
+  }, [refetch]);
 
   if (loading || !data) {
     return (

--- a/frontend/src/pages/title/MovieDetail.tsx
+++ b/frontend/src/pages/title/MovieDetail.tsx
@@ -20,6 +20,7 @@ import { Section } from "../../components/title-detail/Section";
 import { formatCurrency } from "../../components/title-detail/utils";
 import SectionErrorBoundary from "../../components/SectionErrorBoundary";
 import SuggestionsRow from "../../components/title-detail/SuggestionsRow";
+import EditWatchedAtDialog from "../../components/EditWatchedAtDialog";
 
 export default function MovieDetail({ data }: { data: MovieDetailsResponse }) {
   const { t } = useTranslation();
@@ -28,6 +29,7 @@ export default function MovieDetail({ data }: { data: MovieDetailsResponse }) {
   const [playCount, setPlayCount] = useState(0);
   const [watchHistory, setWatchHistory] = useState<WatchHistoryEntry[]>([]);
   const [historyOpen, setHistoryOpen] = useState(false);
+  const [editEntry, setEditEntry] = useState<string | null>(null);
 
   useEffect(() => {
     api
@@ -117,13 +119,16 @@ export default function MovieDetail({ data }: { data: MovieDetailsResponse }) {
                 i < watchHistory.length - 1 ? "border-b border-zinc-800/50" : ""
               }`}
             >
-              <span className="text-zinc-500 shrink-0">
-                {new Date(entry.watchedAt).toLocaleDateString("en-US", {
+              <button
+                onClick={() => setEditEntry(entry.id)}
+                className="text-zinc-500 shrink-0 hover:text-zinc-300 cursor-pointer transition-colors underline-offset-2 hover:underline"
+              >
+                {new Date(entry.watchedAt.replace(" ", "T") + "Z").toLocaleDateString("en-US", {
                   year: "numeric",
                   month: "short",
                   day: "numeric",
                 })}
-              </span>
+              </button>
               {entry.note && <span className="text-zinc-400 italic">{entry.note}</span>}
             </li>
           ))}
@@ -248,6 +253,22 @@ export default function MovieDetail({ data }: { data: MovieDetailsResponse }) {
             )}
           </div>
         </Section>
+      )}
+
+      {editEntry && (
+        <EditWatchedAtDialog
+          open={true}
+          onClose={() => setEditEntry(null)}
+          entryId={editEntry}
+          currentWatchedAt={watchHistory.find(e => e.id === editEntry)?.watchedAt ?? ""}
+          anchorDate={title.release_date}
+          onUpdated={(newWatchedAt) => {
+            setWatchHistory(prev =>
+              prev.map(e => e.id === editEntry ? { ...e, watchedAt: newWatchedAt } : e)
+            );
+            setEditEntry(null);
+          }}
+        />
       )}
     </div>
   );

--- a/server/db/repository/episodes.ts
+++ b/server/db/repository/episodes.ts
@@ -402,6 +402,21 @@ export async function watchEpisode(episodeId: number, userId: string) {
   });
 }
 
+export async function setWatchedEpisodeWatchedAt(
+  episodeId: number,
+  userId: string,
+  watchedAt: string,
+): Promise<void> {
+  return traceDbQuery("setWatchedEpisodeWatchedAt", async () => {
+    const db = getDb();
+    await db
+      .update(watchedEpisodes)
+      .set({ watchedAt })
+      .where(and(eq(watchedEpisodes.episodeId, episodeId), eq(watchedEpisodes.userId, userId)))
+      .run();
+  });
+}
+
 export async function unwatchEpisode(episodeId: number, userId: string) {
   return traceDbQuery("unwatchEpisode", async () => {
     const db = getDb();

--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -38,6 +38,7 @@ export {
   getReleasedEpisodesWithAirDate,
   watchEpisode,
   unwatchEpisode,
+  setWatchedEpisodeWatchedAt,
   watchEpisodesBulk,
   unwatchEpisodesBulk,
   backdateWatchedEpisodesToAirDate,
@@ -50,6 +51,9 @@ export {
   logWatch,
   getTitlePlayCount,
   getTitleWatchHistory,
+  getWatchHistoryById,
+  updateWatchHistoryWatchedAt,
+  getLatestWatchHistoryFor,
 } from "./watch-history";
 
 export {
@@ -144,6 +148,7 @@ export {
   watchTitle,
   unwatchTitle,
   getWatchedTitleIds,
+  setWatchedTitleWatchedAt,
 } from "./watched-titles";
 
 export {

--- a/server/db/repository/watch-history.test.ts
+++ b/server/db/repository/watch-history.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
+import { makeParsedTitle } from "../../test-utils/fixtures";
+import { upsertTitles, createUser, upsertEpisodes } from "../repository";
+import { getRawDb } from "../bun-db";
+import {
+  getWatchHistoryById,
+  updateWatchHistoryWatchedAt,
+  getLatestWatchHistoryFor,
+  logWatch,
+} from "./watch-history";
+
+let userId: string;
+let otherUserId: string;
+
+function makeEpisode(titleId: string, n: number) {
+  return {
+    title_id: titleId,
+    season_number: 1,
+    episode_number: n,
+    name: `Episode ${n}`,
+    overview: null,
+    air_date: "2024-01-01",
+    still_path: null,
+  };
+}
+
+function getEpisodeId(titleId: string, episodeNumber: number): number {
+  const db = getRawDb();
+  const row = db
+    .prepare("SELECT id FROM episodes WHERE title_id = ? AND episode_number = ?")
+    .get(titleId, episodeNumber) as { id: number } | undefined;
+  return row!.id;
+}
+
+beforeEach(async () => {
+  setupTestDb();
+  userId = await createUser("testuser", "hash");
+  otherUserId = await createUser("otheruser", "hash2");
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+describe("getWatchHistoryById", () => {
+  it("returns null for unknown id", async () => {
+    const row = await getWatchHistoryById("nonexistent", userId);
+    expect(row).toBeNull();
+  });
+
+  it("returns the row for the correct user", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-ghb-1", objectType: "MOVIE" })]);
+    await logWatch(userId, "movie-ghb-1");
+
+    const db = getRawDb();
+    const histRow = db.prepare("SELECT id FROM watch_history WHERE user_id = ?").get(userId) as { id: string };
+
+    const result = await getWatchHistoryById(histRow.id, userId);
+    expect(result).not.toBeNull();
+    expect(result!.titleId).toBe("movie-ghb-1");
+    expect(result!.userId).toBe(userId);
+  });
+
+  it("returns null for another user's row id", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-ghb-2", objectType: "MOVIE" })]);
+    await logWatch(otherUserId, "movie-ghb-2");
+
+    const db = getRawDb();
+    const histRow = db.prepare("SELECT id FROM watch_history WHERE user_id = ?").get(otherUserId) as { id: string };
+
+    const result = await getWatchHistoryById(histRow.id, userId);
+    expect(result).toBeNull();
+  });
+});
+
+describe("updateWatchHistoryWatchedAt", () => {
+  it("updates the watched_at value for the correct row", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-upd-1", objectType: "MOVIE" })]);
+    await logWatch(userId, "movie-upd-1");
+
+    const db = getRawDb();
+    const histRow = db.prepare("SELECT id FROM watch_history WHERE user_id = ?").get(userId) as { id: string };
+
+    await updateWatchHistoryWatchedAt(histRow.id, userId, "2020-06-15 12:00:00");
+
+    const updated = db.prepare("SELECT watched_at FROM watch_history WHERE id = ?").get(histRow.id) as { watched_at: string };
+    expect(updated.watched_at).toBe("2020-06-15 12:00:00");
+  });
+
+  it("does not affect rows belonging to another user", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-upd-2", objectType: "MOVIE" })]);
+    await logWatch(otherUserId, "movie-upd-2");
+
+    const db = getRawDb();
+    const histRow = db.prepare("SELECT id, watched_at FROM watch_history WHERE user_id = ?").get(otherUserId) as { id: string; watched_at: string };
+    const originalWatchedAt = histRow.watched_at;
+
+    await updateWatchHistoryWatchedAt(histRow.id, userId, "2020-06-15 12:00:00");
+
+    const unchanged = db.prepare("SELECT watched_at FROM watch_history WHERE id = ?").get(histRow.id) as { watched_at: string };
+    expect(unchanged.watched_at).toBe(originalWatchedAt);
+  });
+});
+
+describe("getLatestWatchHistoryFor", () => {
+  it("returns null when no history rows exist", async () => {
+    const result = await getLatestWatchHistoryFor(userId, "nonexistent-title", null);
+    expect(result).toBeNull();
+  });
+
+  it("returns the maximum watched_at for a movie (episodeId = null)", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-lat-1", objectType: "MOVIE" })]);
+    await logWatch(userId, "movie-lat-1", undefined, "2024-01-01 10:00:00");
+    await logWatch(userId, "movie-lat-1", undefined, "2024-06-15 08:00:00");
+    await logWatch(userId, "movie-lat-1", undefined, "2023-12-31 23:59:59");
+
+    const result = await getLatestWatchHistoryFor(userId, "movie-lat-1", null);
+    expect(result).toBe("2024-06-15 08:00:00");
+  });
+
+  it("returns the maximum watched_at for a specific episode", async () => {
+    await upsertTitles([makeParsedTitle({ id: "show-lat-1", objectType: "SHOW" })]);
+    await upsertEpisodes([makeEpisode("show-lat-1", 1)]);
+    const epId = getEpisodeId("show-lat-1", 1);
+
+    await logWatch(userId, "show-lat-1", epId, "2024-03-01 00:00:00");
+    await logWatch(userId, "show-lat-1", epId, "2024-09-20 00:00:00");
+
+    const result = await getLatestWatchHistoryFor(userId, "show-lat-1", epId);
+    expect(result).toBe("2024-09-20 00:00:00");
+  });
+
+  it("does not mix movie and episode rows when episodeId is null", async () => {
+    await upsertTitles([makeParsedTitle({ id: "show-lat-2", objectType: "SHOW" })]);
+    await upsertEpisodes([makeEpisode("show-lat-2", 1)]);
+    const epId = getEpisodeId("show-lat-2", 1);
+
+    await logWatch(userId, "show-lat-2", epId, "2024-11-01 00:00:00");
+    await logWatch(userId, "show-lat-2", undefined, "2024-01-01 00:00:00");
+
+    const movieResult = await getLatestWatchHistoryFor(userId, "show-lat-2", null);
+    expect(movieResult).toBe("2024-01-01 00:00:00");
+  });
+});

--- a/server/db/repository/watch-history.ts
+++ b/server/db/repository/watch-history.ts
@@ -1,4 +1,4 @@
-import { eq, and, count, desc } from "drizzle-orm";
+import { eq, and, count, desc, isNull } from "drizzle-orm";
 import { getDb } from "../schema";
 import { watchHistory } from "../schema";
 import { traceDbQuery } from "../../tracing";
@@ -33,6 +33,65 @@ export async function getTitlePlayCount(userId: string, titleId: string): Promis
       .where(and(eq(watchHistory.userId, userId), eq(watchHistory.titleId, titleId)))
       .get();
     return row?.cnt ?? 0;
+  });
+}
+
+export async function getWatchHistoryById(
+  id: string,
+  userId: string,
+): Promise<{ id: string; userId: string; titleId: string; episodeId: number | null; watchedAt: string } | null> {
+  return traceDbQuery("getWatchHistoryById", async () => {
+    const db = getDb();
+    const row = await db
+      .select({
+        id: watchHistory.id,
+        userId: watchHistory.userId,
+        titleId: watchHistory.titleId,
+        episodeId: watchHistory.episodeId,
+        watchedAt: watchHistory.watchedAt,
+      })
+      .from(watchHistory)
+      .where(and(eq(watchHistory.id, id), eq(watchHistory.userId, userId)))
+      .get();
+    return row ?? null;
+  });
+}
+
+export async function updateWatchHistoryWatchedAt(
+  id: string,
+  userId: string,
+  watchedAt: string,
+): Promise<void> {
+  return traceDbQuery("updateWatchHistoryWatchedAt", async () => {
+    const db = getDb();
+    await db
+      .update(watchHistory)
+      .set({ watchedAt })
+      .where(and(eq(watchHistory.id, id), eq(watchHistory.userId, userId)))
+      .run();
+  });
+}
+
+export async function getLatestWatchHistoryFor(
+  userId: string,
+  titleId: string,
+  episodeId: number | null,
+): Promise<string | null> {
+  return traceDbQuery("getLatestWatchHistoryFor", async () => {
+    const db = getDb();
+    const conditions = [
+      eq(watchHistory.userId, userId),
+      eq(watchHistory.titleId, titleId),
+      episodeId === null ? isNull(watchHistory.episodeId) : eq(watchHistory.episodeId, episodeId),
+    ];
+    const row = await db
+      .select({ watchedAt: watchHistory.watchedAt })
+      .from(watchHistory)
+      .where(and(...conditions))
+      .orderBy(desc(watchHistory.watchedAt))
+      .limit(1)
+      .get();
+    return row?.watchedAt ?? null;
   });
 }
 

--- a/server/db/repository/watched-titles.ts
+++ b/server/db/repository/watched-titles.ts
@@ -40,6 +40,21 @@ export async function unwatchTitle(titleId: string, userId: string) {
   });
 }
 
+export async function setWatchedTitleWatchedAt(
+  titleId: string,
+  userId: string,
+  watchedAt: string,
+): Promise<void> {
+  return traceDbQuery("setWatchedTitleWatchedAt", async () => {
+    const db = getDb();
+    await db
+      .update(watchedTitles)
+      .set({ watchedAt })
+      .where(and(eq(watchedTitles.titleId, titleId), eq(watchedTitles.userId, userId)))
+      .run();
+  });
+}
+
 export async function getWatchedTitleIds(userId: string): Promise<Set<string>> {
   return traceDbQuery("getWatchedTitleIds", async () => {
     const db = getDb();

--- a/server/routes/watched.test.ts
+++ b/server/routes/watched.test.ts
@@ -7,12 +7,24 @@ import { getRawDb } from "../db/bun-db";
 import watchedApp from "./watched";
 import type { AppEnv } from "../types";
 
+let secondUserId: string;
+
 let userId: string;
 
 function makeAuthedApp() {
   const a = new Hono<AppEnv>();
   a.use("*", async (c, next) => {
     c.set("user", { id: userId, username: "testuser", name: null, role: null, is_admin: false });
+    await next();
+  });
+  a.route("/watched", watchedApp);
+  return a;
+}
+
+function makeAuthedAppAs(uid: string) {
+  const a = new Hono<AppEnv>();
+  a.use("*", async (c, next) => {
+    c.set("user", { id: uid, username: "user", name: null, role: null, is_admin: false });
     await next();
   });
   a.route("/watched", watchedApp);
@@ -44,6 +56,7 @@ async function getEpisodeId(titleId: string, season: number, episode: number): P
 beforeEach(async () => {
   setupTestDb();
   userId = await createUser("testuser", "hash");
+  secondUserId = await createUser("otheruser", "hash2");
 });
 
 afterAll(() => {
@@ -766,6 +779,190 @@ describe("Watch history logging", () => {
     const row = db.prepare("SELECT COUNT(*) as cnt FROM watch_history WHERE user_id = ? AND title_id = ?")
       .get(userId, "show-hist-bulk") as { cnt: number };
     expect(row.cnt).toBe(2);
+  });
+});
+
+describe("PATCH /watched/history/:id", () => {
+  it("returns 400 with issues when watched_at is missing", async () => {
+    const app = makeAuthedApp();
+    const res = await app.request("/watched/history/some-id", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("returns 400 with issues when watched_at is malformed", async () => {
+    const app = makeAuthedApp();
+    const res = await app.request("/watched/history/some-id", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ watched_at: "not-a-date" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("returns 400 when watched_at is a future date", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-future-1", objectType: "MOVIE" })]);
+    const app = makeAuthedApp();
+    await app.request("/watched/movies/movie-future-1", { method: "POST" });
+
+    const db = getRawDb();
+    const histRow = db.prepare("SELECT id FROM watch_history WHERE user_id = ?").get(userId) as { id: string };
+
+    const future = new Date();
+    future.setFullYear(future.getFullYear() + 1);
+    const futureStr = future.toISOString().slice(0, 10);
+
+    const res = await app.request(`/watched/history/${histRow.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ watched_at: futureStr }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.issues[0].message).toContain("future");
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    const app = makeUnauthApp();
+    const res = await app.request("/watched/history/some-id", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ watched_at: "2024-01-01" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when the entry belongs to another user", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-other-1", objectType: "MOVIE" })]);
+    const otherApp = makeAuthedAppAs(secondUserId);
+    await otherApp.request("/watched/movies/movie-other-1", { method: "POST" });
+
+    const db = getRawDb();
+    const histRow = db.prepare("SELECT id FROM watch_history WHERE user_id = ?").get(secondUserId) as { id: string };
+
+    const app = makeAuthedApp();
+    const res = await app.request(`/watched/history/${histRow.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ watched_at: "2024-01-01" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("happy path (movie): updates watch_history and watched_titles", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-patch-1", objectType: "MOVIE" })]);
+    const app = makeAuthedApp();
+    await app.request("/watched/movies/movie-patch-1", { method: "POST" });
+
+    const db = getRawDb();
+    const histRow = db.prepare("SELECT id FROM watch_history WHERE user_id = ?").get(userId) as { id: string };
+
+    const res = await app.request(`/watched/history/${histRow.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ watched_at: "2023-05-10" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.watchedAt).toBe("2023-05-10 00:00:00");
+
+    const histUpdated = db.prepare("SELECT watched_at FROM watch_history WHERE id = ?").get(histRow.id) as { watched_at: string };
+    expect(histUpdated.watched_at).toBe("2023-05-10 00:00:00");
+
+    const titleUpdated = db.prepare("SELECT watched_at FROM watched_titles WHERE title_id = ? AND user_id = ?").get("movie-patch-1", userId) as { watched_at: string };
+    expect(titleUpdated.watched_at).toBe("2023-05-10 00:00:00");
+  });
+
+  it("happy path (episode): updates watch_history and watched_episodes", async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    await upsertTitles([makeParsedTitle({ id: "show-patch-1", objectType: "SHOW" })]);
+    await upsertEpisodes([
+      { title_id: "show-patch-1", season_number: 1, episode_number: 1, name: "Ep1", overview: null, air_date: today, still_path: null },
+    ]);
+    const epId = await getEpisodeId("show-patch-1", 1, 1);
+
+    const app = makeAuthedApp();
+    await app.request(`/watched/${epId}`, { method: "POST" });
+
+    const db = getRawDb();
+    const histRow = db.prepare("SELECT id FROM watch_history WHERE user_id = ? AND episode_id = ?").get(userId, epId) as { id: string };
+
+    const res = await app.request(`/watched/history/${histRow.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ watched_at: "2022-11-20 15:30:00" }),
+    });
+    expect(res.status).toBe(200);
+
+    const histUpdated = db.prepare("SELECT watched_at FROM watch_history WHERE id = ?").get(histRow.id) as { watched_at: string };
+    expect(histUpdated.watched_at).toBe("2022-11-20 15:30:00");
+
+    const epUpdated = db.prepare("SELECT watched_at FROM watched_episodes WHERE episode_id = ? AND user_id = ?").get(epId, userId) as { watched_at: string };
+    expect(epUpdated.watched_at).toBe("2022-11-20 15:30:00");
+  });
+
+  it("mirror guard: PATCH on older history entry does not overwrite watched_episodes with newer value", async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    await upsertTitles([makeParsedTitle({ id: "show-guard-1", objectType: "SHOW" })]);
+    await upsertEpisodes([
+      { title_id: "show-guard-1", season_number: 1, episode_number: 1, name: "Ep1", overview: null, air_date: today, still_path: null },
+    ]);
+    const epId = await getEpisodeId("show-guard-1", 1, 1);
+
+    const db = getRawDb();
+    // Insert two history rows manually — first watch, then a rewatch with a later timestamp.
+    db.prepare("INSERT INTO watched_episodes (episode_id, user_id, watched_at) VALUES (?, ?, ?)").run(epId, userId, "2024-10-01 00:00:00");
+    db.prepare("INSERT INTO watch_history (id, user_id, title_id, episode_id, watched_at) VALUES (?, ?, ?, ?, ?)").run("hist-older", userId, "show-guard-1", epId, "2023-01-01 00:00:00");
+    db.prepare("INSERT INTO watch_history (id, user_id, title_id, episode_id, watched_at) VALUES (?, ?, ?, ?, ?)").run("hist-newer", userId, "show-guard-1", epId, "2024-10-01 00:00:00");
+
+    const app = makeAuthedApp();
+    const res = await app.request("/watched/history/hist-older", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ watched_at: "2023-06-15" }),
+    });
+    expect(res.status).toBe(200);
+
+    // watched_episodes should still reflect the latest history row's timestamp.
+    const epRow = db.prepare("SELECT watched_at FROM watched_episodes WHERE episode_id = ? AND user_id = ?").get(epId, userId) as { watched_at: string };
+    expect(epRow.watched_at).toBe("2024-10-01 00:00:00");
+  });
+
+  it("returns 429 and Retry-After header after 50 requests", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-rl-1", objectType: "MOVIE" })]);
+    const app = makeAuthedAppAs(secondUserId);
+    await app.request("/watched/movies/movie-rl-1", {
+      method: "POST",
+    });
+
+    const db = getRawDb();
+    const histRow = db.prepare("SELECT id FROM watch_history WHERE user_id = ?").get(secondUserId) as { id: string };
+
+    const today = new Date().toISOString().slice(0, 10);
+    for (let i = 0; i < 50; i++) {
+      await app.request(`/watched/history/${histRow.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ watched_at: today }),
+      });
+    }
+
+    const res51 = await app.request(`/watched/history/${histRow.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ watched_at: today }),
+    });
+    expect(res51.status).toBe(429);
+    expect(res51.headers.get("Retry-After")).not.toBeNull();
   });
 });
 

--- a/server/routes/watched.ts
+++ b/server/routes/watched.ts
@@ -5,15 +5,30 @@ import {
   getEpisodeAirDate, getReleasedEpisodeIds, getReleasedEpisodesWithAirDate,
   watchTitle, unwatchTitle, getEpisodeTitleId, getEpisodeTitleIds,
   backdateWatchedEpisodesToAirDate,
+  setWatchedTitleWatchedAt, setWatchedEpisodeWatchedAt,
 } from "../db/repository";
-import { logWatch, getTitlePlayCount, getTitleWatchHistory } from "../db/repository/watch-history";
+import { logWatch, getTitlePlayCount, getTitleWatchHistory, getWatchHistoryById, updateWatchHistoryWatchedAt, getLatestWatchHistoryFor } from "../db/repository/watch-history";
 import { localDateForTimezone } from "../utils/timezone";
 import type { AppEnv } from "../types";
 import { ok, err } from "./response";
 import { zValidator } from "../lib/validator";
 import { onWatchedTitle, onWatchedEpisode, onWatchedEpisodesBulk } from "../achievements/triggers";
+import { MemoryRateLimitStore } from "../middleware/rate-limit";
+import { logger } from "../logger";
 
 const app = new Hono<AppEnv>();
+
+const log = logger.child({ module: "watched" });
+
+const editHistorySchema = z.object({
+  watched_at: z.string().regex(/^\d{4}-\d{2}-\d{2}( \d{2}:\d{2}:\d{2})?$/),
+});
+
+let _watchedEditStore: MemoryRateLimitStore | null = null;
+function getWatchedEditStore(): MemoryRateLimitStore {
+  if (!_watchedEditStore) _watchedEditStore = new MemoryRateLimitStore();
+  return _watchedEditStore;
+}
 
 function isReleased(airDate: string | null, timezone: string): boolean {
   if (!airDate) return false;
@@ -104,6 +119,45 @@ app.get("/history/:titleId", async (c) => {
     getTitlePlayCount(user.id, titleId),
   ]);
   return ok(c, { history, playCount });
+});
+
+app.patch("/history/:id", zValidator("json", editHistorySchema), async (c) => {
+  const user = c.get("user")!;
+  const id = c.req.param("id");
+  const { watched_at } = c.req.valid("json");
+  const timezone = c.req.header("X-Timezone") || "UTC";
+
+  const { allowed, retryAfterMs } = await getWatchedEditStore().consume(
+    `watched-edit:${user.id}`, 50, 60 * 60 * 1000, Date.now(),
+  );
+  if (!allowed) {
+    c.header("Retry-After", String(Math.ceil(retryAfterMs / 1000)));
+    return c.json({ error: "Too many requests" }, 429);
+  }
+
+  const row = await getWatchHistoryById(id, user.id);
+  if (!row) return c.json({ error: "Not found" }, 404);
+
+  const todayLocal = localDateForTimezone(timezone);
+  if (watched_at.slice(0, 10) > todayLocal) {
+    return c.json({ error: "Validation failed", issues: [{ message: "Cannot set a future watched date" }] }, 400);
+  }
+
+  const normalised = watched_at.length === 10 ? `${watched_at} 00:00:00` : watched_at;
+
+  await updateWatchHistoryWatchedAt(id, user.id, normalised);
+
+  const latest = await getLatestWatchHistoryFor(user.id, row.titleId, row.episodeId);
+  if (latest === normalised) {
+    if (row.episodeId === null) {
+      await setWatchedTitleWatchedAt(row.titleId, user.id, normalised);
+    } else {
+      await setWatchedEpisodeWatchedAt(row.episodeId, user.id, normalised);
+    }
+  }
+
+  log.info("Watched timestamp edited", { historyId: id, userId: user.id });
+  return ok(c, { id, watchedAt: normalised });
 });
 
 app.post("/:episodeId", async (c) => {


### PR DESCRIPTION
## Summary

- Adds `PATCH /watched/history/:id` endpoint with zod validation, per-user rate limiting (50 req/hr), and future-date guard
- Mirrors timestamp edits to `watched_titles`/`watched_episodes` only when the patched row is the most-recent history entry (mirror guard)
- `EditWatchedAtDialog` component with a react-day-picker calendar and quick-select chips (Today / Yesterday / Last week / On release)
- Wired into `MovieDetail` (history panel) and `EpisodeDetailPage` (watched-date badge)
- `StatsPage` and `RecentActivityCard` refetch on the `watch-history:updated` custom event

## Test plan

- [ ] Server repo unit tests: `getWatchHistoryById`, `updateWatchHistoryWatchedAt`, `getLatestWatchHistoryFor` — `server/db/repository/watch-history.test.ts`
- [ ] Route integration tests: validation, auth, 404 scoping, movie happy path, episode happy path, mirror guard, rate limit — `server/routes/watched.test.ts` (8 new cases)
- [ ] Frontend component tests: dialog renders, chip visibility, Save/Cancel behavior, event dispatch — `frontend/src/components/EditWatchedAtDialog.test.tsx`
- [ ] Full CI pipeline passed locally: `bun run check` (tsc + lint + all tests + build + wrangler dry-run)

Closes #781

🤖 Generated with [Claude Code](https://claude.com/claude-code)