### PR TITLE
perf(browse): kill duplicate /api/browse requests via useInfiniteQuery

### DIFF
--- a/frontend/src/components/CategoryBrowse.test.tsx
+++ b/frontend/src/components/CategoryBrowse.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, beforeEach, spyOn } from "bun:test";
-import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import { render, screen, cleanup, waitFor, act } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import * as api from "../api";
 import { AuthContext } from "../context/AuthContext";
@@ -86,11 +87,17 @@ const mockAuthValue = {
   refresh: async () => {},
 };
 
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
 function Wrapper({ children }: { children: ReactNode }) {
   return (
-    <MemoryRouter>
-      <AuthContext value={mockAuthValue as never}>{children}</AuthContext>
-    </MemoryRouter>
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter>
+        <AuthContext value={mockAuthValue as never}>{children}</AuthContext>
+      </MemoryRouter>
+    </QueryClientProvider>
   );
 }
 
@@ -143,10 +150,12 @@ describe("CategoryBrowse pagination", () => {
     });
 
     expect(intersectionCallback).not.toBeNull();
-    intersectionCallback!(
-      [{ isIntersecting: true } as IntersectionObserverEntry],
-      {} as IntersectionObserver,
-    );
+    act(() => {
+      intersectionCallback!(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
+    });
 
     // While page 2 is in flight the existing title must stay rendered —
     // i.e. the entire list must not be replaced with the centered loader.
@@ -158,6 +167,75 @@ describe("CategoryBrowse pagination", () => {
     resolvePage2?.();
     await waitFor(() => {
       expect(screen.getByText("Title 2")).toBeDefined();
+    });
+  });
+
+  it("fires exactly one request on initial mount", async () => {
+    const browseSpy = spyOn(api, "browseTitles");
+    browseSpy.mockImplementation(() =>
+      Promise.resolve(makeBrowseResponse(1, [makeSearchTitle(1)], 1)),
+    );
+    spies.push(browseSpy);
+
+    render(
+      <CategoryBrowse
+        category="popular"
+        type={[]}
+        onTypeChange={() => {}}
+        genre={[]}
+        onGenreChange={() => {}}
+        provider={[]}
+        onProviderChange={() => {}}
+        language={[]}
+        onLanguageChange={() => {}}
+        hideFilterBar
+      />,
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Title 1")).toBeDefined();
+    });
+
+    expect(browseSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire a duplicate request when parent re-renders with identical props", async () => {
+    const browseSpy = spyOn(api, "browseTitles");
+    browseSpy.mockImplementation(() =>
+      Promise.resolve(makeBrowseResponse(1, [makeSearchTitle(1)], 1)),
+    );
+    spies.push(browseSpy);
+
+    function Parent() {
+      return (
+        <CategoryBrowse
+          category="popular"
+          type={[]}
+          onTypeChange={() => {}}
+          genre={[]}
+          onGenreChange={() => {}}
+          provider={[]}
+          onProviderChange={() => {}}
+          language={[]}
+          onLanguageChange={() => {}}
+          hideFilterBar
+        />
+      );
+    }
+
+    const { rerender } = render(<Parent />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Title 1")).toBeDefined();
+    });
+
+    const callCountAfterMount = browseSpy.mock.calls.length;
+    rerender(<Parent />);
+
+    // Allow any async effects to settle
+    await waitFor(() => {
+      expect(browseSpy.mock.calls.length).toBe(callCountAfterMount);
     });
   });
 });

--- a/frontend/src/components/CategoryBrowse.tsx
+++ b/frontend/src/components/CategoryBrowse.tsx
@@ -1,11 +1,11 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import * as api from "../api";
 import type { Title } from "../types";
 import { normalizeSearchTitle } from "../types";
 import TitleList from "./TitleList";
 import FilterBar from "./FilterBar";
 import type { BrowseCategory } from "./CategoryBar";
-import { useAsyncError } from "../hooks/useAsyncError";
 
 export function filterBrowseTitles(
   titles: Title[],
@@ -103,74 +103,54 @@ export default function CategoryBrowse({
   onResultsCount,
   onlyMine,
 }: Props) {
-  const [titles, setTitles] = useState<Title[]>([]);
-  const [loadingMore, setLoadingMore] = useState(false);
-  const [page, setPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(1);
-  const { run, error, pending: loading } = useAsyncError();
-  const [availableGenres, setAvailableGenres] = useState<string[]>([]);
-
-  const [availableProviders, setAvailableProviders] = useState<{ id: number; name: string; iconUrl: string }[]>([]);
-  const [availableLanguages, setAvailableLanguages] = useState<{ code: string; name: string }[]>([]);
-  const [regionProviderIds, setRegionProviderIds] = useState<number[]>([]);
-  const [priorityLanguageCodes, setPriorityLanguageCodes] = useState<string[]>([]);
-
-  const fetchTitles = useCallback((pageNum: number, append: boolean) => {
-    return run(async () => {
-      if (append) {
-        setLoadingMore(true);
-      }
-      try {
-        const yearMinNum = yearMin ? parseInt(yearMin, 10) : undefined;
-        const yearMaxNum = yearMax ? parseInt(yearMax, 10) : undefined;
-        const minRatingNum = minRating ? parseFloat(minRating) : undefined;
-        const res = await api.browseTitles({
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery({
+    queryKey: ["browse", category, type, genre, provider, language, yearMin, yearMax, minRating, onlyMine],
+    queryFn: ({ pageParam, signal }) =>
+      api.browseTitles(
+        {
           category,
           type: type.length ? type.join(",") : undefined,
-          page: pageNum,
+          page: pageParam as number,
           genre: genre.length ? genre.join(",") : undefined,
           provider: provider.length ? provider.join(",") : undefined,
           language: language.length ? language.join(",") : undefined,
-          yearMin: yearMinNum != null && Number.isFinite(yearMinNum) ? yearMinNum : undefined,
-          yearMax: yearMaxNum != null && Number.isFinite(yearMaxNum) ? yearMaxNum : undefined,
-          minRating: minRatingNum != null && Number.isFinite(minRatingNum) ? minRatingNum : undefined,
+          yearMin: yearMin ? parseInt(yearMin, 10) : undefined,
+          yearMax: yearMax ? parseInt(yearMax, 10) : undefined,
+          minRating: minRating ? parseFloat(minRating) : undefined,
           onlyMine: onlyMine || undefined,
-        });
-        const normalized = res.titles.map(normalizeSearchTitle);
-        if (append) {
-          setTitles((prev) => [...prev, ...normalized]);
-        } else {
-          setTitles(normalized);
-        }
-        if (res.availableGenres) {
-          setAvailableGenres(res.availableGenres);
-        }
-        if (res.availableProviders) {
-          setAvailableProviders(res.availableProviders);
-        }
-        if (res.availableLanguages) {
-          setAvailableLanguages(res.availableLanguages);
-        }
-        if (res.regionProviderIds) {
-          setRegionProviderIds(res.regionProviderIds);
-        }
-        if (res.priorityLanguageCodes) {
-          setPriorityLanguageCodes(res.priorityLanguageCodes);
-        }
-        setTotalPages(res.totalPages);
-        if (!append) {
-          onResultsCount?.(res.totalResults);
-        }
-        setPage(pageNum);
-      } finally {
-        setLoadingMore(false);
-      }
-    });
-  }, [run, category, type, genre, provider, language, yearMin, yearMax, minRating, onlyMine, onResultsCount]);
+        },
+        signal,
+      ),
+    initialPageParam: 1,
+    getNextPageParam: (last: { page: number; totalPages: number }) =>
+      last.page < last.totalPages ? last.page + 1 : undefined,
+    staleTime: 60_000,
+  });
 
+  const titles = useMemo(
+    () => data?.pages.flatMap((p) => p.titles.map(normalizeSearchTitle)) ?? [],
+    [data],
+  );
+
+  const lastPage = data?.pages[data.pages.length - 1];
+  const totalPages = lastPage?.totalPages ?? 1;
+  const page = lastPage?.page ?? 1;
+
+  // Report total results count on first page load
   useEffect(() => {
-    fetchTitles(1, false);
-  }, [fetchTitles]);
+    const firstPage = data?.pages[0];
+    if (firstPage) {
+      onResultsCount?.(firstPage.totalResults);
+    }
+  }, [data?.pages, onResultsCount]);
 
   const sentinelRef = useRef<HTMLDivElement>(null);
 
@@ -180,8 +160,8 @@ export default function CategoryBrowse({
 
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries[0].isIntersecting && page < totalPages && !loadingMore) {
-          fetchTitles(page + 1, true);
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          void fetchNextPage();
         }
       },
       { rootMargin: "200px" }
@@ -189,7 +169,7 @@ export default function CategoryBrowse({
 
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [page, totalPages, loadingMore, fetchTitles]);
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   // Stabilize the titles array passed into TitleList so React.memo can short-
   // circuit re-renders when neither `titles` nor `hideTracked` changed.
@@ -197,6 +177,8 @@ export default function CategoryBrowse({
     () => (hideTracked ? titles.filter((t) => !t.is_tracked) : titles),
     [titles, hideTracked]
   );
+
+  const errorMessage = isError && error instanceof Error ? error.message : isError ? "Failed to load titles" : null;
 
   return (
     <div className="space-y-4">
@@ -207,28 +189,28 @@ export default function CategoryBrowse({
           showDaysFilter={false}
           genre={genre}
           onGenreChange={onGenreChange}
-          genres={availableGenres}
+          genres={[]}
           provider={provider}
           onProviderChange={onProviderChange}
-          providers={availableProviders}
-          regionProviderIds={regionProviderIds}
+          providers={[]}
+          regionProviderIds={[]}
           language={language}
           onLanguageChange={onLanguageChange}
-          languages={availableLanguages}
-          priorityLanguageCodes={priorityLanguageCodes}
+          languages={[]}
+          priorityLanguageCodes={[]}
           onClearFilters={onClearFilters}
           hideTracked={hideTracked}
           onHideTrackedChange={onHideTrackedChange}
         />
       )}
 
-      {error && (
+      {errorMessage && (
         <div className="bg-red-900/50 border border-red-800 text-red-200 px-4 py-2 rounded-lg text-sm">
-          {error}
+          {errorMessage}
         </div>
       )}
 
-      {loading && titles.length === 0 ? (
+      {isLoading && titles.length === 0 ? (
         <div className="text-center py-12 text-zinc-500">Loading...</div>
       ) : (
         <>
@@ -238,24 +220,24 @@ export default function CategoryBrowse({
             showProviderBadge={showProviderBadge}
             showRating={showRating}
           />
-          {error && (
+          {errorMessage && (
             <div className="text-center py-4 text-red-400">
-              <p>{error}</p>
+              <p>{errorMessage}</p>
               <button
-                onClick={() => fetchTitles(page + 1, true)}
+                onClick={() => void fetchNextPage()}
                 className="mt-2 text-sm underline hover:text-red-300"
               >
                 Retry
               </button>
             </div>
           )}
-          {!error && page < totalPages && (
+          {!errorMessage && page < totalPages && (
             <div ref={sentinelRef} className="text-center py-4">
-              {loadingMore ? (
+              {isFetchingNextPage ? (
                 <div className="text-zinc-500 text-sm">Loading...</div>
               ) : (
                 <button
-                  onClick={() => fetchTitles(page + 1, true)}
+                  onClick={() => void fetchNextPage()}
                   className="bg-white/[0.05] border border-white/[0.08] text-zinc-300 px-6 py-2.5 rounded-xl text-[13px] font-semibold sm:hidden"
                 >
                   Load more

--- a/frontend/src/components/SuggestedForYouRow.test.tsx
+++ b/frontend/src/components/SuggestedForYouRow.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, mock, afterEach } from "bun:test";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import type { SuggestionsAggregateResponse, SearchTitle } from "../types";
+import "../i18n";
+
+function makeSearchTitle(id: string): SearchTitle {
+  return {
+    id,
+    objectType: "MOVIE" as const,
+    title: `Title ${id}`,
+    originalTitle: null,
+    releaseYear: 2024,
+    releaseDate: null,
+    runtimeMinutes: null,
+    shortDescription: null,
+    genres: [],
+    imdbId: null,
+    tmdbId: "1",
+    posterUrl: null,
+    ageCertification: null,
+    originalLanguage: "en",
+    tmdbUrl: null,
+    offers: [],
+    scores: { imdbScore: null, imdbVotes: null, tmdbScore: 7.5 },
+  };
+}
+
+const mockGetSuggestionsAggregate = mock<() => Promise<SuggestionsAggregateResponse>>(() =>
+  Promise.resolve({ flat: [], groups: [] }),
+);
+
+mock.module("../api", () => ({
+  getSuggestionsAggregate: mockGetSuggestionsAggregate,
+}));
+
+const { default: SuggestedForYouRow } = await import("./SuggestedForYouRow");
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  mockGetSuggestionsAggregate.mockReset();
+  mockGetSuggestionsAggregate.mockImplementation(() =>
+    Promise.resolve({ flat: [], groups: [] }),
+  );
+});
+
+describe("SuggestedForYouRow", () => {
+  it("calls getSuggestionsAggregate exactly once on mount", async () => {
+    mockGetSuggestionsAggregate.mockImplementation(() =>
+      Promise.resolve({ flat: [makeSearchTitle("s1"), makeSearchTitle("s2")], groups: [] }),
+    );
+
+    render(<SuggestedForYouRow />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Title s1")).toBeDefined();
+    });
+
+    expect(mockGetSuggestionsAggregate).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-call getSuggestionsAggregate on parent re-render", async () => {
+    mockGetSuggestionsAggregate.mockImplementation(() =>
+      Promise.resolve({ flat: [makeSearchTitle("s1")], groups: [] }),
+    );
+
+    function Parent() {
+      return <SuggestedForYouRow />;
+    }
+
+    const { rerender } = render(<Parent />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Title s1")).toBeDefined();
+    });
+
+    const callsAfterMount = mockGetSuggestionsAggregate.mock.calls.length;
+    rerender(<Parent />);
+
+    await waitFor(() => {
+      expect(mockGetSuggestionsAggregate.mock.calls.length).toBe(callsAfterMount);
+    });
+  });
+
+  it("renders nothing when data is empty", async () => {
+    mockGetSuggestionsAggregate.mockImplementation(() =>
+      Promise.resolve({ flat: [], groups: [] }),
+    );
+
+    const { container } = render(<SuggestedForYouRow />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(mockGetSuggestionsAggregate).toHaveBeenCalledTimes(1);
+    });
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/src/components/SuggestedForYouRow.tsx
+++ b/frontend/src/components/SuggestedForYouRow.tsx
@@ -1,30 +1,21 @@
-import { useEffect, useState } from "react";
 import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
+import { useQuery } from "@tanstack/react-query";
 import * as api from "../api";
-import type { SearchTitle } from "../types";
 import FullBleedCarousel from "./FullBleedCarousel";
 import { Kicker } from "./design";
 
 export default function SuggestedForYouRow() {
   const { t } = useTranslation();
-  const [titles, setTitles] = useState<SearchTitle[]>([]);
-  const [loaded, setLoaded] = useState(false);
 
-  useEffect(() => {
-    const controller = new AbortController();
-    api.getSuggestionsAggregate({ limit: 20 }, controller.signal)
-      .then((res) => {
-        if (!controller.signal.aborted) setTitles(res.flat);
-      })
-      .catch(() => {})
-      .finally(() => {
-        if (!controller.signal.aborted) setLoaded(true);
-      });
-    return () => controller.abort();
-  }, []);
+  const { data: aggregate, isLoading } = useQuery({
+    queryKey: ["suggestions", 60],
+    queryFn: ({ signal }) => api.getSuggestionsAggregate({ limit: 60 }, signal),
+    staleTime: 5 * 60_000,
+  });
+  const titles = aggregate?.flat.slice(0, 20) ?? [];
 
-  if (!loaded || titles.length === 0) return null;
+  if (isLoading || titles.length === 0) return null;
 
   return (
     <section>

--- a/frontend/src/lib/queryClient.ts
+++ b/frontend/src/lib/queryClient.ts
@@ -4,6 +4,7 @@ export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 30_000,
+      gcTime: 5 * 60_000,
       retry: 1,
       retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 10_000),
     },

--- a/frontend/src/pages/BrowsePage.test.tsx
+++ b/frontend/src/pages/BrowsePage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, mock, afterEach } from "bun:test";
-import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup, act, waitFor } from "@testing-library/react";
 import { MemoryRouter, useSearchParams } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useEffect } from "react";
@@ -11,14 +11,16 @@ function newTestClient() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } });
 }
 
-// Mutable so individual tests can override subscriptions without re-mocking
+// Mutable so individual tests can override auth state without re-mocking
 let mockSubscriptions: { providerIds: number[]; onlyMine: boolean } | null = null;
+let mockUser: { id: string; username: string; display_name: null; auth_provider: string; is_admin: boolean } | null = null;
+let mockAuthLoading = false;
 
 mock.module("../context/AuthContext", () => ({
   useAuth: () => ({
-    user: null,
+    user: mockUser,
     providers: null,
-    loading: false,
+    loading: mockAuthLoading,
     subscriptions: mockSubscriptions,
     refreshSubscriptions: mock(() => Promise.resolve()),
     login: mock(() => Promise.resolve()),
@@ -50,7 +52,9 @@ mock.module("../components/SearchBar", () => ({
   ),
 }));
 mock.module("../components/NewReleases", () => ({ default: () => null }));
-mock.module("../components/CategoryBrowse", () => ({ default: () => null }));
+mock.module("../components/CategoryBrowse", () => ({
+  default: () => <div data-testid="category-browse" />,
+}));
 
 const { default: BrowsePage } = await import("./BrowsePage");
 
@@ -68,6 +72,8 @@ function makeWrapper(initialPath: string) {
 afterEach(() => {
   cleanup();
   mockSubscriptions = null;
+  mockUser = null;
+  mockAuthLoading = false;
 });
 
 describe("BrowsePage active filter chips", () => {
@@ -198,5 +204,55 @@ describe("BrowsePage subscription preselect", () => {
     });
 
     expect(captured?.get("provider")).toBeNull();
+  });
+});
+
+describe("BrowsePage CategoryBrowse mount gate", () => {
+  it("renders CategoryBrowse immediately when user is not authenticated", async () => {
+    mockUser = null;
+    mockSubscriptions = null;
+    mockAuthLoading = false;
+
+    await act(async () => {
+      render(<BrowsePage />, {
+        wrapper: makeWrapper("/browse"),
+      });
+    });
+
+    // With no user, subscriptionsReady flips true immediately
+    await waitFor(() => {
+      expect(screen.getByTestId("category-browse")).toBeDefined();
+    });
+  });
+
+  it("does not render CategoryBrowse while authenticated user subscriptions are still loading", async () => {
+    mockUser = { id: "u1", username: "alice", display_name: null, auth_provider: "local", is_admin: false };
+    mockSubscriptions = null; // not yet loaded
+    mockAuthLoading = false;
+
+    await act(async () => {
+      render(<BrowsePage />, {
+        wrapper: makeWrapper("/browse"),
+      });
+    });
+
+    // subscriptions is null + user is set → subscriptionsReady stays false
+    expect(screen.queryByTestId("category-browse")).toBeNull();
+  });
+
+  it("renders CategoryBrowse once subscriptions settle for authenticated user", async () => {
+    mockUser = { id: "u1", username: "alice", display_name: null, auth_provider: "local", is_admin: false };
+    mockSubscriptions = { providerIds: [8], onlyMine: false };
+    mockAuthLoading = false;
+
+    await act(async () => {
+      render(<BrowsePage />, {
+        wrapper: makeWrapper("/browse"),
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("category-browse")).toBeDefined();
+    });
   });
 });

--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, useReducer } from "react";
+import { useCallback, useEffect, useRef, useState, useReducer, useMemo } from "react";
 import { useSearchParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
@@ -62,7 +62,7 @@ function useQueryParamArray(
   key: string
 ): [string[], (values: string[]) => void] {
   const raw = searchParams.get(key) || "";
-  const value = raw ? raw.split(",") : [];
+  const value = useMemo(() => (raw ? raw.split(",") : []), [raw]);
   const setValue = useCallback(
     (newValues: string[]) => {
       setSearchParams(
@@ -124,7 +124,13 @@ export default function BrowsePage() {
   const { run: runAsync, error: searchError, reset: resetSearchError } = useAsyncError();
   const { t } = useTranslation();
   const isMobile = useIsMobile();
-  const { subscriptions } = useAuth();
+  const { user, subscriptions, loading: authLoading } = useAuth();
+  // subscriptionsReady: true once we can safely mount CategoryBrowse without a
+  // provider-race double-fire. For unauthenticated visits (no user) auth loading
+  // finishing is sufficient. For authenticated visits we wait until subscriptions
+  // is non-null (populated).
+  const subscriptionsReady =
+    !authLoading && (!user || subscriptions !== null);
   useGridNavigation();
 
   // ── Browse filter data (shared cache, loaded once across pages) ──────────────
@@ -644,7 +650,7 @@ export default function BrowsePage() {
               onResultsCount={setResultsCount}
               onlyMine={onlyMine}
             />
-          ) : (
+          ) : subscriptionsReady ? (
             <CategoryBrowse
               key={category}
               category={category}
@@ -668,7 +674,7 @@ export default function BrowsePage() {
               onResultsCount={setResultsCount}
               onlyMine={onlyMine}
             />
-          )}
+          ) : null}
         </div>
       )}
     </div>

--- a/frontend/src/pages/DiscoveryPage.tsx
+++ b/frontend/src/pages/DiscoveryPage.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from "react-i18next";
 import * as api from "../api";
 import type {
   Recommendation,
-  SuggestionsAggregateResponse,
   SuggestionsGroup,
   SuggestionSeedReason,
   SearchTitle,
@@ -532,7 +531,6 @@ function RecommendationCard({
 export default function DiscoveryPage() {
   const { t } = useTranslation();
   const qc = useQueryClient();
-  const [aggregate, setAggregate] = useState<SuggestionsAggregateResponse | null>(null);
   const [tab, setTab] = useState<"foryou" | "activity">("foryou");
   const [trackedSet, setTrackedSet] = useState<Set<string>>(() => new Set());
   const [dismissedSet, setDismissedSet] = useState<Set<string>>(() => new Set());
@@ -549,13 +547,11 @@ export default function DiscoveryPage() {
   });
   const unreadCount = countData?.count ?? 0;
 
-  useEffect(() => {
-    const controller = new AbortController();
-    api.getSuggestionsAggregate({ limit: 60 }, controller.signal)
-      .then((res) => { if (!controller.signal.aborted) setAggregate(res); })
-      .catch(() => {});
-    return () => controller.abort();
-  }, []);
+  const { data: aggregate } = useQuery({
+    queryKey: ["suggestions", 60],
+    queryFn: ({ signal }) => api.getSuggestionsAggregate({ limit: 60 }, signal),
+    staleTime: 5 * 60_000,
+  });
 
   // Group received recommendations by title ID for hero + friend overlays
   const recsByTitle = useMemo(() => {


### PR DESCRIPTION
## Summary

On the `/browse` page the same `GET /api/browse?category=popular&page=1&provider=...` was firing 6+ times per load. Three root causes fixed:

- **`useQueryParamArray` identity churn**: the helper did `raw.split(",")` on every render → new array identity → churned the `fetchTitles` useCallback dep → re-fired its useEffect. Fixed with `useMemo([raw])`.
- **Provider preselect race**: first render fired with no provider (subscriptions hadn't loaded), then async preselect rewrote the URL → second identical fetch. Fixed by gating `<CategoryBrowse>` mount until `subscriptions` settles.
- **No deduplication**: `CategoryBrowse` used raw `useState`/`useCallback`/`useEffect`, not TanStack Query — so even identical requests weren't deduplicated. **Migrated to `useInfiniteQuery`** (natural fit for infinite scroll) with a stable query key covering all filter params; `staleTime: 60s`.

Also migrated `SuggestedForYouRow` and `DiscoveryPage` suggestions from raw `useEffect` to `useQuery(["suggestions", 60])` with `staleTime: 5min` — they now share a single cache entry, so navigating between home and discovery costs zero network requests within the TTL.

**Must merge before** `perf(browse): slim /api/browse response` (PR #833) — that PR removes catalogue fields from the API response; this PR removes the consumers of those fields.

## Test plan

- [ ] Open `/browse` in DevTools Network — confirm exactly **one** `browse?...page=1` request (with provider), no duplicates on filter-unrelated re-renders
- [ ] Navigate home → discovery → home — `/api/suggestions` fires once total (not once per mount)
- [ ] Infinite scroll still works (sentinel IntersectionObserver → page 2 request)
- [ ] `bun run check` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)