### PR TITLE
feat(discovery): surface matchScore chip in DiscoveryPage hero

### DIFF
--- a/frontend/src/pages/DiscoveryPage.test.tsx
+++ b/frontend/src/pages/DiscoveryPage.test.tsx
@@ -571,4 +571,33 @@ describe("For you tab — suggestions", () => {
       expect(mockTrackTitle.mock.calls[0]?.[0]).toBe("movie-2");
     });
   });
+
+  it("hero renders an amber match-score chip when matchScore is present", async () => {
+    const title = makeSearchTitle("movie-1", { matchScore: 94 });
+    mockGetSuggestionsAggregate.mockImplementation(() =>
+      Promise.resolve(makeAggregate({ flat: [title], groups: [] }))
+    );
+
+    render(<DiscoveryPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Top pick for you")).toBeDefined();
+    });
+    // Chip text node is lowercase; CSS text-transform: uppercase is visual-only
+    expect(screen.getByText("94% match")).toBeDefined();
+  });
+
+  it("hero omits the match-score chip when matchScore is absent", async () => {
+    const title = makeSearchTitle("movie-1");
+    mockGetSuggestionsAggregate.mockImplementation(() =>
+      Promise.resolve(makeAggregate({ flat: [title], groups: [] }))
+    );
+
+    render(<DiscoveryPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Top pick for you")).toBeDefined();
+    });
+    expect(screen.queryByText(/% match/)).toBeNull();
+  });
 });

--- a/frontend/src/pages/DiscoveryPage.tsx
+++ b/frontend/src/pages/DiscoveryPage.tsx
@@ -255,7 +255,7 @@ function DiscoveryHero({
           <Chip variant="default">{hero.objectType === "SHOW" ? "TV Series" : "Movie"}</Chip>
           {hero.genres?.slice(0, 3).map((g) => <Chip key={g} variant="default">{g}</Chip>)}
           {hero.releaseYear && <Chip variant="default">{hero.releaseYear}</Chip>}
-          {/* TODO(scoring): no match score from /api/suggestions yet */}
+          {hero.matchScore != null && <Chip variant="amber">{hero.matchScore}% match</Chip>}
         </div>
 
         {/* Two-source signal grid */}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -102,6 +102,7 @@ export interface SearchTitle {
     tmdbScore: number | null;
   };
   isTracked?: boolean;
+  matchScore?: number;
 }
 
 export interface SearchOffer {

--- a/server/routes/suggestions.test.ts
+++ b/server/routes/suggestions.test.ts
@@ -308,6 +308,81 @@ describe("GET /suggestions", () => {
     const body = await res.json();
     expect(body.groups[0].hiddenCount).toBe(1);
   });
+
+  it("each flat result has a numeric matchScore in [0, 100]", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-100", tmdbId: "100", objectType: "MOVIE" })]);
+    await trackTitle("movie-100", mockUserId);
+
+    (tmdbClient.fetchMovieSuggestions as any).mockResolvedValueOnce({
+      results: [makeTmdbDiscoverMovie({ id: 200, title: "Suggestion", vote_average: 7.5 })],
+      page: 1, total_pages: 1, total_results: 1,
+    });
+
+    const res = await app.request("/suggestions");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.flat.length).toBeGreaterThan(0);
+    for (const title of body.flat) {
+      expect(typeof title.matchScore).toBe("number");
+      expect(title.matchScore).toBeGreaterThanOrEqual(0);
+      expect(title.matchScore).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("sorts flat by matchScore — loved+low-tmdb outranks tracked+high-tmdb", async () => {
+    await upsertTitles([
+      makeParsedTitle({ id: "movie-10", tmdbId: "10", objectType: "MOVIE" }),
+      makeParsedTitle({ id: "movie-20", tmdbId: "20", objectType: "MOVIE" }),
+    ]);
+    await rateTitle(mockUserId, "movie-10", "LOVE"); // reason: loved (highest affinity)
+    await trackTitle("movie-20", mockUserId);         // reason: tracked (lowest affinity)
+
+    // loved seed → low-tmdb suggestion: quality=0.6, affinity=1.0 → matchScore 78
+    (tmdbClient.fetchMovieSuggestions as any).mockResolvedValueOnce({
+      results: [makeTmdbDiscoverMovie({ id: 500, title: "Loved Pick", vote_average: 6.0 })],
+      page: 1, total_pages: 1, total_results: 1,
+    });
+    // tracked seed → high-tmdb suggestion: quality=0.85, affinity=0.55 → matchScore 72
+    (tmdbClient.fetchMovieSuggestions as any).mockResolvedValueOnce({
+      results: [makeTmdbDiscoverMovie({ id: 501, title: "Tracked Pick", vote_average: 8.5 })],
+      page: 1, total_pages: 1, total_results: 1,
+    });
+
+    const res = await app.request("/suggestions");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // movie-500 (loved + tmdb 6.0 → ~78%) should outrank movie-501 (tracked + tmdb 8.5 → ~72%)
+    expect(body.flat[0].id).toBe("movie-500");
+    expect(body.flat[1].id).toBe("movie-501");
+    expect(body.flat[0].matchScore).toBeGreaterThan(body.flat[1].matchScore);
+  });
+
+  it("reason affinity: loved-sourced title gets higher matchScore than tracked-sourced at equal tmdb", async () => {
+    await upsertTitles([
+      makeParsedTitle({ id: "movie-30", tmdbId: "30", objectType: "MOVIE" }),
+      makeParsedTitle({ id: "movie-40", tmdbId: "40", objectType: "MOVIE" }),
+    ]);
+    await rateTitle(mockUserId, "movie-30", "LOVE");
+    await trackTitle("movie-40", mockUserId);
+
+    (tmdbClient.fetchMovieSuggestions as any).mockResolvedValueOnce({
+      results: [makeTmdbDiscoverMovie({ id: 600, title: "Via Loved", vote_average: 7.0 })],
+      page: 1, total_pages: 1, total_results: 1,
+    });
+    (tmdbClient.fetchMovieSuggestions as any).mockResolvedValueOnce({
+      results: [makeTmdbDiscoverMovie({ id: 601, title: "Via Tracked", vote_average: 7.0 })],
+      page: 1, total_pages: 1, total_results: 1,
+    });
+
+    const res = await app.request("/suggestions");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const scored600 = body.flat.find((t: any) => t.id === "movie-600");
+    const scored601 = body.flat.find((t: any) => t.id === "movie-601");
+    expect(scored600).toBeDefined();
+    expect(scored601).toBeDefined();
+    expect(scored600.matchScore).toBeGreaterThan(scored601.matchScore);
+  });
 });
 
 describe("POST /suggestions/dismiss/:titleId", () => {

--- a/server/routes/suggestions.ts
+++ b/server/routes/suggestions.ts
@@ -21,6 +21,21 @@ import { zValidator } from "../lib/validator";
 
 const log = logger.child({ module: "suggestions" });
 
+const REASON_WEIGHT: Record<SuggestionSourceTitle["reason"], number> = {
+  loved: 1.0,
+  liked: 0.85,
+  watched: 0.7,
+  tracked: 0.55,
+};
+
+function computeMatchScore(tmdbScore: number | null, maxReasonWeight: number, seedCount: number): number {
+  const quality = (tmdbScore ?? 6.0) / 10;
+  const affinity = maxReasonWeight;
+  const coBonus = Math.min(0.10, (seedCount - 1) * 0.05);
+  const raw = 0.55 * quality + 0.45 * affinity + coBonus;
+  return Math.round(Math.min(1, Math.max(0, raw)) * 100);
+}
+
 const app = new Hono<AppEnv>();
 
 const dismissParamSchema = z.object({ titleId: z.string().min(1) });
@@ -108,6 +123,27 @@ app.get("/", async (c) => {
       })
       .filter((g) => g.suggestions.length > 0);
 
+    // Compute per-title match score: aggregate affinity across all groups that suggest each title
+    const aggById = new Map<string, { maxWeight: number; seedCount: number }>();
+    for (const group of groups) {
+      const weight = REASON_WEIGHT[group.source.reason];
+      for (const title of group.suggestions) {
+        const existing = aggById.get(title.id);
+        if (existing) {
+          existing.maxWeight = Math.max(existing.maxWeight, weight);
+          existing.seedCount += 1;
+        } else {
+          aggById.set(title.id, { maxWeight: weight, seedCount: 1 });
+        }
+      }
+    }
+    for (const group of groups) {
+      for (const title of group.suggestions) {
+        const agg = aggById.get(title.id)!;
+        title.matchScore = computeMatchScore(title.scores.tmdbScore, agg.maxWeight, agg.seedCount);
+      }
+    }
+
     // Build flat list: iterate groups in order, pick unseen titles
     for (const group of groups) {
       for (const title of group.suggestions) {
@@ -118,8 +154,8 @@ app.get("/", async (c) => {
       }
     }
 
-    // Sort flat by TMDB score descending, then truncate
-    flat.sort((a, b) => (b.scores.tmdbScore ?? 0) - (a.scores.tmdbScore ?? 0));
+    // Sort flat by match score descending, then truncate
+    flat.sort((a, b) => (b.matchScore ?? 0) - (a.matchScore ?? 0));
     flat.splice(limit);
 
     return ok(c, { flat, groups });

--- a/server/tmdb/parser.ts
+++ b/server/tmdb/parser.ts
@@ -31,6 +31,7 @@ export interface ParsedTitle {
   tmdbUrl: string | null;
   offers: ParsedOffer[];
   scores: ParsedScores;
+  matchScore?: number;
 }
 
 export interface ParsedOffer {


### PR DESCRIPTION
## Summary

- Computes a normalized 0–100 `matchScore` per suggestion in `GET /api/suggestions` using: TMDB quality (`tmdbScore` normalized to 0–1) blended with seed-reason affinity (`loved > liked > watched > tracked`) plus a small multi-seed co-occurrence bonus — no new DB queries
- Sorts the `flat` list by `matchScore` descending (previously `tmdbScore`) so the hero "Top pick" and "Ranked by score" order reflect personalization
- Renders the score as an amber `<Chip variant="amber">94% match</Chip>` in the hero banner chip row, replacing the long-standing TODO comment

## Test plan

- [x] `bun run check` passes (2103 server + 991 frontend tests, 0 failures, no TS errors, no ESLint warnings, build + wrangler dry-run clean)
- [x] Server tests: `matchScore` is a `[0, 100]` integer on every flat result; `flat` sorts by matchScore (loved+low-tmdb beats tracked+high-tmdb); equal-tmdb loved-sourced title scores higher than tracked-sourced
- [x] Frontend tests: hero renders `"94% match"` chip when `matchScore` present; chip is absent when `matchScore` is undefined

Closes #820

🤖 Generated with [Claude Code](https://claude.com/claude-code)