### PR TITLE
refactor(home): use MediaCard in Suggested for You carousel

### DIFF
--- a/frontend/src/components/SuggestedForYouRow.tsx
+++ b/frontend/src/components/SuggestedForYouRow.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
 import * as api from "../api";
 import FullBleedCarousel from "./FullBleedCarousel";
+import { MediaCard } from "./MediaCard";
 import { Kicker } from "./design";
 
 export default function SuggestedForYouRow() {
@@ -30,32 +31,21 @@ export default function SuggestedForYouRow() {
       </div>
       <FullBleedCarousel>
         {titles.map((title) => (
-          <Link
+          <div
             key={title.id}
-            to={`/title/${title.id}`}
-            className="w-32 flex-shrink-0 group"
+            className="w-52 flex-shrink-0"
             style={{ scrollSnapAlign: "start" }}
           >
-            <div className="relative aspect-[2/3] rounded-lg overflow-hidden bg-zinc-800">
-              {title.posterUrl ? (
-                <img
-                  src={title.posterUrl}
-                  alt={title.title}
-                  className="w-full h-full object-cover group-hover:scale-105 transition-transform"
-                  loading="lazy"
-                  width={128}
-                  height={192}
-                />
-              ) : (
-                <div className="w-full h-full flex items-center justify-center text-zinc-600 text-xs">
-                  N/A
-                </div>
-              )}
-            </div>
-            <p className="text-sm text-white mt-1.5 line-clamp-2 group-hover:text-amber-400 transition-colors">
-              {title.title}
-            </p>
-          </Link>
+            <MediaCard
+              aspect="poster"
+              hoverZoom
+              to={`/title/${title.id}`}
+              imageUrl={title.posterUrl}
+              imageAlt={title.title}
+              title={title.title}
+              titleClamp={2}
+            />
+          </div>
         ))}
       </FullBleedCarousel>
     </section>


### PR DESCRIPTION
## Summary
- Standardize the "Suggested for You" carousel on `MediaCard` so it visually matches "Recommended for You" and "Movies to Watch" (w-52 with shadcn `Card` chrome, two-line clamped title, hover zoom) instead of the smaller w-32 inline card.
- No data-shape changes: `SearchTitle.posterUrl` is already a fully-qualified TMDB URL (built server-side in `server/tmdb/parser.ts:72`), so it can be passed directly to `MediaCard`'s `imageUrl` prop.

## Test plan
- [x] `bun run check:fast` (server tsc + e2e tsc + frontend tsc + ESLint) — clean
- [x] `cd frontend && bun test src/components/SuggestedForYouRow.test.tsx src/components/MediaCard.test.tsx` — 23/23 pass
- [ ] Visually confirm on the home page that the "Suggested for You" row matches the "Recommended for You" row (card chrome, sizing, hover state)

https://claude.ai/code/session_019m6vrLSCbquozqRAMVxShG

---
_Generated by [Claude Code](https://claude.ai/code/session_019m6vrLSCbquozqRAMVxShG)_