### PR TITLE
feat(ui): unify home-page cards via shared MediaCard

### DIFF
--- a/frontend/src/components/EpisodeShowCard.tsx
+++ b/frontend/src/components/EpisodeShowCard.tsx
@@ -1,5 +1,4 @@
 import { memo } from "react";
-import { Link } from "react-router";
 import { CheckCircle } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { Episode } from "../types";
@@ -10,6 +9,7 @@ import {
 } from "./EpisodeComponents";
 import WatchButtonGroup from "./WatchButtonGroup";
 import EpisodeCountdown from "./EpisodeCountdown";
+import { MediaCard } from "./MediaCard";
 
 /** Shared card component used across Unwatched, Today, Coming Up, and Calendar sections */
 export const EpisodeShowCard = memo(function EpisodeShowCard({
@@ -32,87 +32,79 @@ export const EpisodeShowCard = memo(function EpisodeShowCard({
   isConfirming?: boolean;
 }) {
   const { t } = useTranslation();
-  const imageUrl = getEpisodeCardImageUrl(episode);
+  const episodeLink = `/title/${episode.title_id}/season/${episode.season_number}/episode/${episode.episode_number}`;
 
   return (
-    <div className="bg-zinc-900 rounded-xl overflow-hidden flex flex-col h-full">
-      {/* Episode image with badge */}
-      <Link to={`/title/${episode.title_id}/season/${episode.season_number}/episode/${episode.episode_number}`} className="block relative">
-        {imageUrl ? (
-          <img
-            src={imageUrl}
-            alt={episode.name || formatEpisodeCode(episode)}
-            className="w-full aspect-video object-cover"
-            loading="lazy"
-          />
-        ) : (
-          <div className="w-full aspect-video bg-gradient-to-b from-zinc-800 to-zinc-950" />
-        )}
-        {episodeCount > 1 && (
-          <span className="absolute top-2 right-2 bg-black/75 backdrop-blur-sm text-zinc-100 font-mono text-[11px] font-semibold px-2 py-0.5 rounded-full">
-            {episodeCount} new
+    <MediaCard
+      aspect="video"
+      hoverZoom={false}
+      to={episodeLink}
+      imageUrl={getEpisodeCardImageUrl(episode)}
+      imageAlt={episode.name || formatEpisodeCode(episode)}
+      badge={
+        episodeCount > 1
+          ? { label: `${episodeCount} new`, tone: "neutral" }
+          : undefined
+      }
+      titleTo={`/title/${episode.title_id}`}
+      title={episode.show_title}
+      titleClamp={1}
+      subtitleTo={episodeLink}
+      subtitle={
+        <>
+          <span className="text-amber-400 font-medium">
+            {formatEpisodeCode(episode)}
           </span>
-        )}
-      </Link>
-
-      {/* Content */}
-      <div className="p-3 flex flex-col flex-1">
-        <Link to={`/title/${episode.title_id}`} className="hover:text-amber-400 transition-colors">
-          <h3 className="font-semibold text-white text-sm truncate">{episode.show_title}</h3>
-        </Link>
-        <Link to={`/title/${episode.title_id}/season/${episode.season_number}/episode/${episode.episode_number}`} className="hover:text-amber-400 transition-colors">
-          <p className="text-xs mt-0.5">
-            <span className="text-amber-400 font-medium">{formatEpisodeCode(episode)}</span>
-            {episode.name && <span className="text-zinc-400"> · {episode.name}</span>}
-          </p>
-        </Link>
-
-        {/* Season + progress / countdown */}
-        {showCountdown ? (
-          <div className="mt-1.5">
-            <EpisodeCountdown airDate={episode.air_date} />
-          </div>
+          {episode.name && (
+            <span className="text-zinc-400"> · {episode.name}</span>
+          )}
+        </>
+      }
+      meta={
+        showCountdown ? (
+          <EpisodeCountdown airDate={episode.air_date} />
         ) : (
-          <p className="text-xs text-zinc-500 mt-1.5">
-            {t("home.season", { number: episode.season_number })} · {t("home.episodesRemaining", { count: episodeCount })}
-          </p>
-        )}
-
-        {/* Stream button — only for released episodes */}
-        {isEpisodeReleased(episode) && (
-          <div className="mt-2">
+          <>
+            {t("home.season", { number: episode.season_number })} ·{" "}
+            {t("home.episodesRemaining", { count: episodeCount })}
+          </>
+        )
+      }
+      footer={
+        <>
+          {isEpisodeReleased(episode) && (
             <WatchButtonGroup offers={episode.offers ?? []} variant="dropdown" />
-          </div>
-        )}
-
-        {/* Actions (only for Unwatched) */}
-        {showActions && onToggleWatched && (
-          <div className="mt-auto pt-3 space-y-1.5">
-            <button
-              onClick={() => onToggleWatched(episode.id, !!episode.is_watched)}
-              className="w-full flex items-center justify-center gap-1.5 px-3 py-1.5 bg-amber-500 hover:bg-amber-400 text-black text-xs font-semibold rounded-lg transition-colors cursor-pointer"
-            >
-              <CheckCircle size={14} />
-              {t("home.markWatched")}
-            </button>
-            {episodeCount > 1 && allEpisodeIds && onMarkAllWatched && (
+          )}
+          {showActions && onToggleWatched && (
+            <div className="space-y-1.5">
               <button
-                onClick={() => onMarkAllWatched(allEpisodeIds)}
-                className={`w-full text-center text-xs transition-colors cursor-pointer ${
-                  isConfirming
-                    ? "text-red-400 hover:text-red-300 font-medium"
-                    : "text-zinc-400 hover:text-emerald-400"
-                }`}
+                onClick={() => onToggleWatched(episode.id, !!episode.is_watched)}
+                className="w-full flex items-center justify-center gap-1.5 px-3 py-1.5 bg-amber-500 hover:bg-amber-400 text-black text-xs font-semibold rounded-lg transition-colors cursor-pointer"
               >
-                {isConfirming
-                  ? t("home.confirmMarkAllWatched", { count: allEpisodeIds.length })
-                  : t("home.markAllWatched")}
+                <CheckCircle size={14} />
+                {t("home.markWatched")}
               </button>
-            )}
-          </div>
-        )}
-      </div>
-    </div>
+              {episodeCount > 1 && allEpisodeIds && onMarkAllWatched && (
+                <button
+                  onClick={() => onMarkAllWatched(allEpisodeIds)}
+                  className={`w-full text-center text-xs transition-colors cursor-pointer ${
+                    isConfirming
+                      ? "text-red-400 hover:text-red-300 font-medium"
+                      : "text-zinc-400 hover:text-emerald-400"
+                  }`}
+                >
+                  {isConfirming
+                    ? t("home.confirmMarkAllWatched", {
+                        count: allEpisodeIds.length,
+                      })
+                    : t("home.markAllWatched")}
+                </button>
+              )}
+            </div>
+          )}
+        </>
+      }
+    />
   );
 });
 

--- a/frontend/src/components/MediaCard.test.tsx
+++ b/frontend/src/components/MediaCard.test.tsx
@@ -1,0 +1,203 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { render, screen, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { MediaCard } from "./MediaCard";
+
+afterEach(cleanup);
+
+function hasClass(container: Element, cls: string) {
+  return Array.from(container.querySelectorAll("*")).some((el) => {
+    const c = (el as HTMLElement).className;
+    return typeof c === "string" && c.includes(cls);
+  });
+}
+
+const baseProps = {
+  to: "/title/abc",
+  imageUrl: "https://example.com/img.jpg",
+  imageAlt: "Test image",
+  aspect: "poster" as const,
+};
+
+describe("MediaCard", () => {
+  it("renders the image with correct src and alt when imageUrl is set", () => {
+    const { getByAltText } = render(
+      <MemoryRouter>
+        <MediaCard {...baseProps} />
+      </MemoryRouter>,
+    );
+    const img = getByAltText("Test image") as HTMLImageElement;
+    expect(img.src).toContain("https://example.com/img.jpg");
+  });
+
+  it("renders gradient placeholder and no img when imageUrl is null", () => {
+    const { container, queryByAltText } = render(
+      <MemoryRouter>
+        <MediaCard {...baseProps} imageUrl={null} />
+      </MemoryRouter>,
+    );
+    expect(queryByAltText("Test image")).toBeNull();
+    expect(hasClass(container, "from-zinc-800")).toBe(true);
+  });
+
+  it("applies aspect-video class for video aspect", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <MediaCard {...baseProps} aspect="video" />
+      </MemoryRouter>,
+    );
+    expect(hasClass(container, "aspect-video")).toBe(true);
+  });
+
+  it("applies aspect-[2/3] class for poster aspect", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <MediaCard {...baseProps} aspect="poster" />
+      </MemoryRouter>,
+    );
+    expect(hasClass(container, "aspect-[2/3]")).toBe(true);
+  });
+
+  it("renders neutral badge with bg-black/75 at top-right by default", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <MediaCard {...baseProps} badge={{ label: "3 new", tone: "neutral" }} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("3 new")).toBeTruthy();
+    expect(hasClass(container, "bg-black/75")).toBe(true);
+    expect(hasClass(container, "right-2")).toBe(true);
+  });
+
+  it("renders accent badge with bg-amber-400", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <MediaCard {...baseProps} badge={{ label: "in 5 days", tone: "accent" }} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("in 5 days")).toBeTruthy();
+    expect(hasClass(container, "bg-amber-400")).toBe(true);
+  });
+
+  it("renders badge at left-2 when position is top-left", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <MediaCard {...baseProps} badge={{ label: "new", position: "top-left" }} />
+      </MemoryRouter>,
+    );
+    expect(hasClass(container, "left-2")).toBe(true);
+  });
+
+  it("renders amber ring when unread is true", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <MediaCard {...baseProps} unread />
+      </MemoryRouter>,
+    );
+    expect(hasClass(container, "ring-amber-500/60")).toBe(true);
+  });
+
+  it("renders unread dot when unread and no badge", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <MediaCard {...baseProps} unread />
+      </MemoryRouter>,
+    );
+    expect(hasClass(container, "bg-amber-500")).toBe(true);
+  });
+
+  it("renders overlayAction inside the media surface", () => {
+    render(
+      <MemoryRouter>
+        <MediaCard
+          {...baseProps}
+          overlayAction={<button aria-label="overlay-btn">X</button>}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole("button", { name: "overlay-btn" })).toBeTruthy();
+  });
+
+  it("links the media image to the `to` prop", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <MediaCard {...baseProps} />
+      </MemoryRouter>,
+    );
+    const hrefs = Array.from(container.querySelectorAll("a")).map((a) =>
+      a.getAttribute("href"),
+    );
+    expect(hrefs).toContain("/title/abc");
+  });
+
+  it("links the title to titleTo when provided", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <MediaCard
+          {...baseProps}
+          title="My Title"
+          titleTo="/title/abc/season/1"
+        />
+      </MemoryRouter>,
+    );
+    const hrefs = Array.from(container.querySelectorAll("a")).map((a) =>
+      a.getAttribute("href"),
+    );
+    expect(hrefs).toContain("/title/abc/season/1");
+  });
+
+  it("always renders chrome (bg-zinc-900)", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <MediaCard {...baseProps} />
+      </MemoryRouter>,
+    );
+    expect(hasClass(container, "bg-zinc-900")).toBe(true);
+  });
+
+  it("renders footer content pinned below the body", () => {
+    render(
+      <MemoryRouter>
+        <MediaCard {...baseProps} footer={<button>Mark watched</button>} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole("button", { name: "Mark watched" })).toBeTruthy();
+  });
+
+  it("omits the padded body when no title/subtitle/meta/footer are provided", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <MediaCard {...baseProps} />
+      </MemoryRouter>,
+    );
+    expect(hasClass(container, "p-3")).toBe(false);
+  });
+
+  it("renders a progress bar with the correct inline width", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <MediaCard {...baseProps} progressPercent={60} />
+      </MemoryRouter>,
+    );
+    const bar = container.querySelector('[style*="60%"]') as HTMLElement | null;
+    expect(bar).toBeTruthy();
+  });
+
+  it("applies line-clamp-2 to title when titleClamp is 2", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <MediaCard {...baseProps} title="Long title" titleClamp={2} />
+      </MemoryRouter>,
+    );
+    expect(hasClass(container, "line-clamp-2")).toBe(true);
+  });
+
+  it("applies truncate to title by default", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <MediaCard {...baseProps} title="Long title" />
+      </MemoryRouter>,
+    );
+    expect(hasClass(container, "truncate")).toBe(true);
+  });
+});

--- a/frontend/src/components/MediaCard.tsx
+++ b/frontend/src/components/MediaCard.tsx
@@ -1,0 +1,177 @@
+import type { ReactNode } from "react";
+import { Link } from "react-router";
+import { Card } from "./ui/card";
+import { cn } from "@/lib/utils";
+
+export type MediaCardAspect = "video" | "poster";
+
+export interface MediaCardBadgeProps {
+  label: ReactNode;
+  tone?: "neutral" | "accent";
+  position?: "top-left" | "top-right";
+}
+
+export function MediaCardBadge({
+  label,
+  tone = "neutral",
+  position = "top-right",
+}: MediaCardBadgeProps) {
+  return (
+    <span
+      className={cn(
+        "absolute top-2 z-10 inline-flex items-center rounded-full px-2 py-0.5 font-mono text-[11px] font-semibold leading-none select-none",
+        position === "top-left" ? "left-2" : "right-2",
+        tone === "accent"
+          ? "bg-amber-400 text-zinc-950"
+          : "bg-black/75 backdrop-blur-sm text-zinc-100",
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+export interface MediaCardProps {
+  to: string;
+  imageUrl: string | null;
+  imageAlt: string;
+  aspect: MediaCardAspect;
+
+  badge?: MediaCardBadgeProps;
+  unread?: boolean;
+  overlayAction?: ReactNode;
+  progressPercent?: number;
+
+  title?: ReactNode;
+  titleTo?: string;
+  titleClamp?: 1 | 2;
+  subtitle?: ReactNode;
+  subtitleTo?: string;
+  meta?: ReactNode;
+  footer?: ReactNode;
+
+  hoverZoom?: boolean;
+  className?: string;
+}
+
+export function MediaCard({
+  to,
+  imageUrl,
+  imageAlt,
+  aspect,
+  badge,
+  unread,
+  overlayAction,
+  progressPercent,
+  title,
+  titleTo,
+  titleClamp = 1,
+  subtitle,
+  subtitleTo,
+  meta,
+  footer,
+  hoverZoom = true,
+  className,
+}: MediaCardProps) {
+  const hasBody =
+    title != null || subtitle != null || meta != null || footer != null;
+
+  return (
+    <Card
+      padding="none"
+      radius="xl"
+      tone="solid"
+      border="subtle"
+      className={cn(
+        "group/mediacard flex h-full w-full flex-col overflow-hidden",
+        className,
+      )}
+    >
+      {/* Media image */}
+      <Link to={to} className="relative block">
+        <div
+          className={cn(
+            "relative w-full overflow-hidden bg-zinc-800",
+            aspect === "video" ? "aspect-video" : "aspect-[2/3]",
+          )}
+        >
+          {imageUrl ? (
+            <img
+              src={imageUrl}
+              alt={imageAlt}
+              loading="lazy"
+              className={cn(
+                "h-full w-full object-cover",
+                hoverZoom &&
+                  "transition-transform duration-300 group-hover/mediacard:scale-105",
+              )}
+            />
+          ) : (
+            <div className="h-full w-full bg-gradient-to-b from-zinc-800 to-zinc-950" />
+          )}
+
+          {unread && (
+            <div className="pointer-events-none absolute inset-0 rounded-[inherit] ring-2 ring-amber-500/60" />
+          )}
+
+          {progressPercent != null && (
+            <div className="absolute inset-x-0 bottom-0 h-[3px] bg-black/40">
+              <div
+                className="h-full bg-amber-400"
+                style={{ width: `${progressPercent}%` }}
+              />
+            </div>
+          )}
+        </div>
+
+        {badge && <MediaCardBadge {...badge} />}
+
+        {unread && !badge && (
+          <div className="absolute right-2 top-2 h-2 w-2 rounded-full bg-amber-500" />
+        )}
+
+        {overlayAction && (
+          <div className="absolute right-1.5 top-1.5">{overlayAction}</div>
+        )}
+      </Link>
+
+      {hasBody && (
+        <div className="flex flex-1 flex-col p-3">
+          {title != null && (
+            <Link
+              to={titleTo ?? to}
+              className="block text-white transition-colors hover:text-amber-400 group-hover/mediacard:text-amber-400"
+            >
+              <h3
+                className={cn(
+                  "text-sm font-semibold",
+                  titleClamp === 2 ? "line-clamp-2" : "truncate",
+                )}
+              >
+                {title}
+              </h3>
+            </Link>
+          )}
+
+          {subtitle != null &&
+            (subtitleTo ? (
+              <Link
+                to={subtitleTo}
+                className="block transition-colors hover:text-amber-400"
+              >
+                <div className="mt-0.5 text-xs">{subtitle}</div>
+              </Link>
+            ) : (
+              <div className="mt-0.5 text-xs">{subtitle}</div>
+            ))}
+
+          {meta != null && (
+            <div className="mt-1.5 text-xs text-zinc-500">{meta}</div>
+          )}
+
+          {footer != null && <div className="mt-auto pt-3">{footer}</div>}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/components/MovieRow.tsx
+++ b/frontend/src/components/MovieRow.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
-import { Link } from "react-router";
 import { Check } from "lucide-react";
 import * as api from "../api";
 import ScrollableRow from "./ScrollableRow";
 import { posterUrl as buildPosterUrl } from "../lib/tmdb-images";
+import { MediaCard } from "./MediaCard";
 
 export interface MovieTrackItem {
   id: string;
@@ -45,6 +45,21 @@ function relativeRelease(date: string | null): string {
   return formatReleaseDate(date, null);
 }
 
+function releaseMeta(variant: "to_watch" | "upcoming", movie: MovieTrackItem): string {
+  if (variant === "to_watch") {
+    return movie.release_date
+      ? `Released ${relativeRelease(movie.release_date)}`
+      : movie.release_year
+        ? String(movie.release_year)
+        : "";
+  }
+  return movie.release_date
+    ? formatReleaseDate(movie.release_date, null)
+    : movie.release_year
+      ? String(movie.release_year)
+      : "";
+}
+
 export default function MovieRow({ variant, movies }: MovieRowProps) {
   const [dismissed, setDismissed] = useState<Set<string>>(new Set());
 
@@ -68,44 +83,39 @@ export default function MovieRow({ variant, movies }: MovieRowProps) {
   return (
     <ScrollableRow className="gap-3 px-4 pb-2">
       {visible.map((movie) => (
-        <div key={movie.id} style={{ width: 104, flexShrink: 0 }}>
-          <Link to={`/title/${movie.id}`} className="block relative">
-            <div
-              className="w-[104px] h-[156px] rounded-lg overflow-hidden bg-zinc-800"
-            >
-              {movie.poster_url && (
-                <img
-                  src={buildPosterUrl(movie.poster_url, "w185") ?? undefined}
-                  alt={movie.title}
-                  className="w-full h-full object-cover"
-                  loading="lazy"
-                />
-              )}
-            </div>
-            {variant === "upcoming" && movie.release_date && (
-              <span className="absolute top-1.5 left-1.5 px-1.5 py-0.5 rounded-full text-[10px] font-bold bg-amber-400 text-zinc-950 leading-none">
-                {relativeRelease(movie.release_date)}
-              </span>
-            )}
-            {variant === "to_watch" && (
-              <button
-                aria-label="Mark watched"
-                onClick={(e) => {
-                  e.preventDefault();
-                  void handleWatched(movie.id);
-                }}
-                className="absolute top-1.5 right-1.5 w-7 h-7 rounded-full bg-black/60 border border-amber-400/70 text-amber-400 flex items-center justify-center hover:bg-amber-400 hover:text-zinc-950 transition-colors cursor-pointer"
-              >
-                <Check size={14} />
-              </button>
-            )}
-          </Link>
-          <p className="mt-1.5 text-xs text-zinc-200 line-clamp-2 leading-snug">{movie.title}</p>
-          <p className="text-[11px] text-zinc-500 leading-none mt-0.5">
-            {variant === "to_watch"
-              ? (movie.release_date ? `Released ${relativeRelease(movie.release_date)}` : (movie.release_year ? String(movie.release_year) : ""))
-              : (movie.release_date ? formatReleaseDate(movie.release_date, null) : (movie.release_year ? String(movie.release_year) : ""))}
-          </p>
+        <div key={movie.id} className="w-32 flex-shrink-0">
+          <MediaCard
+            aspect="poster"
+            to={`/title/${movie.id}`}
+            imageUrl={buildPosterUrl(movie.poster_url, "w185") ?? null}
+            imageAlt={movie.title}
+            title={movie.title}
+            titleClamp={2}
+            meta={releaseMeta(variant, movie)}
+            badge={
+              variant === "upcoming" && movie.release_date
+                ? {
+                    label: relativeRelease(movie.release_date),
+                    tone: "accent",
+                    position: "top-left",
+                  }
+                : undefined
+            }
+            overlayAction={
+              variant === "to_watch" ? (
+                <button
+                  aria-label="Mark watched"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    void handleWatched(movie.id);
+                  }}
+                  className="w-7 h-7 rounded-full bg-black/60 border border-amber-400/70 text-amber-400 flex items-center justify-center hover:bg-amber-400 hover:text-zinc-950 transition-colors cursor-pointer"
+                >
+                  <Check size={14} />
+                </button>
+              ) : undefined
+            }
+          />
         </div>
       ))}
     </ScrollableRow>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -22,6 +22,7 @@ import UpNextRow from "../components/UpNextRow";
 import FriendsLovedRow from "../components/FriendsLovedRow";
 import SuggestedForYouRow from "../components/SuggestedForYouRow";
 import MovieRow from "../components/MovieRow";
+import { MediaCard } from "../components/MediaCard";
 import type { UpNextItem, MovieTrackResponse } from "../api";
 
 export interface UnwatchedCardEntry {
@@ -277,25 +278,28 @@ function MobileFeedHome({
           <div className="flex gap-3 px-5 overflow-x-auto scrollbar-none pb-1">
             {cwEntries.map(([titleId, eps]) => {
               const ep = eps[0];
-              const pUrl = ep.poster_url;
               return (
-                <Link key={titleId} to={`/title/${titleId}`} className="w-[132px] shrink-0">
-                  <div className="aspect-[2/3] rounded-[10px] overflow-hidden relative mb-2 bg-zinc-800">
-                    {pUrl && <img src={pUrl} alt="" className="w-full h-full object-cover" loading="lazy" />}
-                    {/* Progress bar */}
-                    <div className="absolute bottom-0 left-0 right-0 h-[3px] bg-black/40">
-                      <div className="h-full bg-amber-400" style={{ width: `${ep.total_episodes ? Math.round((ep.watched_episodes_count ?? 0) / ep.total_episodes * 100) : 0}%` }} />
-                    </div>
-                    {/* Unwatched badge */}
-                    <div className="absolute top-1.5 right-1.5 bg-black/70 text-amber-400 text-[10px] font-bold font-mono px-1.5 py-0.5 rounded-full">
-                      +{eps.length}
-                    </div>
-                  </div>
-                  <div className="text-[12px] font-medium leading-[1.2] truncate mb-0.5">{ep.show_title}</div>
-                  <div className="font-mono text-[10px] text-zinc-400">
-                    E{ep.episode_number}
-                  </div>
-                </Link>
+                <div key={titleId} className="w-[132px] shrink-0">
+                  <MediaCard
+                    aspect="poster"
+                    to={`/title/${titleId}`}
+                    imageUrl={ep.poster_url}
+                    imageAlt={ep.show_title}
+                    progressPercent={
+                      ep.total_episodes
+                        ? Math.round(
+                            ((ep.watched_episodes_count ?? 0) /
+                              ep.total_episodes) *
+                              100,
+                          )
+                        : 0
+                    }
+                    badge={{ label: `+${eps.length}`, tone: "neutral" }}
+                    title={ep.show_title}
+                    titleClamp={1}
+                    meta={`E${ep.episode_number}`}
+                  />
+                </div>
               );
             })}
           </div>
@@ -316,15 +320,16 @@ function MobileFeedHome({
           </div>
           <div className="px-5 grid grid-cols-3 gap-2.5">
             {today7.map((ep) => (
-              <Link key={ep.id} to={`/title/${ep.title_id}`}>
-                <div className="aspect-[2/3] rounded-lg overflow-hidden mb-1.5 bg-zinc-800">
-                  {ep.poster_url && <img src={ep.poster_url} alt="" className="w-full h-full object-cover" loading="lazy" />}
-                </div>
-                <div className="text-[11px] font-medium leading-[1.15] truncate">{ep.show_title}</div>
-                <div className="font-mono text-[9px] text-zinc-400 uppercase tracking-[0.3px]">
-                  {ep.air_date ? ep.air_date.slice(5) : ""}
-                </div>
-              </Link>
+              <MediaCard
+                key={ep.id}
+                aspect="poster"
+                to={`/title/${ep.title_id}`}
+                imageUrl={ep.poster_url ?? null}
+                imageAlt={ep.show_title}
+                title={ep.show_title}
+                titleClamp={1}
+                meta={ep.air_date ? ep.air_date.slice(5) : ""}
+              />
             ))}
           </div>
         </>
@@ -623,44 +628,29 @@ export default function HomePage() {
               </Link>
             </div>
             <FullBleedCarousel>
-              {recommendations.map((rec) => {
-                const posterSrc = posterUrl(rec.title.poster_url, "w185");
-                const isUnread = !rec.read_at;
-                return (
-                  <Link
-                    key={rec.id}
+              {recommendations.map((rec) => (
+                <div
+                  key={rec.id}
+                  className="w-32 flex-shrink-0"
+                  style={{ scrollSnapAlign: "start" }}
+                >
+                  <MediaCard
+                    aspect="poster"
+                    hoverZoom
                     to={`/title/${rec.title.id}`}
-                    className="w-32 flex-shrink-0 group"
-                    style={{ scrollSnapAlign: "start" }}
-                  >
-                    <div className={`relative aspect-[2/3] rounded-lg overflow-hidden bg-zinc-800 ${isUnread ? "ring-2 ring-amber-500/60" : ""}`}>
-                      {posterSrc ? (
-                        <img
-                          src={posterSrc}
-                          alt={rec.title.title}
-                          className="w-full h-full object-cover group-hover:scale-105 transition-transform"
-                          loading="lazy"
-                          width={185}
-                          height={278}
-                        />
-                      ) : (
-                        <div className="w-full h-full flex items-center justify-center text-zinc-600 text-xs">
-                          N/A
-                        </div>
-                      )}
-                      {isUnread && (
-                        <div className="absolute top-1.5 right-1.5 w-2 h-2 rounded-full bg-amber-500" />
-                      )}
-                    </div>
-                    <p className="text-sm text-white mt-1.5 line-clamp-2 group-hover:text-amber-400 transition-colors select-text">
-                      {rec.title.title}
-                    </p>
-                    <p className="text-xs text-zinc-400 truncate select-text">
-                      from @{rec.from_user.username}
-                    </p>
-                  </Link>
-                );
-              })}
+                    imageUrl={posterUrl(rec.title.poster_url, "w185")}
+                    imageAlt={rec.title.title}
+                    unread={!rec.read_at}
+                    title={rec.title.title}
+                    titleClamp={2}
+                    subtitle={
+                      <span className="text-zinc-400">
+                        from @{rec.from_user.username}
+                      </span>
+                    }
+                  />
+                </div>
+              ))}
             </FullBleedCarousel>
           </section>
         ) : null;


### PR DESCRIPTION
## Summary

- Introduces a new `MediaCard` component built on the existing `ui/card.tsx` `Card` primitive, giving all home-page cards identical chrome (`bg-zinc-900`, `rounded-xl`, `border-white/[0.06]`), a single canonical badge style, and unified title/subtitle/meta/footer slots — all by construction
- Migrates `EpisodeShowCard`, `MovieRow` (movie tiles), the recommendations tile, and the mobile `MobileFeedHome` Continue-watching / This-week tiles to render through `MediaCard`
- Episodes keep the 16:9 `aspect-video` landscape still; movie / recs / mobile tiles keep the 2:3 `aspect-[2/3]` portrait poster — natural media shapes are preserved, no image cropping

## What changed

**New `MediaCard` component** (`frontend/src/components/MediaCard.tsx`):
- Always renders the `Card` chrome (`bg-zinc-900 rounded-xl border-white/[0.06]`) — no opt-out
- `aspect` prop switches the media box between `aspect-video` (16:9) and `aspect-[2/3]` (2:3)
- One canonical badge: `font-mono text-[11px] px-2 py-0.5 rounded-full`, tone `neutral` (black/blur) or `accent` (amber solid), configurable position (`top-left` / `top-right`)
- `unread` prop drives the amber ring + dot (used by recommendations)
- `overlayAction` slot for the movie round Mark-watched button (preserves `aria-label="Mark watched"` for tests)
- `progressPercent` prop for the bottom progress bar (mobile Continue-watching)
- `hoverZoom` (default `true`) — image scales on card hover via named `group/mediacard`; episodes pass `false`
- Body rendered only when at least one of `title` / `subtitle` / `meta` / `footer` is provided

**Migrated consumers:**
| Consumer | Note |
|---|---|
| `EpisodeShowCard.tsx` | Root div + image + body → `MediaCard aspect="video"`. `DeckCardWrapper` left untouched (AgendaCalendar dependency). |
| `MovieRow.tsx` | Per-movie inline markup → `MediaCard aspect="poster"`. `aria-label="Mark watched"` button passed verbatim through `overlayAction`. Tile width `104px` → `w-32` (128 px) for boxed-poster breathing room. |
| `HomePage.tsx` recommendations | Inline tile → `MediaCard aspect="poster"` with `unread` ring/dot. |
| `HomePage.tsx` MobileFeedHome | Continue-watching tiles → `MediaCard` with `progressPercent` + badge. This-week grid tiles → `MediaCard`. Tonight hero and Also-airing rows left untouched. |

**Intentional minor visual shifts (flag if unexpected):**
- Recommendations: `N/A` text placeholder → standard gradient; `select-text` on title dropped
- Mobile tiles: `text-[10px]`/`text-[9px]` → `text-xs` (body type-scale normalized)
- Episode title now also turns amber on hover anywhere over the card (was title-link-only before)

## Test plan

- [x] New `MediaCard.test.tsx` — 18 tests covering aspect, badge tone/position, unread ring/dot, overlayAction, link hrefs, chrome, body presence, progress bar, title clamp
- [x] `EpisodeShowCard.test.tsx` — all 4 existing tests pass (stream-button link gating unchanged)
- [x] `MovieRow.test.tsx` — all 8 existing tests pass (`aria-label="Mark watched"`, optimistic removal, date text preserved)
- [x] `bun run check` — 995 frontend + 2079 server tests, zero failures; TypeScript strict, ESLint zero errors/warnings, build + wrangler dry-run green

🤖 Generated with [Claude Code](https://claude.com/claude-code)