### PR TITLE
fix: add logging and Sentry capture for swallowed route errors

### DIFF
--- a/server/routes/search.test.ts
+++ b/server/routes/search.test.ts
@@ -7,6 +7,7 @@ import { CONFIG } from "../config";
 import { upsertTitles, trackTitle, createUser, getOffersForTitle } from "../db/repository";
 import { makeParsedTitle, makeTmdbSearchMultiMovie, makeTmdbMovieDetails } from "../test-utils/fixtures";
 import * as tmdbClient from "../tmdb/client";
+import Sentry from "../sentry";
 
 const searchApp = (await import("./search")).default;
 
@@ -270,6 +271,19 @@ describe("GET /search — validation", () => {
   it("happy-path: q + year_min + type", async () => {
     const res = await app.request("/search?q=foo&year_min=2000&type=MOVIE");
     expect(res.status).toBe(200);
+  });
+});
+
+describe("GET /search — outer catch (TMDB failure)", () => {
+  it("returns 500 with a generic message and captures the error when TMDB search throws", async () => {
+    (tmdbClient.searchMulti as any).mockRejectedValueOnce(new Error("TMDB upstream 503"));
+    const captureSpy = spyOn(Sentry, "captureException");
+    const res = await app.request("/search?q=malcolm");
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Search failed");
+    expect(captureSpy).toHaveBeenCalled();
+    captureSpy.mockRestore();
   });
 });
 

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -6,6 +6,7 @@ import { parseSearchResult, parseMovieDetails, parseTvDetails, type ParsedTitle 
 import { getTrackedTitleIds, upsertTitles } from "../db/repository";
 import { logger } from "../logger";
 import { syncFailureTotal } from "../metrics";
+import Sentry from "../sentry";
 
 const log = logger.child({ module: "search" });
 import { ok, err } from "./response";
@@ -108,7 +109,11 @@ app.get("/", zValidator("query", searchQuerySchema), async (c) => {
 
     return ok(c, { titles: titlesWithTracked, count: titlesWithTracked.length });
   } catch (e: unknown) {
-    return err(c, (e as Error).message, 500);
+    const message = e instanceof Error ? e.message : String(e);
+    const stack = e instanceof Error ? e.stack : undefined;
+    Sentry.captureException(e);
+    log.error("Search failed", { query, error: message, stack });
+    return err(c, "Search failed", 500);
   }
 });
 

--- a/server/routes/social.test.ts
+++ b/server/routes/social.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { describe, it, expect, beforeEach, afterAll, spyOn } from "bun:test";
 import { Hono } from "hono";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
 import { createUser, createSession, getSessionWithUser, upsertTitles } from "../db/repository";
+import * as repository from "../db/repository";
+import Sentry from "../sentry";
 import { makeParsedTitle } from "../test-utils/fixtures";
 import { requireAuth, optionalAuth } from "../middleware/auth";
 import socialApp from "./social";
@@ -341,5 +343,17 @@ describe("GET /social/friends-loved", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toHaveProperty("items");
+  });
+
+  it("returns 500 with a generic message and captures the error when the DB query throws", async () => {
+    const spy = spyOn(repository, "getFriendsLovedThisWeek").mockRejectedValueOnce(new Error("D1 connection lost"));
+    const captureSpy = spyOn(Sentry, "captureException");
+    const res = await app.request("/social/friends-loved", { headers: authHeaders(userAToken) });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Failed to load friends-loved");
+    expect(captureSpy).toHaveBeenCalled();
+    spy.mockRestore();
+    captureSpy.mockRestore();
   });
 });

--- a/server/routes/social.ts
+++ b/server/routes/social.ts
@@ -6,6 +6,7 @@ import { logger } from "../logger";
 import { ok, err } from "./response";
 import { zValidator } from "../lib/validator";
 import { onFollow } from "../achievements/triggers";
+import Sentry from "../sentry";
 
 const friendsLovedQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(50).optional().default(20),
@@ -110,11 +111,19 @@ app.get("/following/:userId", async (c) => {
 // GET /friends-loved — Top-rated titles from followed users in the last 7 days
 app.get("/friends-loved", zValidator("query", friendsLovedQuerySchema), async (c) => {
   const user = c.get("user");
-  if (!user) return c.json({ error: "Unauthorized" }, 401);
+  if (!user) return err(c, "Authentication required", 401);
 
   const { limit } = c.req.valid("query");
-  const items = await getFriendsLovedThisWeek(user.id, limit);
-  return c.json({ items });
+  try {
+    const items = await getFriendsLovedThisWeek(user.id, limit);
+    return ok(c, { items });
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    const stack = e instanceof Error ? e.stack : undefined;
+    Sentry.captureException(e);
+    log.error("friends-loved query failed", { userId: user.id, error: message, stack });
+    return err(c, "Failed to load friends-loved", 500);
+  }
 });
 
 export default app;


### PR DESCRIPTION
## Summary

- **#810** `GET /api/search` — the outer `catch` at `search.ts:110` was returning `err(c, rawMessage, 500)` with no `log.error` and no `Sentry.captureException`. Because the handler catches locally it bypasses the global `onError`, so the error was fully dark in both CF logs and Sentry. Now logs structured `{ query, error, stack }` and captures to Sentry; client receives a generic `"Search failed"` message.
- **#811** `GET /api/social/friends-loved` — the handler had no `try/catch`, so a DB throw escaped as a bare "Unhandled error" CF event with no userId context. Wrapped in try/catch with the same pattern; also normalised the 401 and success responses to `err()`/`ok()` helpers to match every sibling handler.
- Both fixes follow the established pattern in `integrations.ts` / `auth-custom.ts`: explicit `Sentry.captureException(e)` + `log.error` with context + generic client message.

## Test plan

- [x] Added regression test for #810: mocks `searchMulti` to reject, asserts `status=500`, `body.error="Search failed"` (generic, not leaked), `Sentry.captureException` called
- [x] Added regression test for #811: spies `repository.getFriendsLovedThisWeek` to reject, asserts `status=500`, `body.error="Failed to load friends-loved"`, `Sentry.captureException` called
- [x] All existing tests in both files remain green (42/42)
- [x] `bun run check` passes (tsc + ESLint + full test suite + build + wrangler dry-run)

Closes #810
Closes #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)