### PR TITLE
Fix spacing consistency in EpisodeShowCard footer

### DIFF
--- a/frontend/src/components/EpisodeShowCard.test.tsx
+++ b/frontend/src/components/EpisodeShowCard.test.tsx
@@ -108,4 +108,32 @@ describe("EpisodeShowCard", () => {
     const link = container.querySelector('a[href="https://example.com/watch"]');
     expect(link).toBeTruthy();
   });
+
+  it("wraps the Stream button and Mark Watched action in a single spacing container", () => {
+    const episode = makeEpisode({ air_date: "2020-01-01" });
+    const { container } = render(
+      <Wrapper>
+        <EpisodeShowCard
+          episode={episode}
+          episodeCount={1}
+          showActions
+          onToggleWatched={() => {}}
+        />
+      </Wrapper>
+    );
+
+    const streamLink = container.querySelector(
+      'a[href="https://example.com/watch"]'
+    );
+    const markWatchedBtn = container.querySelector("button.bg-amber-500");
+    expect(streamLink).toBeTruthy();
+    expect(markWatchedBtn).toBeTruthy();
+
+    // Both controls must live inside the same space-y-1.5 wrapper so the
+    // gap above "Mark Watched" matches the rest of the card's spacing.
+    const spacingWrapper = container.querySelector(".space-y-1\\.5");
+    expect(spacingWrapper).toBeTruthy();
+    expect(spacingWrapper!.contains(streamLink!)).toBe(true);
+    expect(spacingWrapper!.contains(markWatchedBtn!)).toBe(true);
+  });
 });

--- a/frontend/src/components/EpisodeShowCard.tsx
+++ b/frontend/src/components/EpisodeShowCard.tsx
@@ -71,7 +71,7 @@ export const EpisodeShowCard = memo(function EpisodeShowCard({
         )
       }
       footer={
-        <>
+        <div className="space-y-1.5">
           {isEpisodeReleased(episode) && (
             <WatchButtonGroup offers={episode.offers ?? []} variant="dropdown" />
           )}
@@ -102,7 +102,7 @@ export const EpisodeShowCard = memo(function EpisodeShowCard({
               )}
             </div>
           )}
-        </>
+        </div>
       }
     />
   );


### PR DESCRIPTION
## Summary

- Wrapped the Stream button and Mark Watched action in a shared `space-y-1.5` container to ensure consistent vertical spacing throughout the card footer
- Changed footer wrapper from fragment (`<>`) to `<div>` to enable proper spacing class application
- Added test to verify both controls are contained within the spacing wrapper

## Linked issues

Closes #

## Test plan

- [x] Added unit test verifying Stream button and Mark Watched action are wrapped in `.space-y-1.5` container
- [x] `bun run check` passes locally

https://claude.ai/code/session_017FAYfyfEoDnGyfPs8AE1Rr