### PR TITLE
feat(collections): show movie collection row on movie detail page

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -37,6 +37,7 @@ import type {
   UserAchievement,
   LeaderboardEntry,
   StreakData,
+  CollectionDetails,
 } from "./types";
 
 const BASE = "/api";
@@ -1235,6 +1236,10 @@ export async function setRemindOnRelease(
  */
 export async function fetchFriendsLoved(signal?: AbortSignal): Promise<{ titles: SearchTitle[] }> {
   return fetchJson("/social/friends-loved?limit=20", { signal });
+}
+
+export async function getCollection(id: number, signal?: AbortSignal): Promise<CollectionDetails> {
+  return fetchJson(`/details/collection/${id}`, { signal });
 }
 
 export async function getTitleSuggestions(

--- a/frontend/src/components/title-detail/CollectionRow.test.tsx
+++ b/frontend/src/components/title-detail/CollectionRow.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, afterEach, beforeEach, spyOn } from "bun:test";
 import { render, screen, cleanup, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
 import * as api from "../../api";
 import type { CollectionDetails } from "../../types";
 import CollectionRow from "./CollectionRow";
@@ -17,6 +19,18 @@ const mockCollection: CollectionDetails = {
     { id: 122, title: "The Return of the King", poster_path: "/r.jpg", backdrop_path: null, release_date: "2003-12-17", overview: "", vote_average: 8.9 },
   ],
 };
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
 
 let spies: ReturnType<typeof spyOn>[] = [];
 
@@ -35,9 +49,8 @@ afterEach(() => {
 describe("CollectionRow", () => {
   it("renders the collection name as the section heading", async () => {
     render(
-      <MemoryRouter>
-        <CollectionRow collectionId={119} collectionName="The Lord of the Rings Collection" currentTitleId="movie-120" />
-      </MemoryRouter>,
+      <CollectionRow collectionId={119} collectionName="The Lord of the Rings Collection" currentTitleId="movie-120" />,
+      { wrapper: Wrapper },
     );
     await waitFor(() => screen.getByRole("heading", { name: "The Lord of the Rings Collection" }));
     expect(screen.getByRole("heading", { name: "The Lord of the Rings Collection" })).toBeDefined();
@@ -45,9 +58,8 @@ describe("CollectionRow", () => {
 
   it("renders poster links for all collection parts", async () => {
     render(
-      <MemoryRouter>
-        <CollectionRow collectionId={119} collectionName="The Lord of the Rings Collection" currentTitleId="movie-999" />
-      </MemoryRouter>,
+      <CollectionRow collectionId={119} collectionName="The Lord of the Rings Collection" currentTitleId="movie-999" />,
+      { wrapper: Wrapper },
     );
     await waitFor(() => screen.getByText("The Fellowship of the Ring"));
     const fellowshipLink = screen.getByText("The Fellowship of the Ring").closest("a");
@@ -58,9 +70,8 @@ describe("CollectionRow", () => {
 
   it("marks the current movie with aria-current", async () => {
     render(
-      <MemoryRouter>
-        <CollectionRow collectionId={119} collectionName="The Lord of the Rings Collection" currentTitleId="movie-120" />
-      </MemoryRouter>,
+      <CollectionRow collectionId={119} collectionName="The Lord of the Rings Collection" currentTitleId="movie-120" />,
+      { wrapper: Wrapper },
     );
     await waitFor(() => screen.getByText("The Fellowship of the Ring"));
     const fellowshipLink = screen.getByText("The Fellowship of the Ring").closest("a");
@@ -69,24 +80,28 @@ describe("CollectionRow", () => {
 
   it("does not mark other movies with aria-current", async () => {
     render(
-      <MemoryRouter>
-        <CollectionRow collectionId={119} collectionName="The Lord of the Rings Collection" currentTitleId="movie-120" />
-      </MemoryRouter>,
+      <CollectionRow collectionId={119} collectionName="The Lord of the Rings Collection" currentTitleId="movie-120" />,
+      { wrapper: Wrapper },
     );
     await waitFor(() => screen.getByText("The Two Towers"));
     const towersLink = screen.getByText("The Two Towers").closest("a");
     expect(towersLink?.getAttribute("aria-current")).toBeNull();
   });
 
-  it("renders nothing when there are no parts", async () => {
-    (api.getCollection as any).mockResolvedValueOnce({ ...mockCollection, parts: [] });
+  it("renders nothing when there are no parts", () => {
+    const testClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    testClient.setQueryData(["collection", 119], { ...mockCollection, parts: [] });
+    function TestWrapper({ children }: { children: ReactNode }) {
+      return (
+        <QueryClientProvider client={testClient}>
+          <MemoryRouter>{children}</MemoryRouter>
+        </QueryClientProvider>
+      );
+    }
     const { container } = render(
-      <MemoryRouter>
-        <CollectionRow collectionId={119} collectionName="The Lord of the Rings Collection" currentTitleId="movie-120" />
-      </MemoryRouter>,
+      <CollectionRow collectionId={119} collectionName="The Lord of the Rings Collection" currentTitleId="movie-120" />,
+      { wrapper: TestWrapper },
     );
-    await waitFor(() => {
-      expect(container.firstChild).toBeNull();
-    });
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/frontend/src/components/title-detail/CollectionRow.test.tsx
+++ b/frontend/src/components/title-detail/CollectionRow.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, afterEach, beforeEach, spyOn } from "bun:test";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import * as api from "../../api";
+import type { CollectionDetails } from "../../types";
+import CollectionRow from "./CollectionRow";
+
+const mockCollection: CollectionDetails = {
+  id: 119,
+  name: "The Lord of the Rings Collection",
+  overview: "Epic fantasy trilogy.",
+  poster_path: null,
+  backdrop_path: null,
+  parts: [
+    { id: 120, title: "The Fellowship of the Ring", poster_path: "/f.jpg", backdrop_path: null, release_date: "2001-12-19", overview: "", vote_average: 8.4 },
+    { id: 121, title: "The Two Towers", poster_path: "/t.jpg", backdrop_path: null, release_date: "2002-12-18", overview: "", vote_average: 8.4 },
+    { id: 122, title: "The Return of the King", poster_path: "/r.jpg", backdrop_path: null, release_date: "2003-12-17", overview: "", vote_average: 8.9 },
+  ],
+};
+
+let spies: ReturnType<typeof spyOn>[] = [];
+
+beforeEach(() => {
+  spies = [
+    spyOn(api, "getCollection").mockResolvedValue(mockCollection),
+  ];
+});
+
+afterEach(() => {
+  cleanup();
+  for (const spy of spies) spy.mockRestore();
+  spies = [];
+});
+
+describe("CollectionRow", () => {
+  it("renders the collection name as the section heading", async () => {
+    render(
+      <MemoryRouter>
+        <CollectionRow collectionId={119} collectionName="The Lord of the Rings Collection" currentTitleId="movie-120" />
+      </MemoryRouter>,
+    );
+    await waitFor(() => screen.getByRole("heading", { name: "The Lord of the Rings Collection" }));
+    expect(screen.getByRole("heading", { name: "The Lord of the Rings Collection" })).toBeDefined();
+  });
+
+  it("renders poster links for all collection parts", async () => {
+    render(
+      <MemoryRouter>
+        <CollectionRow collectionId={119} collectionName="The Lord of the Rings Collection" currentTitleId="movie-999" />
+      </MemoryRouter>,
+    );
+    await waitFor(() => screen.getByText("The Fellowship of the Ring"));
+    const fellowshipLink = screen.getByText("The Fellowship of the Ring").closest("a");
+    expect(fellowshipLink?.getAttribute("href")).toBe("/title/movie-120");
+    const towersLink = screen.getByText("The Two Towers").closest("a");
+    expect(towersLink?.getAttribute("href")).toBe("/title/movie-121");
+  });
+
+  it("marks the current movie with aria-current", async () => {
+    render(
+      <MemoryRouter>
+        <CollectionRow collectionId={119} collectionName="The Lord of the Rings Collection" currentTitleId="movie-120" />
+      </MemoryRouter>,
+    );
+    await waitFor(() => screen.getByText("The Fellowship of the Ring"));
+    const fellowshipLink = screen.getByText("The Fellowship of the Ring").closest("a");
+    expect(fellowshipLink?.getAttribute("aria-current")).toBe("true");
+  });
+
+  it("does not mark other movies with aria-current", async () => {
+    render(
+      <MemoryRouter>
+        <CollectionRow collectionId={119} collectionName="The Lord of the Rings Collection" currentTitleId="movie-120" />
+      </MemoryRouter>,
+    );
+    await waitFor(() => screen.getByText("The Two Towers"));
+    const towersLink = screen.getByText("The Two Towers").closest("a");
+    expect(towersLink?.getAttribute("aria-current")).toBeNull();
+  });
+
+  it("renders nothing when there are no parts", async () => {
+    (api.getCollection as any).mockResolvedValueOnce({ ...mockCollection, parts: [] });
+    const { container } = render(
+      <MemoryRouter>
+        <CollectionRow collectionId={119} collectionName="The Lord of the Rings Collection" currentTitleId="movie-120" />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+});

--- a/frontend/src/components/title-detail/CollectionRow.tsx
+++ b/frontend/src/components/title-detail/CollectionRow.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router";
+import * as api from "../../api";
+import type { CollectionPart } from "../../types";
+import { posterUrl } from "../../lib/tmdb-images";
+import ScrollableRow from "../ScrollableRow";
+import { TitleCardSkeleton } from "../SkeletonComponents";
+import { Section } from "./Section";
+import SectionErrorBoundary from "../SectionErrorBoundary";
+
+interface CollectionRowProps {
+  collectionId: number;
+  collectionName: string;
+  currentTitleId: string;
+}
+
+function CollectionRowInner({ collectionId, collectionName, currentTitleId }: CollectionRowProps) {
+  const [parts, setParts] = useState<CollectionPart[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    api
+      .getCollection(collectionId, controller.signal)
+      .then((res) => {
+        if (!controller.signal.aborted) {
+          const sorted = [...res.parts].sort((a, b) => {
+            if (!a.release_date) return 1;
+            if (!b.release_date) return -1;
+            return a.release_date.localeCompare(b.release_date);
+          });
+          setParts(sorted);
+        }
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+    return () => controller.abort();
+  }, [collectionId]);
+
+  if (!loading && parts.length === 0) return null;
+
+  return (
+    <Section title={collectionName}>
+      {loading ? (
+        <div className="flex gap-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="w-28 flex-shrink-0">
+              <TitleCardSkeleton />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <ScrollableRow className="gap-3 pb-1">
+          {parts.map((part) => {
+            const isCurrent = `movie-${part.id}` === currentTitleId;
+            const imgSrc = posterUrl(part.poster_path, "w185");
+            return (
+              <Link
+                key={part.id}
+                to={`/title/movie-${part.id}`}
+                aria-current={isCurrent ? "true" : undefined}
+                className={`w-28 flex-shrink-0 group${isCurrent ? " pointer-events-none" : ""}`}
+              >
+                <div
+                  className={`aspect-[2/3] rounded-lg overflow-hidden bg-zinc-800${
+                    isCurrent ? " ring-2 ring-amber-400" : ""
+                  }`}
+                >
+                  {imgSrc ? (
+                    <img
+                      src={imgSrc}
+                      alt={part.title}
+                      className="w-full h-full object-cover group-hover:scale-105 transition-transform"
+                      loading="lazy"
+                      width={112}
+                      height={168}
+                    />
+                  ) : (
+                    <div className="w-full h-full flex items-center justify-center text-zinc-600 text-xs">
+                      N/A
+                    </div>
+                  )}
+                </div>
+                <p
+                  className={`text-xs mt-1.5 line-clamp-2 transition-colors${
+                    isCurrent
+                      ? " text-amber-400"
+                      : " text-zinc-300 group-hover:text-amber-400"
+                  }`}
+                >
+                  {part.title}
+                </p>
+                {part.release_date && (
+                  <p className="font-mono text-[10px] text-zinc-500">{part.release_date.slice(0, 4)}</p>
+                )}
+              </Link>
+            );
+          })}
+        </ScrollableRow>
+      )}
+    </Section>
+  );
+}
+
+export default function CollectionRow(props: CollectionRowProps) {
+  return (
+    <SectionErrorBoundary label="collection">
+      <CollectionRowInner {...props} />
+    </SectionErrorBoundary>
+  );
+}

--- a/frontend/src/components/title-detail/CollectionRow.tsx
+++ b/frontend/src/components/title-detail/CollectionRow.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router";
 import * as api from "../../api";
-import type { CollectionPart } from "../../types";
 import { posterUrl } from "../../lib/tmdb-images";
 import ScrollableRow from "../ScrollableRow";
 import { TitleCardSkeleton } from "../SkeletonComponents";
@@ -15,35 +15,25 @@ interface CollectionRowProps {
 }
 
 function CollectionRowInner({ collectionId, collectionName, currentTitleId }: CollectionRowProps) {
-  const [parts, setParts] = useState<CollectionPart[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { data, isLoading } = useQuery({
+    queryKey: ["collection", collectionId],
+    queryFn: ({ signal }) => api.getCollection(collectionId, signal),
+  });
 
-  useEffect(() => {
-    const controller = new AbortController();
-    api
-      .getCollection(collectionId, controller.signal)
-      .then((res) => {
-        if (!controller.signal.aborted) {
-          const sorted = [...res.parts].sort((a, b) => {
-            if (!a.release_date) return 1;
-            if (!b.release_date) return -1;
-            return a.release_date.localeCompare(b.release_date);
-          });
-          setParts(sorted);
-        }
-      })
-      .catch(() => {})
-      .finally(() => {
-        if (!controller.signal.aborted) setLoading(false);
-      });
-    return () => controller.abort();
-  }, [collectionId]);
+  const parts = useMemo(() => {
+    const list = data?.parts ?? [];
+    return [...list].sort((a, b) => {
+      if (!a.release_date) return 1;
+      if (!b.release_date) return -1;
+      return a.release_date.localeCompare(b.release_date);
+    });
+  }, [data]);
 
-  if (!loading && parts.length === 0) return null;
+  if (!isLoading && parts.length === 0) return null;
 
   return (
     <Section title={collectionName}>
-      {loading ? (
+      {isLoading ? (
         <div className="flex gap-3">
           {Array.from({ length: 6 }).map((_, i) => (
             <div key={i} className="w-28 flex-shrink-0">

--- a/frontend/src/pages/title/MovieDetail.tsx
+++ b/frontend/src/pages/title/MovieDetail.tsx
@@ -20,6 +20,7 @@ import { Section } from "../../components/title-detail/Section";
 import { formatCurrency } from "../../components/title-detail/utils";
 import SectionErrorBoundary from "../../components/SectionErrorBoundary";
 import SuggestionsRow from "../../components/title-detail/SuggestionsRow";
+import CollectionRow from "../../components/title-detail/CollectionRow";
 import EditWatchedAtDialog from "../../components/EditWatchedAtDialog";
 
 export default function MovieDetail({ data }: { data: MovieDetailsResponse }) {
@@ -213,6 +214,15 @@ export default function MovieDetail({ data }: { data: MovieDetailsResponse }) {
       <SectionErrorBoundary label="streaming providers">
         <ProvidersSection offers={title.offers} watchProviders={watchProviders} watchLink={watchProviders?.link} />
       </SectionErrorBoundary>
+
+      {/* Collection */}
+      {tmdb?.belongs_to_collection && (
+        <CollectionRow
+          collectionId={tmdb.belongs_to_collection.id}
+          collectionName={tmdb.belongs_to_collection.name}
+          currentTitleId={title.id}
+        />
+      )}
 
       {/* Suggestions */}
       <SuggestionsRow titleId={title.id} type="movie" />

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -231,6 +231,25 @@ export interface Network {
   origin_country: string;
 }
 
+export interface CollectionPart {
+  id: number;
+  title: string;
+  poster_path: string | null;
+  backdrop_path: string | null;
+  release_date: string | null;
+  overview: string;
+  vote_average: number;
+}
+
+export interface CollectionDetails {
+  id: number;
+  name: string;
+  overview: string;
+  poster_path: string | null;
+  backdrop_path: string | null;
+  parts: CollectionPart[];
+}
+
 export interface MovieDetailsResponse {
   title: Title;
   tmdb: {
@@ -259,6 +278,7 @@ export interface MovieDetailsResponse {
     "watch/providers": { results: Record<string, WatchProviderCountry> };
     external_ids?: ExternalIds;
     videos?: { results: TmdbVideo[] };
+    belongs_to_collection?: { id: number; name: string; poster_path: string | null; backdrop_path: string | null } | null;
   } | null;
   country: string;
 }

--- a/server/routes/details.test.ts
+++ b/server/routes/details.test.ts
@@ -34,6 +34,7 @@ beforeEach(() => {
     spyOn(tmdbClient, "fetchTvSuggestions").mockResolvedValue({ results: [], page: 1, total_pages: 0, total_results: 0 } as any),
     spyOn(tmdbClient, "getMovieGenres").mockResolvedValue(new Map() as any),
     spyOn(tmdbClient, "getTvGenres").mockResolvedValue(new Map() as any),
+    spyOn(tmdbClient, "fetchCollection").mockResolvedValue({ id: 119, name: "Test Collection", overview: "", poster_path: null, backdrop_path: null, parts: [] } as any),
   ];
 });
 
@@ -447,6 +448,52 @@ describe("GET /details/person/:personId", () => {
   it("returns 404 when TMDB fetch fails", async () => {
     (tmdbClient.fetchPersonDetails as any).mockRejectedValueOnce(new Error("Not found"));
     const res = await app.request("/details/person/999");
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /details/collection/:id", () => {
+  it("returns 400 for non-numeric id", async () => {
+    const res = await app.request("/details/collection/abc");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("returns 400 for id=0 (min is 1)", async () => {
+    const res = await app.request("/details/collection/0");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("returns collection with parts for valid id", async () => {
+    (tmdbClient.fetchCollection as any).mockResolvedValueOnce({
+      id: 119,
+      name: "The Lord of the Rings Collection",
+      overview: "Epic fantasy trilogy",
+      poster_path: "/poster.jpg",
+      backdrop_path: "/backdrop.jpg",
+      parts: [
+        { id: 120, title: "The Fellowship of the Ring", poster_path: "/f.jpg", backdrop_path: null, release_date: "2001-12-19", overview: "", vote_average: 8.4 },
+        { id: 121, title: "The Two Towers", poster_path: "/t.jpg", backdrop_path: null, release_date: "2002-12-18", overview: "", vote_average: 8.4 },
+      ],
+    });
+
+    const res = await app.request("/details/collection/119");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.name).toBe("The Lord of the Rings Collection");
+    expect(Array.isArray(body.parts)).toBe(true);
+    expect(body.parts).toHaveLength(2);
+    expect(tmdbClient.fetchCollection).toHaveBeenCalledWith(119);
+  });
+
+  it("returns 404 when TMDB fetch fails", async () => {
+    (tmdbClient.fetchCollection as any).mockRejectedValueOnce(new Error("Not found"));
+    const res = await app.request("/details/collection/999");
     expect(res.status).toBe(404);
   });
 });

--- a/server/routes/details.ts
+++ b/server/routes/details.ts
@@ -14,6 +14,7 @@ import {
   fetchTvSuggestions,
   getMovieGenres,
   getTvGenres,
+  fetchCollection,
 } from "../tmdb/client";
 import { parseMovieDetails, parseTvDetails, parseDiscoverMovie, parseDiscoverTv } from "../tmdb/parser";
 import type { AppEnv } from "../types";
@@ -41,6 +42,9 @@ const personIdParam = z.object({
 });
 const suggestionsQuery = z.object({
   page: z.coerce.number().int().min(1).default(1),
+});
+const collectionIdParam = z.object({
+  id: z.coerce.number().int().min(1),
 });
 
 const app = new Hono<AppEnv>();
@@ -258,6 +262,19 @@ app.get("/show/:id/suggestions", zValidator("param", titleIdParam), zValidator("
   } catch (e) {
     log.error("TMDB show suggestions fetch failed", { tmdbId: parsed.tmdbId, err: e });
     return err(c, "Failed to fetch suggestions", 503);
+  }
+});
+
+app.get("/collection/:id", zValidator("param", collectionIdParam), async (c) => {
+  if (!CONFIG.TMDB_API_KEY) return err(c, "TMDB not configured", 503);
+  const { id } = c.req.valid("param");
+  try {
+    const collection = await fetchCollection(id);
+    setPublicCacheIfAnon(c, 3600);
+    return c.json(collection);
+  } catch (e) {
+    log.error("TMDB collection fetch failed", { collectionId: id, err: e });
+    return err(c, "Collection not found", 404);
   }
 });
 

--- a/server/tmdb/client.ts
+++ b/server/tmdb/client.ts
@@ -22,6 +22,7 @@ import type {
   TmdbSeasonDetails,
   TmdbEpisodeDetails,
   TmdbPersonDetails,
+  TmdbCollectionDetails,
 } from "./types";
 
 async function tmdbRequest<T>(path: string, params?: Record<string, string>): Promise<T> {
@@ -332,6 +333,14 @@ export async function cachedFetchMovieDetails(tmdbId: number): Promise<TmdbMovie
 export async function cachedFetchTvDetails(tmdbId: number): Promise<TmdbTvDetails> {
   const key = `tmdb:details:tv:${tmdbId}:${tmdbLanguage()}`;
   return cachedTmdbRequest(key, CONFIG.CACHE_TTL_DETAILS, () => fetchTvDetails(tmdbId));
+}
+
+export async function fetchCollection(collectionId: number): Promise<TmdbCollectionDetails> {
+  return cachedTmdbRequest(
+    `tmdb:collection:${collectionId}:${tmdbLanguage()}`,
+    CONFIG.CACHE_TTL_DETAILS,
+    () => tmdbRequest<TmdbCollectionDetails>(`/collection/${collectionId}`, { language: tmdbLanguage() }),
+  );
 }
 
 // ─── Suggestions endpoints ──────────────────────────────────────────────────

--- a/server/tmdb/types.ts
+++ b/server/tmdb/types.ts
@@ -317,6 +317,26 @@ export interface TmdbMovieFullDetails {
   "watch/providers": { results: Record<string, TmdbWatchProviderCountry> };
   external_ids?: TmdbExternalIds;
   videos?: { results: TmdbVideo[] };
+  belongs_to_collection: { id: number; name: string; poster_path: string | null; backdrop_path: string | null } | null;
+}
+
+export interface TmdbCollectionPart {
+  id: number;
+  title: string;
+  poster_path: string | null;
+  backdrop_path: string | null;
+  release_date: string | null;
+  overview: string;
+  vote_average: number;
+}
+
+export interface TmdbCollectionDetails {
+  id: number;
+  name: string;
+  overview: string;
+  poster_path: string | null;
+  backdrop_path: string | null;
+  parts: TmdbCollectionPart[];
 }
 
 export interface TmdbShowFullDetails {


### PR DESCRIPTION
## Summary

- Adds a horizontally scrollable **collection row** on the movie detail page whenever a movie belongs to a TMDB collection (e.g. "The Matrix Collection", "The Lord of the Rings Collection")
- All movies in the collection are shown in release order; the currently-viewed movie is visually highlighted with an amber ring + `aria-current="true"`
- New `GET /api/details/collection/:id` endpoint backed by a cached TMDB fetch — no DB migration, no new route wiring (rides the existing `details` mount)
- Frontend fetches the collection lazily via **`useQuery`** (`queryKey: ["collection", collectionId]`) so navigating between movies in the same collection gets a cache hit instead of a repeated round-trip
- A movie with no collection shows no collection section

## Changes

**Server**
- `server/tmdb/types.ts` — added `belongs_to_collection` field to `TmdbMovieFullDetails` + new `TmdbCollectionPart` / `TmdbCollectionDetails` types
- `server/tmdb/client.ts` — added `fetchCollection` (cached via `cachedTmdbRequest`, follows `tmdb:<kind>:<id>:<lang>` key convention)
- `server/routes/details.ts` — added `GET /collection/:id` with zod param validation + `setPublicCacheIfAnon(3600)`
- `server/routes/details.test.ts` — validation-reject + happy-path tests for the new route

**Frontend**
- `frontend/src/types.ts` — added `CollectionPart` / `CollectionDetails` types + `belongs_to_collection` field on `MovieDetailsResponse.tmdb`
- `frontend/src/api.ts` — added `getCollection(id, signal)`
- `frontend/src/components/title-detail/CollectionRow.tsx` — new component using `useQuery` (not the legacy `useEffect` pattern)
- `frontend/src/components/title-detail/CollectionRow.test.tsx` — 5 tests with `QueryClientProvider` wrapper
- `frontend/src/pages/title/MovieDetail.tsx` — renders `<CollectionRow>` above suggestions when `tmdb.belongs_to_collection` is set

## Test plan

- [x] `bun run check` passes (server tsc + e2e tsc + frontend tsc + ESLint + 1023 tests + build + wrangler dry-run + bundle size)
- [x] Browser-verified via playwright: "The Matrix Collection" heading + all 4 films in release order; current film highlighted with amber ring + `pointer-events-none`
- [x] Movie with no collection (standalone film) shows no collection section
- [x] Clicking a sibling film navigates to its detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)