### PR TITLE
perf(up-next): eliminate N+1 and deduplicate session queries

### DIFF
--- a/drizzle/0052_idx_up_next_perf.sql
+++ b/drizzle/0052_idx_up_next_perf.sql
@@ -1,0 +1,3 @@
+CREATE INDEX `idx_episodes_title_air` ON `episodes` (`title_id`,`air_date`);
+--> statement-breakpoint
+CREATE INDEX `idx_watched_user_episode` ON `watched_episodes` (`user_id`,`episode_id`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -358,6 +358,20 @@
       "when": 1778415487985,
       "tag": "0050_0048_achievements_v2",
       "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "6",
+      "when": 1747699200000,
+      "tag": "0051_idx_watch_history_user_title_ts_id",
+      "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "6",
+      "when": 1747785600000,
+      "tag": "0052_idx_up_next_perf",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -133,6 +133,6 @@ describe("fixSkippedMigrations", () => {
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(51);
+    expect(migrations.cnt).toBe(53);
   });
 });

--- a/server/db/repository/episodes.test.ts
+++ b/server/db/repository/episodes.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeEach, afterAll } from "bun:test";
 import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
 import { makeParsedTitle } from "../../test-utils/fixtures";
 import { upsertTitles, createUser, trackTitle, upsertEpisodes, watchEpisode, watchEpisodesBulk } from "../repository";
-import { getUnwatchedEpisodes } from "./episodes";
+import { getUnwatchedEpisodes, getUnwatchedEpisodesWithMeta, getNextUnwatchedEpisodesForTitles } from "./episodes";
+import { getRawDb } from "../bun-db";
 
 let userId: string;
 
@@ -130,5 +131,112 @@ describe("getUnwatchedEpisodes", () => {
     expect(show2Episodes.map((e) => e.episode_number)).toEqual([1, 2]);
     const show3Episodes = results.filter((e) => e.title_id === "show-3");
     expect(show3Episodes.map((e) => e.episode_number)).toEqual([1, 2]);
+  });
+});
+
+describe("getUnwatchedEpisodesWithMeta", () => {
+  it("returns the same episodes as getUnwatchedEpisodes and includes a lastWatchedByTitle map", async () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+    await upsertEpisodes([
+      { title_id: "show-1", season_number: 1, episode_number: 1, name: "Ep1", overview: null, air_date: yesterday, still_path: null },
+      { title_id: "show-1", season_number: 1, episode_number: 2, name: "Ep2", overview: null, air_date: yesterday, still_path: null },
+    ]);
+
+    // Watch ep1 so lastWatchedByTitle is populated
+    const db = getRawDb();
+    const ep1 = db.prepare("SELECT id FROM episodes WHERE title_id='show-1' AND episode_number=1").get() as { id: number };
+    await watchEpisode(ep1.id, userId);
+
+    const plain = await getUnwatchedEpisodes(userId);
+    const { episodes: withMetaEps, lastWatchedByTitle } = await getUnwatchedEpisodesWithMeta(userId);
+
+    // Episode results must match
+    expect(withMetaEps.map((e) => e.id)).toEqual(plain.map((e) => e.id));
+
+    // lastWatchedByTitle must contain show-1 with a valid Date
+    expect(lastWatchedByTitle.has("show-1")).toBe(true);
+    expect(lastWatchedByTitle.get("show-1")).toBeInstanceOf(Date);
+  });
+
+  it("returns an empty lastWatchedByTitle map when nothing has been watched", async () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+    await upsertEpisodes([
+      { title_id: "show-1", season_number: 1, episode_number: 1, name: "Ep1", overview: null, air_date: yesterday, still_path: null },
+    ]);
+
+    const { lastWatchedByTitle } = await getUnwatchedEpisodesWithMeta(userId);
+    expect(lastWatchedByTitle.size).toBe(0);
+  });
+});
+
+describe("getNextUnwatchedEpisodesForTitles", () => {
+  it("returns empty map when given an empty titleIds array", async () => {
+    const result = await getNextUnwatchedEpisodesForTitles(userId, [], "UTC");
+    expect(result.size).toBe(0);
+  });
+
+  it("returns the correct next unwatched episode for each show", async () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+    const twoDaysAgo = new Date(Date.now() - 2 * 86400000).toISOString().slice(0, 10);
+
+    // show-1: 3 episodes, first one already watched → next should be ep 2
+    await upsertEpisodes([
+      { title_id: "show-1", season_number: 1, episode_number: 1, name: "S1E1 Watched", overview: null, air_date: twoDaysAgo, still_path: null },
+      { title_id: "show-1", season_number: 1, episode_number: 2, name: "S1E2 Next", overview: null, air_date: yesterday, still_path: null },
+      { title_id: "show-1", season_number: 1, episode_number: 3, name: "S1E3 Later", overview: null, air_date: yesterday, still_path: null },
+    ]);
+
+    // show-2 (needs to be created + tracked)
+    await upsertTitles([makeParsedTitle({ id: "show-next-2", objectType: "SHOW", title: "Next Show 2" })]);
+    await trackTitle("show-next-2", userId);
+    await upsertEpisodes([
+      { title_id: "show-next-2", season_number: 1, episode_number: 1, name: "B-S1E1 Watched", overview: null, air_date: twoDaysAgo, still_path: null },
+      { title_id: "show-next-2", season_number: 1, episode_number: 2, name: "B-S1E2 Next", overview: null, air_date: yesterday, still_path: null },
+    ]);
+
+    // Watch first episodes of both shows
+    const db = getRawDb();
+    const ep1Show1 = db.prepare("SELECT id FROM episodes WHERE title_id='show-1' AND season_number=1 AND episode_number=1").get() as { id: number };
+    const ep1Show2 = db.prepare("SELECT id FROM episodes WHERE title_id='show-next-2' AND season_number=1 AND episode_number=1").get() as { id: number };
+    await watchEpisode(ep1Show1.id, userId);
+    await watchEpisode(ep1Show2.id, userId);
+
+    const result = await getNextUnwatchedEpisodesForTitles(userId, ["show-1", "show-next-2"], "UTC");
+
+    expect(result.size).toBe(2);
+
+    const show1Next = result.get("show-1");
+    expect(show1Next).toBeDefined();
+    expect(show1Next!.episode_number).toBe(2);
+    expect(show1Next!.season_number).toBe(1);
+
+    const show2Next = result.get("show-next-2");
+    expect(show2Next).toBeDefined();
+    expect(show2Next!.episode_number).toBe(2);
+    expect(show2Next!.season_number).toBe(1);
+  });
+
+  it("omits a title when all its episodes are watched", async () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+    await upsertEpisodes([
+      { title_id: "show-1", season_number: 1, episode_number: 1, name: "Only Episode", overview: null, air_date: yesterday, still_path: null },
+    ]);
+
+    const db = getRawDb();
+    const ep = db.prepare("SELECT id FROM episodes WHERE title_id='show-1' AND season_number=1 AND episode_number=1").get() as { id: number };
+    await watchEpisode(ep.id, userId);
+
+    const result = await getNextUnwatchedEpisodesForTitles(userId, ["show-1"], "UTC");
+    expect(result.has("show-1")).toBe(false);
+  });
+
+  it("omits a title when it has no aired episodes", async () => {
+    const tomorrow = new Date(Date.now() + 86400000).toISOString().slice(0, 10);
+    await upsertEpisodes([
+      { title_id: "show-1", season_number: 1, episode_number: 1, name: "Future Ep", overview: null, air_date: tomorrow, still_path: null },
+    ]);
+
+    const result = await getNextUnwatchedEpisodesForTitles(userId, ["show-1"], "UTC");
+    expect(result.has("show-1")).toBe(false);
   });
 });

--- a/server/db/repository/episodes.ts
+++ b/server/db/repository/episodes.ts
@@ -156,8 +156,12 @@ export async function deleteEpisodesForTitle(titleId: string) {
   });
 }
 
-export async function getUnwatchedEpisodes(userId: string, timezone = "UTC") {
-  return traceDbQuery("getUnwatchedEpisodes", async () => {
+/**
+ * Core implementation: fetches unwatched episodes and returns them alongside
+ * the lastWatchedByTitle map so callers can reuse it without a second query.
+ */
+export async function getUnwatchedEpisodesWithMeta(userId: string, timezone = "UTC") {
+  return traceDbQuery("getUnwatchedEpisodesWithMeta", async () => {
     const db = getDb();
     const today = localDateForTimezone(timezone);
 
@@ -230,12 +234,20 @@ export async function getUnwatchedEpisodes(userId: string, timezone = "UTC") {
     });
 
     const offersByTitle = await getOffersWithPlex([...new Set(sortedRows.map((r) => r.title_id))], userId);
-    return sortedRows.map((row) => ({
+    const episodeRows = sortedRows.map((row) => ({
       ...row,
       is_watched: false,
       offers: offersByTitle.get(row.title_id) ?? [],
     }));
+
+    return { episodes: episodeRows, lastWatchedByTitle };
   });
+}
+
+/** Convenience wrapper that preserves the original public signature. */
+export async function getUnwatchedEpisodes(userId: string, timezone = "UTC") {
+  const { episodes: episodeRows } = await getUnwatchedEpisodesWithMeta(userId, timezone);
+  return episodeRows;
 }
 
 /**
@@ -277,6 +289,73 @@ export async function getNextUnwatchedEpisode(userId: string, titleId: string, t
       .get();
 
     return row ?? null;
+  });
+}
+
+export type NextUnwatchedEpisodeRow = {
+  id: number;
+  title_id: string;
+  season_number: number;
+  episode_number: number;
+  name: string | null;
+  air_date: string | null;
+};
+
+/**
+ * Batch variant of getNextUnwatchedEpisode. Returns a Map<titleId, row> for
+ * all requested titles in a single query using ROW_NUMBER() window function.
+ * Eliminates the N+1 pattern in the Up Next route.
+ */
+export async function getNextUnwatchedEpisodesForTitles(
+  userId: string,
+  titleIds: string[],
+  timezone = "UTC",
+): Promise<Map<string, NextUnwatchedEpisodeRow>> {
+  return traceDbQuery("getNextUnwatchedEpisodesForTitles", async () => {
+    if (titleIds.length === 0) return new Map();
+
+    const db = getDb();
+    const today = localDateForTimezone(timezone);
+
+    // Build a comma-separated list of quoted title IDs for the IN clause.
+    // We use sql.join to safely parameterise each value.
+    const titleIdList = sql.join(
+      titleIds.map((id) => sql`${id}`),
+      sql`, `,
+    );
+
+    const rows = await db.all<NextUnwatchedEpisodeRow>(sql`
+      SELECT id, title_id, season_number, episode_number, name, air_date
+      FROM (
+        SELECT
+          e.id,
+          e.title_id,
+          e.season_number,
+          e.episode_number,
+          e.name,
+          e.air_date,
+          ROW_NUMBER() OVER (
+            PARTITION BY e.title_id
+            ORDER BY e.season_number ASC, e.episode_number ASC
+          ) AS rn
+        FROM episodes e
+        INNER JOIN tracked t ON t.title_id = e.title_id AND t.user_id = ${userId}
+        WHERE e.title_id IN (${titleIdList})
+          AND e.air_date IS NOT NULL
+          AND e.air_date <= ${today}
+          AND NOT EXISTS (
+            SELECT 1 FROM watched_episodes we
+            WHERE we.episode_id = e.id AND we.user_id = ${userId}
+          )
+      )
+      WHERE rn = 1
+    `);
+
+    const result = new Map<string, NextUnwatchedEpisodeRow>();
+    for (const row of rows) {
+      result.set(row.title_id, row);
+    }
+    return result;
   });
 }
 

--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -29,7 +29,9 @@ export {
   getEpisodesByDateRange,
   deleteEpisodesForTitle,
   getUnwatchedEpisodes,
+  getUnwatchedEpisodesWithMeta,
   getNextUnwatchedEpisode,
+  getNextUnwatchedEpisodesForTitles,
   getLastWatchedAtPerShow,
   getEpisodeAirDate,
   getEpisodeTitleId,
@@ -46,6 +48,7 @@ export {
   getWatchedEpisodesForExport,
   getEpisodeIdsBySE,
 } from "./episodes";
+export type { NextUnwatchedEpisodeRow } from "./episodes";
 
 export {
   logWatch,

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -134,6 +134,7 @@ export const episodes = sqliteTable(
     ),
     index("idx_episodes_air_date").on(table.airDate),
     index("idx_episodes_title_id").on(table.titleId),
+    index("idx_episodes_title_air").on(table.titleId, table.airDate),
   ]
 );
 
@@ -300,6 +301,7 @@ export const watchedEpisodes = sqliteTable(
   (table) => [
     primaryKey({ columns: [table.episodeId, table.userId] }),
     index("idx_watched_episodes_user_id").on(table.userId),
+    index("idx_watched_user_episode").on(table.userId, table.episodeId),
   ]
 );
 

--- a/server/routes/up-next.ts
+++ b/server/routes/up-next.ts
@@ -1,9 +1,8 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import {
-  getUnwatchedEpisodes,
-  getNextUnwatchedEpisode,
-  getLastWatchedAtPerShow,
+  getUnwatchedEpisodesWithMeta,
+  getNextUnwatchedEpisodesForTitles,
   getDiscoveryFeed,
 } from "../db/repository";
 import { zValidator } from "../lib/validator";
@@ -45,7 +44,10 @@ app.get("/", zValidator("query", querySchema), async (c) => {
   log.debug("Building up-next queue", { userId: user.id, limit });
 
   // 1. Fetch all unwatched aired episodes for the user.
-  const unwatchedRows = await getUnwatchedEpisodes(user.id, timezone);
+  //    getUnwatchedEpisodesWithMeta calls getLastWatchedAtPerShow exactly once
+  //    and returns the map so we don't repeat that query.
+  const { episodes: unwatchedRows, lastWatchedByTitle: lastWatchedMap } =
+    await getUnwatchedEpisodesWithMeta(user.id, timezone);
 
   // Group by titleId so we can determine in-progress vs newly-aired.
   const byTitle = new Map<
@@ -78,16 +80,22 @@ app.get("/", zValidator("query", querySchema), async (c) => {
     }
   }
 
-  // 3. Sort in-progress by most recently watched.
-  const lastWatchedMap = await getLastWatchedAtPerShow(user.id);
-
+  // 3. Sort in-progress by most recently watched (map already obtained above).
   inProgressTitleIds.sort((a, b) => {
     const aDate = lastWatchedMap.get(a)?.getTime() ?? 0;
     const bDate = lastWatchedMap.get(b)?.getTime() ?? 0;
     return bDate - aDate;
   });
 
-  // 4. Build result items.
+  // 4. Batch-fetch next unwatched episode for every candidate title in one query,
+  //    eliminating the previous N+1 pattern (up to 2*limit sequential DB calls).
+  const candidateTitleIds = [
+    ...inProgressTitleIds.slice(0, limit),
+    ...newlyAiredTitleIds.slice(0, limit),
+  ];
+  const nextEpMap = await getNextUnwatchedEpisodesForTitles(user.id, candidateTitleIds, timezone);
+
+  // 5. Build result items.
   const items: UpNextItem[] = [];
   const seen = new Set<string>();
 
@@ -99,9 +107,7 @@ app.get("/", zValidator("query", querySchema), async (c) => {
 
     const entry = byTitle.get(titleId)!;
     const numericTitleId = parseInt(titleId, 10);
-
-    // Find the actual next episode to watch.
-    const nextEp = await getNextUnwatchedEpisode(user.id, titleId, timezone);
+    const nextEp = nextEpMap.get(titleId);
 
     items.push({
       kind: "in_progress",
@@ -125,8 +131,7 @@ app.get("/", zValidator("query", querySchema), async (c) => {
 
     const entry = byTitle.get(titleId)!;
     const numericTitleId = parseInt(titleId, 10);
-
-    const nextEp = await getNextUnwatchedEpisode(user.id, titleId, timezone);
+    const nextEp = nextEpMap.get(titleId);
 
     items.push({
       kind: "newly_aired",


### PR DESCRIPTION
## Summary

- `GET /api/up-next?limit=12` was ~550 ms despite returning tiny data; root causes were all query-level
- **Kill `getNextUnwatchedEpisode` N+1**: replaced up to `2*limit` sequential per-title DB queries with a single `ROW_NUMBER() OVER (PARTITION BY title_id ORDER BY ...)` window query (`getNextUnwatchedEpisodesForTitles`) — Map lookup replaces every per-iteration await
- **Deduplicate `getLastWatchedAtPerShow`**: was called twice per request (once inside `getUnwatchedEpisodes`, once again in the route); new `getUnwatchedEpisodesWithMeta` returns the map alongside episodes so the route reuses it
- **Two non-destructive indexes**: `idx_episodes_title_air ON episodes(title_id, air_date)` and `idx_watched_user_episode ON watched_episodes(user_id, episode_id)` — `CREATE INDEX` only, no table changes

## Test plan

- [ ] `bun run check` green
- [ ] `episodes.test.ts` golden test: `getNextUnwatchedEpisodesForTitles` output matches per-title `getNextUnwatchedEpisode` for a multi-show fixture
- [ ] `migrations.test.ts` green with new indexes
- [ ] `/api/up-next` response time noticeably lower in local dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)