### PR TITLE
fix(jobs): include payload and runAt in permanent-failure logs and Sentry

### DIFF
--- a/server/jobs/durable-object.test.ts
+++ b/server/jobs/durable-object.test.ts
@@ -315,6 +315,32 @@ describe("JobQueueDO", () => {
     });
   });
 
+  it("surfaces job payload and runAt in permanent failure Sentry extra and log", async () => {
+    const consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+    processorModule.handlers["sync-titles"] = async () => {
+      throw new Error("payload test failure");
+    };
+    // enqueue with a payload and maxAttempts=1 so first failure is permanent
+    await do_.enqueue("sync-titles", JSON.stringify({ marker: "p801" }), undefined, 1);
+    await do_.runJob(null);
+
+    expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+    const capturedCtx = captureExceptionSpy.mock.calls[0]?.[1] as { extra?: Record<string, unknown> };
+    expect(capturedCtx?.extra?.data).toBe('{"marker":"p801"}');
+    expect(typeof capturedCtx?.extra?.runAt).toBe("string");
+
+    // JSON log line
+    const errorCalls = consoleErrorSpy.mock.calls
+      .map((args) => { try { return JSON.parse(args[0] as string) as Record<string, unknown>; } catch { return null; } })
+      .filter((obj): obj is Record<string, unknown> => obj !== null && obj.level === "error");
+    const permanentLog = errorCalls.find((obj) => obj.msg === "Job failed permanently");
+    expect(permanentLog).toBeDefined();
+    expect(permanentLog!.data).toBe('{"marker":"p801"}');
+    expect(typeof permanentLog!.runAt).toBe("string");
+
+    consoleErrorSpy.mockRestore();
+  });
+
   it("does NOT capture transient retry failures to Sentry", async () => {
     processorModule.handlers["sync-titles"] = async () => {
       throw new Error("transient error");

--- a/server/jobs/durable-object.test.ts
+++ b/server/jobs/durable-object.test.ts
@@ -317,6 +317,7 @@ describe("JobQueueDO", () => {
 
   it("surfaces job payload and runAt in permanent failure Sentry extra and log", async () => {
     const consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+    consoleErrorSpy.mockClear(); // discard calls leaked from prior test files (Bun cross-file spy leak on Linux CI)
     processorModule.handlers["sync-titles"] = async () => {
       throw new Error("payload test failure");
     };

--- a/server/jobs/durable-object.ts
+++ b/server/jobs/durable-object.ts
@@ -202,10 +202,10 @@ export class JobQueueDO {
 
     let rows = this.ctx.storage.sql
       .exec(
-        "SELECT id, name, data, attempts, max_attempts FROM jobs WHERE status = 'pending' AND run_at <= ? ORDER BY run_at ASC LIMIT 1",
+        "SELECT id, name, data, attempts, max_attempts, run_at FROM jobs WHERE status = 'pending' AND run_at <= ? ORDER BY run_at ASC LIMIT 1",
         now,
       )
-      .toArray() as Pick<DOJobRow, "id" | "name" | "data" | "attempts" | "max_attempts">[];
+      .toArray() as Pick<DOJobRow, "id" | "name" | "data" | "attempts" | "max_attempts" | "run_at">[];
 
     if (rows.length === 0) {
       if (cron) {
@@ -222,10 +222,10 @@ export class JobQueueDO {
           );
           rows = this.ctx.storage.sql
             .exec(
-              "SELECT id, name, data, attempts, max_attempts FROM jobs WHERE status = 'pending' AND run_at <= ? ORDER BY run_at ASC LIMIT 1",
+              "SELECT id, name, data, attempts, max_attempts, run_at FROM jobs WHERE status = 'pending' AND run_at <= ? ORDER BY run_at ASC LIMIT 1",
               now,
             )
-            .toArray() as Pick<DOJobRow, "id" | "name" | "data" | "attempts" | "max_attempts">[];
+            .toArray() as Pick<DOJobRow, "id" | "name" | "data" | "attempts" | "max_attempts" | "run_at">[];
         }
       }
       if (rows.length === 0) {
@@ -351,7 +351,7 @@ export class JobQueueDO {
         Sentry.captureException(err, {
           level: "error",
           tags: { jobName: job.name, jobId: String(job.id) },
-          extra: { attempts: newAttempts, maxAttempts: job.max_attempts, lastError: message },
+          extra: { attempts: newAttempts, maxAttempts: job.max_attempts, lastError: message, data: job.data, runAt: job.run_at },
           fingerprint: ["job-permanent-failure", job.name],
         });
         log.error("Job failed permanently", {
@@ -361,6 +361,8 @@ export class JobQueueDO {
           maxAttempts: job.max_attempts,
           error: message,
           stack: err instanceof Error ? err.stack : undefined,
+          data: job.data,
+          runAt: job.run_at,
         });
       }
     }

--- a/server/jobs/processor.test.ts
+++ b/server/jobs/processor.test.ts
@@ -426,6 +426,7 @@ describe("processor Sentry capture on permanent failure", () => {
 
   it("surfaces job payload and runAt in permanent failure Sentry extra and log", async () => {
     const consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+    consoleErrorSpy.mockClear(); // discard calls leaked from prior test files (Bun cross-file spy leak on Linux CI)
     mockFetchNewReleases.mockRejectedValueOnce(new Error("payload test failure"));
     const db = getDb();
     await db.insert(jobs).values({

--- a/server/jobs/processor.test.ts
+++ b/server/jobs/processor.test.ts
@@ -423,4 +423,37 @@ describe("processor Sentry capture on permanent failure", () => {
     expect(bc.data?.name).toBe("sync-titles");
     expect(bc.data?.attempt).toBe("1");
   });
+
+  it("surfaces job payload and runAt in permanent failure Sentry extra and log", async () => {
+    const consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+    mockFetchNewReleases.mockRejectedValueOnce(new Error("payload test failure"));
+    const db = getDb();
+    await db.insert(jobs).values({
+      name: "sync-titles",
+      status: "pending",
+      attempts: 2,
+      maxAttempts: 3,
+      runAt: new Date().toISOString(),
+      data: JSON.stringify({ marker: "p801" }),
+    });
+
+    await processPendingJobs();
+
+    // Sentry extra has data and runAt
+    expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+    const capturedCtx = captureExceptionSpy.mock.calls[0]?.[1] as { extra?: Record<string, unknown> };
+    expect(capturedCtx?.extra?.data).toBe('{"marker":"p801"}');
+    expect(typeof capturedCtx?.extra?.runAt).toBe("string");
+
+    // JSON log line has data and runAt
+    const errorCalls = consoleErrorSpy.mock.calls
+      .map((args) => { try { return JSON.parse(args[0] as string) as Record<string, unknown>; } catch { return null; } })
+      .filter((obj): obj is Record<string, unknown> => obj !== null && obj.level === "error");
+    const permanentLog = errorCalls.find((obj) => obj.msg === "Job failed permanently");
+    expect(permanentLog).toBeDefined();
+    expect(permanentLog!.data).toBe('{"marker":"p801"}');
+    expect(typeof permanentLog!.runAt).toBe("string");
+
+    consoleErrorSpy.mockRestore();
+  });
 });

--- a/server/jobs/processor.ts
+++ b/server/jobs/processor.ts
@@ -539,7 +539,7 @@ export async function processPendingJobs(): Promise<number> {
         Sentry.captureException(err, {
           level: "error",
           tags: { jobName: job.name, jobId: String(job.id) },
-          extra: { attempts: newAttempts, maxAttempts: job.maxAttempts, lastError: message },
+          extra: { attempts: newAttempts, maxAttempts: job.maxAttempts, lastError: message, data: job.data, runAt: job.runAt },
           fingerprint: ["job-permanent-failure", job.name],
         });
         log.error("Job failed permanently", {
@@ -549,6 +549,8 @@ export async function processPendingJobs(): Promise<number> {
           maxAttempts: job.maxAttempts,
           error: message,
           stack: err instanceof Error ? err.stack : undefined,
+          data: job.data,
+          runAt: job.runAt,
         });
       }
     }


### PR DESCRIPTION
## Summary

- Adds `data` (job payload) and `runAt` to the permanent-failure `Sentry.captureException` `extra` object in both `server/jobs/durable-object.ts` and `server/jobs/processor.ts`
- Adds the same fields to the `log.error("Job failed permanently", ...)` call in both files so the log line is self-sufficient regardless of whether Sentry captures surface
- Widens the `SELECT` in `JobQueueDO.runJob` to include `run_at` (two identical statements) and updates the `Pick<DOJobRow, ...>` type cast to match

Closes #801

## Test plan

- [x] Added `"surfaces job payload and runAt in permanent failure Sentry extra and log"` test in `server/jobs/processor.test.ts` (describe block `"processor Sentry capture on permanent failure"`)
- [x] Added identical sibling test in `server/jobs/durable-object.test.ts`
- [x] Both tests confirmed RED before code change, GREEN after
- [x] `bun run check` passed (server tsc + e2e tsc + frontend tsc + ESLint + all tests + build + wrangler dry-run)

**Infra check (no code):** The existing `Sentry.captureException` is gated on `env.SENTRY_DSN` in the CF Worker/DO binding (`server/worker.ts:90-93`). If issue #801 recurs after deploy, verify `SENTRY_DSN` is set on the production CF Worker binding — that is the most likely reason Sentry captures are not surfacing. This payload enrichment makes the log line self-sufficient regardless of Sentry.