### PR TITLE
Production hardening from monitoring sweeps (#817, #830, #838, #839, #843)

### DIFF
--- a/server/jobs/durable-object.test.ts
+++ b/server/jobs/durable-object.test.ts
@@ -334,7 +334,7 @@ describe("JobQueueDO", () => {
     const errorCalls = consoleErrorSpy.mock.calls
       .map((args) => { try { return JSON.parse(args[0] as string) as Record<string, unknown>; } catch { return null; } })
       .filter((obj): obj is Record<string, unknown> => obj !== null && obj.level === "error");
-    const permanentLog = errorCalls.find((obj) => obj.msg === "Job failed permanently");
+    const permanentLog = errorCalls.find((obj) => typeof obj.msg === "string" && obj.msg.includes("failed permanently"));
     expect(permanentLog).toBeDefined();
     expect(permanentLog!.data).toBe('{"marker":"p801"}');
     expect(typeof permanentLog!.runAt).toBe("string");

--- a/server/jobs/durable-object.ts
+++ b/server/jobs/durable-object.ts
@@ -354,7 +354,7 @@ export class JobQueueDO {
           extra: { attempts: newAttempts, maxAttempts: job.max_attempts, lastError: message, data: job.data, runAt: job.run_at },
           fingerprint: ["job-permanent-failure", job.name],
         });
-        log.error("Job failed permanently", {
+        log.error(`Job ${job.name} failed permanently (id=${job.id}, attempts=${newAttempts}/${job.max_attempts})`, {
           name: job.name,
           jobId: job.id,
           attempts: newAttempts,

--- a/server/jobs/processor.test.ts
+++ b/server/jobs/processor.test.ts
@@ -180,6 +180,42 @@ describe("processPendingJobs", () => {
     expect(allJobs[0].completedAt).not.toBeNull();
   });
 
+  it("permanent failure log message embeds job name, id, and attempt count (#838)", async () => {
+    mockFetchNewReleases.mockRejectedValueOnce(new Error("TMDB 503"));
+    const captureSpy = spyOn(Sentry, "captureException");
+    const consoleSpy = spyOn(console, "error");
+
+    const db = getDb();
+    await db.insert(jobs).values({
+      name: "sync-titles",
+      status: "pending",
+      attempts: 2,
+      maxAttempts: 3,
+      runAt: new Date().toISOString(),
+    });
+    const inserted = await getAllJobs();
+    const jobId = inserted[0].id;
+
+    await processPendingJobs();
+
+    const permanentLogs = consoleSpy.mock.calls
+      .map(([line]) => (typeof line === "string" ? line : ""))
+      .filter((line) => line.includes("failed permanently"));
+
+    expect(permanentLogs.length).toBeGreaterThan(0);
+    const entry = JSON.parse(permanentLogs[0]);
+    expect(entry.msg).toContain("sync-titles failed permanently");
+    expect(entry.msg).toContain(`id=${jobId}`);
+    expect(entry.msg).toContain("attempts=3/3");
+    expect(captureSpy).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ fingerprint: ["job-permanent-failure", "sync-titles"] }),
+    );
+
+    consoleSpy.mockRestore();
+    captureSpy.mockRestore();
+  });
+
   it("marks unknown job types as failed", async () => {
     await insertJob("unknown-job-type");
     await processPendingJobs();
@@ -347,7 +383,7 @@ describe("processor error logging includes stack traces", () => {
       .map((args) => { try { return JSON.parse(args[0] as string) as Record<string, unknown>; } catch { return null; } })
       .filter((obj): obj is Record<string, unknown> => obj !== null && obj.level === "error");
 
-    const permanentLog = errorCalls.find((obj) => obj.msg === "Job failed permanently");
+    const permanentLog = errorCalls.find((obj) => typeof obj.msg === "string" && obj.msg.includes("failed permanently"));
     expect(permanentLog).toBeDefined();
     // stack must be a top-level string field (not nested inside err)
     expect(typeof permanentLog!.stack).toBe("string");
@@ -450,7 +486,7 @@ describe("processor Sentry capture on permanent failure", () => {
     const errorCalls = consoleErrorSpy.mock.calls
       .map((args) => { try { return JSON.parse(args[0] as string) as Record<string, unknown>; } catch { return null; } })
       .filter((obj): obj is Record<string, unknown> => obj !== null && obj.level === "error");
-    const permanentLog = errorCalls.find((obj) => obj.msg === "Job failed permanently");
+    const permanentLog = errorCalls.find((obj) => typeof obj.msg === "string" && obj.msg.includes("failed permanently"));
     expect(permanentLog).toBeDefined();
     expect(permanentLog!.data).toBe('{"marker":"p801"}');
     expect(typeof permanentLog!.runAt).toBe("string");

--- a/server/jobs/processor.ts
+++ b/server/jobs/processor.ts
@@ -542,7 +542,7 @@ export async function processPendingJobs(): Promise<number> {
           extra: { attempts: newAttempts, maxAttempts: job.maxAttempts, lastError: message, data: job.data, runAt: job.runAt },
           fingerprint: ["job-permanent-failure", job.name],
         });
-        log.error("Job failed permanently", {
+        log.error(`Job ${job.name} failed permanently (id=${job.id}, attempts=${newAttempts}/${job.maxAttempts})`, {
           name: job.name,
           jobId: job.id,
           attempts: newAttempts,

--- a/server/logger.test.ts
+++ b/server/logger.test.ts
@@ -1,9 +1,60 @@
-import { describe, it, expect } from "bun:test";
-import { getRecentLogs, type LogLevel } from "./logger";
+import { describe, it, expect, spyOn } from "bun:test";
+import { Hono } from "hono";
+import { getRecentLogs, requestLogger, type LogLevel } from "./logger";
 
 // The ring buffer is disabled in test environment (NODE_ENV=test),
 // so getRecentLogs always returns []. These tests verify the function
 // signature and that it never throws.
+
+describe("requestLogger — slow request warning", () => {
+  it("emits a warn log when handler duration exceeds 5000ms", async () => {
+    const consoleSpy = spyOn(console, "error");
+    const nowSpy = spyOn(performance, "now")
+      .mockReturnValueOnce(0)     // start
+      .mockReturnValueOnce(6000); // end → 6000ms elapsed
+
+    const app = new Hono();
+    app.use("*", requestLogger());
+    app.get("/slow-path", (c) => c.json({ ok: true }));
+
+    await app.request("/slow-path");
+
+    const slowLogs = consoleSpy.mock.calls
+      .map(([line]) => (typeof line === "string" ? line : ""))
+      .filter((line) => line.includes("Slow request"));
+
+    expect(slowLogs.length).toBeGreaterThan(0);
+    const entry = JSON.parse(slowLogs[0]);
+    expect(entry.msg).toContain("GET /slow-path");
+    expect(entry.msg).toContain("6000ms");
+    expect(entry.level).toBe("warn");
+
+    nowSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+
+  it("does not emit a slow-request warn for a fast response", async () => {
+    const consoleSpy = spyOn(console, "error");
+    const nowSpy = spyOn(performance, "now")
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(200); // 200ms — below threshold
+
+    const app = new Hono();
+    app.use("*", requestLogger());
+    app.get("/fast-path", (c) => c.json({ ok: true }));
+
+    await app.request("/fast-path");
+
+    const slowLogs = consoleSpy.mock.calls
+      .map(([line]) => (typeof line === "string" ? line : ""))
+      .filter((line) => line.includes("Slow request"));
+
+    expect(slowLogs.length).toBe(0);
+
+    nowSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+});
 
 describe("getRecentLogs", () => {
   it("returns an array (empty when buffer is disabled in test env)", () => {

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -155,6 +155,8 @@ export function normalizeRoutePath(path: string): string {
     .replace(/\/\d+(?=\/|$)/g, "/:id");
 }
 
+const SLOW_REQUEST_THRESHOLD_MS = 5000;
+
 export function requestLogger(): MiddlewareHandler {
   const log = logger.child({ module: "http" });
   return async (c, next) => {
@@ -164,6 +166,12 @@ export function requestLogger(): MiddlewareHandler {
     const status = c.res.status;
     const method = c.req.method;
     const route = normalizeRoutePath(c.req.path);
+
+    if (durationMs > SLOW_REQUEST_THRESHOLD_MS) {
+      log.warn(`Slow request: ${method} ${c.req.path} (${Math.round(durationMs)}ms)`, {
+        status, duration: Math.round(durationMs), route, method,
+      });
+    }
 
     // 5xx → error; 401/403 auth failures → info (expected from bots/expired sessions);
     // other 4xx → warn; 2xx/3xx → info

--- a/server/routes/user-settings.test.ts
+++ b/server/routes/user-settings.test.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { describe, it, expect, beforeEach, afterAll, spyOn } from "bun:test";
 import { Hono } from "hono";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
 import { createUser, upsertTitles, setHomepageLayout } from "../db/repository";
+import * as repository from "../db/repository";
 import { makeParsedTitle, makeParsedOffer } from "../test-utils/fixtures";
 import userSettingsApp, { DEFAULT_HOMEPAGE_LAYOUT, HOMEPAGE_SECTION_IDS } from "./user-settings";
 import type { AppEnv } from "../types";
+import Sentry from "../sentry";
 
 let userId: string;
 
@@ -32,6 +34,21 @@ afterAll(() => {
 });
 
 describe("GET /user/settings/homepage-layout", () => {
+  it("returns 500 with a structured error and captures via Sentry when DB query throws", async () => {
+    const app = makeAuthedApp();
+    const dbSpy = spyOn(repository, "getHomepageLayout").mockRejectedValueOnce(new Error("D1 connection lost"));
+    const captureSpy = spyOn(Sentry, "captureException");
+
+    const res = await app.request("/user/settings/homepage-layout");
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Failed to load homepage layout");
+    expect(captureSpy).toHaveBeenCalled();
+
+    dbSpy.mockRestore();
+    captureSpy.mockRestore();
+  });
+
   it("returns default layout for new user", async () => {
     const app = makeAuthedApp();
     const res = await app.request("/user/settings/homepage-layout");

--- a/server/routes/user-settings.ts
+++ b/server/routes/user-settings.ts
@@ -2,8 +2,12 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { getHomepageLayout, setHomepageLayout, getUserDepartureSettings, updateUserDepartureSettings, getCrowdedWeekSettings, updateCrowdedWeekSettings, getAppearanceSettings, updateAppearanceSettings, getSubscribedProviderIds, setSubscribedProviderIds, getOnlyMineFilter, setOnlyMineFilter, filterValidProviderIds } from "../db/repository";
 import type { AppEnv } from "../types";
-import { ok } from "./response";
+import { ok, err } from "./response";
 import { zValidator } from "../lib/validator";
+import Sentry from "../sentry";
+import { logger } from "../logger";
+
+const log = logger.child({ module: "user-settings" });
 
 // Keep in sync with frontend/src/types.ts HomepageSectionId / DEFAULT_HOMEPAGE_LAYOUT.
 export const HOMEPAGE_SECTION_IDS = ["streak", "up_next", "unwatched", "movies_to_watch", "recommendations", "today", "upcoming", "upcoming_movies", "airing_soon", "friends_loved"] as const;
@@ -88,8 +92,16 @@ const app = new Hono<AppEnv>();
 
 app.get("/homepage-layout", async (c) => {
   const user = c.get("user")!;
-  const raw = await getHomepageLayout(user.id);
-  return ok(c, { homepage_layout: parseLayout(raw) });
+  try {
+    const raw = await getHomepageLayout(user.id);
+    return ok(c, { homepage_layout: parseLayout(raw) });
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    const stack = e instanceof Error ? e.stack : undefined;
+    Sentry.captureException(e);
+    log.error("homepage-layout fetch failed", { userId: user.id, error: message, stack });
+    return err(c, "Failed to load homepage layout", 500);
+  }
 });
 
 app.put(

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -301,8 +301,18 @@ function createApp(env: Env) {
         stack: err instanceof Error ? err.stack : undefined,
       });
     }
-    const db = getDb();
-    c.set("auth", createAuth(db, platform, oidcConfig));
+    let db;
+    try {
+      db = getDb();
+      c.set("auth", createAuth(db, platform, oidcConfig));
+    } catch (err) {
+      logger.error("Auth context init failed", {
+        error: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
+      });
+      Sentry.captureException(err);
+      return c.json({ error: "Service initializing, please retry" }, 503);
+    }
 
     await next();
   });


### PR DESCRIPTION
## Summary

- **#830** — Apply `social.ts` try/catch pattern to `GET /user/settings/homepage-layout`: DB errors now emit a structured 500 + Sentry event instead of bypassing to an "Unhandled error"
- **#817** — Wrap `getDb()`/`createAuth()` in the worker `app.use("*", ...)` cold-start block; a transient isolate init failure now returns a clean 503 instead of an unhandled rejection
- **#838** — Embed job name, id, and attempt count in the `"Job failed permanently"` log message template so CF Observability's default events view shows triage context without drilling into structured fields
- **#839** — Add `SLOW_REQUEST_THRESHOLD_MS = 5000` warn log in `requestLogger()` so future p95 latency spikes can be attributed to specific endpoints via `messageTemplate` search in CF Observability
- **#843** — Verified: `server/routes/social.ts:117-126` try/catch from #811 is intact; the single recurrence in the monitoring window was on the pre-fix deploy `34376078`

## Test plan

- [ ] New regression test in `server/routes/user-settings.test.ts`: `getHomepageLayout` throws → 500 body `"Failed to load homepage layout"` + `Sentry.captureException` called
- [ ] New tests in `server/logger.test.ts`: slow-path (6 s mock) emits `"Slow request: GET /slow-path (6000ms)"` warn; fast-path (200 ms mock) emits no slow-request warn
- [ ] New test in `server/jobs/processor.test.ts`: permanent-failure log message contains `"sync-titles failed permanently (id=…, attempts=3/3)"` + `Sentry.captureException` with fingerprint
- [ ] `bun run check` passes (2131 server tests + 1018 frontend tests, 0 failures, all bundle sizes within budget)
- [ ] Updated two existing tests in `durable-object.test.ts` and `processor.test.ts` that matched on the old static `"Job failed permanently"` message to use substring match

Closes #817, Closes #830, Closes #838, Closes #839, Closes #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)