### PR TITLE
fix(admin): replace type assertion with zValidator for GET /admin/users

### DIFF
--- a/server/routes/admin.test.ts
+++ b/server/routes/admin.test.ts
@@ -233,6 +233,15 @@ describe("GET /admin/users", () => {
     expect(body.users.some((u: { username: string }) => u.username === "tobebanned")).toBe(true);
   });
 
+  it("accepts a valid filter + page", async () => {
+    const res = await app.request("/admin/users?filter=active&page=1", {
+      headers: { Cookie: adminCookie },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.users)).toBe(true);
+  });
+
   it("returns 403 for non-admin", async () => {
     const userId = await createUser("regular", "hash");
     const token = await createSession(userId);
@@ -295,6 +304,26 @@ describe("validation", () => {
       method: "PUT",
       headers: { Cookie: adminCookie, "Content-Type": "application/json" },
       body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects GET /admin/users with invalid filter enum", async () => {
+    const res = await app.request("/admin/users?filter=superadmin", {
+      headers: { Cookie: adminCookie },
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects GET /admin/users with non-numeric page", async () => {
+    const res = await app.request("/admin/users?page=abc", {
+      headers: { Cookie: adminCookie },
     });
     expect(res.status).toBe(400);
     const body = await res.json();

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -140,11 +140,15 @@ app.put("/settings", zValidator("json", updateSettingsSchema), async (c) => {
 
 const PAGE_SIZE = 50;
 
+const usersQuerySchema = z.object({
+  search: z.string().optional(),
+  filter: z.enum(["all", "active", "banned"]).default("all"),
+  page: z.coerce.number().int().min(1).default(1),
+});
+
 // GET /api/admin/users?search=&filter=all|active|banned&page=1
-app.get("/users", async (c) => {
-  const search = c.req.query("search") || undefined;
-  const filter = (c.req.query("filter") as "all" | "active" | "banned") || "all";
-  const page = Math.max(1, parseInt(c.req.query("page") || "1", 10));
+app.get("/users", zValidator("query", usersQuerySchema), async (c) => {
+  const { search, filter, page } = c.req.valid("query");
   const offset = (page - 1) * PAGE_SIZE;
 
   const [rows, total] = await Promise.all([


### PR DESCRIPTION
## Summary

- Replaces the compile-time-only `as "all" | "active" | "banned"` cast on the `filter` query param with a proper `zValidator("query", usersQuerySchema)` schema
- Adds `z.coerce.number().int().min(1).default(1)` for `page`, eliminating the latent `parseInt("abc") → NaN` offset bug
- Invalid `filter` (e.g. `?filter=superadmin`) now returns HTTP 400 with `{ error: "Validation failed", issues }` instead of silently leaking an unvalidated string to the DB query

## Test plan

- [x] `bun test server/routes/admin.test.ts` — 45 pass, 0 fail (3 new tests: `rejects invalid filter enum`, `rejects non-numeric page`, `accepts valid filter + page`)
- [x] `bun run check` — full CI pipeline passes (tsc + lint + all tests + build + wrangler dry-run)

Closes #821

🤖 Generated with [Claude Code](https://claude.com/claude-code)