### PR TITLE
fix: prevent collection row highlight ring from being clipped

### DIFF
--- a/frontend/src/components/title-detail/CollectionRow.test.tsx
+++ b/frontend/src/components/title-detail/CollectionRow.test.tsx
@@ -88,6 +88,17 @@ describe("CollectionRow", () => {
     expect(towersLink?.getAttribute("aria-current")).toBeNull();
   });
 
+  it("gives the scroll row top padding so the current item's ring isn't clipped", async () => {
+    render(
+      <CollectionRow collectionId={119} collectionName="The Lord of the Rings Collection" currentTitleId="movie-120" />,
+      { wrapper: Wrapper },
+    );
+    await waitFor(() => screen.getByText("The Fellowship of the Ring"));
+    const row = screen.getByText("The Fellowship of the Ring").closest("a")!.parentElement!;
+    expect(row.className).toContain("py-1");
+    expect(row.className).not.toContain("pb-1");
+  });
+
   it("renders nothing when there are no parts", () => {
     const testClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     testClient.setQueryData(["collection", 119], { ...mockCollection, parts: [] });

--- a/frontend/src/components/title-detail/CollectionRow.tsx
+++ b/frontend/src/components/title-detail/CollectionRow.tsx
@@ -42,7 +42,7 @@ function CollectionRowInner({ collectionId, collectionName, currentTitleId }: Co
           ))}
         </div>
       ) : (
-        <ScrollableRow className="gap-3 pb-1">
+        <ScrollableRow className="gap-3 py-1">
           {parts.map((part) => {
             const isCurrent = `movie-${part.id}` === currentTitleId;
             const imgSrc = posterUrl(part.poster_path, "w185");


### PR DESCRIPTION
## Summary

The current movie in a collection row (e.g. *Harry Potter Collection* on a title detail page) is highlighted with an amber ring (`ring-2 ring-amber-400`). The **top edge of that ring was being cropped**.

**Root cause:** the ring is a `box-shadow` painted just outside the poster. The row is rendered by `ScrollableRow`, whose inner element is a horizontal scroll container (`flex overflow-x-auto`). Per CSS, `overflow-x: auto` forces `overflow-y: visible` to compute to a clipping value, so the container clips in both axes at its padding edge. `CollectionRow` passed `className="gap-3 pb-1"` — bottom padding only — so the current poster sat flush against the top clip edge and the top ~2px of its ring was cut off.

**Fix:** change the padding from `pb-1` to `py-1` so the ring has room above the poster as well. One-line source change.

## Test plan

- [x] Added a regression test in `CollectionRow.test.tsx` asserting the scroll row has `py-1` (and no longer `pb-1`).
- [x] `bun test` for `CollectionRow.test.tsx` — 6 pass.
- [x] `bun run check` — full type-check + lint + tests + build + wrangler dry-run all green.
- [ ] Manual: open a movie that belongs to a collection, scroll to the collection row, confirm the amber ring around the current movie is fully visible (top no longer cut off).

https://claude.ai/code/session_016ww4dNnxzYYuNBmwz3atCJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016ww4dNnxzYYuNBmwz3atCJ)_