### PR TITLE
feat(query): Phase 2 — retire useApiCall, migrate all remaining pages to useQuery

### DIFF
--- a/frontend/src/components/BottomTabBar.test.tsx
+++ b/frontend/src/components/BottomTabBar.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, mock, afterEach } from "bun:test";
 import { render, screen, cleanup } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 // Initialize i18n
 import "../i18n";
@@ -13,6 +14,10 @@ mock.module("../api", () => ({
 
 import BottomTabBar from "./BottomTabBar";
 import { AuthContext } from "../context/AuthContext";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
 
 const mockUser = { id: "1", username: "test", display_name: null, auth_provider: "local", is_admin: false };
 
@@ -27,9 +32,11 @@ const mockAuthValue = {
 
 function Wrapper({ children, authValue }: { children: ReactNode; authValue?: typeof mockAuthValue }) {
   return (
-    <MemoryRouter>
-      <AuthContext value={(authValue ?? mockAuthValue) as any}>{children}</AuthContext>
-    </MemoryRouter>
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter>
+        <AuthContext value={(authValue ?? mockAuthValue) as any}>{children}</AuthContext>
+      </MemoryRouter>
+    </QueryClientProvider>
   );
 }
 
@@ -51,11 +58,13 @@ describe("BottomTabBar", () => {
   it("renders Browse and Sign In when user is not authenticated", () => {
     const noUserAuth = { ...mockAuthValue, user: null };
     render(
-      <MemoryRouter>
-        <AuthContext value={noUserAuth as any}>
-          <BottomTabBar />
-        </AuthContext>
-      </MemoryRouter>
+      <QueryClientProvider client={newTestClient()}>
+        <MemoryRouter>
+          <AuthContext value={noUserAuth as any}>
+            <BottomTabBar />
+          </AuthContext>
+        </MemoryRouter>
+      </QueryClientProvider>
     );
 
     expect(screen.getByText("Browse")).toBeDefined();
@@ -69,11 +78,13 @@ describe("BottomTabBar", () => {
   it("renders nothing while auth is loading", () => {
     const loadingAuth = { ...mockAuthValue, loading: true };
     const { container } = render(
-      <MemoryRouter>
-        <AuthContext value={loadingAuth as any}>
-          <BottomTabBar />
-        </AuthContext>
-      </MemoryRouter>
+      <QueryClientProvider client={newTestClient()}>
+        <MemoryRouter>
+          <AuthContext value={loadingAuth as any}>
+            <BottomTabBar />
+          </AuthContext>
+        </MemoryRouter>
+      </QueryClientProvider>
     );
 
     expect(container.innerHTML).toBe("");
@@ -100,11 +111,13 @@ describe("BottomTabBar", () => {
   it("links to correct routes when not authenticated", () => {
     const noUserAuth = { ...mockAuthValue, user: null };
     render(
-      <MemoryRouter>
-        <AuthContext value={noUserAuth as any}>
-          <BottomTabBar />
-        </AuthContext>
-      </MemoryRouter>
+      <QueryClientProvider client={newTestClient()}>
+        <MemoryRouter>
+          <AuthContext value={noUserAuth as any}>
+            <BottomTabBar />
+          </AuthContext>
+        </MemoryRouter>
+      </QueryClientProvider>
     );
 
     const links = screen.getAllByRole("link");

--- a/frontend/src/components/BottomTabBar.tsx
+++ b/frontend/src/components/BottomTabBar.tsx
@@ -2,7 +2,7 @@ import { NavLink } from "react-router";
 import { Home, Search, CalendarDays, Bookmark, MoreHorizontal, LogIn } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../context/AuthContext";
-import { useApiCall } from "../hooks/useApiCall";
+import { useQuery } from "@tanstack/react-query";
 import * as api from "../api";
 
 const ICON_SIZE = 22;
@@ -11,10 +11,11 @@ export default function BottomTabBar() {
   const { user, loading } = useAuth();
   const { t } = useTranslation();
 
-  const { data: countData } = useApiCall(
-    (signal) => (user ? api.getUnreadRecommendationCount(signal) : Promise.resolve({ count: 0 })),
-    [user?.id],
-  );
+  const { data: countData } = useQuery({
+    queryKey: ["notification-count"],
+    queryFn: ({ signal }) => api.getUnreadRecommendationCount(signal),
+    enabled: !!user,
+  });
 
   const unreadCount = countData?.count ?? 0;
 

--- a/frontend/src/pages/AchievementDetailPage.test.tsx
+++ b/frontend/src/pages/AchievementDetailPage.test.tsx
@@ -2,6 +2,7 @@ import { describe, test, expect, spyOn, afterEach, beforeEach, mock } from "bun:
 import { render, screen, waitFor, cleanup } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router";
 import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import * as api from "../api";
 import type { AchievementDetail } from "../api";
 
@@ -25,23 +26,31 @@ mock.module("../context/AuthContext", () => ({
 
 const { default: AchievementDetailPage } = await import("./AchievementDetailPage");
 
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
 function OwnWrapper({ children }: { children: ReactNode }) {
   return (
-    <MemoryRouter initialEntries={["/achievements/movies_10"]}>
-      <Routes>
-        <Route path="/achievements/:key" element={<>{children}</>} />
-      </Routes>
-    </MemoryRouter>
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter initialEntries={["/achievements/movies_10"]}>
+        <Routes>
+          <Route path="/achievements/:key" element={<>{children}</>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
   );
 }
 
 function OtherWrapper({ children }: { children: ReactNode }) {
   return (
-    <MemoryRouter initialEntries={["/u/alice/achievements/movies_10"]}>
-      <Routes>
-        <Route path="/u/:username/achievements/:key" element={<>{children}</>} />
-      </Routes>
-    </MemoryRouter>
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter initialEntries={["/u/alice/achievements/movies_10"]}>
+        <Routes>
+          <Route path="/u/:username/achievements/:key" element={<>{children}</>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
   );
 }
 

--- a/frontend/src/pages/AchievementDetailPage.tsx
+++ b/frontend/src/pages/AchievementDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useParams } from "react-router";
-import { useApiCall } from "../hooks/useApiCall";
+import { useQuery } from "@tanstack/react-query";
 import { getMyAchievementDetail, getUserAchievementDetail } from "../api";
 import { BadgeTile } from "../components/achievements/BadgeTile";
 import { LadderProgress } from "../components/achievements/LadderProgress";
@@ -12,13 +12,14 @@ export default function AchievementDetailPage() {
   const { username, key } = useParams<{ username?: string; key: string }>();
   const isOwnProfile = !username;
 
-  const { data, loading, error } = useApiCall(
-    (signal) =>
+  const { data, isLoading: loading, isError: error } = useQuery({
+    queryKey: ["achievement", username ?? "me", key],
+    queryFn: ({ signal }) =>
       isOwnProfile
         ? getMyAchievementDetail(key!, signal)
         : getUserAchievementDetail(username!, key!, signal),
-    [key, username],
-  );
+    enabled: !!key,
+  });
 
   const backHref = username ? `/u/${username}/achievements` : "/achievements";
 

--- a/frontend/src/pages/AchievementsPage.test.tsx
+++ b/frontend/src/pages/AchievementsPage.test.tsx
@@ -2,6 +2,7 @@ import { describe, test, expect, spyOn, afterEach, beforeEach, mock } from "bun:
 import { render, screen, waitFor, cleanup } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router";
 import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import * as api from "../api";
 import type { UserAchievement } from "../types";
 
@@ -26,25 +27,33 @@ mock.module("../context/AuthContext", () => ({
 
 const { default: AchievementsPage } = await import("./AchievementsPage");
 
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
 // Renders the page as the current user (own profile — /achievements)
 function OwnWrapper({ children }: { children: ReactNode }) {
   return (
-    <MemoryRouter initialEntries={["/achievements"]}>
-      <Routes>
-        <Route path="/achievements" element={<>{children}</>} />
-      </Routes>
-    </MemoryRouter>
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter initialEntries={["/achievements"]}>
+        <Routes>
+          <Route path="/achievements" element={<>{children}</>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
   );
 }
 
 // Renders the page as another user (/u/alice/achievements)
 function OtherWrapper({ children }: { children: ReactNode }) {
   return (
-    <MemoryRouter initialEntries={["/u/alice/achievements"]}>
-      <Routes>
-        <Route path="/u/:username/achievements" element={<>{children}</>} />
-      </Routes>
-    </MemoryRouter>
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter initialEntries={["/u/alice/achievements"]}>
+        <Routes>
+          <Route path="/u/:username/achievements" element={<>{children}</>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
   );
 }
 
@@ -145,11 +154,13 @@ describe("AchievementsPage — own profile", () => {
 
     render(<AchievementsPage />, {
       wrapper: ({ children }: { children: ReactNode }) => (
-        <MemoryRouter initialEntries={["/achievements?cat=watching"]}>
-          <Routes>
-            <Route path="/achievements" element={<>{children}</>} />
-          </Routes>
-        </MemoryRouter>
+        <QueryClientProvider client={newTestClient()}>
+          <MemoryRouter initialEntries={["/achievements?cat=watching"]}>
+            <Routes>
+              <Route path="/achievements" element={<>{children}</>} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>
       ),
     });
 

--- a/frontend/src/pages/AchievementsPage.tsx
+++ b/frontend/src/pages/AchievementsPage.tsx
@@ -1,6 +1,6 @@
 import { useParams, useSearchParams } from "react-router";
 import { useAuth } from "../context/AuthContext";
-import { useApiCall } from "../hooks/useApiCall";
+import { useQuery } from "@tanstack/react-query";
 import * as api from "../api";
 import type { Category, UserAchievement } from "../types";
 import { Kicker } from "../components/design/Kicker";
@@ -41,13 +41,13 @@ export default function AchievementsPage() {
   const baseHref = isOwnProfile ? "/achievements" : `/u/${username}/achievements`;
   const activeCategory = searchParams.get("cat") as Category | null;
 
-  const { data, loading, error } = useApiCall(
-    (signal) =>
+  const { data, isLoading: loading, isError: error } = useQuery({
+    queryKey: ["achievements", username ?? "me"],
+    queryFn: ({ signal }) =>
       isOwnProfile
         ? api.getMyAchievements(signal)
         : api.getUserAchievements(username!, signal),
-    [isOwnProfile, username],
-  );
+  });
 
   if (loading) {
     return (

--- a/frontend/src/pages/DiscoveryPage.test.tsx
+++ b/frontend/src/pages/DiscoveryPage.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, mock, afterEach } from "bun:test";
 import { render, screen, waitFor, cleanup, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { SearchTitle, SuggestionsAggregateResponse, SuggestionSeedReason } from "../types";
 
 // Initialize i18n before anything else
@@ -63,12 +64,21 @@ mock.module("../api", () => ({
   getSuggestionsAggregate: mockGetSuggestionsAggregate,
   dismissSuggestion: mockDismissSuggestion,
   undismissSuggestion: mockUndismissSuggestion,
+  getSharedWatchlist: mock(() => Promise.resolve({ username: "", titles: [] })),
 }));
 
 const { default: DiscoveryPage } = await import("./DiscoveryPage");
 
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
 function Wrapper({ children }: { children: ReactNode }) {
-  return <MemoryRouter>{children}</MemoryRouter>;
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
 }
 
 function makeRecommendation(id: string, overrides: Record<string, unknown> = {}) {

--- a/frontend/src/pages/DiscoveryPage.tsx
+++ b/frontend/src/pages/DiscoveryPage.tsx
@@ -11,7 +11,7 @@ import type {
   SearchTitle,
 } from "../types";
 import { normalizeSearchTitle } from "../types";
-import { useApiCall } from "../hooks/useApiCall";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Skeleton } from "../components/ui/skeleton";
 import { Card } from "../components/ui/card";
 import { PageHeader, Kicker, Pill, Chip } from "../components/design";
@@ -531,22 +531,22 @@ function RecommendationCard({
 
 export default function DiscoveryPage() {
   const { t } = useTranslation();
-  const [recommendations, setRecommendations] = useState<Recommendation[]>([]);
+  const qc = useQueryClient();
   const [aggregate, setAggregate] = useState<SuggestionsAggregateResponse | null>(null);
   const [tab, setTab] = useState<"foryou" | "activity">("foryou");
   const [trackedSet, setTrackedSet] = useState<Set<string>>(() => new Set());
   const [dismissedSet, setDismissedSet] = useState<Set<string>>(() => new Set());
 
-  const { loading, error } = useApiCall(
-    (signal) => api.getRecommendations(undefined, undefined, signal),
-    [],
-    { onSuccess: (data) => setRecommendations(data.recommendations) },
-  );
+  const { isLoading: loading, isError: error, data: recsData } = useQuery({
+    queryKey: ["recommendations"],
+    queryFn: ({ signal }) => api.getRecommendations(undefined, undefined, signal),
+  });
+  const recommendations = useMemo(() => recsData?.recommendations ?? [], [recsData]);
 
-  const { data: countData } = useApiCall(
-    (signal) => api.getUnreadRecommendationCount(signal),
-    [],
-  );
+  const { data: countData } = useQuery({
+    queryKey: ["notification-count"],
+    queryFn: ({ signal }) => api.getUnreadRecommendationCount(signal),
+  });
   const unreadCount = countData?.count ?? 0;
 
   useEffect(() => {
@@ -625,33 +625,45 @@ export default function DiscoveryPage() {
   const handleMarkRead = useCallback(async (rec: Recommendation) => {
     try {
       await api.markRecommendationRead(rec.id);
-      setRecommendations((prev) =>
-        prev.map((r) => r.id === rec.id ? { ...r, read_at: new Date().toISOString() } : r),
-      );
+      qc.setQueryData<{ recommendations: Recommendation[] }>(["recommendations"], (old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          recommendations: old.recommendations.map((r) =>
+            r.id === rec.id ? { ...r, read_at: new Date().toISOString() } : r
+          ),
+        };
+      });
     } catch {
       // Silent failure for mark-read
     }
-  }, []);
+  }, [qc]);
 
   const handleTrackRec = useCallback(async (rec: Recommendation) => {
     try {
       await api.trackTitle(rec.title.id);
       if (!rec.read_at) await api.markRecommendationRead(rec.id);
-      setRecommendations((prev) => prev.filter((r) => r.id !== rec.id));
+      qc.setQueryData<{ recommendations: Recommendation[] }>(["recommendations"], (old) => {
+        if (!old) return old;
+        return { ...old, recommendations: old.recommendations.filter((r) => r.id !== rec.id) };
+      });
       toast.success(t("discovery.tracked", { title: rec.title.title }));
     } catch {
       toast.error(t("discovery.trackFailed"));
     }
-  }, [t]);
+  }, [t, qc]);
 
   const handleDismissRec = useCallback(async (rec: Recommendation) => {
     try {
       await api.deleteRecommendation(rec.id);
-      setRecommendations((prev) => prev.filter((r) => r.id !== rec.id));
+      qc.setQueryData<{ recommendations: Recommendation[] }>(["recommendations"], (old) => {
+        if (!old) return old;
+        return { ...old, recommendations: old.recommendations.filter((r) => r.id !== rec.id) };
+      });
     } catch {
       toast.error(t("discovery.dismissFailed"));
     }
-  }, [t]);
+  }, [t, qc]);
 
   // ─── Derived counts ───────────────────────────────────────────────────────
 
@@ -695,7 +707,7 @@ export default function DiscoveryPage() {
         loading ? (
           <DiscoverySkeleton />
         ) : error ? (
-          <div className="bg-red-900/50 border border-red-800 text-red-200 px-4 py-2 rounded-lg text-sm">{error}</div>
+          <div className="bg-red-900/50 border border-red-800 text-red-200 px-4 py-2 rounded-lg text-sm">{t("discovery.loadFailed", "Failed to load recommendations")}</div>
         ) : isEmpty ? (
           <p className="text-zinc-500 text-sm py-8 text-center">{t("discovery.empty")}</p>
         ) : (

--- a/frontend/src/pages/EpisodeDetailPage.tsx
+++ b/frontend/src/pages/EpisodeDetailPage.tsx
@@ -5,10 +5,10 @@ import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import ScrollableRow from "../components/ScrollableRow";
 import * as api from "../api";
-import type { EpisodeDetailsResponse, CastMember, CrewMember } from "../types";
+import type { CastMember, CrewMember } from "../types";
 import PersonCard from "../components/PersonCard";
 import { DetailPageSkeleton } from "../components/SkeletonComponents";
-import { useApiCall } from "../hooks/useApiCall";
+
 import { useAuth } from "../context/AuthContext";
 import { WatchedIcon } from "../components/EpisodeComponents";
 import ShareButton from "../components/ShareButton";
@@ -35,10 +35,11 @@ export default function EpisodeDetailPage() {
   const { user } = useAuth();
   const { t } = useTranslation();
 
-  const { data, loading, error } = useApiCall<EpisodeDetailsResponse>(
-    (signal) => api.getEpisodeDetails(id!, Number(season), Number(episode), signal),
-    [id, season, episode],
-  );
+  const { data, isLoading: loading, isError: error } = useQuery({
+    queryKey: ["episode-detail", id, season, episode],
+    queryFn: ({ signal }) => api.getEpisodeDetails(id!, Number(season), Number(episode), signal),
+    enabled: !!id && !!season && !!episode,
+  });
 
   const [editHistoryEntry, setEditHistoryEntry] = useState<string | null>(null);
   const qc = useQueryClient();
@@ -112,7 +113,7 @@ export default function EpisodeDetailPage() {
   if (error || !data) {
     return (
       <div className="flex items-center justify-center py-20">
-        <div className="text-red-400 select-text">{error || "Episode not found"}</div>
+        <div className="text-red-400 select-text">Episode not found</div>
       </div>
     );
   }

--- a/frontend/src/pages/PersonPage.tsx
+++ b/frontend/src/pages/PersonPage.tsx
@@ -2,10 +2,10 @@ import { useState } from "react";
 import { useParams, Link } from "react-router";
 import * as api from "../api";
 import ScrollableRow from "../components/ScrollableRow";
-import type { PersonDetailsResponse, PersonCastCredit, PersonCrewCredit } from "../types";
+import type { PersonCastCredit, PersonCrewCredit } from "../types";
 import ExternalLinks from "../components/ExternalLinks";
 import { DetailPageSkeleton } from "../components/SkeletonComponents";
-import { useApiCall } from "../hooks/useApiCall";
+import { useQuery } from "@tanstack/react-query";
 import { profileUrl, posterUrl as mkPosterUrl } from "../lib/tmdb-images";
 
 const BIO_TRUNCATE_LENGTH = 600;
@@ -86,10 +86,11 @@ export default function PersonPage() {
   const { personId } = useParams<{ personId: string }>();
   const [bioExpanded, setBioExpanded] = useState(false);
 
-  const { data, loading, error } = useApiCall<PersonDetailsResponse>(
-    (signal) => api.getPersonDetails(Number(personId), signal),
-    [personId],
-  );
+  const { data, isLoading: loading, isError: error } = useQuery({
+    queryKey: ["person", personId],
+    queryFn: ({ signal }) => api.getPersonDetails(Number(personId), signal),
+    enabled: !!personId,
+  });
 
   if (loading) {
     return <DetailPageSkeleton />;
@@ -98,7 +99,7 @@ export default function PersonPage() {
   if (error || !data) {
     return (
       <div className="flex items-center justify-center py-20">
-        <div className="text-red-400">{error || "Person not found"}</div>
+        <div className="text-red-400">Person not found</div>
       </div>
     );
   }

--- a/frontend/src/pages/SeasonDetailPage.tsx
+++ b/frontend/src/pages/SeasonDetailPage.tsx
@@ -7,10 +7,8 @@ import { useTranslation } from "react-i18next";
 import { CalendarDays, CheckCircle, ChevronDown, Circle, MoreHorizontal, Share2 } from "lucide-react";
 import ScrollableRow from "../components/ScrollableRow";
 import * as api from "../api";
-import type { SeasonDetailsResponse, RatingValue } from "../types";
 import PersonCard from "../components/PersonCard";
 import { DetailPageSkeleton } from "../components/SkeletonComponents";
-import { useApiCall } from "../hooks/useApiCall";
 import { useAuth } from "../context/AuthContext";
 import ShareButton from "../components/ShareButton";
 import { posterUrl as mkPosterUrl, stillUrl as mkStillUrl } from "../lib/tmdb-images";
@@ -44,12 +42,11 @@ export default function SeasonDetailPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
-  const { data, loading, error } = useApiCall<SeasonDetailsResponse>(
-    (signal) => api.getSeasonDetails(id!, Number(season), signal),
-    [id, season],
-  );
-
-  const [episodeRatings, setEpisodeRatings] = useState<Record<number, Record<RatingValue, number>>>({});
+  const { data, isLoading: loading, isError: error } = useQuery({
+    queryKey: ["season-detail", id, season],
+    queryFn: ({ signal }) => api.getSeasonDetails(id!, Number(season), signal),
+    enabled: !!id && !!season,
+  });
   const qc = useQueryClient();
 
   type SeasonStatusEntry = { episode_number: number; id: number; is_watched: boolean };
@@ -72,15 +69,13 @@ export default function SeasonDetailPage() {
     return map;
   }, [statusData]);
 
-  useApiCall(
-    (signal) => id && season
-      ? api.getSeasonEpisodeRatings(id, Number(season), signal)
-      : Promise.resolve({ ratings: {} }),
-    [id, season],
-    {
-      onSuccess: (result) => setEpisodeRatings(result.ratings),
-    },
-  );
+  const { data: ratingsData } = useQuery({
+    queryKey: ["season-ratings", id, season],
+    queryFn: ({ signal }) =>
+      api.getSeasonEpisodeRatings(id!, Number(season), signal),
+    enabled: !!id && !!season,
+  });
+  const episodeRatings = ratingsData?.ratings ?? {};
 
   const toggleWatchedMutation = useMutation({
     mutationFn: ({ epId, wasWatched }: { epId: number; wasWatched: boolean }) =>
@@ -185,7 +180,7 @@ export default function SeasonDetailPage() {
   if (error || !data) {
     return (
       <div className="flex items-center justify-center py-20">
-        <div className="text-red-400">{error || "Season not found"}</div>
+        <div className="text-red-400">Season not found</div>
       </div>
     );
   }

--- a/frontend/src/pages/SharedWatchlistPage.test.tsx
+++ b/frontend/src/pages/SharedWatchlistPage.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
 import { render, screen, waitFor, cleanup } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import "../i18n";
 
@@ -32,42 +33,41 @@ function makeTitle(overrides: Partial<Title> = {}): Title {
   };
 }
 
-const mockFetch = mock((_url: string, _init?: RequestInit) =>
-  Promise.resolve({
-    ok: true,
-    status: 200,
-    json: () => Promise.resolve({ username: "testuser", titles: [makeTitle()] }),
-  } as Response)
+const mockGetSharedWatchlist = mock(() =>
+  Promise.resolve({ username: "testuser", titles: [makeTitle()] })
 );
+
+mock.module("../api", () => ({
+  getSharedWatchlist: mockGetSharedWatchlist,
+}));
 
 const { default: SharedWatchlistPage } = await import("./SharedWatchlistPage");
 
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
 function Wrapper({ token = "abc123" }: { token?: string }) {
   return (
-    <MemoryRouter initialEntries={[`/share/watchlist/${token}`]}>
-      <Routes>
-        <Route path="/share/watchlist/:token" element={<SharedWatchlistPage />} />
-      </Routes>
-    </MemoryRouter>
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter initialEntries={[`/share/watchlist/${token}`]}>
+        <Routes>
+          <Route path="/share/watchlist/:token" element={<SharedWatchlistPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
   );
 }
 
 beforeEach(() => {
-  globalThis.fetch = mockFetch as any;
-  mockFetch.mockImplementation((_url: string) =>
-    Promise.resolve({
-      ok: true,
-      status: 200,
-      json: () => Promise.resolve({ username: "testuser", titles: [makeTitle()] }),
-    } as Response)
+  mockGetSharedWatchlist.mockImplementation(() =>
+    Promise.resolve({ username: "testuser", titles: [makeTitle()] })
   );
 });
 
 afterEach(() => {
   cleanup();
-  mockFetch.mockReset();
-  // @ts-expect-error — restore to undefined so other test files are unaffected
-  globalThis.fetch = undefined;
+  mockGetSharedWatchlist.mockReset();
 });
 
 describe("SharedWatchlistPage", () => {
@@ -87,12 +87,8 @@ describe("SharedWatchlistPage", () => {
   });
 
   it("shows 'This watchlist is empty' when titles array is empty", async () => {
-    mockFetch.mockImplementation((_url: string) =>
-      Promise.resolve({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve({ username: "emptyuser", titles: [] }),
-      } as Response)
+    mockGetSharedWatchlist.mockImplementation(() =>
+      Promise.resolve({ username: "emptyuser", titles: [] })
     );
     render(<Wrapper />);
     await waitFor(() => {
@@ -101,7 +97,7 @@ describe("SharedWatchlistPage", () => {
   });
 
   it("shows error state when fetch throws", async () => {
-    mockFetch.mockImplementation((_url: string) =>
+    mockGetSharedWatchlist.mockImplementation(() =>
       Promise.reject(new Error("Not found"))
     );
     render(<Wrapper />);
@@ -111,16 +107,11 @@ describe("SharedWatchlistPage", () => {
   });
 
   it("shows plural titles count correctly", async () => {
-    mockFetch.mockImplementation((_url: string) =>
+    mockGetSharedWatchlist.mockImplementation(() =>
       Promise.resolve({
-        ok: true,
-        status: 200,
-        json: () =>
-          Promise.resolve({
-            username: "multiuser",
-            titles: [makeTitle({ id: "t1", title: "Movie A" }), makeTitle({ id: "t2", title: "Movie B" })],
-          }),
-      } as Response)
+        username: "multiuser",
+        titles: [makeTitle({ id: "t1", title: "Movie A" }), makeTitle({ id: "t2", title: "Movie B" })],
+      })
     );
     render(<Wrapper />);
     await waitFor(() => {

--- a/frontend/src/pages/SharedWatchlistPage.tsx
+++ b/frontend/src/pages/SharedWatchlistPage.tsx
@@ -2,15 +2,16 @@ import { useParams, Link } from "react-router";
 import { getSharedWatchlist } from "../api";
 import type { Title } from "../types";
 import { TitleGridSkeleton } from "../components/SkeletonComponents";
-import { useApiCall } from "../hooks/useApiCall";
+import { useQuery } from "@tanstack/react-query";
 
 export default function SharedWatchlistPage() {
   const { token } = useParams<{ token: string }>();
 
-  const { data, loading, error } = useApiCall(
-    (signal) => getSharedWatchlist(token!, signal),
-    [token],
-  );
+  const { data, isLoading: loading, isError: error } = useQuery({
+    queryKey: ["shared-watchlist", token],
+    queryFn: ({ signal }) => getSharedWatchlist(token!, signal),
+    enabled: !!token,
+  });
 
   if (loading) {
     return (

--- a/frontend/src/pages/TrackedPage.tsx
+++ b/frontend/src/pages/TrackedPage.tsx
@@ -7,7 +7,7 @@ import * as api from "../api";
 import type { Title } from "../types";
 import TitleList from "../components/TitleList";
 import { TitleGridSkeleton } from "../components/SkeletonComponents";
-import { useApiCall } from "../hooks/useApiCall";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { groupShowsByStatus } from "../lib/groupShows";
 import { useGridNavigation } from "../hooks/useGridNavigation";
 import { useScrollRestoration } from "../hooks/useScrollRestoration";
@@ -88,7 +88,12 @@ function sortTitles(titles: Title[], sort: SortKey): Title[] {
 }
 
 export default function TrackedPage() {
-  const { data, loading, refetch } = useApiCall((signal) => api.getTrackedTitles(signal), []);
+  const qc = useQueryClient();
+  const { data, isLoading: loading } = useQuery({
+    queryKey: ["tracked"],
+    queryFn: ({ signal }) => api.getTrackedTitles(signal),
+  });
+  const refetch = useCallback(() => { void qc.invalidateQueries({ queryKey: ["tracked"] }); }, [qc]);
   const allTitles: Title[] = useMemo(() => data?.titles ?? [], [data]);
   useScrollRestoration("tracked", !loading);
   const { t } = useTranslation();

--- a/frontend/src/pages/UpcomingPage.test.tsx
+++ b/frontend/src/pages/UpcomingPage.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, mock, afterEach, spyOn } from "bun:test";
 import { render, screen, fireEvent, waitFor, cleanup, act } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "../i18n";
 import * as sonner from "sonner";
 
@@ -24,8 +25,16 @@ mock.module("../hooks/useIsMobile", () => ({
 
 const { default: UpcomingPage } = await import("./UpcomingPage");
 
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
 function Wrapper({ children }: { children: ReactNode }) {
-  return <MemoryRouter>{children}</MemoryRouter>;
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
 }
 
 afterEach(() => {
@@ -48,7 +57,7 @@ describe("UpcomingPage", () => {
       Promise.reject(new Error("Network error"))
     );
     render(<UpcomingPage />, { wrapper: Wrapper });
-    await waitFor(() => expect(screen.getByText("Network error")).toBeDefined());
+    await waitFor(() => expect(screen.getByText("Failed to load episodes")).toBeDefined());
   });
 
   it("renders today and upcoming sections on success", async () => {

--- a/frontend/src/pages/UpcomingPage.tsx
+++ b/frontend/src/pages/UpcomingPage.tsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
 import { useSearchParams } from "react-router";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import * as api from "../api";
 import type { Episode } from "../types";
 import {
@@ -10,36 +10,35 @@ import {
   ShowEpisodeGroup,
 } from "../components/EpisodeComponents";
 import { EpisodeListSkeleton } from "../components/SkeletonComponents";
-import { useApiCall } from "../hooks/useApiCall";
 import { useIsMobile } from "../hooks/useIsMobile";
 import AgendaCalendar from "../components/AgendaCalendar";
 
 export default function UpcomingPage() {
-  const [today, setToday] = useState<Episode[]>([]);
-  const [upcoming, setUpcoming] = useState<Episode[]>([]);
   const { t } = useTranslation();
   const [searchParams, setSearchParams] = useSearchParams();
   const isMobile = useIsMobile();
+  const qc = useQueryClient();
 
-  const { loading, error } = useApiCall(
-    (signal) => api.getUpcomingEpisodes(signal),
-    [],
-    {
-      onSuccess: (data) => {
-        setToday(data.today);
-        setUpcoming(data.upcoming);
-      },
-    },
-  );
+  const { isLoading: loading, isError: error, data: upcomingData } = useQuery({
+    queryKey: ["upcoming"],
+    queryFn: ({ signal }) => api.getUpcomingEpisodes(signal),
+  });
+
+  const today = upcomingData?.today ?? [];
+  const upcoming = upcomingData?.upcoming ?? [];
+
+  type UpcomingData = { today: Episode[]; upcoming: Episode[] };
 
   const toggleWatched = async (episodeId: number, currentlyWatched: boolean) => {
-    const updateAll = (eps: Episode[]) =>
+    const updateEps = (eps: Episode[]) =>
       eps.map((ep) => (ep.id === episodeId ? { ...ep, is_watched: !currentlyWatched } : ep));
-    const revertAll = (eps: Episode[]) =>
+    const revertEps = (eps: Episode[]) =>
       eps.map((ep) => (ep.id === episodeId ? { ...ep, is_watched: currentlyWatched } : ep));
 
-    setToday((prev) => updateAll(prev));
-    setUpcoming((prev) => updateAll(prev));
+    qc.setQueryData<UpcomingData>(["upcoming"], (old) => {
+      if (!old) return old;
+      return { today: updateEps(old.today), upcoming: updateEps(old.upcoming) };
+    });
 
     try {
       if (currentlyWatched) {
@@ -48,8 +47,10 @@ export default function UpcomingPage() {
         await api.watchEpisode(episodeId);
       }
     } catch (err) {
-      setToday((prev) => revertAll(prev));
-      setUpcoming((prev) => revertAll(prev));
+      qc.setQueryData<UpcomingData>(["upcoming"], (old) => {
+        if (!old) return old;
+        return { today: revertEps(old.today), upcoming: revertEps(old.upcoming) };
+      });
       console.error("Failed to toggle watched:", err);
       toast.error("Failed to update watched status — please try again");
     }
@@ -71,7 +72,7 @@ export default function UpcomingPage() {
   if (error) {
     return (
       <div className="bg-red-900/50 border border-red-800 text-red-200 px-4 py-2 rounded-lg text-sm">
-        {error}
+        {t("upcoming.error", "Failed to load episodes")}
       </div>
     );
   }

--- a/frontend/src/pages/UserOverlapPage.tsx
+++ b/frontend/src/pages/UserOverlapPage.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { Link, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import * as api from "../api";
-import { useApiCall } from "../hooks/useApiCall";
+import { useQuery } from "@tanstack/react-query";
 import { useAuth } from "../context/AuthContext";
 import TitleCard from "../components/TitleCard";
 import type { OverlapTitle, Provider } from "../types";
@@ -34,10 +34,12 @@ export default function UserOverlapPage() {
   const { user: currentUser } = useAuth();
   const { t } = useTranslation();
 
-  const { data, loading, error } = useApiCall(
-    (signal) => api.getOverlap(friendUsername!, signal),
-    [friendUsername],
-  );
+  const { data, isLoading: loading, isError, error } = useQuery({
+    queryKey: ["user-overlap", friendUsername],
+    queryFn: ({ signal }) => api.getOverlap(friendUsername!, signal),
+    enabled: !!friendUsername,
+    retry: false,
+  });
 
   const [filterMode, setFilterMode] = useState<FilterMode>("all");
   const [selectedGenres, setSelectedGenres] = useState<string[]>([]);
@@ -75,9 +77,10 @@ export default function UserOverlapPage() {
   }, [data, filterMode, selectedGenres, sharedProviderIds]);
 
   // 403 private watchlist state
-  if (error) {
+  if (isError) {
+    const errorMessage = error instanceof Error ? error.message : String(error ?? "");
     const isPrivate =
-      error.includes("private") || error.includes("mutual followers");
+      errorMessage.includes("private") || errorMessage.includes("mutual followers");
     return (
       <div className="max-w-2xl mx-auto py-16 text-center space-y-4">
         <p className="text-zinc-400 text-lg">

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Card } from "../components/ui/card";
 import { Link, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import * as api from "../api";
-import type { PinnedTitle, UserAchievement, StreakData } from "../types";
+import type { PinnedTitle } from "../types";
 import { useAuth } from "../context/AuthContext";
 import ProfileHero from "../components/profile/ProfileHero";
 import BioCard from "../components/profile/BioCard";
@@ -20,7 +20,7 @@ import WatchlistTabs, {
 } from "../components/profile/WatchlistTabs";
 import WatchlistGrid from "../components/profile/WatchlistGrid";
 import { TitleGridSkeleton } from "../components/SkeletonComponents";
-import { useApiCall } from "../hooks/useApiCall";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import ProfileBadgesSummary from "../components/profile/ProfileBadgesSummary";
 import StreakCounter from "../components/profile/StreakCounter";
 
@@ -28,47 +28,33 @@ export default function UserProfilePage() {
   const { username } = useParams<{ username: string }>();
   const { t } = useTranslation();
   const { user: currentUser } = useAuth();
-  const { data, loading, error, refetch } = useApiCall(
-    (signal) => api.getUserProfile(username!, signal),
-    [username],
-  );
+  const qc = useQueryClient();
+  const { data, isLoading: loading, isError: error } = useQuery({
+    queryKey: ["user-profile", username],
+    queryFn: ({ signal }) => api.getUserProfile(username!, signal),
+    enabled: !!username,
+  });
+
+  const isOwnProfileQuery = currentUser?.username === username;
+  const { data: achievementsData } = useQuery({
+    queryKey: ["achievements", username ?? "me"],
+    queryFn: ({ signal }) =>
+      isOwnProfileQuery
+        ? api.getMyAchievements(signal)
+        : api.getUserAchievements(username!, signal),
+    enabled: !!username,
+  });
+
+  const { data: streakData } = useQuery({
+    queryKey: ["streak", username],
+    queryFn: ({ signal }) => api.getMyStreak(signal),
+    enabled: !!currentUser && currentUser.username === username,
+  });
 
   const [followerAdjust, setFollowerAdjust] = useState(0);
   const [activeTab, setActiveTab] = useState<WatchlistTab>("watching");
   const [localBio, setLocalBio] = useState<string | null | undefined>(undefined);
   const [localPinned, setLocalPinned] = useState<PinnedTitle[] | null>(null);
-  const [achievements, setAchievements] = useState<UserAchievement[] | null>(null);
-  const [streakData, setStreakData] = useState<StreakData | null>(null);
-
-  // Fetch achievements for the profile user
-  useEffect(() => {
-    if (!username) return;
-    const controller = new AbortController();
-    const fetchAchievements = async () => {
-      try {
-        const isOwn = currentUser?.username === username;
-        const result = isOwn
-          ? await api.getMyAchievements(controller.signal)
-          : await api.getUserAchievements(username, controller.signal);
-        if (!controller.signal.aborted) setAchievements(result);
-      } catch {
-        // Silently fail (e.g. private profile)
-      }
-    };
-    fetchAchievements();
-    return () => controller.abort();
-  }, [username, currentUser?.username]);
-
-  // Fetch streak for own profile only
-  useEffect(() => {
-    if (!currentUser || currentUser.username !== username) return;
-    const controller = new AbortController();
-    api
-      .getMyStreak(controller.signal)
-      .then((data) => { if (!controller.signal.aborted) setStreakData(data); })
-      .catch(() => { /* ignore */ });
-    return () => controller.abort();
-  }, [username, currentUser]);
 
   const handleFollowToggle = useCallback((isNowFollowing: boolean) => {
     setFollowerAdjust((prev) => prev + (isNowFollowing ? 1 : -1));
@@ -155,7 +141,7 @@ export default function UserProfilePage() {
               isOwnProfile={is_own_profile}
               onBioUpdated={(next) => {
                 setLocalBio(next);
-                refetch();
+                void qc.invalidateQueries({ queryKey: ["user-profile", username] });
               }}
             />
             {(pinnedDisplay.length > 0 || is_own_profile) && (
@@ -169,9 +155,9 @@ export default function UserProfilePage() {
               <StreakCounter streak={streakData} variant="sidebar" />
             )}
             {show_watchlist && <ProgressCard overview={overview} />}
-            {show_watchlist && achievements && achievements.length > 0 && (
+            {show_watchlist && achievementsData && achievementsData.length > 0 && (
               <ProfileBadgesSummary
-                achievements={achievements}
+                achievements={achievementsData}
                 mode={is_own_profile ? "self" : "other"}
                 viewAllHref={is_own_profile
                   ? "/achievements"


### PR DESCRIPTION
## Summary

- Replaces every `useApiCall` invocation across the frontend with `useQuery` (and `useQueryClient` where `invalidateQueries` or `setQueryData` is needed)
- Retires the `useApiCall` hook — no production code imports it anymore
- `DiscoveryPage`: handlers use `qc.setQueryData` for optimistic local mutations; `recommendations` wrapped in `useMemo` to stabilize reference
- `UpcomingPage`: `toggleWatched` uses `qc.setQueryData` with rollback on failure
- `UserProfilePage`: three `useQuery` calls replace the main fetch + 2 `useEffect` + 2 `useState`
- `TrackedPage`: `refetch` replaced with a stable `useCallback` wrapping `qc.invalidateQueries`
- All affected test files updated with `QueryClientProvider` wrappers; `SharedWatchlistPage.test.tsx` migrated from `globalThis.fetch` mock to `mock.module("../api")` to prevent Bun mock-leak cross-file corruption

## Affected files

`BottomTabBar`, `AchievementsPage`, `AchievementDetailPage`, `DiscoveryPage`, `EpisodeDetailPage`, `PersonPage`, `SeasonDetailPage`, `SharedWatchlistPage`, `TrackedPage`, `UpcomingPage`, `UserOverlapPage`, `UserProfilePage` — plus their test files.

## Test plan

- [x] `bun run check` exits 0 (2097 server + 1001 frontend tests, zero TS errors, zero lint warnings, build + wrangler dry-run)
- [x] No remaining `useApiCall` imports outside `hooks/useApiCall.ts` and its test

Part of #822