### PR TITLE
refactor(home): unify movie carousels on FullBleedCarousel

### DIFF
--- a/frontend/src/components/MovieRow.tsx
+++ b/frontend/src/components/MovieRow.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { CheckCircle } from "lucide-react";
 import * as api from "../api";
-import ScrollableRow from "./ScrollableRow";
+import FullBleedCarousel from "./FullBleedCarousel";
 import { posterUrl as buildPosterUrl } from "../lib/tmdb-images";
 import { MediaCard } from "./MediaCard";
 
@@ -81,9 +81,9 @@ export default function MovieRow({ variant, movies }: MovieRowProps) {
   }
 
   return (
-    <ScrollableRow className="gap-3 px-4 pb-2">
+    <FullBleedCarousel>
       {visible.map((movie) => (
-        <div key={movie.id} className="w-52 flex-shrink-0">
+        <div key={movie.id} className="w-52 flex-shrink-0" style={{ scrollSnapAlign: "start" }}>
           <MediaCard
             aspect="poster"
             to={`/title/${movie.id}`}
@@ -118,6 +118,6 @@ export default function MovieRow({ variant, movies }: MovieRowProps) {
           />
         </div>
       ))}
-    </ScrollableRow>
+    </FullBleedCarousel>
   );
 }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -736,7 +736,7 @@ export default function HomePage() {
       case "movies_to_watch":
         return movieData.to_watch.length > 0 ? (
           <section key="movies_to_watch">
-            <div className="flex items-baseline justify-between mb-4 px-4">
+            <div className="flex items-baseline justify-between mb-4">
               <div>
                 <Kicker>Movies</Kicker>
                 <h2 className="text-xl font-bold tracking-[-0.01em]">Movies to Watch</h2>
@@ -750,7 +750,7 @@ export default function HomePage() {
       case "upcoming_movies":
         return movieData.upcoming.length > 0 ? (
           <section key="upcoming_movies">
-            <div className="flex items-baseline justify-between mb-4 px-4">
+            <div className="flex items-baseline justify-between mb-4">
               <div>
                 <Kicker>Movies</Kicker>
                 <h2 className="text-xl font-bold tracking-[-0.01em]">Upcoming Movies</h2>


### PR DESCRIPTION
## Summary

- The "Movies to Watch" and "Upcoming Movies" rows on the home page were the only carousels still using `ScrollableRow` (no fadeout edges, in-bounds arrows). Every other home-page carousel — Unwatched, Up Next, Today, Upcoming, Airing Soon, Recommendations, Friends Loved, Suggested For You — already uses `FullBleedCarousel`.
- Swap `MovieRow` over to `FullBleedCarousel` so both movie rows now span the full viewport with gradient fade edges that match the rest of the page.
- Drop the extra `px-4` from the two movie section headers in `HomePage.tsx` so they sit flush with the other section headers now that the carousel below is full-bleed.

`ScrollableRow` is kept — it's still used by `Cast` on the title-detail page and by skeleton components.

## Test plan

- [x] `bun test src/components/MovieRow.test.tsx` (run from `frontend/`) — 8/8 pass
- [x] `bun run check:fast` — server tsc + e2e tsc + frontend tsc + ESLint all green
- [ ] Manually load the home page and confirm:
  - [ ] "Movies to Watch" / "Upcoming Movies" rows span full viewport with left/right gradient fades
  - [ ] Hover arrows appear outside the body bounds (matching the Unwatched row)
  - [ ] Horizontal scroll still snaps to cards; "Mark watched" still optimistically removes the movie
  - [ ] Title-detail page Cast row is unchanged (still uses `ScrollableRow`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAAxCcACGoqSZcrrkLmc5A)_