### PR TITLE
fix(user-settings): sync homepage-layout schema with all 10 section IDs

### DIFF
--- a/server/routes/user-settings.test.ts
+++ b/server/routes/user-settings.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach, afterAll } from "bun:test";
 import { Hono } from "hono";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
-import { createUser, upsertTitles } from "../db/repository";
+import { createUser, upsertTitles, setHomepageLayout } from "../db/repository";
 import { makeParsedTitle, makeParsedOffer } from "../test-utils/fixtures";
-import userSettingsApp, { DEFAULT_HOMEPAGE_LAYOUT } from "./user-settings";
+import userSettingsApp, { DEFAULT_HOMEPAGE_LAYOUT, HOMEPAGE_SECTION_IDS } from "./user-settings";
 import type { AppEnv } from "../types";
 
 let userId: string;
@@ -132,8 +132,8 @@ describe("PUT /user/settings/homepage-layout", () => {
 
     const res = await app.request("/user/settings/homepage-layout");
     const body = await res.json();
-    // All 6 sections returned; the 4 missing ones are appended
-    expect(body.homepage_layout).toHaveLength(6);
+    // All 10 sections returned; the 8 missing ones are appended from DEFAULT_HOMEPAGE_LAYOUT
+    expect(body.homepage_layout).toHaveLength(10);
     expect(body.homepage_layout[0].id).toBe("today");
     expect(body.homepage_layout[1].id).toBe("unwatched");
   });
@@ -224,6 +224,92 @@ describe("validation", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.homepage_layout.some((s: { id: string }) => s.id === "airing_soon")).toBe(true);
+  });
+});
+
+// ─── homepage-layout: new section IDs regression ─────────────────────────────
+// Regression for #803: user-settings.ts must include all HomepageSectionId values
+// so parseLayout() doesn't strip them. See frontend/src/types.ts for canonical list.
+
+describe("homepage-layout — new section IDs (regression #803)", () => {
+  it("HOMEPAGE_SECTION_IDS contains all 10 sections including movies_to_watch, upcoming_movies, streak, friends_loved", () => {
+    const ids = [...HOMEPAGE_SECTION_IDS];
+    expect(ids).toContain("movies_to_watch");
+    expect(ids).toContain("upcoming_movies");
+    expect(ids).toContain("streak");
+    expect(ids).toContain("friends_loved");
+    expect(ids).toHaveLength(10);
+  });
+
+  it("default layout for new user includes movies_to_watch and upcoming_movies", async () => {
+    const app = makeAuthedApp();
+    const res = await app.request("/user/settings/homepage-layout");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const ids = body.homepage_layout.map((s: { id: string }) => s.id);
+    expect(ids).toContain("movies_to_watch");
+    expect(ids).toContain("upcoming_movies");
+    expect(ids).toContain("streak");
+    expect(ids).toContain("friends_loved");
+    expect(body.homepage_layout).toHaveLength(10);
+  });
+
+  it("parseLayout preserves movies_to_watch, upcoming_movies, streak, friends_loved from stored layout", async () => {
+    const app = makeAuthedApp();
+    const stored = JSON.stringify([
+      { id: "movies_to_watch", enabled: true },
+      { id: "upcoming_movies", enabled: false },
+      { id: "streak", enabled: true },
+      { id: "friends_loved", enabled: true },
+      { id: "up_next", enabled: true },
+    ]);
+    await setHomepageLayout(userId, stored);
+
+    const res = await app.request("/user/settings/homepage-layout");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const ids = body.homepage_layout.map((s: { id: string }) => s.id);
+    expect(ids).toContain("movies_to_watch");
+    expect(ids).toContain("upcoming_movies");
+    expect(ids).toContain("streak");
+    expect(ids).toContain("friends_loved");
+    expect(body.homepage_layout.find((s: { id: string; enabled: boolean }) => s.id === "upcoming_movies")?.enabled).toBe(false);
+  });
+
+  it("PUT accepts movies_to_watch and upcoming_movies — does not 400", async () => {
+    const app = makeAuthedApp();
+    const res = await app.request("/user/settings/homepage-layout", {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        homepage_layout: [
+          { id: "movies_to_watch", enabled: true },
+          { id: "upcoming_movies", enabled: false },
+          { id: "up_next", enabled: true },
+        ],
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const ids = body.homepage_layout.map((s: { id: string }) => s.id);
+    expect(ids).toContain("movies_to_watch");
+    expect(ids).toContain("upcoming_movies");
+  });
+
+  it("PUT with all 10 sections returns 200 and round-trips them", async () => {
+    const app = makeAuthedApp();
+    const fullLayout = HOMEPAGE_SECTION_IDS.map((id, i) => ({ id, enabled: i % 2 === 0 }));
+    const res = await app.request("/user/settings/homepage-layout", {
+      method: "PUT",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ homepage_layout: fullLayout }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.homepage_layout).toHaveLength(10);
+    for (const id of HOMEPAGE_SECTION_IDS) {
+      expect(body.homepage_layout.some((s: { id: string }) => s.id === id)).toBe(true);
+    }
   });
 });
 

--- a/server/routes/user-settings.ts
+++ b/server/routes/user-settings.ts
@@ -5,7 +5,8 @@ import type { AppEnv } from "../types";
 import { ok } from "./response";
 import { zValidator } from "../lib/validator";
 
-export const HOMEPAGE_SECTION_IDS = ["up_next", "unwatched", "recommendations", "today", "upcoming", "airing_soon"] as const;
+// Keep in sync with frontend/src/types.ts HomepageSectionId / DEFAULT_HOMEPAGE_LAYOUT.
+export const HOMEPAGE_SECTION_IDS = ["streak", "up_next", "unwatched", "movies_to_watch", "recommendations", "today", "upcoming", "upcoming_movies", "airing_soon", "friends_loved"] as const;
 export type HomepageSectionId = (typeof HOMEPAGE_SECTION_IDS)[number];
 
 export interface HomepageSection {
@@ -14,25 +15,23 @@ export interface HomepageSection {
 }
 
 export const DEFAULT_HOMEPAGE_LAYOUT: HomepageSection[] = [
+  { id: "streak", enabled: true },
   { id: "up_next", enabled: true },
   { id: "unwatched", enabled: true },
+  { id: "movies_to_watch", enabled: true },
   { id: "recommendations", enabled: true },
   { id: "today", enabled: true },
   { id: "upcoming", enabled: true },
+  { id: "upcoming_movies", enabled: true },
   { id: "airing_soon", enabled: false },
+  { id: "friends_loved", enabled: true },
 ];
 
-// Discriminated union: each known section id is its own member with a fixed
-// `id` literal. This gives precise TypeScript narrowing and rejects unknown
-// section ids at the validator boundary instead of inside the handler.
-const homepageSectionSchema = z.discriminatedUnion("id", [
-  z.object({ id: z.literal("up_next"), enabled: z.boolean().default(true) }),
-  z.object({ id: z.literal("unwatched"), enabled: z.boolean().default(true) }),
-  z.object({ id: z.literal("recommendations"), enabled: z.boolean().default(true) }),
-  z.object({ id: z.literal("today"), enabled: z.boolean().default(true) }),
-  z.object({ id: z.literal("upcoming"), enabled: z.boolean().default(true) }),
-  z.object({ id: z.literal("airing_soon"), enabled: z.boolean().default(false) }),
-]);
+// Derives from HOMEPAGE_SECTION_IDS so adding a new section is a one-line change above.
+const homepageSectionSchema = z.object({
+  id: z.enum(HOMEPAGE_SECTION_IDS),
+  enabled: z.boolean().default(true),
+});
 
 const updateHomepageLayoutSchema = z.object({
   homepage_layout: z


### PR DESCRIPTION
## Summary

- **Root cause of #803 features invisible in production:** `server/routes/user-settings.ts` was never updated when new homepage sections were added. `parseLayout()` validated each stored section against a 6-literal `z.discriminatedUnion` and silently dropped any unknown ID — so `movies_to_watch`, `upcoming_movies`, `streak`, and `friends_loved` were always stripped before reaching the browser. `HomePage.tsx` renders strictly from the server-returned layout (`layout.filter(s => s.enabled).map(s => renderSection(s.id))`), so those rows never rendered in any environment.
- **Secondary breakage:** `AppearanceTab` seeds its layout editor from the frontend `DEFAULT_HOMEPAGE_LAYOUT` and PUTs it back. Once movie sections appeared in the body, `updateHomepageLayoutSchema` (same discriminated union) rejected the whole PUT with a silent 400 — breaking all layout saves.
- **Fix:** Replace the hand-maintained discriminated union with `z.object({ id: z.enum(HOMEPAGE_SECTION_IDS) })` — adding a section is now a one-line change in `HOMEPAGE_SECTION_IDS` only. Extend `HOMEPAGE_SECTION_IDS` and `DEFAULT_HOMEPAGE_LAYOUT` to the canonical 10-entry list matching `frontend/src/types.ts`. Also fixes the pre-existing `streak`/`friends_loved` omission (same root cause, added in #722/#673, never synced to server).

## Test plan

- [x] `bun test server/routes/user-settings.test.ts` — 48 tests (5 new regression tests: HOMEPAGE_SECTION_IDS has 10 entries, new-user default includes all 10, `parseLayout` preserves new IDs from stored layout, PUT accepts `movies_to_watch`/`upcoming_movies` → 200 not 400, full 10-section PUT round-trips correctly)
- [x] `bun run check` — server tsc + e2e tsc + frontend tsc + ESLint zero warnings + all tests (2077 server, 977 frontend) + build + wrangler dry-run

**Manual (post-merge, requires `bun run deploy:cf`):**
- [ ] Home shows "Movies to Watch" and "Upcoming Movies" rows after login
- [ ] Settings → Appearance: reorder/toggle a section, save succeeds (no 400), persists after reload
- [ ] Streak and Friends Loved home rows also appear (pre-existing latent bug now fixed)

No DB migration — all data already exists in `tracked`, `titles`, `watched_titles`.

Closes #803 (follow-up fix for the missed `user-settings.ts` update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)