### PR TITLE
fix(worker): defer achievement registry sync off request critical path (#799)

### DIFF
--- a/server/worker.test.ts
+++ b/server/worker.test.ts
@@ -4,6 +4,8 @@ import { HTTPException } from "hono/http-exception";
 import Sentry from "./sentry";
 import { classifyError } from "./lib/error-classifier";
 import { errorsByCategory } from "./metrics";
+import { maybeDeferRegistrySync, resetAchievementRegistrySync } from "./worker";
+import { logger } from "./logger";
 
 // ─── Scheduled handler cron-branching tests ───────────────────────────────────
 
@@ -159,5 +161,81 @@ describe("CF worker onError handler", () => {
 
     expect(res.status).toBe(403);
     expect(captureSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ─── maybeDeferRegistrySync — deferral contract (#799) ───────────────────────
+
+describe("maybeDeferRegistrySync (#799 deferral contract)", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function makeCtx(): { ctx: any; captured: Promise<unknown>[] } {
+    const captured: Promise<unknown>[] = [];
+    const ctx = { waitUntil: (p: Promise<unknown>) => { captured.push(p); }, passThroughOnException: () => {} };
+    return { ctx, captured };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let logSpy: ReturnType<typeof spyOn<any, any>>;
+
+  beforeEach(() => {
+    resetAchievementRegistrySync();
+    logSpy = spyOn(logger, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    resetAchievementRegistrySync();
+    logSpy.mockRestore();
+  });
+
+  it("returns synchronously without awaiting run", () => {
+    const { ctx, captured } = makeCtx();
+    let runStarted = false;
+    let resolveRun!: () => void;
+    const run = () => new Promise<void>((resolve) => {
+      runStarted = true;
+      resolveRun = resolve;
+    });
+
+    maybeDeferRegistrySync(ctx, run);
+
+    // run was invoked synchronously (promise created) but not yet resolved
+    expect(runStarted).toBe(true);
+    // ctx.waitUntil received exactly one promise
+    expect(captured).toHaveLength(1);
+    // function itself returned without awaiting — resolveRun still pending
+    resolveRun();
+  });
+
+  it("passes a promise to ctx.waitUntil, not void", () => {
+    const { ctx, captured } = makeCtx();
+    maybeDeferRegistrySync(ctx, () => Promise.resolve());
+    expect(captured[0]).toBeInstanceOf(Promise);
+  });
+
+  it("does not call ctx.waitUntil a second time (stampede guard)", () => {
+    const { ctx, captured } = makeCtx();
+    maybeDeferRegistrySync(ctx, () => Promise.resolve());
+    maybeDeferRegistrySync(ctx, () => Promise.resolve());
+
+    expect(captured).toHaveLength(1);
+  });
+
+  it("resets the flag on error so a later request retries", async () => {
+    const { ctx, captured } = makeCtx();
+    maybeDeferRegistrySync(ctx, () => Promise.reject(new Error("sync failed")));
+
+    // Await the captured waitUntil promise (the .catch wrapper)
+    await captured[0];
+
+    // Error was logged
+    expect(logSpy).toHaveBeenCalledWith(
+      "Achievement registry sync failed",
+      expect.objectContaining({ error: "sync failed" }),
+    );
+
+    // Flag was reset — a subsequent call fires again
+    const { ctx: ctx2, captured: captured2 } = makeCtx();
+    maybeDeferRegistrySync(ctx2, () => Promise.resolve());
+    expect(captured2).toHaveLength(1);
   });
 });

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -184,6 +184,33 @@ function invalidateOidcConfig(): void {
   cachedOidcConfig = undefined;
 }
 
+/**
+ * Defer achievement registry sync via ctx.waitUntil so it never blocks a
+ * response. The per-isolate flag prevents stampedes; on error the flag resets
+ * so the next request retries (#799).
+ */
+export function maybeDeferRegistrySync(
+  ctx: ExecutionContext,
+  run: () => Promise<void>,
+): void {
+  if (achievementRegistrySynced) return;
+  achievementRegistrySynced = true;
+  ctx.waitUntil(
+    run().catch((err) => {
+      achievementRegistrySynced = false;
+      logger.error("Achievement registry sync failed", {
+        error: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
+      });
+    }),
+  );
+}
+
+/** Reset the per-isolate achievement sync flag — test seam only. */
+export function resetAchievementRegistrySync(): void {
+  achievementRegistrySynced = false;
+}
+
 /** Resolve OIDC config once per isolate, caching the result. */
 async function resolveOidcConfig(): Promise<typeof cachedOidcConfig> {
   if (oidcConfigLoaded) return cachedOidcConfig;
@@ -231,20 +258,6 @@ function createApp(env: Env) {
         error: err instanceof Error ? err.message : String(err),
         stack: err instanceof Error ? err.stack : undefined,
       });
-    }
-
-    // Sync achievement registry once per isolate (idempotent UPSERT)
-    if (!achievementRegistrySynced) {
-      achievementRegistrySynced = true;
-      try {
-        await syncAchievementRegistry();
-      } catch (err) {
-        achievementRegistrySynced = false;
-        logger.error("Achievement registry sync failed", {
-          error: err instanceof Error ? err.message : String(err),
-          stack: err instanceof Error ? err.stack : undefined,
-        });
-      }
     }
 
     // Create admin on first request if no users exist
@@ -649,6 +662,17 @@ const handler = {
           })
         );
       }
+
+      // Sync achievement registry once per isolate, deferred so it never blocks
+      // the response — the first request to a cold isolate must not pay the ~4s
+      // UPSERT loop cost (#799). Runs in both DO and D1 modes.
+      maybeDeferRegistrySync(ctx, () =>
+        runWithEnv(cfEnv, () =>
+          runWithCache(cache, () =>
+            runWithDb(db, () => syncAchievementRegistry()),
+          ),
+        ),
+      );
 
       return response;
     } catch (err) {


### PR DESCRIPTION
## Summary

- Moves `syncAchievementRegistry()` out of the global `app.use("*")` request middleware, where it was blocking the response with ~4 s of sequential D1 UPSERTs + a ~314 ms DO `/enqueue` RPC on every first request to a cold CF Worker isolate
- Defers it via `ctx.waitUntil()` using a new `maybeDeferRegistrySync()` helper, so the response is flushed before the sync begins — mirroring the existing `processPending()` deferral pattern at `worker.ts:640`
- Preserves the per-isolate stampede guard (`achievementRegistrySynced` flag set `true` before firing) and error-retry semantics (flag reset to `false` on failure so the next isolate request retries)
- Adds 4 regression tests asserting the deferral contract: sync is non-blocking, stampede guard works, flag resets on error

## Root cause clarification

The issue's premise ("/sitemap.xml triggering sync") is partially correct but incomplete. There is **no `/sitemap.xml` route** — a bot hitting that URL simply fell through to the SPA catch-all (`worker.ts:577`), which happened to be the first request to a fresh isolate, triggering the global middleware sync.

**Note on #796:** Commit `6af7839` closed #796 by lowering `TMDB_API_TIMEOUT_MS`. It did not address this code path — the `await syncAchievementRegistry()` has been unchanged since `4bb8912`. Whether to reopen/annotate #796 is left to the reviewer.

## Test plan

- [x] `bun test server/worker.test.ts` — 4 new deferral-contract tests pass alongside the existing 9
- [x] `bun run check` — full CI (server tsc + frontend tsc + ESLint + all tests + wrangler dry-run): 2045 server + 962 frontend, 0 failures

Closes #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)