### PR TITLE
[auto-review] a11y(calendar): add aria-labels to nav buttons and aria-pressed to view toggles

### DIFF
--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -415,14 +415,14 @@ function MobileCalendar({
               <div className="text-[32px] font-extrabold tracking-[-1.2px]">{monthLabel}</div>
             </div>
             <div className="flex gap-2 items-center">
-              <button onClick={prevMonth} className="w-8 h-8 rounded-full bg-white/[0.06] flex items-center justify-center text-zinc-300">‹</button>
-              <button onClick={nextMonth} className="w-8 h-8 rounded-full bg-white/[0.06] flex items-center justify-center text-zinc-300">›</button>
+              <button onClick={prevMonth} aria-label="Previous month" className="w-8 h-8 rounded-full bg-white/[0.06] flex items-center justify-center text-zinc-300">‹</button>
+              <button onClick={nextMonth} aria-label="Next month" className="w-8 h-8 rounded-full bg-white/[0.06] flex items-center justify-center text-zinc-300">›</button>
             </div>
           </div>
           {/* Month/Agenda toggle */}
           <div className="flex gap-2 px-5 pb-4">
-            <button onClick={() => setMobileView("month")} className="px-3 py-1.5 rounded-full bg-amber-400 text-black text-[11px] font-bold font-mono">Month</button>
-            <button onClick={() => setMobileView("agenda")} className="px-3 py-1.5 rounded-full bg-white/[0.06] text-zinc-300 text-[11px] font-semibold font-mono">Agenda</button>
+            <button onClick={() => setMobileView("month")} aria-pressed={true} className="px-3 py-1.5 rounded-full bg-amber-400 text-black text-[11px] font-bold font-mono">Month</button>
+            <button onClick={() => setMobileView("agenda")} aria-pressed={false} className="px-3 py-1.5 rounded-full bg-white/[0.06] text-zinc-300 text-[11px] font-semibold font-mono">Agenda</button>
           </div>
           {loadingMonth ? (
             <div className="text-center py-8 text-zinc-500 font-mono text-xs">Loading...</div>
@@ -436,8 +436,8 @@ function MobileCalendar({
         <div>
           {/* Month/Agenda toggle */}
           <div className="flex gap-2 px-4 pt-2 pb-2">
-            <button onClick={() => setMobileView("month")} className="px-3 py-1.5 rounded-full bg-white/[0.06] text-zinc-300 text-[11px] font-semibold font-mono">Month</button>
-            <button onClick={() => setMobileView("agenda")} className="px-3 py-1.5 rounded-full bg-amber-400 text-black text-[11px] font-bold font-mono">Agenda</button>
+            <button onClick={() => setMobileView("month")} aria-pressed={false} className="px-3 py-1.5 rounded-full bg-white/[0.06] text-zinc-300 text-[11px] font-semibold font-mono">Month</button>
+            <button onClick={() => setMobileView("agenda")} aria-pressed={true} className="px-3 py-1.5 rounded-full bg-amber-400 text-black text-[11px] font-bold font-mono">Agenda</button>
           </div>
           <AgendaCalendar
             searchParams={searchParams}
@@ -805,6 +805,7 @@ function GridCalendar({
     <div className="flex flex-wrap items-center gap-2 justify-end">
       <button
         onClick={prevMonth}
+        aria-label="Previous month"
         className="p-1.5 rounded-lg hover:bg-zinc-800 text-zinc-400 hover:text-white transition-colors cursor-pointer"
       >
         <ChevronLeftIcon className="size-5" />
@@ -817,6 +818,7 @@ function GridCalendar({
       </button>
       <button
         onClick={nextMonth}
+        aria-label="Next month"
         className="p-1.5 rounded-lg hover:bg-zinc-800 text-zinc-400 hover:text-white transition-colors cursor-pointer"
       >
         <ChevronRightIcon className="size-5" />
@@ -826,6 +828,7 @@ function GridCalendar({
         <button
           key={f.value}
           onClick={() => setTypeFilter(f.value)}
+          aria-pressed={typeFilter === f.value}
           className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
             typeFilter === f.value
               ? "bg-amber-500 text-zinc-950"


### PR DESCRIPTION
## What

Three groups of interactive elements in `CalendarPage.tsx` were missing accessible names or state:

1. **Desktop prev/next month buttons** (`ChevronLeftIcon` / `ChevronRightIcon`) — icon-only buttons with no `aria-label`. Screen readers announced them as unlabelled.
2. **Mobile prev/next month buttons** (`‹` / `›` text glyphs) — single-glyph text is not a meaningful label for AT; added explicit `aria-label="Previous month"` / `"Next month"`.
3. **Mobile Month/Agenda view toggle buttons** — no `aria-pressed`, so assistive technology couldn't determine which view was active. Each branch now declares its own static `aria-pressed` value (`true` / `false`).
4. **Desktop type-filter buttons** (All / Movies / TV) — no `aria-pressed` to indicate the selected filter.

## Scope

Single file: `frontend/src/pages/CalendarPage.tsx`, 9 insertions / 6 deletions.

`bun run check:fast` passes (0 TS errors, 0 ESLint warnings).

---
_Source: ux_

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4KvYxKrRBwa6w8VMqr9C1)_