### PR TITLE
feat(query): Phase 1 — useQuery/useMutation for all watched toggles + retire event bus

### DIFF
--- a/frontend/src/components/BackdateWatchedButton.tsx
+++ b/frontend/src/components/BackdateWatchedButton.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { CalendarDays } from "lucide-react";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
@@ -22,6 +23,7 @@ interface Props {
 export default function BackdateWatchedButton({ titleId, scope, variant = "default", onComplete }: Props) {
   const { user } = useAuth();
   const { t } = useTranslation();
+  const qc = useQueryClient();
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
 
@@ -39,6 +41,11 @@ export default function BackdateWatchedButton({ titleId, scope, variant = "defau
           t("episodes.backdateSuccess", "Backdated {{count}} episode to air date", { count: updated }),
         );
       }
+      qc.invalidateQueries({ queryKey: ["watch-history"] });
+      qc.invalidateQueries({ queryKey: ["stats"] });
+      qc.invalidateQueries({ queryKey: ["activity"] });
+      qc.invalidateQueries({ queryKey: ["calendar"] });
+      qc.invalidateQueries({ queryKey: ["home", "auth"] });
       onComplete?.(updated);
     } catch {
       toast.error(t("episodes.backdateError", "Failed to backdate watched episodes"));

--- a/frontend/src/components/EditWatchedAtDialog.test.tsx
+++ b/frontend/src/components/EditWatchedAtDialog.test.tsx
@@ -1,8 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
 import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "../i18n";
 import EditWatchedAtDialog from "./EditWatchedAtDialog";
 import * as api from "../api";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
 
 let spies: ReturnType<typeof spyOn>[] = [];
 
@@ -28,7 +33,12 @@ function renderDialog(overrides: Partial<Parameters<typeof EditWatchedAtDialog>[
     onUpdated: mock((_: string) => {}),
   };
   const props = { ...defaults, ...overrides };
-  return { result: render(<EditWatchedAtDialog {...props} />), props };
+  const qc = newTestClient();
+  return {
+    result: render(<QueryClientProvider client={qc}><EditWatchedAtDialog {...props} /></QueryClientProvider>),
+    props,
+    qc,
+  };
 }
 
 describe("EditWatchedAtDialog", () => {
@@ -70,13 +80,9 @@ describe("EditWatchedAtDialog", () => {
     });
   });
 
-  it("dispatches watch-history:updated event on successful save", async () => {
-    const events: Event[] = [];
-    const handler = (e: Event) => events.push(e);
-    window.addEventListener("watch-history:updated", handler);
-
-    const onClose = mock(() => {});
-    renderDialog({ onClose });
+  it("invalidates query caches on successful save", async () => {
+    const { qc } = renderDialog();
+    const invalidateSpy = spyOn(qc, "invalidateQueries");
 
     fireEvent.click(screen.getByText("Save"));
 
@@ -85,9 +91,13 @@ describe("EditWatchedAtDialog", () => {
     });
 
     await waitFor(() => {
-      expect(events.length).toBeGreaterThan(0);
+      expect(invalidateSpy).toHaveBeenCalled();
     });
 
-    window.removeEventListener("watch-history:updated", handler);
+    const keys = invalidateSpy.mock.calls.map((call: any[]) => (call[0] as any)?.queryKey);
+    expect(keys).toContainEqual(["stats"]);
+    expect(keys).toContainEqual(["activity"]);
+
+    invalidateSpy.mockRestore();
   });
 });

--- a/frontend/src/components/EditWatchedAtDialog.tsx
+++ b/frontend/src/components/EditWatchedAtDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import {
   AlertDialog,
@@ -29,6 +30,7 @@ function toYMD(d: Date): string {
 
 export default function EditWatchedAtDialog({ open, onClose, entryId, currentWatchedAt, anchorDate, onUpdated }: Props) {
   const { t } = useTranslation();
+  const qc = useQueryClient();
   const [selected, setSelected] = useState<Date | undefined>(toDate(currentWatchedAt));
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -54,7 +56,11 @@ export default function EditWatchedAtDialog({ open, onClose, entryId, currentWat
     try {
       const result = await api.patchWatchHistoryEntry(entryId, toYMD(selected));
       onUpdated(result.watchedAt);
-      window.dispatchEvent(new CustomEvent("watch-history:updated"));
+      qc.invalidateQueries({ queryKey: ["watch-history"] });
+      qc.invalidateQueries({ queryKey: ["stats"] });
+      qc.invalidateQueries({ queryKey: ["activity"] });
+      qc.invalidateQueries({ queryKey: ["calendar"] });
+      qc.invalidateQueries({ queryKey: ["home", "auth"] });
       onClose();
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Failed to save";

--- a/frontend/src/components/profile/RecentActivityCard.test.tsx
+++ b/frontend/src/components/profile/RecentActivityCard.test.tsx
@@ -1,13 +1,22 @@
 import { describe, it, expect, afterEach, mock } from "bun:test";
 import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import "../../i18n";
 import RecentActivityCard from "./RecentActivityCard";
 import type { ActivityEvent, ActivityFeedResponse } from "../../types";
 
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
 function Wrapper({ children }: { children: ReactNode }) {
-  return <MemoryRouter>{children}</MemoryRouter>;
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
 }
 
 function event(overrides: Partial<ActivityEvent>): ActivityEvent {

--- a/frontend/src/components/profile/RecentActivityCard.tsx
+++ b/frontend/src/components/profile/RecentActivityCard.tsx
@@ -1,4 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import type { InfiniteData } from "@tanstack/react-query";
 import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import { BookmarkPlus, Play, Quote, Star, X } from "lucide-react";
@@ -280,62 +282,44 @@ interface ActivityFeedProps {
 
 function ActivityFeed({ username, isOwnProfile, pageSize, fetcher }: ActivityFeedProps) {
   const { t } = useTranslation();
-  const [events, setEvents] = useState<ActivityEvent[]>([]);
-  const [cursor, setCursor] = useState<string | null>(null);
-  const [hasMore, setHasMore] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const [loadingMore, setLoadingMore] = useState(false);
-  const [error, setError] = useState(false);
-  const [tick, setTick] = useState(0);
+  const qc = useQueryClient();
 
-  useEffect(() => {
-    const handler = () => setTick((t) => t + 1);
-    window.addEventListener("watch-history:updated", handler);
-    return () => window.removeEventListener("watch-history:updated", handler);
-  }, []);
+  const {
+    data,
+    isLoading: loading,
+    isError: error,
+    isFetchingNextPage: loadingMore,
+    hasNextPage: hasMore,
+    fetchNextPage,
+  } = useInfiniteQuery({
+    queryKey: ["activity", username, pageSize],
+    queryFn: ({ pageParam }) => fetcher(username, { limit: pageSize, before: pageParam }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (last) => (last.has_more && last.next_cursor) ? last.next_cursor : undefined,
+  });
 
-  useEffect(() => {
-    const controller = new AbortController();
-    fetcher(username, { limit: pageSize })
-      .then((res) => {
-        if (controller.signal.aborted) return;
-        setEvents(res.activities);
-        setCursor(res.next_cursor);
-        setHasMore(res.has_more);
-        setLoading(false);
-      })
-      .catch(() => {
-        if (controller.signal.aborted) return;
-        setError(true);
-        setLoading(false);
-      });
-    return () => controller.abort();
-  }, [username, pageSize, fetcher, tick]);
+  const events = data?.pages.flatMap((p) => p.activities) ?? [];
 
-  const handleHide = useCallback((event: ActivityEvent) => {
-    setEvents((prev) => prev.filter((e) => e.id !== event.id));
-    api.hideActivityEvent(event.type, event.id).catch(() => {
-      setEvents((prev) =>
-        [...prev, event].sort((a, b) => b.created_at.localeCompare(a.created_at)),
-      );
+  const handleHide = useCallback((eventToHide: ActivityEvent) => {
+    const snapshot = qc.getQueryData<InfiniteData<ActivityFeedResponse>>(["activity", username, pageSize]);
+    qc.setQueryData<InfiniteData<ActivityFeedResponse>>(["activity", username, pageSize], (prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        pages: prev.pages.map((page) => ({
+          ...page,
+          activities: page.activities.filter((e) => e.id !== eventToHide.id),
+        })),
+      };
     });
-  }, []);
+    api.hideActivityEvent(eventToHide.type, eventToHide.id).catch(() => {
+      qc.setQueryData(["activity", username, pageSize], snapshot);
+    });
+  }, [qc, username, pageSize]);
 
   const loadMore = useCallback(() => {
-    if (!cursor || loadingMore) return;
-    setLoadingMore(true);
-    fetcher(username, { limit: pageSize, before: cursor })
-      .then((res) => {
-        setEvents((prev) => [...prev, ...res.activities]);
-        setCursor(res.next_cursor);
-        setHasMore(res.has_more);
-        setLoadingMore(false);
-      })
-      .catch(() => {
-        setError(true);
-        setLoadingMore(false);
-      });
-  }, [username, pageSize, cursor, loadingMore, fetcher]);
+    fetchNextPage();
+  }, [fetchNextPage]);
 
   if (error) return null;
 

--- a/frontend/src/pages/CalendarPage.test.tsx
+++ b/frontend/src/pages/CalendarPage.test.tsx
@@ -1,7 +1,12 @@
 import { describe, it, expect, mock, afterEach, beforeEach } from "bun:test";
 import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
 
 // Initialize i18n before anything else (avoids mock.module leak)
 import "../i18n";
@@ -40,7 +45,11 @@ mock.module("../api", () => ({
 const { default: CalendarPage, SlideOverPanel } = await import("./CalendarPage");
 
 function Wrapper({ children }: { children: ReactNode }) {
-  return <MemoryRouter>{children}</MemoryRouter>;
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
 }
 
 afterEach(() => {
@@ -210,9 +219,11 @@ describe("CalendarPage", () => {
 
   it("?view=week param activates week view", async () => {
     render(
-      <MemoryRouter initialEntries={["/?view=week"]}>
-        <CalendarPage />
-      </MemoryRouter>
+      <QueryClientProvider client={newTestClient()}>
+        <MemoryRouter initialEntries={["/?view=week"]}>
+          <CalendarPage />
+        </MemoryRouter>
+      </QueryClientProvider>
     );
     const columns = await waitFor(() => screen.getAllByTestId("week-day-column"));
     expect(columns.length).toBe(7);
@@ -255,9 +266,11 @@ describe("CalendarPage", () => {
 
   it("?density=compact param activates compact density", () => {
     render(
-      <MemoryRouter initialEntries={["/?density=compact"]}>
-        <CalendarPage />
-      </MemoryRouter>
+      <QueryClientProvider client={newTestClient()}>
+        <MemoryRouter initialEntries={["/?density=compact"]}>
+          <CalendarPage />
+        </MemoryRouter>
+      </QueryClientProvider>
     );
     const compactBtn = screen.getByRole("button", { name: /compact/i });
     expect(compactBtn.getAttribute("aria-pressed")).toBe("true");

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
+import { useQuery, useQueries, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link, useSearchParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import {
@@ -35,6 +36,8 @@ import AgendaCalendar, {
 } from "../components/AgendaCalendar";
 import { PageHeader } from "../components/design";
 
+
+type CalendarData = { titles: Title[]; episodes: Episode[]; count: number };
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -362,24 +365,12 @@ function MobileCalendar({
     return new Date(y, m - 1, 1);
   }, [monthParam]);
 
-  const [episodes, setEpisodes] = useState<Episode[]>([]);
-  const [loadingMonth, setLoadingMonth] = useState(false);
-
-  useEffect(() => {
-    if (mobileView !== "month") return;
-    const controller = new AbortController();
-    const { signal } = controller;
-    void (async () => {
-      setLoadingMonth(true);
-      try {
-        const data = await getCalendarTitles({ month: formatMonth(currentMonth) }, signal);
-        if (!signal.aborted) setEpisodes(data.episodes || []);
-      } catch { /* ignore */ } finally {
-        if (!signal.aborted) setLoadingMonth(false);
-      }
-    })();
-    return () => { controller.abort(); };
-  }, [mobileView, currentMonth]);
+  const { data: mobileCalData, isFetching: loadingMonth } = useQuery<CalendarData>({
+    queryKey: ["calendar", formatMonth(currentMonth), undefined],
+    queryFn: ({ signal }) => getCalendarTitles({ month: formatMonth(currentMonth) }, signal),
+    enabled: mobileView === "month",
+  });
+  const episodes = useMemo(() => mobileCalData?.episodes ?? [], [mobileCalData]);
 
   const dotDates = useMemo(() => {
     const set = new Set<string>();
@@ -568,11 +559,17 @@ function GridCalendar({
     return new Date(y, m - 1, 1);
   }, [monthParam]);
 
-  const [titles, setTitles] = useState<Title[]>([]);
-  const [episodes, setEpisodes] = useState<Episode[]>([]);
-  const [loading, setLoading] = useState(false);
   const [crowdedWeekThreshold, setCrowdedWeekThreshold] = useState(5);
   const [crowdedWeekBadgeEnabled, setCrowdedWeekBadgeEnabled] = useState(true);
+  const qc = useQueryClient();
+  const calendarMonthKey = formatMonth(currentMonth);
+  const calendarTypeKey = typeFilter || undefined;
+  const { data: calendarData, isFetching: loading } = useQuery<CalendarData>({
+    queryKey: ["calendar", calendarMonthKey, calendarTypeKey],
+    queryFn: ({ signal }) => getCalendarTitles({ month: calendarMonthKey, type: calendarTypeKey }, signal),
+  });
+  const titles = useMemo(() => calendarData?.titles ?? [], [calendarData]);
+  const episodes = useMemo(() => calendarData?.episodes ?? [], [calendarData]);
 
   const year = currentMonth.getFullYear();
   const month = currentMonth.getMonth();
@@ -591,24 +588,6 @@ function GridCalendar({
     return () => controller.abort();
   }, []);
 
-  useEffect(() => {
-    const controller = new AbortController();
-    const { signal } = controller;
-    setLoading(true);
-    getCalendarTitles({
-      month: formatMonth(currentMonth),
-      type: typeFilter || undefined,
-    }, signal)
-      .then((data) => {
-        if (!signal.aborted) {
-          setTitles(data.titles);
-          setEpisodes(data.episodes || []);
-        }
-      })
-      .catch((err) => { if (!signal.aborted) console.error(err); })
-      .finally(() => { if (!signal.aborted) setLoading(false); });
-    return () => controller.abort();
-  }, [currentMonth, typeFilter]);
 
   const itemsByDate = useMemo(() => {
     const map = new Map<string, CalendarItem[]>();
@@ -713,43 +692,90 @@ function GridCalendar({
     setMonthParam(formatMonth(new Date(year, month + 1, 1)));
   const today = formatDateKey(new Date());
 
-  const toggleWatched = async (
-    episodeId: number,
-    currentlyWatched: boolean
-  ) => {
-    setEpisodes((prev) =>
-      prev.map((ep) =>
-        ep.id === episodeId
-          ? { ...ep, is_watched: !currentlyWatched }
-          : ep
-      )
-    );
-    try {
-      if (currentlyWatched) {
-        await unwatchEpisode(episodeId);
-      } else {
-        await watchEpisode(episodeId);
-      }
-    } catch (err) {
-      setEpisodes((prev) =>
-        prev.map((ep) =>
-          ep.id === episodeId
-            ? { ...ep, is_watched: currentlyWatched }
-            : ep
-        )
-      );
-      console.error("Failed to toggle watched:", err);
-      toast.error("Failed to update watched status — please try again");
-    }
-  };
-
   const isEpisodeReleased = (ep: Episode) =>
     ep.air_date ? ep.air_date <= today : false;
 
-  const toggleBulkWatched = async (
-    episodeIds: number[],
-    markWatched: boolean
-  ) => {
+  const episodeToggleMutation = useMutation({
+    mutationFn: ({ episodeId, currentlyWatched }: { episodeId: number; currentlyWatched: boolean }) =>
+      currentlyWatched ? unwatchEpisode(episodeId) : watchEpisode(episodeId),
+    onMutate: async ({ episodeId, currentlyWatched }) => {
+      await qc.cancelQueries({ queryKey: ["calendar"] });
+      const snapshots = qc.getQueriesData<CalendarData>({ queryKey: ["calendar"] });
+      qc.setQueriesData<CalendarData>({ queryKey: ["calendar"] }, (old) => {
+        if (!old) return old;
+        return { ...old, episodes: old.episodes.map((ep) => ep.id === episodeId ? { ...ep, is_watched: !currentlyWatched } : ep) };
+      });
+      return { snapshots };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.snapshots) {
+        for (const [key, data] of context.snapshots) qc.setQueryData(key, data);
+      }
+      toast.error("Failed to update watched status — please try again");
+    },
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: ["calendar"] });
+      void qc.invalidateQueries({ queryKey: ["stats"] });
+      void qc.invalidateQueries({ queryKey: ["activity"] });
+    },
+  });
+
+  const bulkToggleMutation = useMutation({
+    mutationFn: ({ episodeIds, markWatched }: { episodeIds: number[]; markWatched: boolean }) =>
+      watchEpisodesBulk(episodeIds, markWatched),
+    onMutate: async ({ episodeIds, markWatched }) => {
+      await qc.cancelQueries({ queryKey: ["calendar"] });
+      const snapshots = qc.getQueriesData<CalendarData>({ queryKey: ["calendar"] });
+      const idSet = new Set(episodeIds);
+      qc.setQueriesData<CalendarData>({ queryKey: ["calendar"] }, (old) => {
+        if (!old) return old;
+        return { ...old, episodes: old.episodes.map((ep) => idSet.has(ep.id) ? { ...ep, is_watched: markWatched } : ep) };
+      });
+      return { snapshots };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.snapshots) {
+        for (const [key, data] of context.snapshots) qc.setQueryData(key, data);
+      }
+      toast.error("Failed to update watched status — please try again");
+    },
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: ["calendar"] });
+      void qc.invalidateQueries({ queryKey: ["stats"] });
+      void qc.invalidateQueries({ queryKey: ["activity"] });
+    },
+  });
+
+  const titleToggleMutation = useMutation({
+    mutationFn: ({ titleId, currentlyWatched }: { titleId: string; currentlyWatched: boolean }) =>
+      currentlyWatched ? unwatchMovie(titleId) : watchMovie(titleId),
+    onMutate: async ({ titleId, currentlyWatched }) => {
+      await qc.cancelQueries({ queryKey: ["calendar"] });
+      const snapshots = qc.getQueriesData<CalendarData>({ queryKey: ["calendar"] });
+      qc.setQueriesData<CalendarData>({ queryKey: ["calendar"] }, (old) => {
+        if (!old) return old;
+        return { ...old, titles: old.titles.map((t) => t.id === titleId ? { ...t, is_watched: !currentlyWatched } : t) };
+      });
+      return { snapshots };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.snapshots) {
+        for (const [key, data] of context.snapshots) qc.setQueryData(key, data);
+      }
+      toast.error("Failed to update watched status — please try again");
+    },
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: ["calendar"] });
+      void qc.invalidateQueries({ queryKey: ["stats"] });
+      void qc.invalidateQueries({ queryKey: ["activity"] });
+    },
+  });
+
+  const toggleWatched = (episodeId: number, currentlyWatched: boolean) => {
+    episodeToggleMutation.mutate({ episodeId, currentlyWatched });
+  };
+
+  const toggleBulkWatched = (episodeIds: number[], markWatched: boolean) => {
     const effectiveIds = markWatched
       ? episodeIds.filter((id) => {
           const ep = episodes.find((e) => e.id === id);
@@ -757,43 +783,11 @@ function GridCalendar({
         })
       : episodeIds;
     if (effectiveIds.length === 0) return;
-
-    const idSet = new Set(effectiveIds);
-    setEpisodes((prev) =>
-      prev.map((ep) =>
-        idSet.has(ep.id) ? { ...ep, is_watched: markWatched } : ep
-      )
-    );
-    try {
-      await watchEpisodesBulk(effectiveIds, markWatched);
-    } catch (err) {
-      setEpisodes((prev) =>
-        prev.map((ep) =>
-          idSet.has(ep.id) ? { ...ep, is_watched: !markWatched } : ep
-        )
-      );
-      console.error("Failed to bulk toggle watched:", err);
-      toast.error("Failed to update watched status — please try again");
-    }
+    bulkToggleMutation.mutate({ episodeIds: effectiveIds, markWatched });
   };
 
-  const toggleTitleWatched = async (titleId: string, currentlyWatched: boolean) => {
-    setTitles((prev) =>
-      prev.map((t) => t.id === titleId ? { ...t, is_watched: !currentlyWatched } : t)
-    );
-    try {
-      if (currentlyWatched) {
-        await unwatchMovie(titleId);
-      } else {
-        await watchMovie(titleId);
-      }
-    } catch (err) {
-      setTitles((prev) =>
-        prev.map((t) => t.id === titleId ? { ...t, is_watched: currentlyWatched } : t)
-      );
-      console.error("Failed to toggle movie watched:", err);
-      toast.error("Failed to update watched status — please try again");
-    }
+  const toggleTitleWatched = (titleId: string, currentlyWatched: boolean) => {
+    titleToggleMutation.mutate({ titleId, currentlyWatched });
   };
 
   const monthTitle = currentMonth.toLocaleDateString("en-US", {
@@ -1098,46 +1092,39 @@ function WeekCalendar({
   }, [weekStart]);
 
   // Data loading — fetch the month(s) that overlap the week
-  const [titles, setTitles] = useState<Title[]>([]);
-  const [episodes, setEpisodes] = useState<Episode[]>([]);
-  const [loading, setLoading] = useState(false);
+  const startMonth = formatMonth(weekStart);
+  const endMonth = formatMonth(weekDays[6]);
+  const weekMonths = startMonth === endMonth ? [startMonth] : [startMonth, endMonth];
+  const weekTypeKey = typeFilter || undefined;
 
-  useEffect(() => {
-    const controller = new AbortController();
-    const { signal } = controller;
-    setLoading(true);
+  const weekQueries = useQueries({
+    queries: weekMonths.map((m) => ({
+      queryKey: ["calendar", m, weekTypeKey] as const,
+      queryFn: ({ signal }: { signal: AbortSignal }) =>
+        getCalendarTitles({ month: m, type: weekTypeKey }, signal),
+    })),
+  });
 
-    // The week may span two months; fetch both if needed
-    const startMonth = formatMonth(weekStart);
-    const weekEnd = weekDays[6];
-    const endMonth = formatMonth(weekEnd);
-    const months =
-      startMonth === endMonth ? [startMonth] : [startMonth, endMonth];
+  const loading = weekQueries.some((q) => q.isFetching);
 
-    Promise.all(
-      months.map((m) =>
-        getCalendarTitles({ month: m, type: typeFilter || undefined }, signal)
-      )
-    )
-      .then((results) => {
-        if (signal.aborted) return;
-        const allTitles: Title[] = [];
-        const allEpisodes: Episode[] = [];
-        for (const data of results) {
-          allTitles.push(...data.titles);
-          allEpisodes.push(...(data.episodes || []));
-        }
-        // Deduplicate by id
-        const seenTitles = new Set<string>();
-        const seenEps = new Set<number>();
-        setTitles(allTitles.filter((t) => { if (seenTitles.has(t.id)) return false; seenTitles.add(t.id); return true; }));
-        setEpisodes(allEpisodes.filter((e) => { if (seenEps.has(e.id)) return false; seenEps.add(e.id); return true; }));
-      })
-      .catch((err) => { if (!signal.aborted) console.error(err); })
-      .finally(() => { if (!signal.aborted) setLoading(false); });
-
-    return () => controller.abort();
-  }, [weekStart, weekDays, typeFilter]);
+  const weekQ0Data = weekQueries[0]?.data;
+  const weekQ1Data = weekQueries[1]?.data;
+  const { titles, episodes } = useMemo(() => {
+    const allTitles: Title[] = [];
+    const allEpisodes: Episode[] = [];
+    for (const data of [weekQ0Data, weekQ1Data]) {
+      if (data) {
+        allTitles.push(...data.titles);
+        allEpisodes.push(...(data.episodes || []));
+      }
+    }
+    const seenTitles = new Set<string>();
+    const seenEps = new Set<number>();
+    return {
+      titles: allTitles.filter((t) => { if (seenTitles.has(t.id)) return false; seenTitles.add(t.id); return true; }),
+      episodes: allEpisodes.filter((e) => { if (seenEps.has(e.id)) return false; seenEps.add(e.id); return true; }),
+    };
+  }, [weekQ0Data, weekQ1Data]);
 
   const itemsByDate = useMemo(() => {
     const map = new Map<string, CalendarItem[]>();

--- a/frontend/src/pages/EpisodeDetailPage.test.tsx
+++ b/frontend/src/pages/EpisodeDetailPage.test.tsx
@@ -1,7 +1,12 @@
 import { describe, it, expect, mock, afterEach, spyOn } from "bun:test";
 import { render, screen, fireEvent, waitFor, cleanup, act } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
 import * as sonner from "sonner";
 import "../i18n";
 
@@ -50,6 +55,7 @@ mock.module("../api", () => ({
   getEpisodeDetails: mockGetEpisodeDetails,
   getSeasonDetails: mockGetSeasonDetails,
   getSeasonEpisodeStatus: mockGetSeasonEpisodeStatus,
+  getWatchHistory: mock(() => Promise.resolve({ history: [], playCount: 0 })),
   watchEpisode: mockWatchEpisode,
   unwatchEpisode: mockUnwatchEpisode,
   watchEpisodesBulk: mockWatchEpisodesBulk,
@@ -59,11 +65,13 @@ const { default: EpisodeDetailPage } = await import("./EpisodeDetailPage");
 
 function Wrapper({ children }: { children: ReactNode }) {
   return (
-    <MemoryRouter initialEntries={["/title/tv-100/season/1/episode/1"]}>
-      <Routes>
-        <Route path="/title/:id/season/:season/episode/:episode" element={children} />
-      </Routes>
-    </MemoryRouter>
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter initialEntries={["/title/tv-100/season/1/episode/1"]}>
+        <Routes>
+          <Route path="/title/:id/season/:season/episode/:episode" element={children} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
   );
 }
 
@@ -136,11 +144,13 @@ describe("EpisodeDetailPage", () => {
     }));
 
     const UnreleasedWrapper = ({ children }: { children: ReactNode }) => (
-      <MemoryRouter initialEntries={["/title/tv-100/season/1/episode/3"]}>
-        <Routes>
-          <Route path="/title/:id/season/:season/episode/:episode" element={children} />
-        </Routes>
-      </MemoryRouter>
+      <QueryClientProvider client={newTestClient()}>
+        <MemoryRouter initialEntries={["/title/tv-100/season/1/episode/3"]}>
+          <Routes>
+            <Route path="/title/:id/season/:season/episode/:episode" element={children} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
     );
 
     render(<EpisodeDetailPage />, { wrapper: UnreleasedWrapper });

--- a/frontend/src/pages/EpisodeDetailPage.tsx
+++ b/frontend/src/pages/EpisodeDetailPage.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState } from "react";
+import { useMemo, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useParams, Link } from "react-router";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import ScrollableRow from "../components/ScrollableRow";
 import * as api from "../api";
-import type { EpisodeDetailsResponse, CastMember, CrewMember, WatchHistoryEntry } from "../types";
+import type { EpisodeDetailsResponse, CastMember, CrewMember } from "../types";
 import PersonCard from "../components/PersonCard";
 import { DetailPageSkeleton } from "../components/SkeletonComponents";
 import { useApiCall } from "../hooks/useApiCall";
@@ -39,47 +40,69 @@ export default function EpisodeDetailPage() {
     [id, season, episode],
   );
 
-  const [episodeStatus, setEpisodeStatus] = useState<{ id: number; is_watched: boolean } | null>(null);
-  const [watchHistoryEntries, setWatchHistoryEntries] = useState<WatchHistoryEntry[]>([]);
   const [editHistoryEntry, setEditHistoryEntry] = useState<string | null>(null);
+  const qc = useQueryClient();
 
-  useApiCall(
-    (signal) => user && id && season
-      ? api.getSeasonEpisodeStatus(id, Number(season), signal)
-      : Promise.resolve({ episodes: [] }),
-    [user, id, season, episode],
-    {
-      onSuccess: (result) => {
-        const match = result.episodes.find((ep) => ep.episode_number === Number(episode));
-        setEpisodeStatus(match ? { id: match.id, is_watched: match.is_watched } : null);
-      },
-    },
+  type SeasonStatusEntry = { episode_number: number; id: number; is_watched: boolean };
+  type SeasonStatusData = { episodes: SeasonStatusEntry[] };
+
+  const { data: statusData } = useQuery({
+    queryKey: ["season-status", id, season],
+    queryFn: ({ signal }) =>
+      user && id && season
+        ? api.getSeasonEpisodeStatus(id, Number(season), signal)
+        : Promise.resolve({ episodes: [] as SeasonStatusEntry[] }),
+    enabled: !!user && !!id && !!season,
+  });
+
+  const episodeStatus = useMemo(() => {
+    const match = statusData?.episodes.find((ep) => ep.episode_number === Number(episode));
+    return match ? { id: match.id, is_watched: match.is_watched } : null;
+  }, [statusData, episode]);
+
+  const { data: historyData } = useQuery({
+    queryKey: ["watch-history", id, episodeStatus?.id],
+    queryFn: ({ signal }) => api.getWatchHistory(id!, { episodeId: episodeStatus!.id }, signal),
+    enabled: !!id && !!episodeStatus?.id && !!episodeStatus?.is_watched,
+  });
+  const watchHistoryEntries = useMemo(
+    () => historyData?.history ?? [],
+    [historyData],
   );
 
-  useEffect(() => {
-    if (episodeStatus?.is_watched && id) {
-      api.getWatchHistory(id, { episodeId: episodeStatus.id })
-        .then(({ history }) => setWatchHistoryEntries(history))
-        .catch(() => {});
-    }
-  }, [episodeStatus?.is_watched, episodeStatus?.id, id]);
-
-  const toggleWatched = async () => {
-    if (!episodeStatus) return;
-
-    const wasWatched = episodeStatus.is_watched;
-    setEpisodeStatus({ ...episodeStatus, is_watched: !wasWatched });
-
-    try {
-      if (wasWatched) {
-        await api.unwatchEpisode(episodeStatus.id);
-      } else {
-        await api.watchEpisode(episodeStatus.id);
+  const toggleMutation = useMutation({
+    mutationFn: (status: { id: number; is_watched: boolean }) =>
+      status.is_watched ? api.unwatchEpisode(status.id) : api.watchEpisode(status.id),
+    onMutate: async (status) => {
+      await qc.cancelQueries({ queryKey: ["season-status", id, season] });
+      const snapshot = qc.getQueryData<SeasonStatusData>(["season-status", id, season]);
+      qc.setQueryData<SeasonStatusData>(["season-status", id, season], (old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          episodes: old.episodes.map((ep) =>
+            ep.id === status.id ? { ...ep, is_watched: !status.is_watched } : ep
+          ),
+        };
+      });
+      return { snapshot };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.snapshot !== undefined) {
+        qc.setQueryData(["season-status", id, season], context.snapshot);
       }
-    } catch {
-      setEpisodeStatus({ ...episodeStatus, is_watched: wasWatched });
       toast.error(t("episodes.watchedError", "Failed to update watched status"));
-    }
+    },
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: ["season-status", id, season] });
+      void qc.invalidateQueries({ queryKey: ["stats"] });
+      void qc.invalidateQueries({ queryKey: ["activity"] });
+    },
+  });
+
+  const toggleWatched = () => {
+    if (!episodeStatus) return;
+    toggleMutation.mutate(episodeStatus);
   };
 
   if (loading) {
@@ -249,8 +272,8 @@ export default function EpisodeDetailPage() {
           entryId={editHistoryEntry}
           currentWatchedAt={watchHistoryEntries.find(e => e.id === editHistoryEntry)?.watchedAt ?? ""}
           anchorDate={data?.tmdb?.air_date ?? null}
-          onUpdated={(newWatchedAt) => {
-            setWatchHistoryEntries(prev => prev.map(e => e.id === editHistoryEntry ? { ...e, watchedAt: newWatchedAt } : e));
+          onUpdated={() => {
+            void qc.invalidateQueries({ queryKey: ["watch-history", id] });
             setEditHistoryEntry(null);
           }}
         />

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -1,8 +1,13 @@
 import { describe, it, expect, mock, afterEach } from "bun:test";
 import { render, screen, cleanup, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import "../i18n";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
 
 // --- Mocks ---
 
@@ -155,7 +160,11 @@ mock.module("../api", () => ({
 const { default: HomePage } = await import("./HomePage");
 
 function Wrapper({ children }: { children: ReactNode }) {
-  return <MemoryRouter>{children}</MemoryRouter>;
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
 }
 
 afterEach(() => {

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useMemo, useRef, useCallback, useReducer } from "react";
+import { useState, useMemo, useRef, useCallback } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Card } from "../components/ui/card";
 import { Link } from "react-router";
 import { Maximize2 } from "lucide-react";
@@ -62,66 +63,17 @@ export function buildUnwatchedCards(episodes: Episode[]): UnwatchedCardEntry[] {
   return entries;
 }
 
-type HomeState =
-  | { status: "loading" }
-  | { status: "anon"; popularTitles: Title[] }
-  | { status: "auth"; today: Episode[]; upcoming: Episode[]; unwatched: Episode[]; recommendations: Recommendation[]; layout: HomepageSection[]; upNextItems: UpNextItem[]; friendsLovedItems: FriendsLovedItem[] }
-  | { status: "error"; message: string };
-
-type HomeAction =
-  | { type: "LOAD_ANON_SUCCESS"; popularTitles: Title[] }
-  | { type: "LOAD_AUTH_SUCCESS"; today: Episode[]; upcoming: Episode[]; unwatched: Episode[]; recommendations: Recommendation[]; layout: HomepageSection[]; upNextItems: UpNextItem[]; friendsLovedItems: FriendsLovedItem[] }
-  | { type: "LOAD_ERROR"; message: string }
-  | { type: "TOGGLE_WATCHED"; episodeId: number; currentlyWatched: boolean }
-  | { type: "TOGGLE_WATCHED_REVERT"; episodeId: number; currentlyWatched: boolean }
-  | { type: "REPLACE_UNWATCHED"; unwatched: Episode[] }
-  | { type: "MARK_ALL_WATCHED"; episodeIds: number[] }
-  | { type: "REMOVE_UP_NEXT_EPISODE"; episodeId: number };
-
-function homeReducer(state: HomeState, action: HomeAction): HomeState {
-  switch (action.type) {
-    case "LOAD_ANON_SUCCESS":
-      return { status: "anon", popularTitles: action.popularTitles };
-    case "LOAD_AUTH_SUCCESS":
-      return { status: "auth", today: action.today, upcoming: action.upcoming, unwatched: action.unwatched, recommendations: action.recommendations, layout: action.layout, upNextItems: action.upNextItems, friendsLovedItems: action.friendsLovedItems };
-    case "LOAD_ERROR":
-      return { status: "error", message: action.message };
-    case "TOGGLE_WATCHED": {
-      if (state.status !== "auth") return state;
-      const update = (ep: Episode) => ep.id === action.episodeId ? { ...ep, is_watched: !action.currentlyWatched } : ep;
-      return {
-        ...state,
-        today: state.today.map(update),
-        upcoming: state.upcoming.map(update),
-        unwatched: !action.currentlyWatched
-          ? state.unwatched.filter((ep) => ep.id !== action.episodeId)
-          : state.unwatched,
-      };
-    }
-    case "TOGGLE_WATCHED_REVERT": {
-      if (state.status !== "auth") return state;
-      const revert = (ep: Episode) => ep.id === action.episodeId ? { ...ep, is_watched: action.currentlyWatched } : ep;
-      return { ...state, today: state.today.map(revert), upcoming: state.upcoming.map(revert) };
-    }
-    case "REPLACE_UNWATCHED":
-      if (state.status !== "auth") return state;
-      return { ...state, unwatched: action.unwatched };
-    case "MARK_ALL_WATCHED": {
-      if (state.status !== "auth") return state;
-      const idSet = new Set(action.episodeIds);
-      return { ...state, unwatched: state.unwatched.filter((ep) => !idSet.has(ep.id)) };
-    }
-    case "REMOVE_UP_NEXT_EPISODE": {
-      if (state.status !== "auth") return state;
-      return {
-        ...state,
-        upNextItems: state.upNextItems.filter((item) => item.nextEpisodeId !== action.episodeId),
-      };
-    }
-    default:
-      return state;
-  }
-}
+type AuthHomeData = {
+  today: Episode[];
+  upcoming: Episode[];
+  unwatched: Episode[];
+  recommendations: Recommendation[];
+  layout: HomepageSection[];
+  upNextItems: UpNextItem[];
+  friendsLovedItems: FriendsLovedItem[];
+  streakData: StreakData | null;
+  movieData: MovieTrackResponse;
+};
 
 function getGreeting(): string {
   const h = new Date().getHours();
@@ -338,128 +290,144 @@ export default function HomePage() {
   const { user, loading: authLoading } = useAuth();
   const isMobile = useIsMobile();
   const { t } = useTranslation();
-  const [state, dispatch] = useReducer(homeReducer, { status: "loading" });
+  const qc = useQueryClient();
   const [confirmingTitleId, setConfirmingTitleId] = useState<string | null>(null);
   const confirmTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [streakData, setStreakData] = useState<StreakData | null>(null);
-  const [movieData, setMovieData] = useState<MovieTrackResponse>({ to_watch: [], upcoming: [] });
 
-  useEffect(() => {
-    if (authLoading) return;
-    const controller = new AbortController();
-    const { signal } = controller;
-
-    if (!user) {
+  const { data: anonData, isLoading: anonLoading } = useQuery({
+    queryKey: ["home", "anon"],
+    enabled: !authLoading && !user,
+    queryFn: ({ signal }) =>
       api.browseTitles({ category: "popular", page: 1 }, signal)
-        .then((res) => { if (!signal.aborted) dispatch({ type: "LOAD_ANON_SUCCESS", popularTitles: res.titles.map(normalizeSearchTitle) }); })
-        .catch(() => { if (!signal.aborted) dispatch({ type: "LOAD_ANON_SUCCESS", popularTitles: [] }); });
-      return () => controller.abort();
-    }
+        .then((res) => res.titles.map(normalizeSearchTitle))
+        .catch(() => [] as Title[]),
+  });
 
-    async function load() {
-      try {
-        const [episodeData, recData, layoutData, upNextData, friendsLovedData, streakResult, moviesResult] = await Promise.all([
-          api.getUpcomingEpisodes(signal),
-          api.getRecommendations(6, undefined, signal).catch(() => ({ recommendations: [], count: 0 })),
-          (api.getHomepageLayout?.(signal) ?? Promise.resolve({ homepage_layout: DEFAULT_HOMEPAGE_LAYOUT })).catch(() => ({ homepage_layout: DEFAULT_HOMEPAGE_LAYOUT })),
-          api.getUpNext(12, signal).catch(() => ({ items: [] as UpNextItem[] })),
-          api.getFriendsLoved(20, signal).catch(() => ({ items: [] as FriendsLovedItem[] })),
-          api.getMyStreak(signal).catch(() => null),
-          api.getMovieTracking(signal).catch(() => ({ to_watch: [], upcoming: [] })),
-        ]);
-        if (signal.aborted) return;
-        if (streakResult) setStreakData(streakResult);
-        setMovieData(moviesResult);
-        dispatch({ type: "LOAD_AUTH_SUCCESS", today: episodeData.today, upcoming: episodeData.upcoming, unwatched: episodeData.unwatched, recommendations: recData.recommendations, layout: layoutData.homepage_layout, upNextItems: upNextData.items, friendsLovedItems: friendsLovedData.items });
-      } catch (err: unknown) {
-        if (!signal.aborted) dispatch({ type: "LOAD_ERROR", message: err instanceof Error ? err.message : String(err) });
-      }
-    }
-    load();
-    return () => controller.abort();
-  }, [user, authLoading]);
+  const { data: authData, isLoading: authDataLoading, isError: authDataError, error: authError } = useQuery<AuthHomeData>({
+    queryKey: ["home", "auth"],
+    enabled: !authLoading && !!user,
+    queryFn: async ({ signal }) => {
+      const [episodeData, recData, layoutData, upNextData, friendsLovedData, streakResult, moviesResult] = await Promise.all([
+        api.getUpcomingEpisodes(signal),
+        api.getRecommendations(6, undefined, signal).catch(() => ({ recommendations: [] as Recommendation[], count: 0 })),
+        (api.getHomepageLayout?.(signal) ?? Promise.resolve({ homepage_layout: DEFAULT_HOMEPAGE_LAYOUT })).catch(() => ({ homepage_layout: DEFAULT_HOMEPAGE_LAYOUT })),
+        api.getUpNext(12, signal).catch(() => ({ items: [] as UpNextItem[] })),
+        api.getFriendsLoved(20, signal).catch(() => ({ items: [] as FriendsLovedItem[] })),
+        api.getMyStreak(signal).catch(() => null),
+        api.getMovieTracking(signal).catch(() => ({ to_watch: [], upcoming: [] } as MovieTrackResponse)),
+      ]);
+      return {
+        today: episodeData.today,
+        upcoming: episodeData.upcoming,
+        unwatched: episodeData.unwatched,
+        recommendations: recData.recommendations,
+        layout: layoutData.homepage_layout,
+        upNextItems: upNextData.items,
+        friendsLovedItems: friendsLovedData.items,
+        streakData: streakResult,
+        movieData: moviesResult,
+      };
+    },
+  });
 
-  // Cleanup confirmation timer
-  useEffect(() => {
-    return () => {
-      if (confirmTimerRef.current) clearTimeout(confirmTimerRef.current);
-    };
-  }, []);
-
-  const toggleWatched = useCallback(async (episodeId: number, currentlyWatched: boolean) => {
-    dispatch({ type: "TOGGLE_WATCHED", episodeId, currentlyWatched });
-    try {
-      if (currentlyWatched) {
-        await api.unwatchEpisode(episodeId);
-      } else {
-        await api.watchEpisode(episodeId);
-      }
-    } catch (err) {
-      dispatch({ type: "TOGGLE_WATCHED_REVERT", episodeId, currentlyWatched });
-      if (!currentlyWatched) {
-        try {
-          const data = await api.getUpcomingEpisodes();
-          dispatch({ type: "REPLACE_UNWATCHED", unwatched: data.unwatched });
-        } catch { /* ignore refetch failure */ }
-      }
-      console.error("Failed to toggle watched:", err);
+  const toggleWatchedMutation = useMutation({
+    mutationFn: ({ episodeId, currentlyWatched }: { episodeId: number; currentlyWatched: boolean }) =>
+      currentlyWatched ? api.unwatchEpisode(episodeId) : api.watchEpisode(episodeId),
+    onMutate: async ({ episodeId, currentlyWatched }) => {
+      await qc.cancelQueries({ queryKey: ["home", "auth"] });
+      const snapshot = qc.getQueryData<AuthHomeData>(["home", "auth"]);
+      qc.setQueryData<AuthHomeData>(["home", "auth"], (prev) => {
+        if (!prev) return prev;
+        const update = (ep: Episode) => ep.id === episodeId ? { ...ep, is_watched: !currentlyWatched } : ep;
+        return {
+          ...prev,
+          today: prev.today.map(update),
+          upcoming: prev.upcoming.map(update),
+          unwatched: !currentlyWatched
+            ? prev.unwatched.filter((ep) => ep.id !== episodeId)
+            : prev.unwatched,
+        };
+      });
+      return { snapshot };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.snapshot) qc.setQueryData(["home", "auth"], context.snapshot);
       toast.error("Failed to update watched status — please try again");
-    }
-  }, []);
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ["home", "auth"] });
+      qc.invalidateQueries({ queryKey: ["stats"] });
+      qc.invalidateQueries({ queryKey: ["activity"] });
+    },
+  });
 
-  const markAllWatched = useCallback(async (episodeIds: number[]) => {
-    dispatch({ type: "MARK_ALL_WATCHED", episodeIds });
-    try {
-      await api.watchEpisodesBulk(episodeIds, true);
-    } catch (err) {
-      try {
-        const data = await api.getUpcomingEpisodes();
-        dispatch({ type: "REPLACE_UNWATCHED", unwatched: data.unwatched });
-      } catch { /* ignore refetch failure */ }
-      console.error("Failed to bulk mark watched:", err);
+  const markAllWatchedMutation = useMutation({
+    mutationFn: (episodeIds: number[]) => api.watchEpisodesBulk(episodeIds, true),
+    onMutate: async (episodeIds) => {
+      await qc.cancelQueries({ queryKey: ["home", "auth"] });
+      const snapshot = qc.getQueryData<AuthHomeData>(["home", "auth"]);
+      const idSet = new Set(episodeIds);
+      qc.setQueryData<AuthHomeData>(["home", "auth"], (prev) => {
+        if (!prev) return prev;
+        return { ...prev, unwatched: prev.unwatched.filter((ep) => !idSet.has(ep.id)) };
+      });
+      return { snapshot };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.snapshot) qc.setQueryData(["home", "auth"], context.snapshot);
       toast.error("Failed to mark episodes as watched — please try again");
-    }
-  }, []);
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ["home", "auth"] });
+      qc.invalidateQueries({ queryKey: ["stats"] });
+      qc.invalidateQueries({ queryKey: ["activity"] });
+    },
+  });
+
+  const upNextMarkWatchedMutation = useMutation({
+    mutationFn: (episodeId: number) => api.watchEpisode(episodeId),
+    onMutate: async (episodeId) => {
+      await qc.cancelQueries({ queryKey: ["home", "auth"] });
+      qc.setQueryData<AuthHomeData>(["home", "auth"], (prev) => {
+        if (!prev) return prev;
+        return { ...prev, upNextItems: prev.upNextItems.filter((item) => item.nextEpisodeId !== episodeId) };
+      });
+    },
+    onError: () => {
+      toast.error("Failed to mark episode as watched — please try again");
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ["home", "auth"] });
+      qc.invalidateQueries({ queryKey: ["stats"] });
+      qc.invalidateQueries({ queryKey: ["activity"] });
+    },
+  });
 
   const handleMarkAllWatched = useCallback((titleId: string, episodeIds: number[]) => {
     if (confirmingTitleId === titleId) {
-      // Second click — execute
       if (confirmTimerRef.current) clearTimeout(confirmTimerRef.current);
       setConfirmingTitleId(null);
-      markAllWatched(episodeIds);
+      markAllWatchedMutation.mutate(episodeIds);
     } else {
-      // First click — enter confirmation
       setConfirmingTitleId(titleId);
       if (confirmTimerRef.current) clearTimeout(confirmTimerRef.current);
       confirmTimerRef.current = setTimeout(() => setConfirmingTitleId(null), 3000);
     }
-  }, [confirmingTitleId, markAllWatched]);
+  }, [confirmingTitleId, markAllWatchedMutation]);
 
-  // Derived data from reducer state — wrapped in useMemo so downstream deps
-  // get stable array references when state.status !== "auth".
   const { today, upcoming, unwatched, recommendations, layout, upNextItems, friendsLovedItems } = useMemo(() => {
-    if (state.status === "auth") {
-      return { today: state.today, upcoming: state.upcoming, unwatched: state.unwatched, recommendations: state.recommendations, layout: state.layout, upNextItems: state.upNextItems, friendsLovedItems: state.friendsLovedItems };
+    if (authData) {
+      return { today: authData.today, upcoming: authData.upcoming, unwatched: authData.unwatched, recommendations: authData.recommendations, layout: authData.layout, upNextItems: authData.upNextItems, friendsLovedItems: authData.friendsLovedItems };
     }
     return { today: [] as Episode[], upcoming: [] as Episode[], unwatched: [] as Episode[], recommendations: [] as Recommendation[], layout: DEFAULT_HOMEPAGE_LAYOUT, upNextItems: [] as UpNextItem[], friendsLovedItems: [] as FriendsLovedItem[] };
-  }, [state]);
+  }, [authData]);
 
-  const handleUpNextMarkWatched = useCallback(async (episodeId: number) => {
-    dispatch({ type: "REMOVE_UP_NEXT_EPISODE", episodeId });
-    try {
-      await api.watchEpisode(episodeId);
-    } catch (err) {
-      // Optimistic removal stands; log the failure.
-      console.error("Failed to mark episode as watched:", err);
-      toast.error("Failed to mark episode as watched — please try again");
-    }
-  }, []);
+  const streakData = authData?.streakData ?? null;
+  const movieData = authData?.movieData ?? { to_watch: [], upcoming: [] };
 
-  // Stable slice for the unauthenticated landing page so TitleList sees the
-  // same array reference on unrelated re-renders.
   const popularTitlesPreview = useMemo(
-    () => state.status === "anon" ? state.popularTitles.slice(0, 12) : [],
-    [state]
+    () => (anonData ?? []).slice(0, 12),
+    [anonData]
   );
 
   const unwatchedCards = useMemo(() => buildUnwatchedCards(unwatched), [unwatched]);
@@ -506,7 +474,7 @@ export default function HomePage() {
     });
   }, [upcoming]);
 
-  if (authLoading || state.status === "loading") {
+  if (authLoading || (user ? (authData === undefined && authDataLoading) : anonLoading)) {
     return <HomeAuthSkeleton />;
   }
 
@@ -550,10 +518,10 @@ export default function HomePage() {
     );
   }
 
-  if (state.status === "error") {
+  if (authDataError) {
     return (
       <div className="bg-red-900/50 border border-red-800 text-red-200 px-4 py-2 rounded-lg text-sm">
-        {state.message}
+        {authError instanceof Error ? authError.message : String(authError)}
       </div>
     );
   }
@@ -570,7 +538,7 @@ export default function HomePage() {
         return unwatched.length > 0 ? (
           <>
             <div className="-mt-6">
-              <HeroBanner episodes={unwatched} onToggleWatched={toggleWatched} />
+              <HeroBanner episodes={unwatched} onToggleWatched={(id, w) => toggleWatchedMutation.mutate({ episodeId: id, currentlyWatched: w })} />
             </div>
             <section key="unwatched">
               <div className="flex items-baseline justify-between mb-4">
@@ -599,7 +567,7 @@ export default function HomePage() {
                         episodeCount={card.totalEpisodeCount}
                         showActions
                         allEpisodeIds={card.allEpisodeIds}
-                        onToggleWatched={toggleWatched}
+                        onToggleWatched={(id, w) => toggleWatchedMutation.mutate({ episodeId: id, currentlyWatched: w })}
                         onMarkAllWatched={(ids) => handleMarkAllWatched(card.titleId, ids)}
                         isConfirming={confirmingTitleId === card.titleId}
                       />
@@ -755,7 +723,7 @@ export default function HomePage() {
                 <h2 className="text-xl font-bold tracking-[-0.01em]">{t("home.upNext.title")}</h2>
               </div>
             </div>
-            <UpNextRow items={upNextItems} onMarkWatched={handleUpNextMarkWatched} />
+            <UpNextRow items={upNextItems} onMarkWatched={(id) => upNextMarkWatchedMutation.mutate(id)} />
           </section>
         );
 

--- a/frontend/src/pages/SeasonDetailPage.test.tsx
+++ b/frontend/src/pages/SeasonDetailPage.test.tsx
@@ -1,7 +1,12 @@
 import { describe, it, expect, mock, afterEach, spyOn } from "bun:test";
 import { render, screen, fireEvent, waitFor, cleanup, act } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
 import * as sonner from "sonner";
 import "../i18n";
 
@@ -66,11 +71,13 @@ const { default: SeasonDetailPage } = await import("./SeasonDetailPage");
 
 function Wrapper({ children }: { children: ReactNode }) {
   return (
-    <MemoryRouter initialEntries={["/title/tv-100/season/1"]}>
-      <Routes>
-        <Route path="/title/:id/season/:season" element={children} />
-      </Routes>
-    </MemoryRouter>
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter initialEntries={["/title/tv-100/season/1"]}>
+        <Routes>
+          <Route path="/title/:id/season/:season" element={children} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
   );
 }
 

--- a/frontend/src/pages/SeasonDetailPage.tsx
+++ b/frontend/src/pages/SeasonDetailPage.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Card } from "../components/ui/card";
 import { useParams, Link, useNavigate } from "react-router";
 import { toast } from "sonner";
@@ -48,24 +49,28 @@ export default function SeasonDetailPage() {
     [id, season],
   );
 
-  const [statusMap, setStatusMap] = useState<Map<number, EpisodeStatus>>(new Map());
   const [episodeRatings, setEpisodeRatings] = useState<Record<number, Record<RatingValue, number>>>({});
+  const qc = useQueryClient();
 
-  useApiCall(
-    (signal) => user && id && season
-      ? api.getSeasonEpisodeStatus(id, Number(season), signal)
-      : Promise.resolve({ episodes: [] }),
-    [user, id, season],
-    {
-      onSuccess: (result) => {
-        const map = new Map<number, EpisodeStatus>();
-        for (const ep of result.episodes) {
-          map.set(ep.episode_number, { id: ep.id, is_watched: ep.is_watched });
-        }
-        setStatusMap(map);
-      },
-    },
-  );
+  type SeasonStatusEntry = { episode_number: number; id: number; is_watched: boolean };
+  type SeasonStatusData = { episodes: SeasonStatusEntry[] };
+
+  const { data: statusData } = useQuery({
+    queryKey: ["season-status", id, season],
+    queryFn: ({ signal }) =>
+      user && id && season
+        ? api.getSeasonEpisodeStatus(id, Number(season), signal)
+        : Promise.resolve({ episodes: [] as SeasonStatusEntry[] }),
+    enabled: !!user && !!id && !!season,
+  });
+
+  const statusMap = useMemo(() => {
+    const map = new Map<number, EpisodeStatus>();
+    for (const ep of statusData?.episodes ?? []) {
+      map.set(ep.episode_number, { id: ep.id, is_watched: ep.is_watched });
+    }
+    return map;
+  }, [statusData]);
 
   useApiCall(
     (signal) => id && season
@@ -77,56 +82,88 @@ export default function SeasonDetailPage() {
     },
   );
 
-  const toggleWatched = async (episodeNumber: number) => {
+  const toggleWatchedMutation = useMutation({
+    mutationFn: ({ epId, wasWatched }: { epId: number; wasWatched: boolean }) =>
+      wasWatched ? api.unwatchEpisode(epId) : api.watchEpisode(epId),
+    onMutate: async ({ epId, wasWatched }) => {
+      await qc.cancelQueries({ queryKey: ["season-status", id, season] });
+      const snapshot = qc.getQueryData<SeasonStatusData>(["season-status", id, season]);
+      qc.setQueryData<SeasonStatusData>(["season-status", id, season], (old) => {
+        if (!old) return old;
+        return { ...old, episodes: old.episodes.map((ep) => ep.id === epId ? { ...ep, is_watched: !wasWatched } : ep) };
+      });
+      return { snapshot };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.snapshot !== undefined) qc.setQueryData(["season-status", id, season], context.snapshot);
+      toast.error(t("episodes.watchedError", "Failed to update watched status"));
+    },
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: ["season-status", id, season] });
+      void qc.invalidateQueries({ queryKey: ["stats"] });
+      void qc.invalidateQueries({ queryKey: ["activity"] });
+    },
+  });
+
+  const airDateMutation = useMutation({
+    mutationFn: ({ epId }: { epId: number }) => api.watchEpisodesBulk([epId], true, { useAirDate: true }),
+    onMutate: async ({ epId }) => {
+      await qc.cancelQueries({ queryKey: ["season-status", id, season] });
+      const snapshot = qc.getQueryData<SeasonStatusData>(["season-status", id, season]);
+      qc.setQueryData<SeasonStatusData>(["season-status", id, season], (old) => {
+        if (!old) return old;
+        return { ...old, episodes: old.episodes.map((ep) => ep.id === epId ? { ...ep, is_watched: true } : ep) };
+      });
+      return { snapshot };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.snapshot !== undefined) qc.setQueryData(["season-status", id, season], context.snapshot);
+      toast.error(t("episodes.watchedError", "Failed to update watched status"));
+    },
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: ["season-status", id, season] });
+      void qc.invalidateQueries({ queryKey: ["stats"] });
+      void qc.invalidateQueries({ queryKey: ["activity"] });
+    },
+  });
+
+  const allWatchedMutation = useMutation({
+    mutationFn: ({ ids, newWatched, useAirDate }: { ids: number[]; newWatched: boolean; useAirDate?: boolean }) =>
+      api.watchEpisodesBulk(ids, newWatched, newWatched && useAirDate !== undefined ? { useAirDate } : undefined),
+    onMutate: async ({ ids, newWatched }) => {
+      await qc.cancelQueries({ queryKey: ["season-status", id, season] });
+      const snapshot = qc.getQueryData<SeasonStatusData>(["season-status", id, season]);
+      const idSet = new Set(ids);
+      qc.setQueryData<SeasonStatusData>(["season-status", id, season], (old) => {
+        if (!old) return old;
+        return { ...old, episodes: old.episodes.map((ep) => idSet.has(ep.id) ? { ...ep, is_watched: newWatched } : ep) };
+      });
+      return { snapshot };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.snapshot !== undefined) qc.setQueryData(["season-status", id, season], context.snapshot);
+      toast.error(t("episodes.watchedError", "Failed to update watched status"));
+    },
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: ["season-status", id, season] });
+      void qc.invalidateQueries({ queryKey: ["stats"] });
+      void qc.invalidateQueries({ queryKey: ["activity"] });
+    },
+  });
+
+  const toggleWatched = (episodeNumber: number) => {
     const status = statusMap.get(episodeNumber);
     if (!status) return;
-
-    const wasWatched = status.is_watched;
-    setStatusMap((prev) => {
-      const next = new Map(prev);
-      next.set(episodeNumber, { ...status, is_watched: !wasWatched });
-      return next;
-    });
-
-    try {
-      if (wasWatched) {
-        await api.unwatchEpisode(status.id);
-      } else {
-        await api.watchEpisode(status.id);
-      }
-    } catch {
-      setStatusMap((prev) => {
-        const next = new Map(prev);
-        next.set(episodeNumber, { ...status, is_watched: wasWatched });
-        return next;
-      });
-      toast.error(t("episodes.watchedError", "Failed to update watched status"));
-    }
+    toggleWatchedMutation.mutate({ epId: status.id, wasWatched: status.is_watched });
   };
 
-  const markEpisodeOnAirDate = async (episodeNumber: number) => {
+  const markEpisodeOnAirDate = (episodeNumber: number) => {
     const status = statusMap.get(episodeNumber);
     if (!status) return;
-
-    setStatusMap((prev) => {
-      const next = new Map(prev);
-      next.set(episodeNumber, { ...status, is_watched: true });
-      return next;
-    });
-
-    try {
-      await api.watchEpisodesBulk([status.id], true, { useAirDate: true });
-    } catch {
-      setStatusMap((prev) => {
-        const next = new Map(prev);
-        next.set(episodeNumber, { ...status, is_watched: status.is_watched });
-        return next;
-      });
-      toast.error(t("episodes.watchedError", "Failed to update watched status"));
-    }
+    airDateMutation.mutate({ epId: status.id });
   };
 
-  const toggleAllWatched = async (options?: { useAirDate?: boolean }) => {
+  const toggleAllWatched = (options?: { useAirDate?: boolean }) => {
     const episodes = data?.tmdb?.episodes || [];
     const releasedEps = episodes.filter((ep) => isReleased(ep.air_date));
     const releasedStatuses = releasedEps
@@ -138,23 +175,7 @@ export default function SeasonDetailPage() {
     const allWatched = releasedStatuses.every((e) => e.status.is_watched);
     const newWatched = !allWatched;
     const ids = releasedStatuses.map((e) => e.status.id);
-
-    // Optimistic update
-    const prevMap = new Map(statusMap);
-    setStatusMap((prev) => {
-      const next = new Map(prev);
-      for (const e of releasedStatuses) {
-        next.set(e.episodeNumber, { ...e.status, is_watched: newWatched });
-      }
-      return next;
-    });
-
-    try {
-      await api.watchEpisodesBulk(ids, newWatched, newWatched ? options : undefined);
-    } catch {
-      setStatusMap(prevMap);
-      toast.error(t("episodes.watchedError", "Failed to update watched status"));
-    }
+    allWatchedMutation.mutate({ ids, newWatched, useAirDate: options?.useAirDate });
   };
 
   if (loading) {

--- a/frontend/src/pages/StatsPage.test.tsx
+++ b/frontend/src/pages/StatsPage.test.tsx
@@ -1,8 +1,13 @@
 import { describe, it, expect, mock, afterEach } from "bun:test";
 import { render, screen, cleanup, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import type { StatsResponse } from "../types";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
 
 const baseStats: StatsResponse = {
   overview: {
@@ -38,7 +43,11 @@ mock.module("../api", () => ({
 const { default: StatsPage, formatEta } = await import("./StatsPage");
 
 function Wrapper({ children }: { children: ReactNode }) {
-  return <MemoryRouter>{children}</MemoryRouter>;
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
 }
 
 afterEach(() => {

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -1,7 +1,6 @@
-import { useEffect } from "react";
 import * as api from "../api";
+import { useQuery } from "@tanstack/react-query";
 import type { StatsResponse } from "../types";
-import { useApiCall } from "../hooks/useApiCall";
 
 const MONTH_NAMES = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
@@ -122,13 +121,7 @@ const LANGUAGE_NAMES: Record<string, string> = {
 };
 
 export function StatsView() {
-  const { data, loading, refetch } = useApiCall((signal) => api.getStats(signal), []);
-
-  useEffect(() => {
-    const handler = () => refetch();
-    window.addEventListener("watch-history:updated", handler);
-    return () => window.removeEventListener("watch-history:updated", handler);
-  }, [refetch]);
+  const { data, isLoading: loading } = useQuery({ queryKey: ["stats"], queryFn: ({ signal }) => api.getStats(signal) });
 
   if (loading || !data) {
     return (

--- a/frontend/src/pages/TrackedPage.test.tsx
+++ b/frontend/src/pages/TrackedPage.test.tsx
@@ -1,7 +1,12 @@
 import { describe, it, expect, mock, afterEach } from "bun:test";
 import { render, screen, waitFor, cleanup, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
 
 // Initialize i18n before anything else
 import "../i18n";
@@ -37,7 +42,11 @@ mock.module("../api", () => ({
 const { default: TrackedPage } = await import("./TrackedPage");
 
 function Wrapper({ children }: { children: ReactNode }) {
-  return <MemoryRouter>{children}</MemoryRouter>;
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
 }
 
 afterEach(() => {

--- a/frontend/src/pages/title/MovieDetail.tsx
+++ b/frontend/src/pages/title/MovieDetail.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
+import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Card } from "@/components/ui/card";
 import { useTranslation } from "react-i18next";
 import * as api from "../../api";
@@ -6,7 +7,6 @@ import type {
   CrewMember,
   MovieDetailsResponse,
   ReleaseDatesResult,
-  WatchHistoryEntry,
   WatchProviderCountry,
 } from "../../types";
 import Cast from "../../components/title-detail/Cast";
@@ -25,67 +25,50 @@ import EditWatchedAtDialog from "../../components/EditWatchedAtDialog";
 export default function MovieDetail({ data }: { data: MovieDetailsResponse }) {
   const { t } = useTranslation();
   const { title, tmdb, country } = data;
+  const qc = useQueryClient();
   const [watched, setWatched] = useState(title.is_watched ?? false);
-  const [playCount, setPlayCount] = useState(0);
-  const [watchHistory, setWatchHistory] = useState<WatchHistoryEntry[]>([]);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [editEntry, setEditEntry] = useState<string | null>(null);
-  const [cursor, setCursor] = useState<string | null>(null);
-  const [hasMore, setHasMore] = useState(false);
-  const [loadingMore, setLoadingMore] = useState(false);
 
-  useEffect(() => {
-    api
-      .getWatchHistory(title.id)
-      .then(({ history, playCount: cnt, has_more, next_cursor }) => {
-        setWatchHistory(history);
-        setPlayCount(cnt);
-        setCursor(next_cursor);
-        setHasMore(has_more);
-      })
-      .catch(() => {});
-  }, [title.id]);
+  const {
+    data: historyData,
+    hasNextPage: hasMore,
+    isFetchingNextPage: loadingMore,
+    fetchNextPage,
+  } = useInfiniteQuery({
+    queryKey: ["watch-history", title.id],
+    queryFn: ({ pageParam, signal }) =>
+      api.getWatchHistory(title.id, { before: pageParam }, signal),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (last) =>
+      last.has_more && last.next_cursor ? last.next_cursor : undefined,
+  });
+  const watchHistory = historyData?.pages.flatMap((p) => p.history) ?? [];
+  const playCount = historyData?.pages[0]?.playCount ?? 0;
 
-  async function toggleWatched() {
-    const prev = watched;
-    setWatched(!prev);
-    try {
-      if (prev) {
-        await api.unwatchMovie(title.id);
-        const { history, playCount: cnt, has_more, next_cursor } = await api.getWatchHistory(title.id);
-        setWatchHistory(history);
-        setPlayCount(cnt);
-        setCursor(next_cursor);
-        setHasMore(has_more);
-      } else {
-        await api.watchMovie(title.id);
-        // Refresh history after marking watched
-        const { history, playCount: cnt, has_more, next_cursor } = await api.getWatchHistory(title.id);
-        setWatchHistory(history);
-        setPlayCount(cnt);
-        setCursor(next_cursor);
-        setHasMore(has_more);
-      }
-    } catch {
-      setWatched(prev);
-    }
+  const toggleMutation = useMutation({
+    mutationFn: (currentlyWatched: boolean) =>
+      currentlyWatched ? api.unwatchMovie(title.id) : api.watchMovie(title.id),
+    onMutate: (currentlyWatched) => {
+      setWatched(!currentlyWatched);
+      return { prev: currentlyWatched };
+    },
+    onError: (_err, _vars, context) => {
+      if (context) setWatched(context.prev);
+    },
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: ["watch-history", title.id] });
+      void qc.invalidateQueries({ queryKey: ["stats"] });
+      void qc.invalidateQueries({ queryKey: ["activity"] });
+      void qc.invalidateQueries({ queryKey: ["calendar"] });
+    },
+  });
+
+  function toggleWatched() {
+    toggleMutation.mutate(watched);
   }
 
-  const loadMore = useCallback(async () => {
-    if (!cursor || loadingMore) return;
-    setLoadingMore(true);
-    try {
-      const { history: more, has_more: moreHas, next_cursor: moreCursor } = await api.getWatchHistory(title.id, { before: cursor });
-      setWatchHistory(prev => [...prev, ...more]);
-      setCursor(moreCursor);
-      setHasMore(moreHas);
-    } catch {
-      // ignore
-    } finally {
-      setLoadingMore(false);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cursor, title.id]);
+  const loadMore = () => { void fetchNextPage(); };
 
   const overview = tmdb?.overview || title.short_description;
 
@@ -302,10 +285,8 @@ export default function MovieDetail({ data }: { data: MovieDetailsResponse }) {
           entryId={editEntry}
           currentWatchedAt={watchHistory.find(e => e.id === editEntry)?.watchedAt ?? ""}
           anchorDate={title.release_date}
-          onUpdated={(newWatchedAt) => {
-            setWatchHistory(prev =>
-              prev.map(e => e.id === editEntry ? { ...e, watchedAt: newWatchedAt } : e)
-            );
+          onUpdated={() => {
+            void qc.invalidateQueries({ queryKey: ["watch-history", title.id] });
             setEditEntry(null);
           }}
         />


### PR DESCRIPTION
## Summary

- **CalendarPage**: 3 fetch sites (Grid/Mobile/Week) → `useQuery`/`useQueries`; 3 toggle handlers → `useMutation` with `setQueriesData({ queryKey: ["calendar"] })` for cross-view optimistic updates
- **HomePage**: Delete `HomeState`/`HomeAction`/`homeReducer` + 7-call `useEffect`; replace with `useQuery(["home","anon"])` for unauthenticated view and `useQuery<AuthHomeData>(["home","auth"])` for authenticated view; 3 mutations (`toggleWatched`, `markAllWatched`, `upNextMarkWatched`)
- **Detail pages**: `MovieDetail` → `useInfiniteQuery(["watch-history"])` + `useMutation` for toggle; `EpisodeDetailPage` + `SeasonDetailPage` → `useQuery(["season-status"])` + `useMutation` for all toggles
- **Event bus retired**: Remove `watch-history:updated` `CustomEvent` dispatch; `EditWatchedAtDialog` + `BackdateWatchedButton` now call `queryClient.invalidateQueries`; `StatsPage` → `useQuery(["stats"])`; `RecentActivityCard` → `useInfiniteQuery(["activity"])`

## Test Plan

- [x] `bun run check` exits 0 (2097 server tests, 1001 frontend tests, TypeScript strict, ESLint zero warnings, production build, wrangler dry-run)
- [x] No `watch-history:updated` references remain in production code
- [x] `QueryClientProvider` wrapper added to all affected test files (Calendar, Home, Episode, Season, Stats, RecentActivity, EditWatchedAt, TrackedPage, BackdateWatched)
- [ ] Manual golden paths: toggle episode watched in Grid → switch to Week/Mobile → reflects without stale flash; HomePage mark-watched + mark-all + up-next; detail-page season toggle-all; edit watched date → Stats + Activity refresh

Part of #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)