### PR TITLE
fix(auth): degrade gracefully on D1 fault in /api/auth/custom/providers

### DIFF
--- a/server/routes/auth-custom.test.ts
+++ b/server/routes/auth-custom.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { Hono } from "hono";
+import * as repository from "../db/repository";
+import Sentry from "../sentry";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
 import authCustomApp from "./auth-custom";
 
@@ -22,5 +24,24 @@ describe("GET /providers", () => {
     expect(body.local).toBe(true);
     expect(body.passkey).toBe(true);
     expect(body.oidc).toBeNull();
+  });
+
+  it("returns safe defaults and captures to Sentry when D1 lookup fails", async () => {
+    const oidcSpy = spyOn(repository, "isOidcConfigured").mockRejectedValueOnce(
+      new Error("SQLITE_BUSY"),
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const capSpy = spyOn(Sentry, "captureException").mockReturnValue("evt" as any);
+    capSpy.mockClear();
+
+    const res = await app.request("/providers");
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ local: true, oidc: null, passkey: true });
+    expect(capSpy).toHaveBeenCalledTimes(1);
+
+    oidcSpy.mockRestore();
+    capSpy.mockRestore();
   });
 });

--- a/server/routes/auth-custom.ts
+++ b/server/routes/auth-custom.ts
@@ -1,17 +1,28 @@
 import { Hono } from "hono";
 import { isOidcConfigured } from "../db/repository";
+import { logger } from "../logger";
+import Sentry from "../sentry";
 import type { AppEnv } from "../types";
 
 const app = new Hono<AppEnv>();
+const log = logger.child({ module: "auth-custom" });
 
 // GET /api/auth/custom/providers
 app.get("/providers", async (c) => {
-  const oidcConfigured = await isOidcConfigured();
-  return c.json({
-    local: true,
-    oidc: oidcConfigured ? { name: "OpenID Connect", providerId: "pocketid" } : null,
-    passkey: true,
-  });
+  try {
+    const oidcConfigured = await isOidcConfigured();
+    return c.json({
+      local: true,
+      oidc: oidcConfigured ? { name: "OpenID Connect", providerId: "pocketid" } : null,
+      passkey: true,
+    });
+  } catch (err: unknown) {
+    Sentry.captureException(err);
+    log.error("oidc config lookup failed; serving safe defaults", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return c.json({ local: true, oidc: null, passkey: true });
+  }
 });
 
 export default app;


### PR DESCRIPTION
## Summary

- Wraps `isOidcConfigured()` in a try/catch in `GET /api/auth/custom/providers`
- On D1/SQLite transient failure, returns HTTP 200 with safe defaults `{ local: true, oidc: null, passkey: true }` so local + passkey login keeps working
- Failure is logged via `logger.child({ module: "auth-custom" })` and captured to Sentry

## Test plan

- [ ] Happy path: `GET /api/auth/custom/providers` returns 200 with `local: true`, `passkey: true`, and `oidc: null` (no OIDC configured) or the OIDC provider object (OIDC configured)
- [ ] D1-failure degradation: when `isOidcConfigured()` rejects, the endpoint returns 200 with `{ local: true, oidc: null, passkey: true }` and calls `Sentry.captureException` exactly once

Closes #802

🤖 Generated with [Claude Code](https://claude.com/claude-code)