### PR TITLE
Use tailwind-merge in WatchButton for proper class override

### DIFF
--- a/frontend/src/components/HeroBanner.tsx
+++ b/frontend/src/components/HeroBanner.tsx
@@ -206,18 +206,18 @@ export default function HeroBanner({
           <div className="flex items-center gap-3 flex-wrap">
             <Link
               to={`/title/${current.featured.title_id}`}
-              className="bg-amber-400 hover:bg-amber-300 text-black font-bold text-sm px-5 py-2.5 rounded-lg transition-colors"
+              className="inline-flex items-center bg-amber-400 hover:bg-amber-300 text-black font-bold text-sm px-5 h-10 rounded-lg transition-colors"
             >
               ▶ Play S{current.featured.season_number}·E{current.featured.episode_number}
             </Link>
             <button
               onClick={handleMarkWatched}
               disabled={markingWatched}
-              className="bg-white/[0.08] hover:bg-white/[0.14] border border-white/[0.12] text-zinc-100 font-semibold text-sm px-4 py-2.5 rounded-lg transition-colors disabled:opacity-50 cursor-pointer"
+              className="inline-flex items-center bg-white/[0.08] hover:bg-white/[0.14] border border-white/[0.12] text-zinc-100 font-semibold text-sm px-4 h-10 rounded-lg transition-colors disabled:opacity-50 cursor-pointer"
             >
               {markingWatched ? "Marking…" : "Mark watched"}
             </button>
-            <WatchButtonGroup offers={current.featured.offers ?? []} variant="inline" maxVisible={2} />
+            <WatchButtonGroup offers={current.featured.offers ?? []} variant="inline" maxVisible={2} buttonClassName="text-sm px-4 h-10" />
           </div>
           {/* Metadata strip */}
           {current.featured.offers && current.featured.offers.length > 0 && (

--- a/frontend/src/components/WatchButton.tsx
+++ b/frontend/src/components/WatchButton.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { ExternalLink } from "lucide-react";
 import { getProviderColor } from "../data/providerColors";
+import { cn } from "../lib/utils";
 
 export const PLEX_PROVIDER_ID = 9999;
 
@@ -112,7 +113,10 @@ export default function WatchButton({
       href={effectiveUrl}
       target={target}
       rel="noopener noreferrer"
-      className={`min-h-8 flex items-center justify-center gap-1.5 rounded-lg px-3 py-1.5 ${className?.match(/\btext-(xs|sm|base|lg|xl|\d)/) ? "" : "text-xs"} font-semibold transition-colors duration-200 ${className ?? ""}`}
+      className={cn(
+        "min-h-8 flex items-center justify-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold transition-colors duration-200",
+        className,
+      )}
       style={{
         backgroundColor: hovered ? color.hover : color.bg,
         color: color.text,

--- a/frontend/src/components/WatchButtonGroup.test.tsx
+++ b/frontend/src/components/WatchButtonGroup.test.tsx
@@ -142,6 +142,21 @@ describe("WatchButtonGroup", () => {
     expect(links.length).toBe(2);
   });
 
+  it("applies buttonClassName to inline buttons, overriding default sizing", () => {
+    render(
+      <Wrapper>
+        <WatchButtonGroup offers={[makeOffer()]} variant="inline" buttonClassName="text-sm px-4 h-10" />
+      </Wrapper>
+    );
+    const link = screen.getByRole("link");
+    expect(link.className).toContain("text-sm");
+    expect(link.className).toContain("px-4");
+    expect(link.className).toContain("h-10");
+    // tailwind-merge must strip the conflicting default utilities
+    expect(link.className).not.toContain("text-xs");
+    expect(link.className).not.toContain("px-3");
+  });
+
   it("shows Stream label for FLATRATE offer", () => {
     render(
       <Wrapper>

--- a/frontend/src/components/WatchButtonGroup.tsx
+++ b/frontend/src/components/WatchButtonGroup.tsx
@@ -13,9 +13,11 @@ interface Props {
   maxVisible?: number;
   size?: "sm" | "lg";
   fullWidth?: boolean;
+  /** Applied to each inline-variant button; tailwind-merge lets it override default sizing. */
+  buttonClassName?: string;
 }
 
-export default function WatchButtonGroup({ offers, variant = "dropdown", maxVisible = 4, size = "sm", fullWidth }: Props) {
+export default function WatchButtonGroup({ offers, variant = "dropdown", maxVisible = 4, size = "sm", fullWidth, buttonClassName }: Props) {
   const { subscriptions } = useAuth();
   const subscribedSet = useMemo(
     () => new Set(subscriptions?.providerIds ?? []),
@@ -52,6 +54,7 @@ export default function WatchButtonGroup({ offers, variant = "dropdown", maxVisi
               providerIconUrl={o.provider_icon_url}
               monetizationType={o.monetization_type}
               variant="full"
+              className={buttonClassName}
             />
           </div>
         ))}


### PR DESCRIPTION
## Summary

- Refactored `WatchButton` to use `tailwind-merge` (`cn` utility) instead of manual regex-based class merging, ensuring proper Tailwind utility conflict resolution
- Added `buttonClassName` prop to `WatchButtonGroup` to allow customization of inline-variant button sizing
- Updated `HeroBanner` to pass consistent button sizing (`text-sm px-4 h-10`) to `WatchButtonGroup` and aligned Play/Mark watched buttons to the same height

## Linked issues

Closes #

## Test plan

- [x] Added unit test verifying `buttonClassName` properly overrides default sizing via `tailwind-merge`
- [x] Existing `WatchButtonGroup` tests pass
- [x] `bun run check` passes locally

## Notes

The key improvement is replacing the fragile regex pattern (`className?.match(/\btext-(xs|sm|base|lg|xl|\d)/)`) with `tailwind-merge`, which correctly handles all Tailwind utility conflicts, not just text sizing. This makes the component more robust and maintainable.

https://claude.ai/code/session_0162W8jBTerXLyFycoDkVGbL