### PR TITLE
chore(dev): replace pre-push hook with fast typecheck + changed-tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,9 @@ bun run start            # Runs production server
 bun run sync                              # Default sync
 bun run server/cli/sync.ts [daysBack] [type]  # CLI with args
 
-# CI check (type check + lint + tests — run before committing)
-bun run check                # Full CI pipeline: server tsc + frontend tsc + lint + tests
+# Full CI pipeline check (run before opening a PR)
+bun run check                # All type checks + lint + all tests + build + wrangler dry-run
+bun run check:fast           # Type checks + lint only (fast; same as pre-push hook)
 
 # Linting
 bun run lint                 # Run ESLint on frontend
@@ -64,9 +65,20 @@ bun run deploy:cf            # Deploy to Cloudflare
 - DB tests use in-memory SQLite via `server/test-utils/setup.ts` (`setupTestDb()` / `teardownTestDb()`)
 - Frontend tests use `@testing-library/react` with `happy-dom`
 - External APIs (TMDB, OIDC, Discord) must be mocked — never make real HTTP calls in tests
-- **Run `bun run check` before committing** — this runs the full CI pipeline locally (server type check, frontend type check, ESLint, and all tests). Do not use `bun test` alone as it skips type checking and linting.
+- **Run `bun run check` before opening a PR** — this runs the full CI pipeline locally (all type checks, lint, all tests, frontend build, wrangler dry-run). Do not use `bun test` alone as it skips type checking and linting.
 - Frontend code must pass ESLint with zero errors and zero warnings.
 - Avoid `any` types in source files — use `unknown` for catch blocks and proper types elsewhere. Test files are exempt from `no-explicit-any`.
+
+## Git hooks
+
+The `pre-push` hook (via lefthook) runs two checks **in parallel** on every `git push`:
+
+- **`bun run check:fast`** — server tsc + e2e tsc + frontend tsc + ESLint (fast; seconds)
+- **`bun run test:changed`** — only test files colocated with files changed vs `origin/master`
+
+CI (`test.yml`) runs the full suite on every push and PR to `master`. The hook is a fast local filter; CI is the backstop for anything the heuristic misses.
+
+To bypass: `git push --no-verify`
 
 ## Architecture
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,6 +1,9 @@
 pre-push:
   parallel: true
   commands:
-    check:
-      run: bun run check
-      fail_text: "❌ bun run check failed — fix before pushing (or use --no-verify if you intentionally want to bypass)"
+    types-and-lint:
+      run: bun run check:fast
+      fail_text: "❌ types/lint failed — fix before pushing (or git push --no-verify to bypass). Full suite still runs in CI."
+    changed-tests:
+      run: bun run test:changed
+      fail_text: "❌ tests for changed files failed — fix before pushing (or git push --no-verify to bypass). Full suite still runs in CI."

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "start": "bun run server/index.ts",
     "sync": "bun run server/cli/sync.ts",
     "check": "bunx tsc --noEmit && bunx tsc --noEmit -p e2e/tsconfig.json && cd frontend && bunx tsc -b --noEmit && bun run lint && cd .. && bun run test:server && bun run test:frontend && bun run build && bunx wrangler deploy --dry-run --outdir .wrangler/dry-run",
+    "check:fast": "bunx tsc --noEmit && bunx tsc --noEmit -p e2e/tsconfig.json && cd frontend && bunx tsc -b --noEmit && bun run lint",
+    "test:changed": "bun run server/cli/changed-tests.ts",
     "lint": "cd frontend && bun run lint",
     "test": "bun run test:server && bun run test:frontend",
     "test:server": "bun test server/",

--- a/server/cli/changed-tests.test.ts
+++ b/server/cli/changed-tests.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import { mapChangedFilesToTests } from "./changed-tests";
+
+describe("mapChangedFilesToTests", () => {
+  test("includes a changed .test.ts in the server bucket", () => {
+    const result = mapChangedFilesToTests(["server/foo/bar.test.ts"], () => true);
+    expect(result.server).toEqual(["server/foo/bar.test.ts"]);
+    expect(result.frontend).toEqual([]);
+  });
+
+  test("maps a changed .ts source to its colocated .test.ts", () => {
+    const result = mapChangedFilesToTests(
+      ["server/foo/bar.ts"],
+      (p) => p === "server/foo/bar.test.ts"
+    );
+    expect(result.server).toEqual(["server/foo/bar.test.ts"]);
+  });
+
+  test("omits source file when colocated test does not exist", () => {
+    const result = mapChangedFilesToTests(["server/foo/bar.ts"], () => false);
+    expect(result.server).toEqual([]);
+  });
+
+  test("omits a test file when exists returns false (e.g. deleted)", () => {
+    const result = mapChangedFilesToTests(["server/foo/bar.test.ts"], () => false);
+    expect(result.server).toEqual([]);
+  });
+
+  test("maps a changed .tsx source to its colocated .test.tsx", () => {
+    const result = mapChangedFilesToTests(
+      ["frontend/src/components/Foo.tsx"],
+      (p) => p === "frontend/src/components/Foo.test.tsx"
+    );
+    expect(result.frontend).toEqual(["src/components/Foo.test.tsx"]);
+    expect(result.server).toEqual([]);
+  });
+
+  test("maps a changed frontend .ts source to its colocated .test.ts", () => {
+    const result = mapChangedFilesToTests(
+      ["frontend/src/utils/helper.ts"],
+      (p) => p === "frontend/src/utils/helper.test.ts"
+    );
+    expect(result.frontend).toEqual(["src/utils/helper.test.ts"]);
+  });
+
+  test("returns frontend paths relative to frontend/ (strips prefix)", () => {
+    const result = mapChangedFilesToTests(
+      ["frontend/src/pages/HomePage.test.tsx"],
+      () => true
+    );
+    expect(result.frontend).toEqual(["src/pages/HomePage.test.tsx"]);
+  });
+
+  test("ignores non-ts/tsx files (.css, .json, .md, .yml)", () => {
+    const result = mapChangedFilesToTests(
+      ["frontend/src/style.css", "README.md", "package.json", "lefthook.yml"],
+      () => true
+    );
+    expect(result.server).toEqual([]);
+    expect(result.frontend).toEqual([]);
+  });
+
+  test("ignores files outside server/ and frontend/ (e2e, evals, root)", () => {
+    const result = mapChangedFilesToTests(
+      ["e2e/foo.test.ts", "evals/bar.test.ts", "root.test.ts"],
+      () => true
+    );
+    expect(result.server).toEqual([]);
+    expect(result.frontend).toEqual([]);
+  });
+
+  test("deduplicates when both a source file and its test are changed", () => {
+    const result = mapChangedFilesToTests(
+      ["server/foo/bar.ts", "server/foo/bar.test.ts"],
+      () => true
+    );
+    expect(result.server).toEqual(["server/foo/bar.test.ts"]);
+  });
+
+  test("handles multiple changed files across both buckets", () => {
+    const result = mapChangedFilesToTests(
+      [
+        "server/routes/titles.ts",
+        "server/routes/titles.test.ts",
+        "frontend/src/pages/HomePage.test.tsx",
+        "package.json",
+      ],
+      (p) =>
+        p === "server/routes/titles.test.ts" ||
+        p === "frontend/src/pages/HomePage.test.tsx"
+    );
+    expect(result.server).toEqual(["server/routes/titles.test.ts"]);
+    expect(result.frontend).toEqual(["src/pages/HomePage.test.tsx"]);
+  });
+});

--- a/server/cli/changed-tests.ts
+++ b/server/cli/changed-tests.ts
@@ -1,0 +1,103 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+export function mapChangedFilesToTests(
+  files: string[],
+  exists: (p: string) => boolean
+): { server: string[]; frontend: string[] } {
+  const server = new Set<string>();
+  const frontend = new Set<string>();
+
+  for (const file of files) {
+    let candidate: string | null = null;
+
+    if (/\.test\.tsx?$/.test(file)) {
+      candidate = file;
+    } else if (file.endsWith(".tsx")) {
+      candidate = file.replace(/\.tsx$/, ".test.tsx");
+    } else if (file.endsWith(".ts")) {
+      candidate = file.replace(/\.ts$/, ".test.ts");
+    }
+    // Non-ts files (.css, .json, .md, .yml, etc.) — ignored; CI covers broad impact
+
+    if (!candidate || !exists(candidate)) continue;
+
+    if (candidate.startsWith("server/")) {
+      server.add(candidate);
+    } else if (candidate.startsWith("frontend/")) {
+      // Frontend tests run with cwd=frontend/, so strip the prefix
+      frontend.add(candidate.slice("frontend/".length));
+    }
+    // e2e/, evals/, root files → ignored (check doesn't run those either)
+  }
+
+  return { server: [...server], frontend: [...frontend] };
+}
+
+function git(args: string[]): { ok: boolean; out: string } {
+  const proc = Bun.spawnSync(["git", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    ok: proc.exitCode === 0,
+    out: new TextDecoder().decode(proc.stdout).trim(),
+  };
+}
+
+function resolveBaseRef(): string | null {
+  for (const ref of ["origin/master", "master"]) {
+    if (git(["rev-parse", "--verify", ref]).ok) return ref;
+  }
+  return null;
+}
+
+function runBunTest(paths: string[], cwd: string): boolean {
+  const proc = Bun.spawnSync(["bun", "test", ...paths], {
+    cwd,
+    stdout: "inherit",
+    stderr: "inherit",
+    stdin: "inherit",
+  });
+  return proc.exitCode === 0;
+}
+
+if (import.meta.main) {
+  const repoRoot = process.cwd();
+  const baseRef = resolveBaseRef();
+
+  if (!baseRef) {
+    console.log("⚠️  No origin/master found — running full test suite as fallback.");
+    const ok =
+      runBunTest(["server/"], repoRoot) &&
+      runBunTest(["src/"], join(repoRoot, "frontend"));
+    process.exit(ok ? 0 : 1);
+  }
+
+  const { out } = git(["diff", "--name-only", "--diff-filter=ACMR", `${baseRef}...HEAD`]);
+  const changedFiles = out.split("\n").filter(Boolean);
+
+  const { server, frontend } = mapChangedFilesToTests(
+    changedFiles,
+    (p) => existsSync(join(repoRoot, p))
+  );
+
+  if (server.length === 0 && frontend.length === 0) {
+    console.log("✅ No changed test files — full suite still runs in CI.");
+    process.exit(0);
+  }
+
+  let passed = true;
+
+  if (server.length > 0) {
+    console.log(`🔍 Running ${server.length} server test file(s)…`);
+    if (!runBunTest(server, repoRoot)) passed = false;
+  }
+
+  if (frontend.length > 0) {
+    console.log(`🔍 Running ${frontend.length} frontend test file(s)…`);
+    if (!runBunTest(frontend, join(repoRoot, "frontend"))) passed = false;
+  }
+
+  process.exit(passed ? 0 : 1);
+}


### PR DESCRIPTION
## Summary

- **pre-push was running `bun run check` serially** — all 8 steps including ~243 test files, frontend build, and wrangler dry-run on every push. CI already runs the full suite on every push/PR to master, making the local hook a slow duplicate.
- **Now runs two parallel checks** instead:
  - `bun run check:fast` — server tsc + e2e tsc + frontend tsc + ESLint only (~seconds)
  - `bun run test:changed` — only test files colocated with files changed vs `origin/master`
- **`bun run check` is unchanged** — still the full local gate to use before opening a PR

## New files

- `server/cli/changed-tests.ts` — Bun script that diffs against `origin/master`, maps changed source files to colocated tests, and runs only those. Falls back to the full suite if no remote ref is found.
- `server/cli/changed-tests.test.ts` — 11 unit tests for the pure `mapChangedFilesToTests()` mapping function (picked up by CI's server job)

## Test plan

- [ ] `bun run check` — full pipeline still passes (confirms new test file is green)
- [ ] `bun run test:changed` on a branch with some changed files — only the relevant tests run
- [ ] `bun run test:changed` with no changed test files — exits 0 with informational message
- [ ] `git push --no-verify` still bypasses the hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)