### PR TITLE
feat(tanstack-query): finish TanStack Query migration — Batches A-D

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -24,6 +24,32 @@
 
 **Avoiding `any`**: use `unknown` for catch blocks and proper types elsewhere. ESLint enforces this. Test files are exempt from `no-explicit-any`.
 
+## Data fetching (TanStack Query)
+
+Server-cache state lives in `@tanstack/react-query`. The `QueryClient` singleton is in `lib/queryClient.ts` (staleTime 30s, gcTime 5m, retry 1) and is mounted in `main.tsx`. Functions in `api.ts` are the raw fetchers — they belong inside `queryFn`/`mutationFn`, never called directly from a component's `useEffect`.
+
+**Reads → `useQuery`**: Any GET that renders server data.
+- `queryFn: ({ signal }) => api.foo(signal)` — always forward the `signal` for cancellation
+- Use a structured array key; **reuse an existing key when components share data** (e.g. `["filters"]`, `["stats"]`)
+- Gate auth-dependent queries with `enabled`
+- Read `isLoading` / `isError` / `data` instead of manual loading/error state
+- Reference: `HomePage.tsx` (`["home","auth"]` query, line ~297)
+
+**Writes → `useMutation`** with optimistic update + invalidation:
+- `onMutate`: `cancelQueries` → snapshot via `getQueryData` → `setQueryData` optimistic → return snapshot
+- `onError`: roll back from snapshot + `toast.error`
+- `onSettled`: `invalidateQueries` for **every** affected key (e.g. a watch toggle invalidates `["stats"]`, `["activity"]`, `["calendar"]`, `["home","auth"]`)
+- Reference: `HomePage.tsx` `toggleWatchedMutation` (line ~333)
+
+**Keep a raw `api.ts` call (no Query) when**:
+- One-shot imperative action with no cached view to update (file import/export, token download, share-link copy)
+- Auth/session flow owned by `AuthContext` / better-auth
+- The call is *inside* a `queryFn` or `mutationFn` — that is the correct home for `api.ts`
+
+**Deferred — do NOT migrate yet**: Settings-tab **form-value submit** handlers (`updateMyProfile`, `updateAdminSettings`, `updateAppearanceSettings`, `updateActivitySettings`, `updateHomepageLayout`, `updateCrowdedWeekSettings`, `updateDepartureAlertSettings`) wait for the planned react-hook-form work. Their reads and action writes (delete/test/trigger/regenerate) are fair game now.
+
+**Tests**: Every migrated component's colocated test must wrap in a fresh `new QueryClient({ defaultOptions: { queries: { retry: false } } })` provider (see any existing `*.test.tsx` for the pattern).
+
 ## Pages (`frontend/src/pages/`)
 
 | File | Purpose |

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -328,8 +328,8 @@ export async function updateAllTitleVisibility(isPublic: boolean): Promise<void>
   });
 }
 
-export async function searchUsers(query: string): Promise<{ users: UserSummary[] }> {
-  return fetchJson(`/user/search?q=${encodeURIComponent(query)}`);
+export async function searchUsers(query: string, signal?: AbortSignal): Promise<{ users: UserSummary[] }> {
+  return fetchJson(`/user/search?q=${encodeURIComponent(query)}`, { signal });
 }
 
 export async function resolveImdb(url: string): Promise<{ success: boolean; title: SearchTitle }> {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -687,9 +687,10 @@ export async function testNotifier(
 }
 
 export async function getNotifierHistory(
-  id: string
+  id: string,
+  signal?: AbortSignal
 ): Promise<NotifierHistoryResponse> {
-  return fetchJson<NotifierHistoryResponse>(`/notifiers/${encodeURIComponent(id)}/history`);
+  return fetchJson<NotifierHistoryResponse>(`/notifiers/${encodeURIComponent(id)}/history`, { signal });
 }
 
 // ─── Social (Follow/Unfollow) ────────────────────────────────────────────────

--- a/frontend/src/components/AgendaCalendar.test.tsx
+++ b/frontend/src/components/AgendaCalendar.test.tsx
@@ -1,39 +1,13 @@
-import { describe, test, expect, afterEach, mock } from "bun:test";
+import { describe, test, expect, afterEach, mock, beforeEach, spyOn } from "bun:test";
 import { render, cleanup } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import * as api from "../api";
+import * as AuthContextModule from "../context/AuthContext";
 
 // Mock i18n before anything
 import "../i18n";
-
-// Mock auth context
-mock.module("../context/AuthContext", () => ({
-  useAuth: () => ({
-    user: { id: "u1", username: "me", display_name: "Me", auth_provider: "local", is_admin: false },
-    subscriptions: null,
-    providers: null,
-    loading: false,
-    sessionStatus: "authenticated",
-  }),
-  AuthContext: {
-    Provider: ({ children }: { children: ReactNode }) => children,
-  },
-}));
-
-// Mock the api module — include all functions AgendaCalendar (and sub-components) may import
-mock.module("../api", () => ({
-  getCalendarTitles: mock(() => Promise.resolve({ titles: [], episodes: [] })),
-  getCrowdedWeekSettings: mock(() =>
-    Promise.resolve({ crowdedWeekThreshold: 5, crowdedWeekBadgeEnabled: 1 })
-  ),
-  watchEpisode: mock(() => Promise.resolve()),
-  unwatchEpisode: mock(() => Promise.resolve()),
-  watchEpisodesBulk: mock(() => Promise.resolve()),
-  watchMovie: mock(() => Promise.resolve()),
-  unwatchMovie: mock(() => Promise.resolve()),
-  getSubscriptions: mock(() => Promise.resolve({ providerIds: [] })),
-}));
 
 const { default: AgendaCalendar } = await import("./AgendaCalendar");
 
@@ -49,7 +23,37 @@ function Wrapper({ children }: { children: ReactNode }) {
   );
 }
 
+let useAuthSpy: ReturnType<typeof spyOn<typeof AuthContextModule, "useAuth">>;
+let apiSpies: ReturnType<typeof spyOn>[];
+
+beforeEach(() => {
+  useAuthSpy = spyOn(AuthContextModule, "useAuth").mockReturnValue({
+    user: { id: "u1", username: "me", display_name: "Me", auth_provider: "local", is_admin: false },
+    providers: null,
+    loading: false,
+    sessionStatus: "authenticated",
+    subscriptions: null,
+    refreshSubscriptions: mock(() => Promise.resolve()),
+    login: mock(() => Promise.resolve()),
+    signup: mock(() => Promise.resolve()),
+    logout: mock(() => Promise.resolve()),
+    refresh: mock(() => Promise.resolve()),
+  });
+  apiSpies = [
+    spyOn(api, "getCalendarTitles").mockResolvedValue({ titles: [], episodes: [] } as any),
+    spyOn(api, "getCrowdedWeekSettings").mockResolvedValue({ crowdedWeekThreshold: 5, crowdedWeekBadgeEnabled: 1 } as any),
+    spyOn(api, "watchEpisode").mockResolvedValue(undefined as any),
+    spyOn(api, "unwatchEpisode").mockResolvedValue(undefined as any),
+    spyOn(api, "watchEpisodesBulk").mockResolvedValue(undefined as any),
+    spyOn(api, "watchMovie").mockResolvedValue(undefined as any),
+    spyOn(api, "unwatchMovie").mockResolvedValue(undefined as any),
+    spyOn(api, "getSubscriptions").mockResolvedValue({ providerIds: [] } as any),
+  ];
+});
+
 afterEach(() => {
+  useAuthSpy.mockRestore();
+  apiSpies.forEach(s => s.mockRestore());
   cleanup();
 });
 

--- a/frontend/src/components/AgendaCalendar.test.tsx
+++ b/frontend/src/components/AgendaCalendar.test.tsx
@@ -1,0 +1,72 @@
+import { describe, test, expect, afterEach, mock } from "bun:test";
+import { render, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// Mock i18n before anything
+import "../i18n";
+
+// Mock auth context
+mock.module("../context/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: "u1", username: "me", display_name: "Me", auth_provider: "local", is_admin: false },
+    subscriptions: null,
+    providers: null,
+    loading: false,
+    sessionStatus: "authenticated",
+  }),
+  AuthContext: {
+    Provider: ({ children }: { children: ReactNode }) => children,
+  },
+}));
+
+// Mock the api module — include all functions AgendaCalendar (and sub-components) may import
+mock.module("../api", () => ({
+  getCalendarTitles: mock(() => Promise.resolve({ titles: [], episodes: [] })),
+  getCrowdedWeekSettings: mock(() =>
+    Promise.resolve({ crowdedWeekThreshold: 5, crowdedWeekBadgeEnabled: 1 })
+  ),
+  watchEpisode: mock(() => Promise.resolve()),
+  unwatchEpisode: mock(() => Promise.resolve()),
+  watchEpisodesBulk: mock(() => Promise.resolve()),
+  watchMovie: mock(() => Promise.resolve()),
+  unwatchMovie: mock(() => Promise.resolve()),
+  getSubscriptions: mock(() => Promise.resolve({ providerIds: [] })),
+}));
+
+const { default: AgendaCalendar } = await import("./AgendaCalendar");
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AgendaCalendar", () => {
+  test("renders without crashing with mocked api", async () => {
+    const searchParams = new URLSearchParams();
+    const setSearchParams = mock(() => {});
+
+    const { container } = render(
+      <AgendaCalendar
+        searchParams={searchParams}
+        setSearchParams={setSearchParams as any}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    // Component renders something (even if just a loading state)
+    expect(container).toBeDefined();
+  });
+});

--- a/frontend/src/components/AgendaCalendar.tsx
+++ b/frontend/src/components/AgendaCalendar.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, useRef, useCallback, memo } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Link, useSearchParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import ScrollableRow from "./ScrollableRow";
@@ -304,9 +305,14 @@ function AgendaCalendarImpl({
     "type"
   );
   const [hideWatched, setHideWatched] = useState(true);
-  const [crowdedWeekThreshold, setCrowdedWeekThreshold] = useState(5);
-  const [crowdedWeekBadgeEnabled, setCrowdedWeekBadgeEnabled] = useState(true);
   const [months, setMonths] = useState<AgendaMonth[]>([]);
+
+  const { data: crowdedWeekData } = useQuery({
+    queryKey: ["crowded-week-settings"],
+    queryFn: ({ signal }) => getCrowdedWeekSettings(signal),
+  });
+  const crowdedWeekThreshold = crowdedWeekData?.crowdedWeekThreshold ?? 5;
+  const crowdedWeekBadgeEnabled = crowdedWeekData ? crowdedWeekData.crowdedWeekBadgeEnabled !== 0 : true;
   const [loadingMore, setLoadingMore] = useState(false);
   const [initialLoading, setInitialLoading] = useState(true);
   const [activeDate, setActiveDate] = useState(() => new Date());
@@ -333,20 +339,6 @@ function AgendaCalendarImpl({
   });
 
   const today = useMemo(() => formatDateKey(new Date()), []);
-
-  // Load crowded week settings once on mount
-  useEffect(() => {
-    const controller = new AbortController();
-    getCrowdedWeekSettings(controller.signal)
-      .then((s) => {
-        if (!controller.signal.aborted) {
-          setCrowdedWeekThreshold(s.crowdedWeekThreshold);
-          setCrowdedWeekBadgeEnabled(s.crowdedWeekBadgeEnabled !== 0);
-        }
-      })
-      .catch(() => {});
-    return () => controller.abort();
-  }, []);
 
   const loadMonth = useCallback(
     async (monthStr: string): Promise<AgendaMonth | null> => {

--- a/frontend/src/components/EpisodeRatingButtons.test.tsx
+++ b/frontend/src/components/EpisodeRatingButtons.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, mock, afterEach, beforeEach, spyOn } from "bun:test";
 import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
 import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "../i18n";
 import EpisodeRatingButtons from "./EpisodeRatingButtons";
 import * as api from "../api";
@@ -20,8 +21,16 @@ const mockAuthValue = {
   refresh: mock(() => Promise.resolve()),
 };
 
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
 function Wrapper({ children, authValue }: { children: ReactNode; authValue?: typeof mockAuthValue }) {
-  return <AuthContext value={(authValue ?? mockAuthValue) as any}>{children}</AuthContext>;
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <AuthContext value={(authValue ?? mockAuthValue) as any}>{children}</AuthContext>
+    </QueryClientProvider>
+  );
 }
 
 const emptyResponse: EpisodeRatingResponse = {
@@ -179,9 +188,11 @@ describe("EpisodeRatingButtons", () => {
     const noUserAuth = { ...mockAuthValue, user: null };
 
     render(
-      <AuthContext value={noUserAuth as any}>
-        <EpisodeRatingButtons episodeId={1} />
-      </AuthContext>
+      <QueryClientProvider client={newTestClient()}>
+        <AuthContext value={noUserAuth as any}>
+          <EpisodeRatingButtons episodeId={1} />
+        </AuthContext>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {

--- a/frontend/src/components/EpisodeRatingButtons.tsx
+++ b/frontend/src/components/EpisodeRatingButtons.tsx
@@ -79,14 +79,9 @@ export default function EpisodeRatingButtons({ episodeId }: EpisodeRatingButtons
     }
   }
 
-  async function handleReviewSave() {
+  function handleReviewSave() {
     if (submitting || !user || !ratingData?.user_rating) return;
-    try {
-      await api.rateEpisode(episodeId, ratingData.user_rating, reviewText || undefined);
-      toast.success("Review saved");
-    } catch {
-      toast.error("Failed to save review");
-    }
+    rateMutation.mutate({ value: ratingData.user_rating, review: reviewText || undefined });
   }
 
   if (isLoading) {

--- a/frontend/src/components/EpisodeRatingButtons.tsx
+++ b/frontend/src/components/EpisodeRatingButtons.tsx
@@ -32,7 +32,7 @@ export default function EpisodeRatingButtons({ episodeId }: EpisodeRatingButtons
 
   const { data: ratingData, isLoading } = useQuery({
     queryKey: ["episode-rating", episodeId],
-    queryFn: () => api.getEpisodeRating(episodeId),
+    queryFn: ({ signal }) => api.getEpisodeRating(episodeId, signal),
   });
 
   // Sync reviewText and showReview when data loads with an existing review

--- a/frontend/src/components/EpisodeRatingButtons.tsx
+++ b/frontend/src/components/EpisodeRatingButtons.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import { HeartCrack, ThumbsDown, ThumbsUp, Heart } from "lucide-react";
 import { toast } from "sonner";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import * as api from "../api";
 import type { RatingValue, EpisodeRatingResponse } from "../types";
 import { useAuth } from "../context/AuthContext";
@@ -25,73 +26,70 @@ const RATING_CONFIG: {
 
 export default function EpisodeRatingButtons({ episodeId }: EpisodeRatingButtonsProps) {
   const { user } = useAuth();
-  const [ratingData, setRatingData] = useState<EpisodeRatingResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [submitting, setSubmitting] = useState(false);
+  const qc = useQueryClient();
   const [reviewText, setReviewText] = useState("");
   const [showReview, setShowReview] = useState(false);
 
-  const fetchRating = useCallback(async () => {
-    try {
-      const data = await api.getEpisodeRating(episodeId);
-      setRatingData(data);
-      if (data.user_review) {
-        setReviewText(data.user_review);
-        setShowReview(true);
-      }
-    } catch {
-      // non-critical
-    } finally {
-      setLoading(false);
-    }
-  }, [episodeId]);
+  const { data: ratingData, isLoading } = useQuery({
+    queryKey: ["episode-rating", episodeId],
+    queryFn: () => api.getEpisodeRating(episodeId),
+  });
 
+  // Sync reviewText and showReview when data loads with an existing review
   useEffect(() => {
-    fetchRating();
-  }, [fetchRating]);
+    if (ratingData?.user_review) {
+      setReviewText(ratingData.user_review); // eslint-disable-line react-hooks/set-state-in-effect -- syncing server-backed initial value into controlled input
+      setShowReview(true);
+    }
+  }, [ratingData?.user_review]);
+
+  const rateMutation = useMutation({
+    mutationFn: ({ value, review }: { value: RatingValue; review?: string }) =>
+      api.rateEpisode(episodeId, value, review),
+    onSuccess: () => {
+      setShowReview(true);
+      toast.success("Rating saved");
+    },
+    onError: () => toast.error("Failed to update rating"),
+    onSettled: () => qc.invalidateQueries({ queryKey: ["episode-rating", episodeId] }),
+  });
+
+  const unrateMutation = useMutation({
+    mutationFn: () => api.unrateEpisode(episodeId),
+    onSuccess: () => {
+      setShowReview(false);
+      setReviewText("");
+      toast.success("Rating removed");
+    },
+    onError: () => toast.error("Failed to update rating"),
+    onSettled: () => qc.invalidateQueries({ queryKey: ["episode-rating", episodeId] }),
+  });
+
+  const submitting = rateMutation.isPending || unrateMutation.isPending;
 
   async function handleRate(value: RatingValue) {
     if (submitting || !user) return;
 
     const isActive = ratingData?.user_rating === value;
-    setSubmitting(true);
 
-    try {
-      if (isActive) {
-        await api.unrateEpisode(episodeId);
-        setRatingData((prev) => prev ? { ...prev, user_rating: null, user_review: null } : prev);
-        setReviewText("");
-        setShowReview(false);
-        toast.success("Rating removed");
-      } else {
-        await api.rateEpisode(episodeId, value, reviewText || undefined);
-        setRatingData((prev) => prev ? { ...prev, user_rating: value } : prev);
-        setShowReview(true);
-        toast.success("Rating saved");
-      }
-      const updated = await api.getEpisodeRating(episodeId);
-      setRatingData(updated);
-    } catch {
-      toast.error("Failed to update rating");
-    } finally {
-      setSubmitting(false);
+    if (isActive) {
+      unrateMutation.mutate();
+    } else {
+      rateMutation.mutate({ value, review: reviewText || undefined });
     }
   }
 
   async function handleReviewSave() {
     if (submitting || !user || !ratingData?.user_rating) return;
-    setSubmitting(true);
     try {
       await api.rateEpisode(episodeId, ratingData.user_rating, reviewText || undefined);
       toast.success("Review saved");
     } catch {
       toast.error("Failed to save review");
-    } finally {
-      setSubmitting(false);
     }
   }
 
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="flex items-center gap-2" data-testid="episode-rating-loading">
         {RATING_CONFIG.map(({ value }) => (

--- a/frontend/src/components/FollowButton.test.tsx
+++ b/frontend/src/components/FollowButton.test.tsx
@@ -2,10 +2,15 @@ import { describe, it, expect, mock, afterEach, beforeEach, spyOn } from "bun:te
 import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
 import type { ReactNode } from "react";
 import "../i18n";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import FollowButton from "./FollowButton";
 import * as api from "../api";
 import * as sonner from "sonner";
 import { AuthContext } from "../context/AuthContext";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
 
 const mockUser = { id: "user-1", username: "test", display_name: null, auth_provider: "local", is_admin: false };
 
@@ -19,7 +24,11 @@ const mockAuthValue = {
 };
 
 function Wrapper({ children, authValue }: { children: ReactNode; authValue?: typeof mockAuthValue }) {
-  return <AuthContext value={(authValue ?? mockAuthValue) as any}>{children}</AuthContext>;
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <AuthContext value={(authValue ?? mockAuthValue) as any}>{children}</AuthContext>
+    </QueryClientProvider>
+  );
 }
 
 let spies: ReturnType<typeof spyOn>[] = [];
@@ -53,9 +62,11 @@ describe("FollowButton", () => {
   it("returns null when user is not logged in", () => {
     const noUserAuth = { ...mockAuthValue, user: null };
     const { container } = render(
-      <AuthContext value={noUserAuth as any}>
-        <FollowButton userId="user-2" initialIsFollowing={false} />
-      </AuthContext>
+      <QueryClientProvider client={newTestClient()}>
+        <AuthContext value={noUserAuth as any}>
+          <FollowButton userId="user-2" initialIsFollowing={false} />
+        </AuthContext>
+      </QueryClientProvider>
     );
     expect(container.innerHTML).toBe("");
   });

--- a/frontend/src/components/FollowButton.tsx
+++ b/frontend/src/components/FollowButton.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { toast } from "sonner";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import * as api from "../api";
 import { useAuth } from "../context/AuthContext";
 
@@ -11,34 +12,29 @@ interface Props {
 
 export default function FollowButton({ userId, initialIsFollowing, onToggle }: Props) {
   const { user } = useAuth();
+  const qc = useQueryClient();
   const [following, setFollowing] = useState(initialIsFollowing);
-  const [loading, setLoading] = useState(false);
   const [hovered, setHovered] = useState(false);
+
+  const toggleFollowMutation = useMutation({
+    mutationFn: ({ wasFollowing }: { wasFollowing: boolean }) =>
+      wasFollowing ? api.unfollowUser(userId) : api.followUser(userId),
+    onMutate: ({ wasFollowing }) => setFollowing(!wasFollowing),
+    onSuccess: (_data, { wasFollowing }) => {
+      onToggle?.(!wasFollowing);
+      toast.success(!wasFollowing ? "Following" : "Unfollowed");
+    },
+    onError: (_err, { wasFollowing }) => {
+      setFollowing(wasFollowing);
+      toast.error("Failed to update follow status");
+    },
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["user-profile"] }),
+  });
 
   // Don't render if not authenticated or viewing own profile
   if (!user || user.id === userId) return null;
 
-  async function handleClick() {
-    setLoading(true);
-    try {
-      if (following) {
-        await api.unfollowUser(userId);
-        setFollowing(false);
-        onToggle?.(false);
-        toast.success("Unfollowed");
-      } else {
-        await api.followUser(userId);
-        setFollowing(true);
-        onToggle?.(true);
-        toast.success("Following");
-      }
-    } catch (err: unknown) {
-      console.error("Follow toggle failed:", err);
-      toast.error("Failed to update follow status");
-    } finally {
-      setLoading(false);
-    }
-  }
+  const loading = toggleFollowMutation.isPending;
 
   const showUnfollow = following && hovered;
 
@@ -64,7 +60,7 @@ export default function FollowButton({ userId, initialIsFollowing, onToggle }: P
 
   return (
     <button
-      onClick={handleClick}
+      onClick={() => toggleFollowMutation.mutate({ wasFollowing: following })}
       disabled={loading}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}

--- a/frontend/src/components/MovieRow.test.tsx
+++ b/frontend/src/components/MovieRow.test.tsx
@@ -1,8 +1,22 @@
 import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import * as api from "../api";
 import MovieRow from "./MovieRow";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
 
 let mockWatchMovie: ReturnType<typeof spyOn>;
 
@@ -34,11 +48,7 @@ const upcomingMovie = {
 };
 
 function renderRow(variant: "to_watch" | "upcoming", movies: typeof releasedMovie[]) {
-  return render(
-    <MemoryRouter>
-      <MovieRow variant={variant} movies={movies} />
-    </MemoryRouter>,
-  );
+  return render(<MovieRow variant={variant} movies={movies} />, { wrapper: Wrapper });
 }
 
 describe("MovieRow — to_watch variant", () => {

--- a/frontend/src/components/MovieRow.tsx
+++ b/frontend/src/components/MovieRow.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { CheckCircle } from "lucide-react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import * as api from "../api";
 import FullBleedCarousel from "./FullBleedCarousel";
 import { posterUrl as buildPosterUrl } from "../lib/tmdb-images";
@@ -61,24 +62,28 @@ function releaseMeta(variant: "to_watch" | "upcoming", movie: MovieTrackItem): s
 }
 
 export default function MovieRow({ variant, movies }: MovieRowProps) {
+  const qc = useQueryClient();
   const [dismissed, setDismissed] = useState<Set<string>>(new Set());
 
-  const visible = movies.filter((m) => !dismissed.has(m.id));
-
-  if (visible.length === 0) return null;
-
-  async function handleWatched(id: string) {
-    setDismissed((prev) => new Set([...prev, id]));
-    try {
-      await api.watchMovie(id);
-    } catch {
+  const watchMutation = useMutation({
+    mutationFn: (id: string) => api.watchMovie(id),
+    onMutate: (id) => setDismissed((prev) => new Set([...prev, id])),
+    onError: (_err, id) =>
       setDismissed((prev) => {
         const next = new Set(prev);
         next.delete(id);
         return next;
-      });
-    }
-  }
+      }),
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: ["home", "auth"] });
+      void qc.invalidateQueries({ queryKey: ["stats"] });
+      void qc.invalidateQueries({ queryKey: ["activity"] });
+    },
+  });
+
+  const visible = movies.filter((m) => !dismissed.has(m.id));
+
+  if (visible.length === 0) return null;
 
   return (
     <FullBleedCarousel>
@@ -106,7 +111,7 @@ export default function MovieRow({ variant, movies }: MovieRowProps) {
                 <button
                   onClick={(e) => {
                     e.preventDefault();
-                    void handleWatched(movie.id);
+                    watchMutation.mutate(movie.id);
                   }}
                   className="w-full flex items-center justify-center gap-1.5 px-3 py-1.5 bg-amber-500 hover:bg-amber-400 text-black text-xs font-semibold rounded-lg transition-colors cursor-pointer"
                 >

--- a/frontend/src/components/MovieRow.tsx
+++ b/frontend/src/components/MovieRow.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { CheckCircle } from "lucide-react";
+import { toast } from "sonner";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import * as api from "../api";
 import FullBleedCarousel from "./FullBleedCarousel";
@@ -68,12 +69,14 @@ export default function MovieRow({ variant, movies }: MovieRowProps) {
   const watchMutation = useMutation({
     mutationFn: (id: string) => api.watchMovie(id),
     onMutate: (id) => setDismissed((prev) => new Set([...prev, id])),
-    onError: (_err, id) =>
+    onError: (_err, id) => {
       setDismissed((prev) => {
         const next = new Set(prev);
         next.delete(id);
         return next;
-      }),
+      });
+      toast.error("Failed to mark as watched — please try again");
+    },
     onSettled: () => {
       void qc.invalidateQueries({ queryKey: ["home", "auth"] });
       void qc.invalidateQueries({ queryKey: ["stats"] });

--- a/frontend/src/components/NotificationModePicker.test.tsx
+++ b/frontend/src/components/NotificationModePicker.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, afterEach, beforeEach, spyOn } from "bun:test";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import type { ReactNode } from "react";
+import "../i18n";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import * as api from "../api";
+import NotificationModePicker from "./NotificationModePicker";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={newTestClient()}>{children}</QueryClientProvider>;
+}
+
+let spies: ReturnType<typeof spyOn>[] = [];
+
+beforeEach(() => {
+  spies = [
+    spyOn(api, "setNotificationMode").mockResolvedValue(undefined as any),
+    spyOn(api, "setRemindOnRelease").mockResolvedValue({ success: true, scheduledFor: null } as any),
+    spyOn(api, "setTitleSnooze").mockResolvedValue({ success: true } as any),
+  ];
+});
+
+afterEach(() => {
+  cleanup();
+  for (const spy of spies) spy.mockRestore();
+  spies = [];
+});
+
+describe("NotificationModePicker", () => {
+  it("renders mode buttons", () => {
+    render(
+      <NotificationModePicker titleId="t-1" currentMode="all" />,
+      { wrapper: Wrapper },
+    );
+    // 3 mode buttons + 1 snooze button = 4 total
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("marks 'all' mode as active when currentMode is 'all'", () => {
+    render(
+      <NotificationModePicker titleId="t-1" currentMode="all" />,
+      { wrapper: Wrapper },
+    );
+    const allButton = screen.getByRole("button", { name: /all episodes/i });
+    expect(allButton.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("marks 'none' mode as active when currentMode is 'none'", () => {
+    render(
+      <NotificationModePicker titleId="t-1" currentMode="none" />,
+      { wrapper: Wrapper },
+    );
+    const noneButton = screen.getByRole("button", { name: /muted/i });
+    expect(noneButton.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("calls api.setNotificationMode when a mode button is clicked", async () => {
+    render(
+      <NotificationModePicker titleId="t-1" currentMode="all" />,
+      { wrapper: Wrapper },
+    );
+
+    const noneButton = screen.getByRole("button", { name: /muted/i });
+    fireEvent.click(noneButton);
+
+    await waitFor(() => {
+      expect(api.setNotificationMode).toHaveBeenCalledWith("t-1", "none");
+    });
+  });
+
+  it("toggles off current mode (sets to null) when clicking the active mode", async () => {
+    render(
+      <NotificationModePicker titleId="t-1" currentMode="none" />,
+      { wrapper: Wrapper },
+    );
+
+    const noneButton = screen.getByRole("button", { name: /muted/i });
+    fireEvent.click(noneButton);
+
+    await waitFor(() => {
+      expect(api.setNotificationMode).toHaveBeenCalledWith("t-1", null);
+    });
+  });
+
+  it("calls onModeChange callback on success", async () => {
+    let receivedMode: string | null | undefined = undefined;
+    render(
+      <NotificationModePicker
+        titleId="t-1"
+        currentMode="all"
+        onModeChange={(m) => { receivedMode = m; }}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /muted/i }));
+
+    await waitFor(() => {
+      expect(receivedMode).toBe("none");
+    });
+  });
+
+  it("shows remind-on-release button when releaseDate is in the future", () => {
+    const futureDate = new Date(Date.now() + 7 * 86400000).toISOString().slice(0, 10);
+    render(
+      <NotificationModePicker titleId="t-1" currentMode="all" releaseDate={futureDate} />,
+      { wrapper: Wrapper },
+    );
+    expect(screen.getByRole("button", { name: /remind on release day/i })).toBeTruthy();
+  });
+
+  it("does not show remind-on-release button when releaseDate is not provided", () => {
+    render(
+      <NotificationModePicker titleId="t-1" currentMode="all" />,
+      { wrapper: Wrapper },
+    );
+    expect(screen.queryByRole("button", { name: /remind on release day/i })).toBeNull();
+  });
+
+  it("calls api.setRemindOnRelease when remind button is clicked", async () => {
+    const futureDate = new Date(Date.now() + 7 * 86400000).toISOString().slice(0, 10);
+    render(
+      <NotificationModePicker titleId="t-1" currentMode="all" releaseDate={futureDate} remindOnRelease={false} />,
+      { wrapper: Wrapper },
+    );
+
+    const remindBtn = screen.getByRole("button", { name: /remind on release day/i });
+    fireEvent.click(remindBtn);
+
+    await waitFor(() => {
+      expect(api.setRemindOnRelease).toHaveBeenCalledWith("t-1", true);
+    });
+  });
+});

--- a/frontend/src/components/NotificationModePicker.tsx
+++ b/frontend/src/components/NotificationModePicker.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Bell, BellRing, BellOff, BellDot } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import * as api from "../api";
 import SnoozePicker from "./SnoozePicker";
 
@@ -25,30 +26,31 @@ const MODES: { value: NotificationMode; icon: typeof Bell; labelKey: string }[] 
 
 export default function NotificationModePicker({ titleId, currentMode, onModeChange, snoozeUntil, remindOnRelease, releaseDate, onSnoozed, onRemindOnReleaseChange }: Props) {
   const { t } = useTranslation();
+  const qc = useQueryClient();
   const [mode, setMode] = useState<NotificationMode | null>(currentMode ?? null);
   const [remind, setRemind] = useState<boolean>(remindOnRelease ?? false);
 
-  async function handleClick(newMode: NotificationMode) {
-    const value = newMode === mode ? null : newMode;
-    try {
-      await api.setNotificationMode(titleId, value);
+  const modeMutation = useMutation({
+    mutationFn: ({ value }: { value: NotificationMode | null }) => api.setNotificationMode(titleId, value),
+    onMutate: ({ value }) => {
+      const prev = mode;
       setMode(value);
-      onModeChange?.(value);
-    } catch (err) {
-      console.error("Failed to update notification mode", err);
-    }
-  }
+      return { prev };
+    },
+    onSuccess: (_data, { value }) => onModeChange?.(value),
+    onError: (_err, _vars, ctx) => {
+      if (ctx) setMode(ctx.prev);
+    },
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["tracked"] }),
+  });
 
-  async function handleRemindToggle() {
-    const newValue = !remind;
-    try {
-      await api.setRemindOnRelease(titleId, newValue);
-      setRemind(newValue);
-      onRemindOnReleaseChange?.(newValue);
-    } catch (err) {
-      console.error("Failed to update remind-on-release", err);
-    }
-  }
+  const remindMutation = useMutation({
+    mutationFn: ({ newValue }: { newValue: boolean }) => api.setRemindOnRelease(titleId, newValue),
+    onMutate: ({ newValue }) => setRemind(newValue),
+    onSuccess: (_data, { newValue }) => onRemindOnReleaseChange?.(newValue),
+    onError: (_err, { newValue }) => setRemind(!newValue),
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["tracked"] }),
+  });
 
   const activeMode = mode ?? "all";
 
@@ -63,7 +65,11 @@ export default function NotificationModePicker({ titleId, currentMode, onModeCha
             title={t(labelKey)}
             aria-label={t(labelKey)}
             aria-pressed={isActive}
-            onClick={() => handleClick(value)}
+            disabled={modeMutation.isPending || remindMutation.isPending}
+            onClick={() => {
+              const newValue = value === mode ? null : value;
+              modeMutation.mutate({ value: newValue });
+            }}
             className={`flex-1 flex items-center justify-center gap-1 rounded px-1.5 py-1 text-xs transition-colors ${
               isActive
                 ? "bg-amber-500/20 text-amber-400 border border-amber-500/40"
@@ -86,7 +92,8 @@ export default function NotificationModePicker({ titleId, currentMode, onModeCha
           title={t("snooze.remindOnRelease")}
           aria-label={t("snooze.remindOnRelease")}
           aria-pressed={remind}
-          onClick={handleRemindToggle}
+          disabled={modeMutation.isPending || remindMutation.isPending}
+          onClick={() => remindMutation.mutate({ newValue: !remind })}
           className={`flex items-center justify-center gap-1 rounded px-1.5 py-1 text-xs transition-colors border ${
             remind
               ? "bg-purple-500/20 text-purple-400 border-purple-500/40"

--- a/frontend/src/components/NotificationModePicker.tsx
+++ b/frontend/src/components/NotificationModePicker.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Bell, BellRing, BellOff, BellDot } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import * as api from "../api";
 import SnoozePicker from "./SnoozePicker";
@@ -40,6 +41,7 @@ export default function NotificationModePicker({ titleId, currentMode, onModeCha
     onSuccess: (_data, { value }) => onModeChange?.(value),
     onError: (_err, _vars, ctx) => {
       if (ctx) setMode(ctx.prev);
+      toast.error("Failed to update notification mode");
     },
     onSettled: () => void qc.invalidateQueries({ queryKey: ["tracked"] }),
   });
@@ -48,7 +50,10 @@ export default function NotificationModePicker({ titleId, currentMode, onModeCha
     mutationFn: ({ newValue }: { newValue: boolean }) => api.setRemindOnRelease(titleId, newValue),
     onMutate: ({ newValue }) => setRemind(newValue),
     onSuccess: (_data, { newValue }) => onRemindOnReleaseChange?.(newValue),
-    onError: (_err, { newValue }) => setRemind(!newValue),
+    onError: (_err, { newValue }) => {
+      setRemind(!newValue);
+      toast.error("Failed to update reminder setting");
+    },
     onSettled: () => void qc.invalidateQueries({ queryKey: ["tracked"] }),
   });
 

--- a/frontend/src/components/PinButton.test.tsx
+++ b/frontend/src/components/PinButton.test.tsx
@@ -2,10 +2,15 @@ import { describe, it, expect, mock, afterEach, beforeEach, spyOn } from "bun:te
 import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
 import type { ReactNode } from "react";
 import "../i18n";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import PinButton from "./PinButton";
 import * as api from "../api";
 import * as sonner from "sonner";
 import { AuthContext } from "../context/AuthContext";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
 
 const mockUser = {
   id: "user-1",
@@ -25,7 +30,11 @@ const mockAuthValue = {
 };
 
 function Wrapper({ children, authValue }: { children: ReactNode; authValue?: typeof mockAuthValue }) {
-  return <AuthContext value={(authValue ?? mockAuthValue) as any}>{children}</AuthContext>;
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <AuthContext value={(authValue ?? mockAuthValue) as any}>{children}</AuthContext>
+    </QueryClientProvider>
+  );
 }
 
 let spies: ReturnType<typeof spyOn>[] = [];
@@ -61,9 +70,11 @@ describe("PinButton", () => {
   it("returns null when user is not logged in", () => {
     const noUserAuth = { ...mockAuthValue, user: null };
     const { container } = render(
-      <AuthContext value={noUserAuth as any}>
-        <PinButton titleId="movie-1" />
-      </AuthContext>
+      <QueryClientProvider client={newTestClient()}>
+        <AuthContext value={noUserAuth as any}>
+          <PinButton titleId="movie-1" />
+        </AuthContext>
+      </QueryClientProvider>
     );
     expect(container.innerHTML).toBe("");
   });

--- a/frontend/src/components/PinButton.tsx
+++ b/frontend/src/components/PinButton.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { toast } from "sonner";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import * as api from "../api";
 import { useAuth } from "../context/AuthContext";
 
@@ -10,39 +11,36 @@ interface Props {
 
 export default function PinButton({ titleId, isPinned: isPinnedProp = false }: Props) {
   const { user } = useAuth();
+  const qc = useQueryClient();
   const [pinned, setPinned] = useState(isPinnedProp);
-  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     setPinned(isPinnedProp);
   }, [isPinnedProp]);
 
-  if (!user) return null;
-
-  async function handleClick() {
-    setLoading(true);
-    try {
-      if (pinned) {
-        await api.unpinTitle(titleId);
-        setPinned(false);
-        toast.success("Removed from pinned favorites");
-      } else {
-        await api.pinTitle(titleId);
-        setPinned(true);
-        toast.success("Added to pinned favorites");
-      }
-    } catch (err) {
+  const togglePinMutation = useMutation({
+    mutationFn: ({ wasPinned }: { wasPinned: boolean }) =>
+      wasPinned ? api.unpinTitle(titleId) : api.pinTitle(titleId),
+    onMutate: ({ wasPinned }) => setPinned(!wasPinned),
+    onSuccess: (_data, { wasPinned }) =>
+      toast.success(!wasPinned ? "Added to pinned favorites" : "Removed from pinned favorites"),
+    onError: (err, { wasPinned }) => {
+      setPinned(wasPinned);
       const msg = err instanceof Error ? err.message : "Failed to update pinned favorites";
       toast.error(msg);
-    } finally {
-      setLoading(false);
-    }
-  }
+    },
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: ["tracked"] });
+      void qc.invalidateQueries({ queryKey: ["home", "auth"] });
+    },
+  });
+
+  if (!user) return null;
 
   return (
     <button
-      onClick={handleClick}
-      disabled={loading}
+      onClick={() => togglePinMutation.mutate({ wasPinned: pinned })}
+      disabled={togglePinMutation.isPending}
       aria-pressed={pinned}
       title={pinned ? "Unpin from profile" : "Pin to profile"}
       className={`min-h-8 inline-flex items-center justify-center px-3 py-1.5 rounded-md text-xs font-medium transition-colors cursor-pointer ${
@@ -51,7 +49,7 @@ export default function PinButton({ titleId, isPinned: isPinnedProp = false }: P
           : "bg-zinc-800 text-zinc-400 hover:bg-zinc-700 border border-transparent"
       } disabled:opacity-50`}
     >
-      {loading ? "..." : pinned ? "📌 Pinned" : "📌 Pin"}
+      {togglePinMutation.isPending ? "..." : pinned ? "📌 Pinned" : "📌 Pin"}
     </button>
   );
 }

--- a/frontend/src/components/RatingButtons.test.tsx
+++ b/frontend/src/components/RatingButtons.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, mock, afterEach, beforeEach, spyOn } from "bun:test";
 import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
 import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "../i18n";
 import RatingButtons from "./RatingButtons";
 import * as api from "../api";
@@ -20,8 +21,16 @@ const mockAuthValue = {
   refresh: mock(() => Promise.resolve()),
 };
 
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
 function Wrapper({ children, authValue }: { children: ReactNode; authValue?: typeof mockAuthValue }) {
-  return <AuthContext value={(authValue ?? mockAuthValue) as any}>{children}</AuthContext>;
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <AuthContext value={(authValue ?? mockAuthValue) as any}>{children}</AuthContext>
+    </QueryClientProvider>
+  );
 }
 
 const emptyRatingResponse: TitleRatingResponse = {
@@ -209,9 +218,11 @@ describe("RatingButtons", () => {
     const noUserAuth = { ...mockAuthValue, user: null };
 
     render(
-      <AuthContext value={noUserAuth as any}>
-        <RatingButtons titleId="title-1" />
-      </AuthContext>
+      <QueryClientProvider client={newTestClient()}>
+        <AuthContext value={noUserAuth as any}>
+          <RatingButtons titleId="title-1" />
+        </AuthContext>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -253,7 +264,7 @@ describe("RatingButtons", () => {
     render(<RatingButtons titleId="title-42" />, { wrapper: Wrapper });
 
     await waitFor(() => {
-      expect(api.getTitleRating).toHaveBeenCalledWith("title-42");
+      expect(api.getTitleRating).toHaveBeenCalledWith("title-42", expect.anything());
     });
   });
 });

--- a/frontend/src/components/RatingButtons.tsx
+++ b/frontend/src/components/RatingButtons.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect, useCallback } from "react";
 import { HeartCrack, ThumbsDown, ThumbsUp, Heart } from "lucide-react";
 import { toast } from "sonner";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import * as api from "../api";
 import type { RatingValue, TitleRatingResponse } from "../types";
 import { useAuth } from "../context/AuthContext";
@@ -51,56 +51,42 @@ const RATING_CONFIG: {
 
 export default function RatingButtons({ titleId }: RatingButtonsProps) {
   const { user } = useAuth();
-  const [ratingData, setRatingData] = useState<TitleRatingResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [submitting, setSubmitting] = useState(false);
+  const qc = useQueryClient();
 
-  const fetchRating = useCallback(async () => {
-    try {
-      const data = await api.getTitleRating(titleId);
-      setRatingData(data);
-    } catch {
-      // Silently handle — rating data is non-critical
-    } finally {
-      setLoading(false);
-    }
-  }, [titleId]);
+  const { data: ratingData, isLoading } = useQuery({
+    queryKey: ["title-rating", titleId],
+    queryFn: ({ signal }) => api.getTitleRating(titleId, signal),
+  });
 
-  useEffect(() => {
-    fetchRating();
-  }, [fetchRating]);
+  const rateMutation = useMutation({
+    mutationFn: ({ value }: { value: RatingValue }) => api.rateTitle(titleId, value),
+    onSuccess: () => toast.success("Rating saved"),
+    onError: () => toast.error("Failed to update rating"),
+    onSettled: () => qc.invalidateQueries({ queryKey: ["title-rating", titleId] }),
+  });
 
-  async function handleRate(value: RatingValue) {
+  const unrateMutation = useMutation({
+    mutationFn: () => api.unrateTitle(titleId),
+    onSuccess: () => toast.success("Rating removed"),
+    onError: () => toast.error("Failed to update rating"),
+    onSettled: () => qc.invalidateQueries({ queryKey: ["title-rating", titleId] }),
+  });
+
+  const submitting = rateMutation.isPending || unrateMutation.isPending;
+
+  function handleRate(value: RatingValue) {
     if (submitting || !user) return;
 
     const isActive = ratingData?.user_rating === value;
-    setSubmitting(true);
 
-    try {
-      if (isActive) {
-        await api.unrateTitle(titleId);
-        setRatingData((prev) =>
-          prev ? { ...prev, user_rating: null } : prev
-        );
-        toast.success("Rating removed");
-      } else {
-        await api.rateTitle(titleId, value);
-        setRatingData((prev) =>
-          prev ? { ...prev, user_rating: value } : prev
-        );
-        toast.success("Rating saved");
-      }
-      // Refresh to get updated aggregated counts
-      const updated = await api.getTitleRating(titleId);
-      setRatingData(updated);
-    } catch {
-      toast.error("Failed to update rating");
-    } finally {
-      setSubmitting(false);
+    if (isActive) {
+      unrateMutation.mutate();
+    } else {
+      rateMutation.mutate({ value });
     }
   }
 
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="flex items-center gap-2" data-testid="rating-loading">
         {RATING_CONFIG.map(({ value }) => (

--- a/frontend/src/components/RecommendButton.test.tsx
+++ b/frontend/src/components/RecommendButton.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, mock, afterEach, beforeEach, spyOn } from "bun:test";
 import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
 import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "../i18n";
 import RecommendButton from "./RecommendButton";
 import * as api from "../api";
@@ -18,8 +19,16 @@ const mockAuthValue = {
   refresh: mock(() => Promise.resolve()),
 };
 
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
 function Wrapper({ children, authValue }: { children: ReactNode; authValue?: typeof mockAuthValue }) {
-  return <AuthContext value={(authValue ?? mockAuthValue) as any}>{children}</AuthContext>;
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <AuthContext value={(authValue ?? mockAuthValue) as any}>{children}</AuthContext>
+    </QueryClientProvider>
+  );
 }
 
 let spies: ReturnType<typeof spyOn>[] = [];
@@ -54,9 +63,11 @@ describe("RecommendButton", () => {
   it("returns null when not authenticated", () => {
     const noUserAuth = { ...mockAuthValue, user: null };
     const { container } = render(
-      <AuthContext value={noUserAuth as any}>
-        <RecommendButton titleId="movie-123" />
-      </AuthContext>
+      <QueryClientProvider client={newTestClient()}>
+        <AuthContext value={noUserAuth as any}>
+          <RecommendButton titleId="movie-123" />
+        </AuthContext>
+      </QueryClientProvider>
     );
     expect(container.innerHTML).toBe("");
   });
@@ -188,6 +199,11 @@ describe("RecommendButton", () => {
   });
 
   it("toggles to Recommended state after successful send", async () => {
+    // First call returns not recommended; after invalidation refetch returns recommended
+    (api.checkRecommendation as any)
+      .mockResolvedValueOnce({ recommended: false, id: null })
+      .mockResolvedValueOnce({ recommended: true, id: "rec-1" });
+
     render(<RecommendButton titleId="movie-123" />, { wrapper: Wrapper });
 
     await waitFor(() => {

--- a/frontend/src/components/RecommendButton.tsx
+++ b/frontend/src/components/RecommendButton.tsx
@@ -77,6 +77,7 @@ export default function RecommendButton({ titleId }: Props) {
 
   function handleOpen() {
     if (recommended) {
+      if (!recId) return;
       deleteMutation.mutate();
       return;
     }

--- a/frontend/src/components/RecommendButton.tsx
+++ b/frontend/src/components/RecommendButton.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Send, Check, Users, User } from "lucide-react";
 import { toast } from "sonner";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import * as api from "../api";
 import { useAuth } from "../context/AuthContext";
 import {
@@ -19,33 +20,64 @@ type AudienceMode = "all" | "pick";
 
 export default function RecommendButton({ titleId }: Props) {
   const { user } = useAuth();
+  const qc = useQueryClient();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [message, setMessage] = useState("");
-  const [sending, setSending] = useState(false);
-  const [recommended, setRecommended] = useState(false);
-  const [recId, setRecId] = useState<string | null>(null);
   const [audienceMode, setAudienceMode] = useState<AudienceMode>("all");
   const [targetUser, setTargetUser] = useState<SelectedUser | null>(null);
 
-  useEffect(() => {
-    if (!user) return;
-    let cancelled = false;
-    api.checkRecommendation(titleId).then((data) => {
-      if (cancelled) return;
-      setRecommended(data.recommended);
-      setRecId(data.id);
-    }).catch(() => {
-      // Silently ignore check failures
-    });
-    return () => { cancelled = true; };
-  }, [user, titleId]);
+  const { data: recData } = useQuery({
+    queryKey: ["recommendation-check", titleId],
+    enabled: !!user,
+    queryFn: () => api.checkRecommendation(titleId),
+  });
+
+  const recommended = recData?.recommended ?? false;
+  const recId = recData?.id ?? null;
+
+  const sendMutation = useMutation({
+    mutationFn: ({ message: msg, recipientId }: { message?: string; recipientId?: string }) =>
+      api.sendRecommendation(titleId, msg, recipientId),
+    onSuccess: () => {
+      setDialogOpen(false);
+      setMessage("");
+      setTargetUser(null);
+      const successMsg =
+        audienceMode === "pick" && targetUser
+          ? `Recommendation sent to @${targetUser.username}!`
+          : "Recommendation sent to all followers!";
+      toast.success(successMsg);
+    },
+    onError: (err: unknown) => {
+      toast.error(err instanceof Error ? err.message : "Failed to send recommendation");
+    },
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: ["recommendation-check", titleId] });
+      void qc.invalidateQueries({ queryKey: ["recommendations"] });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => api.deleteRecommendation(recId!),
+    onSuccess: () => {
+      toast.success("Recommendation removed");
+    },
+    onError: (err: unknown) => {
+      toast.error(err instanceof Error ? err.message : "Failed to remove recommendation");
+    },
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: ["recommendation-check", titleId] });
+      void qc.invalidateQueries({ queryKey: ["recommendations"] });
+    },
+  });
 
   if (!user) return null;
 
+  const sending = sendMutation.isPending || deleteMutation.isPending;
+
   function handleOpen() {
     if (recommended) {
-      // Unrecommend
-      handleUnrecommend();
+      deleteMutation.mutate();
       return;
     }
     setMessage("");
@@ -54,49 +86,15 @@ export default function RecommendButton({ titleId }: Props) {
     setDialogOpen(true);
   }
 
-  async function handleUnrecommend() {
-    if (!recId) return;
-    setSending(true);
-    try {
-      await api.deleteRecommendation(recId);
-      setRecommended(false);
-      setRecId(null);
-      toast.success("Recommendation removed");
-    } catch (err: unknown) {
-      const errorMessage = err instanceof Error ? err.message : "Failed to remove recommendation";
-      toast.error(errorMessage);
-    } finally {
-      setSending(false);
-    }
-  }
-
-  async function handleSend() {
+  function handleSend() {
     if (audienceMode === "pick" && !targetUser) {
       toast.error("Please select a recipient");
       return;
     }
-    setSending(true);
-    try {
-      const result = await api.sendRecommendation(
-        titleId,
-        message || undefined,
-        audienceMode === "pick" ? targetUser?.id : undefined,
-      );
-      const successMsg = audienceMode === "pick" && targetUser
-        ? `Recommendation sent to @${targetUser.username}!`
-        : "Recommendation sent to all followers!";
-      toast.success(successMsg);
-      setDialogOpen(false);
-      setMessage("");
-      setTargetUser(null);
-      setRecommended(true);
-      setRecId(result.id);
-    } catch (err: unknown) {
-      const errorMessage = err instanceof Error ? err.message : "Failed to send recommendation";
-      toast.error(errorMessage);
-    } finally {
-      setSending(false);
-    }
+    sendMutation.mutate({
+      message: message || undefined,
+      recipientId: audienceMode === "pick" ? targetUser?.id : undefined,
+    });
   }
 
   return (

--- a/frontend/src/components/RecommendButton.tsx
+++ b/frontend/src/components/RecommendButton.tsx
@@ -29,7 +29,7 @@ export default function RecommendButton({ titleId }: Props) {
   const { data: recData } = useQuery({
     queryKey: ["recommendation-check", titleId],
     enabled: !!user,
-    queryFn: () => api.checkRecommendation(titleId),
+    queryFn: ({ signal }) => api.checkRecommendation(titleId, signal),
   });
 
   const recommended = recData?.recommended ?? false;

--- a/frontend/src/components/SnoozePicker.test.tsx
+++ b/frontend/src/components/SnoozePicker.test.tsx
@@ -1,8 +1,18 @@
 import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import type { ReactNode } from "react";
 import "../i18n";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import * as api from "../api";
 import SnoozePicker from "./SnoozePicker";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={newTestClient()}>{children}</QueryClientProvider>;
+}
 
 let mockSetTitleSnooze: ReturnType<typeof spyOn>;
 let mockSetRemindOnRelease: ReturnType<typeof spyOn>;
@@ -20,7 +30,7 @@ afterEach(() => {
 
 describe("SnoozePicker", () => {
   it("renders bell icon when not snoozed", () => {
-    render(<SnoozePicker titleId="movie-123" snoozeUntil={null} />);
+    render(<SnoozePicker titleId="movie-123" snoozeUntil={null} />, { wrapper: Wrapper });
     const btn = screen.getByRole("button", { name: /snooze notifications/i });
     expect(btn).toBeTruthy();
     expect(btn.getAttribute("aria-pressed")).toBe("false");
@@ -28,14 +38,14 @@ describe("SnoozePicker", () => {
 
   it("renders bell-off icon and shows snoozed state when snoozed", () => {
     const futureDate = new Date(Date.now() + 86400000).toISOString();
-    render(<SnoozePicker titleId="movie-123" snoozeUntil={futureDate} />);
+    render(<SnoozePicker titleId="movie-123" snoozeUntil={futureDate} />, { wrapper: Wrapper });
     const btn = screen.getByRole("button", { name: /notifications snoozed/i });
     expect(btn).toBeTruthy();
     expect(btn.getAttribute("aria-pressed")).toBe("true");
   });
 
   it("opens dropdown on click", () => {
-    render(<SnoozePicker titleId="movie-123" snoozeUntil={null} />);
+    render(<SnoozePicker titleId="movie-123" snoozeUntil={null} />, { wrapper: Wrapper });
     const btn = screen.getByRole("button", { name: /snooze notifications/i });
     fireEvent.click(btn);
     expect(screen.getByRole("listbox")).toBeTruthy();
@@ -45,7 +55,7 @@ describe("SnoozePicker", () => {
 
   it("calls setTitleSnooze with ~1 day from now when Snooze 1 day is clicked", async () => {
     const onSnoozed = () => {};
-    render(<SnoozePicker titleId="movie-123" snoozeUntil={null} onSnoozed={onSnoozed} />);
+    render(<SnoozePicker titleId="movie-123" snoozeUntil={null} onSnoozed={onSnoozed} />, { wrapper: Wrapper });
 
     const btn = screen.getByRole("button", { name: /snooze notifications/i });
     fireEvent.click(btn);
@@ -68,7 +78,7 @@ describe("SnoozePicker", () => {
   it("calls setTitleSnooze(id, null) when Clear snooze is clicked", async () => {
     const futureDate = new Date(Date.now() + 86400000).toISOString();
     const onSnoozed = () => {};
-    render(<SnoozePicker titleId="movie-123" snoozeUntil={futureDate} onSnoozed={onSnoozed} />);
+    render(<SnoozePicker titleId="movie-123" snoozeUntil={futureDate} onSnoozed={onSnoozed} />, { wrapper: Wrapper });
 
     const btn = screen.getByRole("button", { name: /notifications snoozed/i });
     fireEvent.click(btn);
@@ -86,7 +96,7 @@ describe("SnoozePicker", () => {
 
   it("shows 'Until release' option when releaseDate is provided", () => {
     const futureRelease = new Date(Date.now() + 7 * 86400000).toISOString().slice(0, 10);
-    render(<SnoozePicker titleId="movie-123" snoozeUntil={null} releaseDate={futureRelease} />);
+    render(<SnoozePicker titleId="movie-123" snoozeUntil={null} releaseDate={futureRelease} />, { wrapper: Wrapper });
 
     const btn = screen.getByRole("button", { name: /snooze notifications/i });
     fireEvent.click(btn);
@@ -95,7 +105,7 @@ describe("SnoozePicker", () => {
   });
 
   it("does not show 'Clear snooze' when not snoozed", () => {
-    render(<SnoozePicker titleId="movie-123" snoozeUntil={null} />);
+    render(<SnoozePicker titleId="movie-123" snoozeUntil={null} />, { wrapper: Wrapper });
 
     const btn = screen.getByRole("button", { name: /snooze notifications/i });
     fireEvent.click(btn);

--- a/frontend/src/components/SnoozePicker.tsx
+++ b/frontend/src/components/SnoozePicker.tsx
@@ -37,10 +37,8 @@ export default function SnoozePicker({ titleId, snoozeUntil, releaseDate, onSnoo
 
   const snoozeMutation = useMutation({
     mutationFn: ({ until }: { until: string | null }) => api.setTitleSnooze(titleId, until),
-    onSuccess: () => {
-      onSnoozed?.();
-      setOpen(false);
-    },
+    onMutate: () => setOpen(false),
+    onSuccess: () => onSnoozed?.(),
     onError: () => toast.error("Failed to snooze title"),
     onSettled: () => {
       void qc.invalidateQueries({ queryKey: ["tracked"] });

--- a/frontend/src/components/SnoozePicker.tsx
+++ b/frontend/src/components/SnoozePicker.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { BellOff, Bell } from "lucide-react";
+import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import * as api from "../api";
 
 interface Props {
@@ -10,56 +12,48 @@ interface Props {
   onSnoozed?: () => void;
 }
 
+type SnoozeType = "1d" | "1w" | "release" | "clear";
+
 interface SnoozeOption {
   labelKey: string;
-  getUntil: () => string | null;
+  type: SnoozeType;
   show?: boolean;
+}
+
+function computeUntil(type: SnoozeType, releaseDate?: string | null): string | null {
+  if (type === "1d") return new Date(Date.now() + 86400000).toISOString();
+  if (type === "1w") return new Date(Date.now() + 7 * 86400000).toISOString();
+  if (type === "release" && releaseDate)
+    return new Date(releaseDate + "T00:00:00.000Z").toISOString();
+  return null;
 }
 
 export default function SnoozePicker({ titleId, snoozeUntil, releaseDate, onSnoozed }: Props) {
   const [open, setOpen] = useState(false);
-  const [loading, setLoading] = useState(false);
   const { t } = useTranslation();
+  const qc = useQueryClient();
 
   const isSnoozed = snoozeUntil != null && new Date(snoozeUntil) > new Date();
 
-  const options: SnoozeOption[] = [
-    {
-      labelKey: "snooze.oneDay",
-      getUntil: () => new Date(Date.now() + 86400000).toISOString(),
-    },
-    {
-      labelKey: "snooze.oneWeek",
-      getUntil: () => new Date(Date.now() + 7 * 86400000).toISOString(),
-    },
-    ...(releaseDate
-      ? [
-          {
-            labelKey: "snooze.untilRelease",
-            getUntil: () => new Date(releaseDate + "T00:00:00.000Z").toISOString(),
-          },
-        ]
-      : []),
-    {
-      labelKey: "snooze.clear",
-      getUntil: () => null,
-      show: isSnoozed,
-    },
-  ];
-
-  async function handleSelect(getUntil: () => string | null) {
-    setOpen(false);
-    setLoading(true);
-    const until = getUntil();
-    try {
-      await api.setTitleSnooze(titleId, until);
+  const snoozeMutation = useMutation({
+    mutationFn: ({ until }: { until: string | null }) => api.setTitleSnooze(titleId, until),
+    onSuccess: () => {
       onSnoozed?.();
-    } catch (err) {
-      console.error("Failed to update snooze", err);
-    } finally {
-      setLoading(false);
-    }
-  }
+      setOpen(false);
+    },
+    onError: () => toast.error("Failed to snooze title"),
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: ["tracked"] });
+      void qc.invalidateQueries({ queryKey: ["home", "auth"] });
+    },
+  });
+
+  const options: SnoozeOption[] = [
+    { labelKey: "snooze.oneDay", type: "1d" },
+    { labelKey: "snooze.oneWeek", type: "1w" },
+    ...(releaseDate ? [{ labelKey: "snooze.untilRelease", type: "release" as SnoozeType }] : []),
+    { labelKey: "snooze.clear", type: "clear", show: isSnoozed },
+  ];
 
   const visibleOptions = options.filter((o) => o.show !== false);
 
@@ -70,7 +64,7 @@ export default function SnoozePicker({ titleId, snoozeUntil, releaseDate, onSnoo
         title={isSnoozed ? t("snooze.snoozed") : t("snooze.snooze")}
         aria-label={isSnoozed ? t("snooze.snoozed") : t("snooze.snooze")}
         aria-pressed={isSnoozed}
-        disabled={loading}
+        disabled={snoozeMutation.isPending}
         onClick={(e) => {
           e.preventDefault();
           setOpen((v) => !v);
@@ -102,7 +96,7 @@ export default function SnoozePicker({ titleId, snoozeUntil, releaseDate, onSnoo
                   aria-selected={false}
                   onClick={(e) => {
                     e.preventDefault();
-                    handleSelect(opt.getUntil);
+                    snoozeMutation.mutate({ until: computeUntil(opt.type, releaseDate) });
                   }}
                   className="w-full text-left text-xs px-3 py-2 hover:bg-zinc-700 transition-colors text-zinc-300"
                 >

--- a/frontend/src/components/StatusPicker.test.tsx
+++ b/frontend/src/components/StatusPicker.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, afterEach, beforeEach, spyOn } from "bun:test";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import type { ReactNode } from "react";
+import "../i18n";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import * as api from "../api";
+import * as sonner from "sonner";
+import StatusPicker from "./StatusPicker";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={newTestClient()}>{children}</QueryClientProvider>;
+}
+
+let spies: ReturnType<typeof spyOn>[] = [];
+
+beforeEach(() => {
+  spies = [
+    spyOn(api, "updateTrackedStatus").mockResolvedValue(undefined as any),
+    spyOn(sonner.toast, "error").mockImplementation(() => "1" as any),
+  ];
+});
+
+afterEach(() => {
+  cleanup();
+  for (const spy of spies) spy.mockRestore();
+  spies = [];
+});
+
+describe("StatusPicker", () => {
+  it("renders the current status", () => {
+    render(
+      <StatusPicker titleId="t-1" objectType="SHOW" currentStatus="watching" onStatusChange={() => {}} />,
+      { wrapper: Wrapper },
+    );
+    expect(screen.getByText(/watching/i)).toBeTruthy();
+  });
+
+  it("renders 'Auto' when status is null", () => {
+    render(
+      <StatusPicker titleId="t-1" objectType="SHOW" currentStatus={null} onStatusChange={() => {}} />,
+      { wrapper: Wrapper },
+    );
+    expect(screen.getByText(/auto/i)).toBeTruthy();
+  });
+
+  it("opens dropdown on click", () => {
+    render(
+      <StatusPicker titleId="t-1" objectType="SHOW" currentStatus={null} onStatusChange={() => {}} />,
+      { wrapper: Wrapper },
+    );
+    fireEvent.click(screen.getByRole("button", { expanded: false }));
+    expect(screen.getByRole("listbox")).toBeTruthy();
+  });
+
+  it("calls api.updateTrackedStatus when an option is clicked", async () => {
+    const onStatusChange = spyOn({ fn: (_: string | null) => {} }, "fn");
+    render(
+      <StatusPicker
+        titleId="t-1"
+        objectType="SHOW"
+        currentStatus={null}
+        onStatusChange={onStatusChange}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    fireEvent.click(screen.getByRole("button", { expanded: false }));
+    const watchingOption = screen.getByRole("option", { name: /watching/i });
+    fireEvent.click(watchingOption);
+
+    await waitFor(() => {
+      expect(api.updateTrackedStatus).toHaveBeenCalledWith("t-1", "watching");
+    });
+  });
+
+  it("calls onStatusChange callback on success", async () => {
+    let called: string | null | undefined = undefined;
+    render(
+      <StatusPicker
+        titleId="t-1"
+        objectType="SHOW"
+        currentStatus={null}
+        onStatusChange={(s) => { called = s; }}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    fireEvent.click(screen.getByRole("button", { expanded: false }));
+    fireEvent.click(screen.getByRole("option", { name: /watching/i }));
+
+    await waitFor(() => {
+      expect(called).toBe("watching");
+    });
+  });
+
+  it("shows error toast when API call fails", async () => {
+    (api.updateTrackedStatus as any).mockRejectedValueOnce(new Error("fail"));
+
+    render(
+      <StatusPicker titleId="t-1" objectType="SHOW" currentStatus={null} onStatusChange={() => {}} />,
+      { wrapper: Wrapper },
+    );
+
+    fireEvent.click(screen.getByRole("button", { expanded: false }));
+    fireEvent.click(screen.getByRole("option", { name: /watching/i }));
+
+    await waitFor(() => {
+      expect(sonner.toast.error).toHaveBeenCalledWith("Failed to update status");
+    });
+  });
+
+  it("renders movie options for MOVIE objectType", () => {
+    render(
+      <StatusPicker titleId="t-1" objectType="MOVIE" currentStatus={null} onStatusChange={() => {}} />,
+      { wrapper: Wrapper },
+    );
+
+    fireEvent.click(screen.getByRole("button", { expanded: false }));
+    const listbox = screen.getByRole("listbox");
+    expect(listbox.textContent).toContain("Plan to Watch");
+    expect(listbox.textContent).not.toContain("Watching");
+  });
+});

--- a/frontend/src/components/StatusPicker.tsx
+++ b/frontend/src/components/StatusPicker.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
+import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import * as api from "../api";
 
 type UserStatus = "plan_to_watch" | "watching" | "on_hold" | "dropped" | "completed";
@@ -34,31 +36,27 @@ const MOVIE_OPTIONS: StatusOption[] = [
 
 export default function StatusPicker({ titleId, objectType, currentStatus, onStatusChange }: Props) {
   const [open, setOpen] = useState(false);
-  const [loading, setLoading] = useState(false);
   const { t } = useTranslation();
+  const qc = useQueryClient();
 
   const options = objectType === "SHOW" ? SHOW_OPTIONS : MOVIE_OPTIONS;
   const activeOption = options.find((o) => o.value === (currentStatus ?? null)) ?? options[0];
 
-  async function handleSelect(status: UserStatus | null) {
-    setOpen(false);
-    setLoading(true);
-    try {
-      await api.updateTrackedStatus(titleId, status);
+  const statusMutation = useMutation({
+    mutationFn: (status: UserStatus | null) => api.updateTrackedStatus(titleId, status),
+    onSuccess: (_data, status) => {
       onStatusChange(status);
-    } catch {
-      // API call failed — do not update the parent; the picker reverts visually
-      // since we haven't called onStatusChange
-    } finally {
-      setLoading(false);
-    }
-  }
+      setOpen(false);
+    },
+    onError: () => toast.error("Failed to update status"),
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["tracked"] }),
+  });
 
   return (
     <div className="relative">
       <button
         onClick={(e) => { e.preventDefault(); setOpen((v) => !v); }}
-        disabled={loading}
+        disabled={statusMutation.isPending}
         className={`w-full text-left text-xs px-2 py-1 rounded bg-zinc-800 hover:bg-zinc-700 transition-colors flex items-center gap-1.5 ${activeOption.color}`}
         aria-haspopup="listbox"
         aria-expanded={open}
@@ -81,7 +79,7 @@ export default function StatusPicker({ titleId, objectType, currentStatus, onSta
                 <button
                   role="option"
                   aria-selected={opt.value === (currentStatus ?? null)}
-                  onClick={(e) => { e.preventDefault(); handleSelect(opt.value); }}
+                  onClick={(e) => { e.preventDefault(); statusMutation.mutate(opt.value); }}
                   className={`w-full text-left text-xs px-3 py-2 hover:bg-zinc-700 transition-colors ${opt.color} ${opt.value === (currentStatus ?? null) ? "bg-zinc-700" : ""}`}
                 >
                   {t(opt.labelKey)}

--- a/frontend/src/components/StatusPicker.tsx
+++ b/frontend/src/components/StatusPicker.tsx
@@ -44,10 +44,8 @@ export default function StatusPicker({ titleId, objectType, currentStatus, onSta
 
   const statusMutation = useMutation({
     mutationFn: (status: UserStatus | null) => api.updateTrackedStatus(titleId, status),
-    onSuccess: (_data, status) => {
-      onStatusChange(status);
-      setOpen(false);
-    },
+    onMutate: () => setOpen(false),
+    onSuccess: (_data, status) => onStatusChange(status),
     onError: () => toast.error("Failed to update status"),
     onSettled: () => void qc.invalidateQueries({ queryKey: ["tracked"] }),
   });

--- a/frontend/src/components/TagList.test.tsx
+++ b/frontend/src/components/TagList.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, afterEach, beforeEach, spyOn } from "bun:test";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import type { ReactNode } from "react";
+import "../i18n";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import * as api from "../api";
+import * as sonner from "sonner";
+import TagList from "./TagList";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={newTestClient()}>{children}</QueryClientProvider>;
+}
+
+let spies: ReturnType<typeof spyOn>[] = [];
+
+beforeEach(() => {
+  spies = [
+    spyOn(api, "updateTrackedTags").mockResolvedValue(undefined as any),
+    spyOn(sonner.toast, "error").mockImplementation(() => "1" as any),
+  ];
+});
+
+afterEach(() => {
+  cleanup();
+  for (const spy of spies) spy.mockRestore();
+  spies = [];
+});
+
+describe("TagList", () => {
+  it("renders existing tags", () => {
+    render(
+      <TagList titleId="t-1" tags={["action", "scifi"]} onTagsChange={() => {}} />,
+      { wrapper: Wrapper },
+    );
+    expect(screen.getByText("action")).toBeTruthy();
+    expect(screen.getByText("scifi")).toBeTruthy();
+  });
+
+  it("renders an input for adding new tags", () => {
+    render(<TagList titleId="t-1" tags={[]} onTagsChange={() => {}} />, { wrapper: Wrapper });
+    expect(screen.getByRole("textbox")).toBeTruthy();
+  });
+
+  it("calls api.updateTrackedTags when adding a tag via Enter", async () => {
+    render(<TagList titleId="t-1" tags={["action"]} onTagsChange={() => {}} />, { wrapper: Wrapper });
+
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "drama" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(api.updateTrackedTags).toHaveBeenCalledWith("t-1", ["action", "drama"]);
+    });
+  });
+
+  it("calls onTagsChange callback after saving", async () => {
+    let called: string[] | undefined;
+    render(
+      <TagList titleId="t-1" tags={[]} onTagsChange={(tags) => { called = tags; }} />,
+      { wrapper: Wrapper },
+    );
+
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "comedy" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(called).toEqual(["comedy"]);
+    });
+  });
+
+  it("removes a tag when the remove button is clicked", async () => {
+    render(
+      <TagList titleId="t-1" tags={["action", "drama"]} onTagsChange={() => {}} />,
+      { wrapper: Wrapper },
+    );
+
+    const removeBtn = screen.getByLabelText("Remove tag action");
+    fireEvent.click(removeBtn);
+
+    await waitFor(() => {
+      expect(api.updateTrackedTags).toHaveBeenCalledWith("t-1", ["drama"]);
+    });
+  });
+
+  it("shows error toast when API call fails", async () => {
+    (api.updateTrackedTags as any).mockRejectedValueOnce(new Error("fail"));
+
+    render(<TagList titleId="t-1" tags={[]} onTagsChange={() => {}} />, { wrapper: Wrapper });
+
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "fail-tag" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(sonner.toast.error).toHaveBeenCalledWith("Failed to save tags");
+    });
+  });
+
+  it("does not add duplicate tags", async () => {
+    render(
+      <TagList titleId="t-1" tags={["action"]} onTagsChange={() => {}} />,
+      { wrapper: Wrapper },
+    );
+
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "action" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(api.updateTrackedTags).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/TagList.tsx
+++ b/frontend/src/components/TagList.tsx
@@ -1,5 +1,7 @@
 import { useState, useRef } from "react";
+import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import * as api from "../api";
 
 interface Props {
@@ -10,18 +12,17 @@ interface Props {
 
 export default function TagList({ titleId, tags, onTagsChange }: Props) {
   const { t } = useTranslation();
+  const qc = useQueryClient();
   const [input, setInput] = useState("");
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  async function saveTags(newTags: string[]) {
-    try {
-      await api.updateTrackedTags(titleId, newTags);
-      onTagsChange(newTags);
-    } catch (err) {
-      console.error("Failed to save tags", err);
-    }
-  }
+  const saveTagsMutation = useMutation({
+    mutationFn: (newTags: string[]) => api.updateTrackedTags(titleId, newTags),
+    onSuccess: (_data, newTags) => onTagsChange(newTags),
+    onError: () => toast.error("Failed to save tags"),
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["tracked"] }),
+  });
 
   function addTag(raw: string) {
     const tag = raw.trim().toLowerCase();
@@ -41,11 +42,11 @@ export default function TagList({ titleId, tags, onTagsChange }: Props) {
     }
     const next = [...tags, tag];
     setInput("");
-    void saveTags(next);
+    saveTagsMutation.mutate(next);
   }
 
   function removeTag(tag: string) {
-    void saveTags(tags.filter((t) => t !== tag));
+    saveTagsMutation.mutate(tags.filter((t) => t !== tag));
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {

--- a/frontend/src/components/TitleCard.test.tsx
+++ b/frontend/src/components/TitleCard.test.tsx
@@ -2,11 +2,16 @@ import { describe, it, expect, mock, afterEach, beforeEach, spyOn } from "bun:te
 import { render, screen, cleanup } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import "../i18n";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import TitleCard from "./TitleCard";
 import { AuthContext } from "../context/AuthContext";
 import * as api from "../api";
 import type { Title } from "../types";
 import type { ReactNode } from "react";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
 
 const mockUser = { id: "1", username: "test", display_name: null, auth_provider: "local", is_admin: false };
 
@@ -21,17 +26,21 @@ const mockAuthValue = {
 
 function Wrapper({ children }: { children: ReactNode }) {
   return (
-    <MemoryRouter>
-      <AuthContext value={mockAuthValue as any}>{children}</AuthContext>
-    </MemoryRouter>
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter>
+        <AuthContext value={mockAuthValue as any}>{children}</AuthContext>
+      </MemoryRouter>
+    </QueryClientProvider>
   );
 }
 
 function NoUserWrapper({ children }: { children: ReactNode }) {
   return (
-    <MemoryRouter>
-      <AuthContext value={{ ...mockAuthValue, user: null } as any}>{children}</AuthContext>
-    </MemoryRouter>
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter>
+        <AuthContext value={{ ...mockAuthValue, user: null } as any}>{children}</AuthContext>
+      </MemoryRouter>
+    </QueryClientProvider>
   );
 }
 

--- a/frontend/src/components/TitleList.test.tsx
+++ b/frontend/src/components/TitleList.test.tsx
@@ -1,11 +1,16 @@
 import { describe, it, expect, mock, afterEach, beforeEach, spyOn } from "bun:test";
 import { render, screen, cleanup } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import TitleList from "./TitleList";
 import { AuthContext } from "../context/AuthContext";
 import * as api from "../api";
 import type { Title } from "../types";
 import type { ReactNode } from "react";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
 
 const mockAuthValue = {
   user: null,
@@ -18,9 +23,11 @@ const mockAuthValue = {
 
 function Wrapper({ children }: { children: ReactNode }) {
   return (
-    <MemoryRouter>
-      <AuthContext value={mockAuthValue as any}>{children}</AuthContext>
-    </MemoryRouter>
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter>
+        <AuthContext value={mockAuthValue as any}>{children}</AuthContext>
+      </MemoryRouter>
+    </QueryClientProvider>
   );
 }
 

--- a/frontend/src/components/TrackButton.test.tsx
+++ b/frontend/src/components/TrackButton.test.tsx
@@ -3,10 +3,15 @@ import { render, screen, fireEvent, waitFor, cleanup, act } from "@testing-libra
 import type { ReactNode } from "react";
 // Initialize i18n before anything else
 import "../i18n";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import TrackButton from "./TrackButton";
 import * as api from "../api";
 import * as sonner from "sonner";
 import { AuthContext } from "../context/AuthContext";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
 
 const mockUser = { id: "1", username: "test", display_name: null, auth_provider: "local", is_admin: false };
 
@@ -20,7 +25,11 @@ const mockAuthValue = {
 };
 
 function Wrapper({ children, authValue }: { children: ReactNode; authValue?: typeof mockAuthValue }) {
-  return <AuthContext value={(authValue ?? mockAuthValue) as any}>{children}</AuthContext>;
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <AuthContext value={(authValue ?? mockAuthValue) as any}>{children}</AuthContext>
+    </QueryClientProvider>
+  );
 }
 
 let spies: ReturnType<typeof spyOn>[] = [];
@@ -54,9 +63,11 @@ describe("TrackButton", () => {
   it("returns null when user is not logged in", () => {
     const noUserAuth = { ...mockAuthValue, user: null };
     const { container } = render(
-      <AuthContext value={noUserAuth as any}>
-        <TrackButton titleId="123" isTracked={false} />
-      </AuthContext>
+      <QueryClientProvider client={newTestClient()}>
+        <AuthContext value={noUserAuth as any}>
+          <TrackButton titleId="123" isTracked={false} />
+        </AuthContext>
+      </QueryClientProvider>
     );
     expect(container.innerHTML).toBe("");
   });

--- a/frontend/src/components/TrackButton.tsx
+++ b/frontend/src/components/TrackButton.tsx
@@ -43,7 +43,10 @@ export default function TrackButton({ titleId, isTracked, onToggle, titleData }:
       setTracked(false);
       toast.error("Failed to track — please try again");
     },
-    onSettled: () => void qc.invalidateQueries({ queryKey: ["tracked"] }),
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: ["tracked"] });
+      void qc.invalidateQueries({ queryKey: ["home", "auth"] });
+    },
   });
 
   const untrackMutation = useMutation({

--- a/frontend/src/components/TrackButton.tsx
+++ b/frontend/src/components/TrackButton.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import * as api from "../api";
 import type { Title } from "../types";
 import { useAuth } from "../context/AuthContext";
@@ -22,8 +23,8 @@ interface Props {
 export default function TrackButton({ titleId, isTracked, onToggle, titleData }: Props) {
   const { user } = useAuth();
   const { t } = useTranslation();
+  const qc = useQueryClient();
   const [tracked, setTracked] = useState(isTracked);
-  const [loading, setLoading] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
 
   // Keep internal state in sync when parent prop changes (e.g., after data refetch)
@@ -31,37 +32,48 @@ export default function TrackButton({ titleId, isTracked, onToggle, titleData }:
     setTracked(isTracked);
   }, [isTracked]);
 
-  if (!user) return null;
-
-  async function handleTrack() {
-    setLoading(true);
-    try {
-      await api.trackTitle(titleId, undefined, titleData);
-      setTracked(true);
+  const trackMutation = useMutation({
+    mutationFn: () => api.trackTitle(titleId, undefined, titleData),
+    onMutate: () => setTracked(true),
+    onSuccess: () => {
       onToggle?.(true);
       toast.success("Title tracked");
-    } catch (err) {
-      console.error("Track toggle failed:", err);
-      toast.error("Failed to track — please try again");
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function handleUntrack() {
-    setConfirmOpen(false);
-    setLoading(true);
-    try {
-      await api.untrackTitle(titleId);
+    },
+    onError: () => {
       setTracked(false);
+      toast.error("Failed to track — please try again");
+    },
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["tracked"] }),
+  });
+
+  const untrackMutation = useMutation({
+    mutationFn: () => api.untrackTitle(titleId),
+    onMutate: () => setTracked(false),
+    onSuccess: () => {
       onToggle?.(false);
       toast.success("Removed from tracked");
-    } catch (err) {
-      console.error("Track toggle failed:", err);
+    },
+    onError: () => {
+      setTracked(true);
       toast.error("Failed to untrack — please try again");
-    } finally {
-      setLoading(false);
-    }
+    },
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: ["tracked"] });
+      void qc.invalidateQueries({ queryKey: ["home", "auth"] });
+    },
+  });
+
+  if (!user) return null;
+
+  const loading = trackMutation.isPending || untrackMutation.isPending;
+
+  function handleTrack() {
+    trackMutation.mutate();
+  }
+
+  function handleUntrack() {
+    setConfirmOpen(false);
+    untrackMutation.mutate();
   }
 
   function handleClick() {

--- a/frontend/src/components/UserSearchDropdown.test.tsx
+++ b/frontend/src/components/UserSearchDropdown.test.tsx
@@ -1,0 +1,76 @@
+import { describe, test, expect, spyOn, afterEach, beforeEach, mock } from "bun:test";
+import { render, screen, waitFor, cleanup, act, fireEvent } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import * as api from "../api";
+
+const { default: UserSearchDropdown } = await import("./UserSearchDropdown");
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={newTestClient()}>{children}</QueryClientProvider>
+  );
+}
+
+const mockUsers = [
+  { id: "u1", username: "alice", display_name: "Alice", image: null },
+  { id: "u2", username: "bob", display_name: null, image: null },
+];
+
+let searchUsersSpy: ReturnType<typeof spyOn<typeof api, "searchUsers">>;
+
+beforeEach(() => {
+  searchUsersSpy = spyOn(api, "searchUsers").mockResolvedValue({ users: mockUsers });
+});
+
+afterEach(() => {
+  searchUsersSpy.mockRestore();
+  cleanup();
+});
+
+describe("UserSearchDropdown", () => {
+  test("renders search input", () => {
+    render(
+      <UserSearchDropdown onSelect={mock(() => {})} />,
+      { wrapper: Wrapper }
+    );
+
+    expect(screen.getByTestId("user-search-input")).toBeDefined();
+  });
+
+  test("no dropdown shown on empty input", () => {
+    render(
+      <UserSearchDropdown onSelect={mock(() => {})} />,
+      { wrapper: Wrapper }
+    );
+
+    expect(screen.queryByTestId("user-search-results")).toBeNull();
+  });
+
+  test("shows results after typing (bypassing debounce via input change)", async () => {
+    // The query triggers after debounce — we type and wait
+    searchUsersSpy.mockResolvedValue({ users: mockUsers });
+
+    render(
+      <UserSearchDropdown onSelect={mock(() => {})} />,
+      { wrapper: Wrapper }
+    );
+
+    const input = screen.getByTestId("user-search-input");
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "alice" } });
+      // Wait past debounce delay
+      await new Promise((r) => setTimeout(r, 350));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("user-search-results")).toBeDefined();
+    });
+
+    expect(screen.getByText("Alice")).toBeDefined();
+  });
+});

--- a/frontend/src/components/UserSearchDropdown.tsx
+++ b/frontend/src/components/UserSearchDropdown.tsx
@@ -29,8 +29,8 @@ export default function UserSearchDropdown({ onSelect, selected, onClear }: Prop
   const { data, isFetching } = useQuery({
     queryKey: ["user-search", debouncedQuery],
     enabled: debouncedQuery.length >= 1,
-    queryFn: () =>
-      api.searchUsers(debouncedQuery).then((d) =>
+    queryFn: ({ signal }) =>
+      api.searchUsers(debouncedQuery, signal).then((d) =>
         d.users.map((u) => ({
           id: u.id,
           username: u.username,
@@ -43,7 +43,7 @@ export default function UserSearchDropdown({ onSelect, selected, onClear }: Prop
   });
 
   const results = data ?? [];
-  const open = debouncedQuery.length >= 1 && results.length > 0;
+  const open = query.length >= 1 && debouncedQuery.length >= 1 && results.length > 0;
   const loading = isFetching;
 
   // Close dropdown when clicking outside

--- a/frontend/src/components/UserSearchDropdown.tsx
+++ b/frontend/src/components/UserSearchDropdown.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { X, Search } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
 import * as api from "../api";
 
 export interface SelectedUser {
@@ -17,50 +18,39 @@ interface Props {
 
 export default function UserSearchDropdown({ onSelect, selected, onClear }: Props) {
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<SelectedUser[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [open, setOpen] = useState(false);
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
+  const [debouncedQuery, setDebouncedQuery] = useState("");
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    if (!query || query.length < 1) {
-      setResults([]);
-      setOpen(false);
-      return;
-    }
+    const t = setTimeout(() => setDebouncedQuery(query), 300);
+    return () => clearTimeout(t);
+  }, [query]);
 
-    debounceRef.current = setTimeout(async () => {
-      setLoading(true);
-      try {
-        const data = await api.searchUsers(query);
-        const mapped = data.users.map((u) => ({
+  const { data, isFetching } = useQuery({
+    queryKey: ["user-search", debouncedQuery],
+    enabled: debouncedQuery.length >= 1,
+    queryFn: () =>
+      api.searchUsers(debouncedQuery).then((d) =>
+        d.users.map((u) => ({
           id: u.id,
           username: u.username,
           displayName: u.display_name ?? null,
           image: u.image,
-        }));
-        setResults(mapped);
-        setOpen(mapped.length > 0);
-      } catch {
-        setResults([]);
-        setOpen(false);
-      } finally {
-        setLoading(false);
-      }
-    }, 300);
+        }))
+      ),
+    placeholderData: (prev) => prev,
+    staleTime: 30_000,
+  });
 
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
-  }, [query]);
+  const results = data ?? [];
+  const open = debouncedQuery.length >= 1 && results.length > 0;
+  const loading = isFetching;
 
   // Close dropdown when clicking outside
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setOpen(false);
+        setQuery("");
       }
     }
     document.addEventListener("mousedown", handleClickOutside);
@@ -112,7 +102,7 @@ export default function UserSearchDropdown({ onSelect, selected, onClear }: Prop
         />
       </div>
 
-      {open && results.length > 0 && (
+      {open && (
         <div className="absolute z-10 mt-1 w-full bg-zinc-800 border border-zinc-700 rounded-md shadow-lg max-h-48 overflow-y-auto" data-testid="user-search-results">
           {results.map((user) => (
             <button
@@ -120,7 +110,6 @@ export default function UserSearchDropdown({ onSelect, selected, onClear }: Prop
               onClick={() => {
                 onSelect(user);
                 setQuery("");
-                setOpen(false);
               }}
               className="w-full flex items-center gap-3 px-3 py-2 hover:bg-zinc-700 transition-colors cursor-pointer text-left"
               data-testid="user-search-result"
@@ -147,7 +136,7 @@ export default function UserSearchDropdown({ onSelect, selected, onClear }: Prop
         </div>
       )}
 
-      {loading && query.length > 0 && (
+      {loading && query.length > 0 && !open && (
         <div className="absolute z-10 mt-1 w-full bg-zinc-800 border border-zinc-700 rounded-md shadow-lg px-3 py-2">
           <span className="text-sm text-zinc-400">Searching...</span>
         </div>

--- a/frontend/src/components/VisibilityButton.test.tsx
+++ b/frontend/src/components/VisibilityButton.test.tsx
@@ -1,10 +1,15 @@
 import { describe, it, expect, mock, afterEach, beforeEach, spyOn } from "bun:test";
 import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
 import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import VisibilityButton from "./VisibilityButton";
 import * as api from "../api";
 import * as sonner from "sonner";
 import { AuthContext } from "../context/AuthContext";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
 
 const mockUser = { id: "1", username: "test", display_name: null, auth_provider: "local", is_admin: false };
 
@@ -18,7 +23,11 @@ const mockAuthValue = {
 };
 
 function Wrapper({ children }: { children: ReactNode }) {
-  return <AuthContext value={mockAuthValue as any}>{children}</AuthContext>;
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <AuthContext value={mockAuthValue as any}>{children}</AuthContext>
+    </QueryClientProvider>
+  );
 }
 
 let spies: ReturnType<typeof spyOn>[] = [];
@@ -41,9 +50,11 @@ describe("VisibilityButton", () => {
   it("returns null when user is not logged in", () => {
     const noUserAuth = { ...mockAuthValue, user: null };
     const { container } = render(
-      <AuthContext value={noUserAuth as any}>
-        <VisibilityButton titleId="123" isPublic={true} isTracked={true} />
-      </AuthContext>
+      <QueryClientProvider client={newTestClient()}>
+        <AuthContext value={noUserAuth as any}>
+          <VisibilityButton titleId="123" isPublic={true} isTracked={true} />
+        </AuthContext>
+      </QueryClientProvider>
     );
     expect(container.innerHTML).toBe("");
   });

--- a/frontend/src/components/VisibilityButton.tsx
+++ b/frontend/src/components/VisibilityButton.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Eye, EyeOff } from "lucide-react";
 import { toast } from "sonner";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import * as api from "../api";
 import { useAuth } from "../context/AuthContext";
 
@@ -14,26 +15,29 @@ interface Props {
 
 export default function VisibilityButton({ titleId, isPublic, isTracked, onToggle, variant = "button" }: Props) {
   const { user } = useAuth();
+  const qc = useQueryClient();
   const [publicState, setPublicState] = useState(isPublic);
-  const [loading, setLoading] = useState(false);
+
+  const visibilityMutation = useMutation({
+    mutationFn: ({ newState }: { newState: boolean }) => api.updateTitleVisibility(titleId, newState),
+    onMutate: ({ newState }) => setPublicState(newState),
+    onSuccess: (_data, { newState }) => {
+      onToggle?.(newState);
+      toast.success(newState ? "Visible on profile" : "Hidden from profile");
+    },
+    onError: (_err, { newState }) => {
+      setPublicState(!newState);
+      toast.error("Failed to update visibility");
+    },
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["tracked"] }),
+  });
 
   if (!user || !isTracked) return null;
 
-  async function toggle(e: React.MouseEvent) {
+  function toggle(e: React.MouseEvent) {
     e.preventDefault();
     e.stopPropagation();
-    setLoading(true);
-    try {
-      const newState = !publicState;
-      await api.updateTitleVisibility(titleId, newState);
-      setPublicState(newState);
-      onToggle?.(newState);
-      toast.success(newState ? "Visible on profile" : "Hidden from profile");
-    } catch {
-      toast.error("Failed to update visibility");
-    } finally {
-      setLoading(false);
-    }
+    visibilityMutation.mutate({ newState: !publicState });
   }
 
   const Icon = publicState ? Eye : EyeOff;
@@ -42,7 +46,7 @@ export default function VisibilityButton({ titleId, isPublic, isTracked, onToggl
     return (
       <button
         onClick={toggle}
-        disabled={loading}
+        disabled={visibilityMutation.isPending}
         className={`absolute top-2 right-2 z-10 p-1.5 rounded-full transition-colors ${
           publicState
             ? "bg-zinc-900/70 text-zinc-300 hover:bg-zinc-900/90 hover:text-white"
@@ -58,7 +62,7 @@ export default function VisibilityButton({ titleId, isPublic, isTracked, onToggl
   return (
     <button
       onClick={toggle}
-      disabled={loading}
+      disabled={visibilityMutation.isPending}
       className={`min-h-8 inline-flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors cursor-pointer ${
         publicState
           ? "bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-white"

--- a/frontend/src/components/title-detail/SuggestionsRow.test.tsx
+++ b/frontend/src/components/title-detail/SuggestionsRow.test.tsx
@@ -1,0 +1,85 @@
+import { describe, test, expect, spyOn, afterEach, beforeEach, mock } from "bun:test";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import * as api from "../../api";
+
+mock.module("../../i18n", () => ({}));
+
+const { default: SuggestionsRow } = await import("./SuggestionsRow");
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+const mockTitles = [
+  { id: "movie-1", title: "Movie One", posterUrl: null, releaseYear: 2024, object_type: "MOVIE" },
+  { id: "movie-2", title: "Movie Two", posterUrl: null, releaseYear: 2023, object_type: "MOVIE" },
+];
+
+let getSuggestionsSpy: ReturnType<typeof spyOn<typeof api, "getTitleSuggestions">>;
+
+beforeEach(() => {
+  getSuggestionsSpy = spyOn(api, "getTitleSuggestions");
+});
+
+afterEach(() => {
+  getSuggestionsSpy.mockRestore();
+  cleanup();
+});
+
+describe("SuggestionsRow", () => {
+  test("renders loading skeletons while fetching", () => {
+    getSuggestionsSpy.mockImplementation(() => new Promise(() => {}));
+
+    render(<SuggestionsRow titleId="movie-1" type="movie" />, { wrapper: Wrapper });
+
+    const skeletons = document.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  test("renders title list on success", async () => {
+    getSuggestionsSpy.mockResolvedValue({
+      titles: mockTitles as any,
+      page: 1,
+      totalPages: 1,
+      totalResults: 2,
+    });
+
+    render(<SuggestionsRow titleId="movie-1" type="movie" />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Movie One")).toBeDefined();
+      expect(screen.getByText("Movie Two")).toBeDefined();
+    });
+  });
+
+  test("returns null when titles are empty after loading", async () => {
+    getSuggestionsSpy.mockResolvedValue({
+      titles: [],
+      page: 1,
+      totalPages: 0,
+      totalResults: 0,
+    });
+
+    const { container } = render(<SuggestionsRow titleId="movie-1" type="movie" />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(getSuggestionsSpy).toHaveBeenCalled();
+    });
+
+    // After loading with empty results, component returns null
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+});

--- a/frontend/src/components/title-detail/SuggestionsRow.tsx
+++ b/frontend/src/components/title-detail/SuggestionsRow.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useState } from "react";
 import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
+import { useQuery } from "@tanstack/react-query";
 import * as api from "../../api";
-import type { SearchTitle } from "../../types";
 import ScrollableRow from "../ScrollableRow";
 import { TitleCardSkeleton } from "../SkeletonComponents";
 import { Section } from "./Section";
@@ -15,27 +14,19 @@ interface SuggestionsRowProps {
 
 function SuggestionsRowInner({ titleId, type }: SuggestionsRowProps) {
   const { t } = useTranslation();
-  const [titles, setTitles] = useState<SearchTitle[]>([]);
-  const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    const controller = new AbortController();
-    api.getTitleSuggestions(type, titleId, 1, controller.signal)
-      .then((res) => {
-        if (!controller.signal.aborted) setTitles(res.titles.slice(0, 20));
-      })
-      .catch(() => {})
-      .finally(() => {
-        if (!controller.signal.aborted) setLoading(false);
-      });
-    return () => controller.abort();
-  }, [titleId, type]);
+  const { data, isLoading } = useQuery({
+    queryKey: ["title-suggestions", type, titleId],
+    queryFn: ({ signal }) => api.getTitleSuggestions(type, titleId, 1, signal),
+  });
 
-  if (!loading && titles.length === 0) return null;
+  const titles = data?.titles.slice(0, 20) ?? [];
+
+  if (!isLoading && titles.length === 0) return null;
 
   return (
     <Section title={t("suggestions.alsoLike")}>
-      {loading ? (
+      {isLoading ? (
         <div className="flex gap-3">
           {Array.from({ length: 6 }).map((_, i) => (
             <div key={i} className="w-28 flex-shrink-0">

--- a/frontend/src/hooks/usePushSubscriptionSync.test.ts
+++ b/frontend/src/hooks/usePushSubscriptionSync.test.ts
@@ -34,6 +34,8 @@ mock.module("../api", () => ({
   getNotifiers: mockGetNotifiers,
   getVapidPublicKey: mockGetVapidPublicKey,
   updateNotifier: mockUpdateNotifier,
+  // stubs to prevent cross-file mock leakage — bun leaks mock.module globally
+  getSubscriptions: mock(() => Promise.resolve({ providerIds: [], onlyMine: false })),
 }));
 
 import { usePushSubscriptionSync } from "./usePushSubscriptionSync";

--- a/frontend/src/pages/AdminUsersPage.test.tsx
+++ b/frontend/src/pages/AdminUsersPage.test.tsx
@@ -1,10 +1,13 @@
 import { describe, test, expect, spyOn, afterEach, beforeEach, mock } from "bun:test";
-import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { render, screen, waitFor, cleanup, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import * as api from "../api";
 import type { AdminUsersResponse } from "../types";
+
+// Initialize i18n so t() returns real strings
+import "../i18n";
 
 // Mock AuthContext as admin user
 mock.module("../context/AuthContext", () => ({
@@ -24,9 +27,6 @@ mock.module("../context/AuthContext", () => ({
     Provider: ({ children }: { children: ReactNode }) => children,
   },
 }));
-
-// Mock i18n
-mock.module("../i18n", () => ({}));
 
 const { default: AdminUsersPage } = await import("./AdminUsersPage");
 
@@ -74,14 +74,46 @@ const mockUsersResponse: AdminUsersResponse = {
   total_pages: 1,
 };
 
+const mockBannedUsersResponse: AdminUsersResponse = {
+  users: [
+    {
+      id: "u1",
+      username: "alice",
+      name: "Alice Smith",
+      email: "alice@example.com",
+      role: "user",
+      is_admin: 0,
+      banned: true,
+      banned_reason: "spamming",
+      auth_provider: "local",
+      created_at: "2024-01-01T00:00:00.000Z",
+    },
+  ],
+  total: 1,
+  page: 1,
+  total_pages: 1,
+};
+
 let getAdminUsersSpy: ReturnType<typeof spyOn<typeof api, "getAdminUsers">>;
+let setAdminUserRoleSpy: ReturnType<typeof spyOn<typeof api, "setAdminUserRole">>;
+let banAdminUserSpy: ReturnType<typeof spyOn<typeof api, "banAdminUser">>;
+let unbanAdminUserSpy: ReturnType<typeof spyOn<typeof api, "unbanAdminUser">>;
+let deleteAdminUserSpy: ReturnType<typeof spyOn<typeof api, "deleteAdminUser">>;
 
 beforeEach(() => {
   getAdminUsersSpy = spyOn(api, "getAdminUsers");
+  setAdminUserRoleSpy = spyOn(api, "setAdminUserRole");
+  banAdminUserSpy = spyOn(api, "banAdminUser");
+  unbanAdminUserSpy = spyOn(api, "unbanAdminUser");
+  deleteAdminUserSpy = spyOn(api, "deleteAdminUser");
 });
 
 afterEach(() => {
   getAdminUsersSpy.mockRestore();
+  setAdminUserRoleSpy.mockRestore();
+  banAdminUserSpy.mockRestore();
+  unbanAdminUserSpy.mockRestore();
+  deleteAdminUserSpy.mockRestore();
   cleanup();
 });
 
@@ -101,6 +133,135 @@ describe("AdminUsersPage", () => {
     await waitFor(() => {
       expect(screen.getByText("alice")).toBeDefined();
       expect(screen.getByText("bob")).toBeDefined();
+    });
+  });
+
+  test("roleToggleMutation — clicking promote calls setAdminUserRole with admin", async () => {
+    getAdminUsersSpy.mockResolvedValue(mockUsersResponse);
+    setAdminUserRoleSpy.mockResolvedValue({ message: "ok" });
+
+    render(<AdminUsersPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("alice")).toBeDefined();
+    });
+
+    // The first non-self user (alice, u1) has a "Promote to admin" button
+    const promoteButtons = screen.getAllByTitle("Promote to admin");
+    fireEvent.click(promoteButtons[0]);
+
+    await waitFor(() => {
+      expect(setAdminUserRoleSpy).toHaveBeenCalledWith("u1", "admin");
+    });
+  });
+
+  test("roleToggleMutation — clicking demote calls setAdminUserRole with user", async () => {
+    const adminUsersResponse: AdminUsersResponse = {
+      ...mockUsersResponse,
+      users: [
+        {
+          id: "u1",
+          username: "alice",
+          name: "Alice Smith",
+          email: "alice@example.com",
+          role: "admin",
+          is_admin: 1,
+          banned: false,
+          banned_reason: null,
+          auth_provider: "local",
+          created_at: "2024-01-01T00:00:00.000Z",
+        },
+      ],
+      total: 1,
+    };
+    getAdminUsersSpy.mockResolvedValue(adminUsersResponse);
+    setAdminUserRoleSpy.mockResolvedValue({ message: "ok" });
+
+    render(<AdminUsersPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("alice")).toBeDefined();
+    });
+
+    const demoteButton = screen.getByTitle("Demote to user");
+    fireEvent.click(demoteButton);
+
+    await waitFor(() => {
+      expect(setAdminUserRoleSpy).toHaveBeenCalledWith("u1", "user");
+    });
+  });
+
+  test("banMutation — clicking ban button opens modal and submitting calls banAdminUser", async () => {
+    getAdminUsersSpy.mockResolvedValue(mockUsersResponse);
+    banAdminUserSpy.mockResolvedValue({ message: "ok" });
+
+    render(<AdminUsersPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("alice")).toBeDefined();
+    });
+
+    // Click the "Ban user" button for alice
+    const banButtons = screen.getAllByTitle("Ban user");
+    fireEvent.click(banButtons[0]);
+
+    // Modal should open — find the confirm button (button role, not heading)
+    await waitFor(() => {
+      expect(screen.getAllByText("Ban User").length).toBeGreaterThanOrEqual(1);
+    });
+
+    // Click the confirm button in the modal (the <button> with text "Ban User")
+    const confirmButton = screen.getAllByRole("button", { name: "Ban User" })[0];
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(banAdminUserSpy).toHaveBeenCalledWith("u1", undefined);
+    });
+  });
+
+  test("unbanMutation — clicking unban calls unbanAdminUser", async () => {
+    getAdminUsersSpy.mockResolvedValue(mockBannedUsersResponse);
+    unbanAdminUserSpy.mockResolvedValue({ message: "ok" });
+
+    render(<AdminUsersPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("alice")).toBeDefined();
+    });
+
+    const unbanButton = screen.getByTitle("Unban user");
+    fireEvent.click(unbanButton);
+
+    await waitFor(() => {
+      expect(unbanAdminUserSpy).toHaveBeenCalledWith("u1");
+    });
+  });
+
+  test("deleteMutation — clicking delete opens confirm modal and submitting calls deleteAdminUser", async () => {
+    getAdminUsersSpy.mockResolvedValue(mockUsersResponse);
+    deleteAdminUserSpy.mockResolvedValue({ message: "ok" });
+
+    render(<AdminUsersPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("alice")).toBeDefined();
+    });
+
+    // Click the "Delete user" button for alice
+    const deleteButtons = screen.getAllByTitle("Delete user");
+    fireEvent.click(deleteButtons[0]);
+
+    // Confirm dialog should appear
+    await waitFor(() => {
+      expect(screen.getByText("Delete User")).toBeDefined();
+    });
+
+    // Click the confirm button
+    const confirmButton = screen.getByText("Delete permanently");
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(deleteAdminUserSpy).toHaveBeenCalledWith("u1");
     });
   });
 });

--- a/frontend/src/pages/AdminUsersPage.test.tsx
+++ b/frontend/src/pages/AdminUsersPage.test.tsx
@@ -1,0 +1,106 @@
+import { describe, test, expect, spyOn, afterEach, beforeEach, mock } from "bun:test";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import * as api from "../api";
+import type { AdminUsersResponse } from "../types";
+
+// Mock AuthContext as admin user
+mock.module("../context/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: "admin-1", username: "admin", display_name: "Admin", auth_provider: "local", is_admin: true },
+    providers: { local: true, oidc: null },
+    loading: false,
+    sessionStatus: "authenticated",
+    subscriptions: null,
+    refreshSubscriptions: mock(() => Promise.resolve()),
+    login: mock(() => Promise.resolve()),
+    signup: mock(() => Promise.resolve()),
+    logout: mock(() => Promise.resolve()),
+    refresh: mock(() => Promise.resolve()),
+  }),
+  AuthContext: {
+    Provider: ({ children }: { children: ReactNode }) => children,
+  },
+}));
+
+// Mock i18n
+mock.module("../i18n", () => ({}));
+
+const { default: AdminUsersPage } = await import("./AdminUsersPage");
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+const mockUsersResponse: AdminUsersResponse = {
+  users: [
+    {
+      id: "u1",
+      username: "alice",
+      name: "Alice Smith",
+      email: "alice@example.com",
+      role: "user",
+      is_admin: 0,
+      banned: false,
+      banned_reason: null,
+      auth_provider: "local",
+      created_at: "2024-01-01T00:00:00.000Z",
+    },
+    {
+      id: "u2",
+      username: "bob",
+      name: "Bob Jones",
+      email: "bob@example.com",
+      role: "user",
+      is_admin: 0,
+      banned: false,
+      banned_reason: null,
+      auth_provider: "local",
+      created_at: "2024-02-01T00:00:00.000Z",
+    },
+  ],
+  total: 2,
+  page: 1,
+  total_pages: 1,
+};
+
+let getAdminUsersSpy: ReturnType<typeof spyOn<typeof api, "getAdminUsers">>;
+
+beforeEach(() => {
+  getAdminUsersSpy = spyOn(api, "getAdminUsers");
+});
+
+afterEach(() => {
+  getAdminUsersSpy.mockRestore();
+  cleanup();
+});
+
+describe("AdminUsersPage", () => {
+  test("renders loading state", () => {
+    getAdminUsersSpy.mockImplementation(() => new Promise(() => {}));
+    render(<AdminUsersPage />, { wrapper: Wrapper });
+    // Loading text is present from i18n key admin.users.loading - check for loading element
+    const el = document.querySelector(".text-zinc-500");
+    expect(el).not.toBeNull();
+  });
+
+  test("renders users on success", async () => {
+    getAdminUsersSpy.mockResolvedValue(mockUsersResponse);
+    render(<AdminUsersPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("alice")).toBeDefined();
+      expect(screen.getByText("bob")).toBeDefined();
+    });
+  });
+});

--- a/frontend/src/pages/AdminUsersPage.test.tsx
+++ b/frontend/src/pages/AdminUsersPage.test.tsx
@@ -4,29 +4,11 @@ import { MemoryRouter } from "react-router";
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import * as api from "../api";
+import * as AuthContextModule from "../context/AuthContext";
 import type { AdminUsersResponse } from "../types";
 
 // Initialize i18n so t() returns real strings
 import "../i18n";
-
-// Mock AuthContext as admin user
-mock.module("../context/AuthContext", () => ({
-  useAuth: () => ({
-    user: { id: "admin-1", username: "admin", display_name: "Admin", auth_provider: "local", is_admin: true },
-    providers: { local: true, oidc: null },
-    loading: false,
-    sessionStatus: "authenticated",
-    subscriptions: null,
-    refreshSubscriptions: mock(() => Promise.resolve()),
-    login: mock(() => Promise.resolve()),
-    signup: mock(() => Promise.resolve()),
-    logout: mock(() => Promise.resolve()),
-    refresh: mock(() => Promise.resolve()),
-  }),
-  AuthContext: {
-    Provider: ({ children }: { children: ReactNode }) => children,
-  },
-}));
 
 const { default: AdminUsersPage } = await import("./AdminUsersPage");
 
@@ -94,6 +76,7 @@ const mockBannedUsersResponse: AdminUsersResponse = {
   total_pages: 1,
 };
 
+let useAuthSpy: ReturnType<typeof spyOn<typeof AuthContextModule, "useAuth">>;
 let getAdminUsersSpy: ReturnType<typeof spyOn<typeof api, "getAdminUsers">>;
 let setAdminUserRoleSpy: ReturnType<typeof spyOn<typeof api, "setAdminUserRole">>;
 let banAdminUserSpy: ReturnType<typeof spyOn<typeof api, "banAdminUser">>;
@@ -101,6 +84,18 @@ let unbanAdminUserSpy: ReturnType<typeof spyOn<typeof api, "unbanAdminUser">>;
 let deleteAdminUserSpy: ReturnType<typeof spyOn<typeof api, "deleteAdminUser">>;
 
 beforeEach(() => {
+  useAuthSpy = spyOn(AuthContextModule, "useAuth").mockReturnValue({
+    user: { id: "admin-1", username: "admin", display_name: "Admin", auth_provider: "local", is_admin: true },
+    providers: { local: true, oidc: null },
+    loading: false,
+    sessionStatus: "authenticated",
+    subscriptions: null,
+    refreshSubscriptions: mock(() => Promise.resolve()),
+    login: mock(() => Promise.resolve()),
+    signup: mock(() => Promise.resolve()),
+    logout: mock(() => Promise.resolve()),
+    refresh: mock(() => Promise.resolve()),
+  });
   getAdminUsersSpy = spyOn(api, "getAdminUsers");
   setAdminUserRoleSpy = spyOn(api, "setAdminUserRole");
   banAdminUserSpy = spyOn(api, "banAdminUser");
@@ -109,6 +104,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  useAuthSpy.mockRestore();
   getAdminUsersSpy.mockRestore();
   setAdminUserRoleSpy.mockRestore();
   banAdminUserSpy.mockRestore();

--- a/frontend/src/pages/AdminUsersPage.tsx
+++ b/frontend/src/pages/AdminUsersPage.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router";
 import { Search, Shield, ShieldOff, Trash2, ChevronLeft, ChevronRight } from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import * as api from "../api";
-import type { AdminUser, AdminUsersResponse } from "../types";
+import type { AdminUser } from "../types";
 import { useAuth } from "../context/AuthContext";
 import { useAsyncError } from "../hooks/useAsyncError";
 import {
@@ -41,10 +42,8 @@ function BannedBadge() {
 export default function AdminUsersPage() {
   const { user: me } = useAuth();
   const { t } = useTranslation();
+  const qc = useQueryClient();
 
-  const [data, setData] = useState<AdminUsersResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState("");
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState<Filter>("all");
   const [page, setPage] = useState(1);
@@ -53,33 +52,25 @@ export default function AdminUsersPage() {
   const [banReason, setBanReason] = useState("");
   const [banTarget, setBanTarget] = useState<string | null>(null);
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    setError("");
-    try {
-      const res = await api.getAdminUsers({ search, filter, page });
-      setData(res);
-    } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setLoading(false);
-    }
-  }, [search, filter, page]);
-
-  useEffect(() => {
-    load();
-  }, [load]);
-
   // Reset to page 1 when search/filter changes
   useEffect(() => {
-    setPage(1);
+    setPage(1); // eslint-disable-line react-hooks/set-state-in-effect -- intentional: filter/search changes should reset pagination
   }, [search, filter]);
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ["admin-users", search, filter, page],
+    queryFn: ({ signal }) => api.getAdminUsers({ search, filter, page }, signal),
+  });
+
+  function invalidate() {
+    void qc.invalidateQueries({ queryKey: ["admin-users"] });
+  }
 
   async function handleRoleToggle(user: AdminUser) {
     const newRole = user.role === "admin" || user.is_admin === 1 ? "user" : "admin";
     await runAction(async () => {
       await api.setAdminUserRole(user.id, newRole);
-      await load();
+      invalidate();
     });
   }
 
@@ -88,14 +79,14 @@ export default function AdminUsersPage() {
       await api.banAdminUser(userId, banReason || undefined);
       setBanTarget(null);
       setBanReason("");
-      await load();
+      invalidate();
     });
   }
 
   async function handleUnban(userId: string) {
     await runAction(async () => {
       await api.unbanAdminUser(userId);
-      await load();
+      invalidate();
     });
   }
 
@@ -103,7 +94,7 @@ export default function AdminUsersPage() {
     await runAction(async () => {
       await api.deleteAdminUser(userId);
       setConfirmDelete(null);
-      await load();
+      invalidate();
     });
   }
 
@@ -226,10 +217,10 @@ export default function AdminUsersPage() {
       </AlertDialog>
 
       {/* User table */}
-      {loading ? (
+      {isLoading ? (
         <div className="text-zinc-500 text-sm py-8 text-center">{t("admin.users.loading")}</div>
-      ) : error ? (
-        <div className="text-red-400 text-sm">{error}</div>
+      ) : isError ? (
+        <div className="text-red-400 text-sm">{error instanceof Error ? error.message : String(error)}</div>
       ) : !data || data.users.length === 0 ? (
         <div className="text-zinc-500 text-sm py-8 text-center">{t("admin.users.empty")}</div>
       ) : (

--- a/frontend/src/pages/AdminUsersPage.tsx
+++ b/frontend/src/pages/AdminUsersPage.tsx
@@ -2,11 +2,11 @@ import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router";
 import { Search, Shield, ShieldOff, Trash2, ChevronLeft, ChevronRight } from "lucide-react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 import * as api from "../api";
 import type { AdminUser } from "../types";
 import { useAuth } from "../context/AuthContext";
-import { useAsyncError } from "../hooks/useAsyncError";
 import {
   AlertDialog,
   AlertDialogPopup,
@@ -47,7 +47,6 @@ export default function AdminUsersPage() {
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState<Filter>("all");
   const [page, setPage] = useState(1);
-  const { run: runAction, error: actionError } = useAsyncError();
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
   const [banReason, setBanReason] = useState("");
   const [banTarget, setBanTarget] = useState<string | null>(null);
@@ -62,40 +61,49 @@ export default function AdminUsersPage() {
     queryFn: ({ signal }) => api.getAdminUsers({ search, filter, page }, signal),
   });
 
-  function invalidate() {
-    void qc.invalidateQueries({ queryKey: ["admin-users"] });
-  }
+  const roleToggleMutation = useMutation({
+    mutationFn: ({ userId, newRole }: { userId: string; newRole: "admin" | "user" }) =>
+      api.setAdminUserRole(userId, newRole),
+    onError: () => toast.error("Failed to update role"),
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["admin-users"] }),
+  });
 
-  async function handleRoleToggle(user: AdminUser) {
+  const banMutation = useMutation({
+    mutationFn: ({ userId, reason }: { userId: string; reason?: string }) =>
+      api.banAdminUser(userId, reason),
+    onSuccess: () => { setBanTarget(null); setBanReason(""); },
+    onError: () => toast.error("Failed to ban user"),
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["admin-users"] }),
+  });
+
+  const unbanMutation = useMutation({
+    mutationFn: (userId: string) => api.unbanAdminUser(userId),
+    onError: () => toast.error("Failed to unban user"),
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["admin-users"] }),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (userId: string) => api.deleteAdminUser(userId),
+    onSuccess: () => setConfirmDelete(null),
+    onError: () => toast.error("Failed to delete user"),
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["admin-users"] }),
+  });
+
+  function handleRoleToggle(user: AdminUser) {
     const newRole = user.role === "admin" || user.is_admin === 1 ? "user" : "admin";
-    await runAction(async () => {
-      await api.setAdminUserRole(user.id, newRole);
-      invalidate();
-    });
+    roleToggleMutation.mutate({ userId: user.id, newRole });
   }
 
-  async function handleBan(userId: string) {
-    await runAction(async () => {
-      await api.banAdminUser(userId, banReason || undefined);
-      setBanTarget(null);
-      setBanReason("");
-      invalidate();
-    });
+  function handleBan(userId: string) {
+    banMutation.mutate({ userId, reason: banReason || undefined });
   }
 
-  async function handleUnban(userId: string) {
-    await runAction(async () => {
-      await api.unbanAdminUser(userId);
-      invalidate();
-    });
+  function handleUnban(userId: string) {
+    unbanMutation.mutate(userId);
   }
 
-  async function handleDelete(userId: string) {
-    await runAction(async () => {
-      await api.deleteAdminUser(userId);
-      setConfirmDelete(null);
-      invalidate();
-    });
+  function handleDelete(userId: string) {
+    deleteMutation.mutate(userId);
   }
 
   if (!me?.is_admin) {
@@ -142,12 +150,6 @@ export default function AdminUsersPage() {
           ))}
         </div>
       </div>
-
-      {actionError && (
-        <div className="bg-red-900/30 border border-red-800 text-red-300 px-4 py-2 rounded-lg text-sm select-text">
-          {actionError}
-        </div>
-      )}
 
       {/* Ban reason modal */}
       <AlertDialog

--- a/frontend/src/pages/CalendarPage.test.tsx
+++ b/frontend/src/pages/CalendarPage.test.tsx
@@ -306,18 +306,20 @@ describe("SlideOverPanel — movie watched toggle", () => {
 
   function renderSlideOver(onToggleTitleWatched?: (id: string, watched: boolean) => void) {
     return render(
-      <MemoryRouter>
-        <SlideOverPanel
-          selectedDate="2024-03-01"
-          items={[{ type: "title", data: movieTitle }]}
-          episodes={[]}
-          titles={[movieTitle]}
-          onClose={noop}
-          onToggleWatched={noop as never}
-          onBulkToggle={noop as never}
-          onToggleTitleWatched={onToggleTitleWatched}
-        />
-      </MemoryRouter>,
+      <QueryClientProvider client={newTestClient()}>
+        <MemoryRouter>
+          <SlideOverPanel
+            selectedDate="2024-03-01"
+            items={[{ type: "title", data: movieTitle }]}
+            episodes={[]}
+            titles={[movieTitle]}
+            onClose={noop}
+            onToggleWatched={noop as never}
+            onBulkToggle={noop as never}
+            onToggleTitleWatched={onToggleTitleWatched}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
     );
   }
 

--- a/frontend/src/pages/CalendarPage.test.tsx
+++ b/frontend/src/pages/CalendarPage.test.tsx
@@ -1,8 +1,11 @@
-import { describe, it, expect, mock, afterEach, beforeEach } from "bun:test";
+import { describe, it, expect, mock, afterEach, beforeEach, spyOn } from "bun:test";
 import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
+import * as api from "../api";
+import * as AuthContextModule from "../context/AuthContext";
+import * as useIsMobileModule from "../hooks/useIsMobile";
 
 function newTestClient() {
   return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
@@ -11,37 +14,7 @@ function newTestClient() {
 // Initialize i18n before anything else (avoids mock.module leak)
 import "../i18n";
 
-// Mock useIsMobile hook
-let mockIsMobile = false;
-mock.module("../hooks/useIsMobile", () => ({
-  useIsMobile: () => mockIsMobile,
-}));
-
-mock.module("../context/AuthContext", () => ({
-  useAuth: () => ({ subscriptions: null, user: null, providers: null, loading: false, sessionStatus: "authenticated" }),
-  AuthContext: { Provider: ({ children }: { children: ReactNode }) => children },
-}));
-
-const mockWatchMovie = mock((_id: string) => Promise.resolve());
-const mockUnwatchMovie = mock((_id: string) => Promise.resolve());
-
-// Mock API calls
-mock.module("../api", () => ({
-  getCalendarTitles: mock(() =>
-    Promise.resolve({ titles: [], episodes: [], count: 0 })
-  ),
-  watchEpisode: mock(() => Promise.resolve()),
-  unwatchEpisode: mock(() => Promise.resolve()),
-  watchEpisodesBulk: mock(() => Promise.resolve()),
-  getCrowdedWeekSettings: mock(() =>
-    Promise.resolve({ crowdedWeekThreshold: 5, crowdedWeekBadgeEnabled: 1 })
-  ),
-  watchMovie: mockWatchMovie,
-  unwatchMovie: mockUnwatchMovie,
-  getSubscriptions: mock(() => Promise.resolve({ providerIds: [] })),
-}));
-
-// Must import after mocks
+// Must import after spies are set up in beforeEach
 const { default: CalendarPage, SlideOverPanel } = await import("./CalendarPage");
 
 function Wrapper({ children }: { children: ReactNode }) {
@@ -52,12 +25,45 @@ function Wrapper({ children }: { children: ReactNode }) {
   );
 }
 
-afterEach(() => {
-  cleanup();
-});
+let useAuthSpy: ReturnType<typeof spyOn<typeof AuthContextModule, "useAuth">>;
+let useIsMobileSpy: ReturnType<typeof spyOn<typeof useIsMobileModule, "useIsMobile">>;
+let apiSpies: ReturnType<typeof spyOn>[];
+let mockWatchMovie: ReturnType<typeof spyOn<typeof api, "watchMovie">>;
+let mockUnwatchMovie: ReturnType<typeof spyOn<typeof api, "unwatchMovie">>;
 
 beforeEach(() => {
-  mockIsMobile = false;
+  useAuthSpy = spyOn(AuthContextModule, "useAuth").mockReturnValue({
+    user: null,
+    providers: null,
+    loading: false,
+    sessionStatus: "authenticated",
+    subscriptions: null,
+    refreshSubscriptions: mock(() => Promise.resolve()),
+    login: mock(() => Promise.resolve()),
+    signup: mock(() => Promise.resolve()),
+    logout: mock(() => Promise.resolve()),
+    refresh: mock(() => Promise.resolve()),
+  });
+  useIsMobileSpy = spyOn(useIsMobileModule, "useIsMobile").mockReturnValue(false);
+  mockWatchMovie = spyOn(api, "watchMovie").mockResolvedValue(undefined as any);
+  mockUnwatchMovie = spyOn(api, "unwatchMovie").mockResolvedValue(undefined as any);
+  apiSpies = [
+    spyOn(api, "getCalendarTitles").mockResolvedValue({ titles: [], episodes: [], count: 0 } as any),
+    spyOn(api, "watchEpisode").mockResolvedValue(undefined as any),
+    spyOn(api, "unwatchEpisode").mockResolvedValue(undefined as any),
+    spyOn(api, "watchEpisodesBulk").mockResolvedValue(undefined as any),
+    spyOn(api, "getCrowdedWeekSettings").mockResolvedValue({ crowdedWeekThreshold: 5, crowdedWeekBadgeEnabled: 1 } as any),
+    spyOn(api, "getSubscriptions").mockResolvedValue({ providerIds: [] } as any),
+  ];
+});
+
+afterEach(() => {
+  useAuthSpy.mockRestore();
+  useIsMobileSpy.mockRestore();
+  mockWatchMovie.mockRestore();
+  mockUnwatchMovie.mockRestore();
+  apiSpies.forEach(s => s.mockRestore());
+  cleanup();
 });
 
 describe("CalendarPage", () => {
@@ -111,7 +117,7 @@ describe("CalendarPage", () => {
   });
 
   it("renders agenda view on mobile without toggle", () => {
-    mockIsMobile = true;
+    useIsMobileSpy.mockReturnValue(true);
     render(<CalendarPage />, { wrapper: Wrapper });
 
     // No toggle buttons on mobile
@@ -147,7 +153,7 @@ describe("CalendarPage", () => {
   });
 
   it("shows hide watched toggle on mobile agenda", () => {
-    mockIsMobile = true;
+    useIsMobileSpy.mockReturnValue(true);
     render(<CalendarPage />, { wrapper: Wrapper });
 
     const toggle = screen.getByTitle("Show watched");

--- a/frontend/src/pages/DiscoveryPage.test.tsx
+++ b/frontend/src/pages/DiscoveryPage.test.tsx
@@ -80,6 +80,7 @@ mock.module("../api", () => ({
   getFriendsLoved: mock(() => Promise.resolve({ titles: [] })),
   getMovieTracking: mock(() => Promise.resolve(null)),
   getMyStreak: mock(() => Promise.resolve(null)),
+  getSubscriptions: mock(() => Promise.resolve({ providerIds: [], onlyMine: false })),
 }));
 
 const { default: DiscoveryPage } = await import("./DiscoveryPage");

--- a/frontend/src/pages/EpisodeDetailPage.test.tsx
+++ b/frontend/src/pages/EpisodeDetailPage.test.tsx
@@ -59,6 +59,8 @@ mock.module("../api", () => ({
   watchEpisode: mockWatchEpisode,
   unwatchEpisode: mockUnwatchEpisode,
   watchEpisodesBulk: mockWatchEpisodesBulk,
+  // stubs to prevent cross-file mock leakage — bun leaks mock.module globally
+  getSubscriptions: mock(() => Promise.resolve({ providerIds: [], onlyMine: false })),
 }));
 
 const { default: EpisodeDetailPage } = await import("./EpisodeDetailPage");

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -155,6 +155,8 @@ mock.module("../api", () => ({
   getMovieTracking: mockGetMovieTracking,
   getMyStreak: mockGetMyStreak,
   getSuggestionsAggregate: mockGetSuggestionsAggregate,
+  // stubs to prevent cross-file mock leakage — bun leaks mock.module globally
+  getSubscriptions: mock(() => Promise.resolve({ providerIds: [], onlyMine: false })),
 }));
 
 const { default: HomePage } = await import("./HomePage");

--- a/frontend/src/pages/InvitePage.test.tsx
+++ b/frontend/src/pages/InvitePage.test.tsx
@@ -1,46 +1,12 @@
-import { describe, it, expect, mock, afterEach, beforeEach } from "bun:test";
+import { describe, it, expect, mock, afterEach, beforeEach, spyOn } from "bun:test";
 import { render, screen, waitFor, cleanup, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import * as api from "../api";
 
 // Initialize i18n before anything else
 import "../i18n";
-
-// Mock auth context
-mock.module("../context/AuthContext", () => ({
-  useAuth: () => ({
-    user: { id: "u1", username: "testuser", display_name: "Test User", auth_provider: "local", is_admin: false },
-    providers: { local: true, oidc: null },
-    loading: false,
-    sessionStatus: "authenticated",
-    login: mock(() => Promise.resolve()),
-    signup: mock(() => Promise.resolve()),
-    logout: mock(() => Promise.resolve()),
-    refresh: mock(() => Promise.resolve()),
-  }),
-  AuthContext: {
-    Provider: ({ children }: { children: ReactNode }) => children,
-  },
-}));
-
-const mockGetInvitations = mock(() =>
-  Promise.resolve({ invitations: [] })
-);
-const mockCreateInvitation = mock(() =>
-  Promise.resolve({ id: "inv-new", code: "NEWCODE", expires_at: new Date(Date.now() + 7 * 86400000).toISOString() })
-);
-const mockRevokeInvitation = mock(() => Promise.resolve());
-const mockRedeemInvitation = mock(() =>
-  Promise.resolve({ success: true, inviter: { id: "u2", username: "alice", display_name: "Alice", image: null } })
-);
-
-mock.module("../api", () => ({
-  getInvitations: mockGetInvitations,
-  createInvitation: mockCreateInvitation,
-  revokeInvitation: mockRevokeInvitation,
-  redeemInvitation: mockRedeemInvitation,
-}));
 
 const { default: InvitePage } = await import("./InvitePage");
 
@@ -76,25 +42,31 @@ function makeInvitation(overrides: Record<string, unknown> = {}) {
   };
 }
 
+let getInvitationsSpy: ReturnType<typeof spyOn<typeof api, "getInvitations">>;
+let createInvitationSpy: ReturnType<typeof spyOn<typeof api, "createInvitation">>;
+let revokeInvitationSpy: ReturnType<typeof spyOn<typeof api, "revokeInvitation">>;
+let redeemInvitationSpy: ReturnType<typeof spyOn<typeof api, "redeemInvitation">>;
+
 beforeEach(() => {
-  mockGetInvitations.mockImplementation(() =>
-    Promise.resolve({ invitations: [] })
-  );
-  mockCreateInvitation.mockImplementation(() =>
-    Promise.resolve({ id: "inv-new", code: "NEWCODE", expires_at: new Date(Date.now() + 7 * 86400000).toISOString() })
-  );
-  mockRevokeInvitation.mockImplementation(() => Promise.resolve());
-  mockRedeemInvitation.mockImplementation(() =>
-    Promise.resolve({ success: true, inviter: { id: "u2", username: "alice", display_name: "Alice", image: null } })
-  );
+  getInvitationsSpy = spyOn(api, "getInvitations").mockResolvedValue({ invitations: [] } as any);
+  createInvitationSpy = spyOn(api, "createInvitation").mockResolvedValue({
+    id: "inv-new",
+    code: "NEWCODE",
+    expires_at: new Date(Date.now() + 7 * 86400000).toISOString(),
+  } as any);
+  revokeInvitationSpy = spyOn(api, "revokeInvitation").mockResolvedValue(undefined as any);
+  redeemInvitationSpy = spyOn(api, "redeemInvitation").mockResolvedValue({
+    success: true,
+    inviter: { id: "u2", username: "alice", display_name: "Alice", image: null },
+  } as any);
 });
 
 afterEach(() => {
+  getInvitationsSpy.mockRestore();
+  createInvitationSpy.mockRestore();
+  revokeInvitationSpy.mockRestore();
+  redeemInvitationSpy.mockRestore();
   cleanup();
-  mockGetInvitations.mockReset();
-  mockCreateInvitation.mockReset();
-  mockRevokeInvitation.mockReset();
-  mockRedeemInvitation.mockReset();
 });
 
 describe("InvitePage", () => {
@@ -103,8 +75,8 @@ describe("InvitePage", () => {
       makeInvitation({ id: "inv-1", code: "CODE1" }),
       makeInvitation({ id: "inv-2", code: "CODE2" }),
     ];
-    mockGetInvitations.mockImplementation(() =>
-      Promise.resolve({ invitations })
+    getInvitationsSpy.mockImplementation(() =>
+      Promise.resolve({ invitations } as any)
     );
 
     render(<InvitePage />, { wrapper: Wrapper });
@@ -116,19 +88,16 @@ describe("InvitePage", () => {
   });
 
   it("generate button creates new invitation", async () => {
-    mockGetInvitations.mockImplementation(() =>
-      Promise.resolve({ invitations: [] })
-    );
     // After creation, refresh will return the new invitation
     let callCount = 0;
-    mockGetInvitations.mockImplementation(() => {
+    getInvitationsSpy.mockImplementation(() => {
       callCount++;
       if (callCount > 1) {
         return Promise.resolve({
           invitations: [makeInvitation({ id: "inv-new", code: "NEWCODE" })],
-        });
+        } as any);
       }
-      return Promise.resolve({ invitations: [] });
+      return Promise.resolve({ invitations: [] } as any);
     });
 
     render(<InvitePage />, { wrapper: Wrapper });
@@ -140,7 +109,7 @@ describe("InvitePage", () => {
     fireEvent.click(screen.getByText("Create Invite Link"));
 
     await waitFor(() => {
-      expect(mockCreateInvitation).toHaveBeenCalled();
+      expect(createInvitationSpy).toHaveBeenCalled();
     });
 
     await waitFor(() => {
@@ -150,8 +119,8 @@ describe("InvitePage", () => {
 
   it("share button present for pending invitations", async () => {
     const invitations = [makeInvitation()];
-    mockGetInvitations.mockImplementation(() =>
-      Promise.resolve({ invitations })
+    getInvitationsSpy.mockImplementation(() =>
+      Promise.resolve({ invitations } as any)
     );
 
     render(<InvitePage />, { wrapper: Wrapper });
@@ -164,12 +133,12 @@ describe("InvitePage", () => {
   it("revoke button works", async () => {
     const invitations = [makeInvitation({ id: "inv-1", code: "REVOKEME" })];
     let callCount = 0;
-    mockGetInvitations.mockImplementation(() => {
+    getInvitationsSpy.mockImplementation(() => {
       callCount++;
       if (callCount > 1) {
-        return Promise.resolve({ invitations: [] });
+        return Promise.resolve({ invitations: [] } as any);
       }
-      return Promise.resolve({ invitations });
+      return Promise.resolve({ invitations } as any);
     });
 
     render(<InvitePage />, { wrapper: Wrapper });
@@ -181,7 +150,7 @@ describe("InvitePage", () => {
     fireEvent.click(screen.getByText("Revoke"));
 
     await waitFor(() => {
-      expect(mockRevokeInvitation).toHaveBeenCalledWith("inv-1");
+      expect(revokeInvitationSpy).toHaveBeenCalledWith("inv-1");
     });
 
     // Card should be removed after revoke (cache invalidated and refetched)
@@ -198,8 +167,8 @@ describe("InvitePage", () => {
         expires_at: new Date(Date.now() - 86400000).toISOString(),
       }),
     ];
-    mockGetInvitations.mockImplementation(() =>
-      Promise.resolve({ invitations })
+    getInvitationsSpy.mockImplementation(() =>
+      Promise.resolve({ invitations } as any)
     );
 
     render(<InvitePage />, { wrapper: Wrapper });
@@ -222,8 +191,8 @@ describe("InvitePage", () => {
         used_by: { id: "u3", username: "bob", display_name: "Bob", image: null },
       }),
     ];
-    mockGetInvitations.mockImplementation(() =>
-      Promise.resolve({ invitations })
+    getInvitationsSpy.mockImplementation(() =>
+      Promise.resolve({ invitations } as any)
     );
 
     render(<InvitePage />, { wrapper: Wrapper });
@@ -237,14 +206,14 @@ describe("InvitePage", () => {
   });
 
   it("auto-redeem from URL query parameter", async () => {
-    mockGetInvitations.mockImplementation(() =>
-      Promise.resolve({ invitations: [] })
+    getInvitationsSpy.mockImplementation(() =>
+      Promise.resolve({ invitations: [] } as any)
     );
 
     render(<InvitePage />, { wrapper: WrapperWithCode });
 
     await waitFor(() => {
-      expect(mockRedeemInvitation).toHaveBeenCalledWith("TESTCODE");
+      expect(redeemInvitationSpy).toHaveBeenCalledWith("TESTCODE");
     });
 
     await waitFor(() => {
@@ -253,8 +222,8 @@ describe("InvitePage", () => {
   });
 
   it("shows empty state when no invitations", async () => {
-    mockGetInvitations.mockImplementation(() =>
-      Promise.resolve({ invitations: [] })
+    getInvitationsSpy.mockImplementation(() =>
+      Promise.resolve({ invitations: [] } as any)
     );
 
     render(<InvitePage />, { wrapper: Wrapper });
@@ -265,14 +234,14 @@ describe("InvitePage", () => {
   });
 
   it("shows error when redeem fails", async () => {
-    mockRedeemInvitation.mockImplementation(() =>
+    redeemInvitationSpy.mockImplementation(() =>
       Promise.reject(new Error("Invitation expired"))
     );
 
     render(<InvitePage />, { wrapper: WrapperWithCode });
 
     await waitFor(() => {
-      expect(mockRedeemInvitation).toHaveBeenCalledWith("TESTCODE");
+      expect(redeemInvitationSpy).toHaveBeenCalledWith("TESTCODE");
     });
 
     await waitFor(() => {

--- a/frontend/src/pages/InvitePage.test.tsx
+++ b/frontend/src/pages/InvitePage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock, afterEach, beforeEach, spyOn } from "bun:test";
+import { describe, it, expect, afterEach, beforeEach, spyOn } from "bun:test";
 import { render, screen, waitFor, cleanup, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import type { ReactNode } from "react";

--- a/frontend/src/pages/InvitePage.test.tsx
+++ b/frontend/src/pages/InvitePage.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, mock, afterEach, beforeEach } from "bun:test";
 import { render, screen, waitFor, cleanup, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 // Initialize i18n before anything else
 import "../i18n";
@@ -43,12 +44,24 @@ mock.module("../api", () => ({
 
 const { default: InvitePage } = await import("./InvitePage");
 
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
 function Wrapper({ children }: { children: ReactNode }) {
-  return <MemoryRouter>{children}</MemoryRouter>;
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
 }
 
 function WrapperWithCode({ children }: { children: ReactNode }) {
-  return <MemoryRouter initialEntries={["/invite?code=TESTCODE"]}>{children}</MemoryRouter>;
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter initialEntries={["/invite?code=TESTCODE"]}>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
 }
 
 function makeInvitation(overrides: Record<string, unknown> = {}) {
@@ -150,9 +163,14 @@ describe("InvitePage", () => {
 
   it("revoke button works", async () => {
     const invitations = [makeInvitation({ id: "inv-1", code: "REVOKEME" })];
-    mockGetInvitations.mockImplementation(() =>
-      Promise.resolve({ invitations })
-    );
+    let callCount = 0;
+    mockGetInvitations.mockImplementation(() => {
+      callCount++;
+      if (callCount > 1) {
+        return Promise.resolve({ invitations: [] });
+      }
+      return Promise.resolve({ invitations });
+    });
 
     render(<InvitePage />, { wrapper: Wrapper });
 
@@ -166,7 +184,7 @@ describe("InvitePage", () => {
       expect(mockRevokeInvitation).toHaveBeenCalledWith("inv-1");
     });
 
-    // Card should be removed after revoke
+    // Card should be removed after revoke (cache invalidated and refetched)
     await waitFor(() => {
       expect(screen.queryByText("REVOKEME")).toBeNull();
     });

--- a/frontend/src/pages/InvitePage.tsx
+++ b/frontend/src/pages/InvitePage.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import { useSearchParams, Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { Plus, Trash2, Clock, CheckCircle2, XCircle, UserPlus } from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import * as api from "../api";
 import type { InvitationItem } from "../types";
 import ShareButton from "../components/ShareButton";
@@ -34,26 +35,21 @@ function formatDate(dateStr: string): string {
 
 export default function InvitePage() {
   const { t } = useTranslation();
+  const qc = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
-  const [invitations, setInvitations] = useState<InvitationItem[]>([]);
-  const [loading, setLoading] = useState(true);
   const [creating, setCreating] = useState(false);
   const [revoking, setRevoking] = useState<string | null>(null);
   const [redeemResult, setRedeemResult] = useState<RedeemResult>(null);
   const [redeeming, setRedeeming] = useState(false);
 
-  const refresh = useCallback(async () => {
-    try {
-      const data = await api.getInvitations();
-      setInvitations(data.invitations.sort((a, b) =>
-        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-      ));
-    } catch {
-      // ignore
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const { data: invitationsData, isLoading } = useQuery({
+    queryKey: ["invitations"],
+    queryFn: ({ signal }) => api.getInvitations(signal),
+  });
+
+  const invitations = (invitationsData?.invitations ?? []).slice().sort((a, b) =>
+    new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+  );
 
   // Auto-redeem from URL query parameter
   useEffect(() => {
@@ -79,15 +75,11 @@ export default function InvitePage() {
       });
   }, [searchParams, setSearchParams, redeeming, t]);
 
-  useEffect(() => {
-    refresh();
-  }, [refresh]);
-
   async function handleCreate() {
     setCreating(true);
     try {
       await api.createInvitation();
-      await refresh();
+      await qc.invalidateQueries({ queryKey: ["invitations"] });
       toast.success(t("invite.created"));
     } catch (err: unknown) {
       toast.error(err instanceof Error ? err.message : String(err));
@@ -100,7 +92,7 @@ export default function InvitePage() {
     setRevoking(id);
     try {
       await api.revokeInvitation(id);
-      setInvitations((prev) => prev.filter((inv) => inv.id !== id));
+      await qc.invalidateQueries({ queryKey: ["invitations"] });
       toast.success(t("invite.revoked"));
     } catch (err: unknown) {
       toast.error(err instanceof Error ? err.message : String(err));
@@ -146,7 +138,7 @@ export default function InvitePage() {
       </button>
 
       {/* Invitations list */}
-      {loading ? (
+      {isLoading ? (
         <div className="space-y-3">
           {[1, 2, 3].map((i) => (
             <div key={i} className="bg-zinc-900 rounded-lg p-4 animate-pulse h-24" />

--- a/frontend/src/pages/InvitePage.tsx
+++ b/frontend/src/pages/InvitePage.tsx
@@ -3,7 +3,7 @@ import { useSearchParams, Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { Plus, Trash2, Clock, CheckCircle2, XCircle, UserPlus } from "lucide-react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 import * as api from "../api";
 import type { InvitationItem } from "../types";
 import ShareButton from "../components/ShareButton";
@@ -37,8 +37,6 @@ export default function InvitePage() {
   const { t } = useTranslation();
   const qc = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
-  const [creating, setCreating] = useState(false);
-  const [revoking, setRevoking] = useState<string | null>(null);
   const [redeemResult, setRedeemResult] = useState<RedeemResult>(null);
   const [redeeming, setRedeeming] = useState(false);
 
@@ -51,12 +49,26 @@ export default function InvitePage() {
     new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
   );
 
+  const createMutation = useMutation({
+    mutationFn: () => api.createInvitation(),
+    onSuccess: () => toast.success(t("invite.created")),
+    onError: (err: unknown) => toast.error(err instanceof Error ? err.message : String(err)),
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["invitations"] }),
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: (id: string) => api.revokeInvitation(id),
+    onSuccess: () => toast.success(t("invite.revoked")),
+    onError: (err: unknown) => toast.error(err instanceof Error ? err.message : String(err)),
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["invitations"] }),
+  });
+
   // Auto-redeem from URL query parameter
   useEffect(() => {
     const code = searchParams.get("code");
     if (!code || redeeming) return;
 
-    setRedeeming(true);
+    setRedeeming(true); // eslint-disable-line react-hooks/set-state-in-effect -- guards against running the effect twice
     api.redeemInvitation(code)
       .then((result) => {
         const inviterName = result.inviter.display_name || result.inviter.username;
@@ -74,32 +86,6 @@ export default function InvitePage() {
         setSearchParams({}, { replace: true });
       });
   }, [searchParams, setSearchParams, redeeming, t]);
-
-  async function handleCreate() {
-    setCreating(true);
-    try {
-      await api.createInvitation();
-      await qc.invalidateQueries({ queryKey: ["invitations"] });
-      toast.success(t("invite.created"));
-    } catch (err: unknown) {
-      toast.error(err instanceof Error ? err.message : String(err));
-    } finally {
-      setCreating(false);
-    }
-  }
-
-  async function handleRevoke(id: string) {
-    setRevoking(id);
-    try {
-      await api.revokeInvitation(id);
-      await qc.invalidateQueries({ queryKey: ["invitations"] });
-      toast.success(t("invite.revoked"));
-    } catch (err: unknown) {
-      toast.error(err instanceof Error ? err.message : String(err));
-    } finally {
-      setRevoking(null);
-    }
-  }
 
   return (
     <div className="max-w-2xl mx-auto space-y-6">
@@ -129,12 +115,12 @@ export default function InvitePage() {
 
       {/* Generate button */}
       <button
-        onClick={handleCreate}
-        disabled={creating}
+        onClick={() => createMutation.mutate()}
+        disabled={createMutation.isPending}
         className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-amber-500 hover:bg-amber-400 text-zinc-950 font-semibold rounded-lg transition-colors disabled:opacity-50 cursor-pointer"
       >
         <Plus className="size-4" />
-        {creating ? t("invite.creating") : t("invite.createLink")}
+        {createMutation.isPending ? t("invite.creating") : t("invite.createLink")}
       </button>
 
       {/* Invitations list */}
@@ -152,8 +138,8 @@ export default function InvitePage() {
             <InvitationCard
               key={inv.id}
               invitation={inv}
-              revoking={revoking === inv.id}
-              onRevoke={handleRevoke}
+              revoking={revokeMutation.isPending && revokeMutation.variables === inv.id}
+              onRevoke={(id) => revokeMutation.mutate(id)}
             />
           ))}
         </div>

--- a/frontend/src/pages/ProfilePage.test.tsx
+++ b/frontend/src/pages/ProfilePage.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, mock, afterEach, beforeEach } from "bun:test";
 import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "../i18n";
 
 // Mock browser Notification API
@@ -43,6 +44,20 @@ mock.module("../api", () => ({
   updateProfileVisibility: mock(() => Promise.resolve()),
   updateTitleVisibility: mock(() => Promise.resolve()),
   updateAllTitleVisibility: mock(() => Promise.resolve()),
+  // stubs to prevent cross-file mock leakage — bun leaks mock.module globally
+  getSubscriptions: mock(() => Promise.resolve({ providerIds: [], onlyMine: false })),
+  getUpcomingEpisodes: mock(() => Promise.resolve({ today: [], upcoming: [], unwatched: [] })),
+  watchEpisode: mock(() => Promise.resolve()),
+  unwatchEpisode: mock(() => Promise.resolve()),
+  watchEpisodesBulk: mock(() => Promise.resolve()),
+  browseTitles: mock(() => Promise.resolve({ titles: [], total: 0 })),
+  getRecommendations: mock(() => Promise.resolve({ recommendations: [], suggestions: [], hasMore: false })),
+  fetchFriendsLoved: mock(() => Promise.resolve({ titles: [] })),
+  watchMovie: mock(() => Promise.resolve()),
+  unwatchMovie: mock(() => Promise.resolve()),
+  getMovieTracking: mock(() => Promise.resolve(null)),
+  rateEpisode: mock(() => Promise.resolve()),
+  unrateEpisode: mock(() => Promise.resolve()),
 }));
 
 // Mock AuthContext
@@ -57,8 +72,16 @@ mock.module("../context/AuthContext", () => ({
 // Import SettingsPage (which now contains the push notification sections)
 const { default: SettingsPage } = await import("./SettingsPage");
 
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
 function Wrapper({ children }: { children: ReactNode }) {
-  return <MemoryRouter initialEntries={["/settings?tab=notifications"]}>{children}</MemoryRouter>;
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter initialEntries={["/settings?tab=notifications"]}>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
 }
 
 afterEach(() => {

--- a/frontend/src/pages/ReelsPage.test.tsx
+++ b/frontend/src/pages/ReelsPage.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, mock, afterEach } from "bun:test";
 import { render, screen, waitFor, cleanup, act, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 mock.module("../context/AuthContext", () => ({
   useAuth: () => ({ subscriptions: null, user: null, providers: null, loading: false, sessionStatus: "authenticated" }),
@@ -69,13 +70,25 @@ mock.module("../api", () => ({
 
 const { default: ReelsPage, getFirstUnwatchedPerShow, normalizeMovieToReelItem } = await import("./ReelsPage");
 
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
 function Wrapper({ children }: { children: ReactNode }) {
-  return <MemoryRouter>{children}</MemoryRouter>;
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
 }
 
 function WrapperWithSearch(initialSearch: string) {
   return function W({ children }: { children: ReactNode }) {
-    return <MemoryRouter initialEntries={[`/reels${initialSearch}`]}>{children}</MemoryRouter>;
+    return (
+      <QueryClientProvider client={newTestClient()}>
+        <MemoryRouter initialEntries={[`/reels${initialSearch}`]}>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
   };
 }
 

--- a/frontend/src/pages/ReelsPage.test.tsx
+++ b/frontend/src/pages/ReelsPage.test.tsx
@@ -1,72 +1,10 @@
-import { describe, it, expect, mock, afterEach } from "bun:test";
+import { describe, it, expect, mock, afterEach, beforeEach, spyOn } from "bun:test";
 import { render, screen, waitFor, cleanup, act, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-
-mock.module("../context/AuthContext", () => ({
-  useAuth: () => ({ subscriptions: null, user: null, providers: null, loading: false, sessionStatus: "authenticated" }),
-  AuthContext: { Provider: ({ children }: { children: ReactNode }) => children },
-}));
-
-const mockGetUpcomingEpisodes = mock(() =>
-  Promise.resolve({ today: [], upcoming: [], unwatched: [] })
-);
-const mockWatchEpisode = mock(() => Promise.resolve());
-const mockUnwatchEpisode = mock(() => Promise.resolve());
-const mockWatchEpisodesBulk = mock(() => Promise.resolve());
-const mockBrowseTitles = mock(() =>
-  Promise.resolve({
-    titles: [],
-    page: 1,
-    totalPages: 1,
-    totalResults: 0,
-    availableGenres: [],
-    availableProviders: [],
-    availableLanguages: [],
-    regionProviderIds: [],
-    priorityLanguageCodes: [],
-  })
-);
-const mockGetRecommendations = mock(() =>
-  Promise.resolve({ recommendations: [], count: 0 })
-);
-const mockFetchFriendsLoved = mock(() =>
-  Promise.resolve({ titles: [] })
-);
-const mockWatchMovie = mock((_id: string) => Promise.resolve());
-const mockUnwatchMovie = mock((_id: string) => Promise.resolve());
-const mockGetMovieTracking = mock(() =>
-  Promise.resolve({
-    to_watch: [
-      {
-        id: "m-1",
-        title: "Inception",
-        release_date: "2024-01-01",
-        release_year: 2024,
-        poster_url: null,
-        offers: [],
-      },
-    ],
-    upcoming: [],
-  })
-);
-
-mock.module("../api", () => ({
-  getUpcomingEpisodes: mockGetUpcomingEpisodes,
-  watchEpisode: mockWatchEpisode,
-  unwatchEpisode: mockUnwatchEpisode,
-  watchEpisodesBulk: mockWatchEpisodesBulk,
-  browseTitles: mockBrowseTitles,
-  getRecommendations: mockGetRecommendations,
-  fetchFriendsLoved: mockFetchFriendsLoved,
-  watchMovie: mockWatchMovie,
-  unwatchMovie: mockUnwatchMovie,
-  getMovieTracking: mockGetMovieTracking,
-  rateEpisode: mock(() => Promise.resolve()),
-  unrateEpisode: mock(() => Promise.resolve()),
-  getSubscriptions: mock(() => Promise.resolve({ providerIds: [] })),
-}));
+import * as api from "../api";
+import * as AuthContextModule from "../context/AuthContext";
 
 const { default: ReelsPage, getFirstUnwatchedPerShow, normalizeMovieToReelItem } = await import("./ReelsPage");
 
@@ -92,18 +30,85 @@ function WrapperWithSearch(initialSearch: string) {
   };
 }
 
+let useAuthSpy: ReturnType<typeof spyOn<typeof AuthContextModule, "useAuth">>;
+let spies: ReturnType<typeof spyOn>[];
+let getUpcomingEpisodesSpy: ReturnType<typeof spyOn<typeof api, "getUpcomingEpisodes">>;
+let watchEpisodeSpy: ReturnType<typeof spyOn<typeof api, "watchEpisode">>;
+let unwatchEpisodeSpy: ReturnType<typeof spyOn<typeof api, "unwatchEpisode">>;
+let watchEpisodesBulkSpy: ReturnType<typeof spyOn<typeof api, "watchEpisodesBulk">>;
+let browseTitlesSpy: ReturnType<typeof spyOn<typeof api, "browseTitles">>;
+let getRecommendationsSpy: ReturnType<typeof spyOn<typeof api, "getRecommendations">>;
+let fetchFriendsLovedSpy: ReturnType<typeof spyOn<typeof api, "fetchFriendsLoved">>;
+let watchMovieSpy: ReturnType<typeof spyOn<typeof api, "watchMovie">>;
+let unwatchMovieSpy: ReturnType<typeof spyOn<typeof api, "unwatchMovie">>;
+let getMovieTrackingSpy: ReturnType<typeof spyOn<typeof api, "getMovieTracking">>;
+
+beforeEach(() => {
+  useAuthSpy = spyOn(AuthContextModule, "useAuth").mockReturnValue({
+    user: { id: "u1", username: "me", display_name: "Me", auth_provider: "local", is_admin: false },
+    providers: { local: true, oidc: null },
+    loading: false,
+    sessionStatus: "authenticated",
+    subscriptions: null,
+    refreshSubscriptions: mock(() => Promise.resolve()),
+    login: mock(() => Promise.resolve()),
+    signup: mock(() => Promise.resolve()),
+    logout: mock(() => Promise.resolve()),
+    refresh: mock(() => Promise.resolve()),
+  });
+  getUpcomingEpisodesSpy = spyOn(api, "getUpcomingEpisodes").mockResolvedValue({ today: [], upcoming: [], unwatched: [] } as any);
+  watchEpisodeSpy = spyOn(api, "watchEpisode").mockResolvedValue(undefined as any);
+  unwatchEpisodeSpy = spyOn(api, "unwatchEpisode").mockResolvedValue(undefined as any);
+  watchEpisodesBulkSpy = spyOn(api, "watchEpisodesBulk").mockResolvedValue(undefined as any);
+  browseTitlesSpy = spyOn(api, "browseTitles").mockResolvedValue({
+    titles: [],
+    page: 1,
+    totalPages: 1,
+    totalResults: 0,
+    availableGenres: [],
+    availableProviders: [],
+    availableLanguages: [],
+    regionProviderIds: [],
+    priorityLanguageCodes: [],
+  } as any);
+  getRecommendationsSpy = spyOn(api, "getRecommendations").mockResolvedValue({ recommendations: [], count: 0 } as any);
+  fetchFriendsLovedSpy = spyOn(api, "fetchFriendsLoved").mockResolvedValue({ titles: [] } as any);
+  watchMovieSpy = spyOn(api, "watchMovie").mockResolvedValue(undefined as any);
+  unwatchMovieSpy = spyOn(api, "unwatchMovie").mockResolvedValue(undefined as any);
+  getMovieTrackingSpy = spyOn(api, "getMovieTracking").mockResolvedValue({
+    to_watch: [
+      {
+        id: "m-1",
+        title: "Inception",
+        release_date: "2024-01-01",
+        release_year: 2024,
+        poster_url: null,
+        offers: [],
+      },
+    ],
+    upcoming: [],
+  } as any);
+  spies = [
+    spyOn(api, "rateEpisode").mockResolvedValue(undefined as any),
+    spyOn(api, "unrateEpisode").mockResolvedValue(undefined as any),
+    spyOn(api, "getSubscriptions").mockResolvedValue({ providerIds: [] } as any),
+  ];
+});
+
 afterEach(() => {
+  useAuthSpy.mockRestore();
+  getUpcomingEpisodesSpy.mockRestore();
+  watchEpisodeSpy.mockRestore();
+  unwatchEpisodeSpy.mockRestore();
+  watchEpisodesBulkSpy.mockRestore();
+  browseTitlesSpy.mockRestore();
+  getRecommendationsSpy.mockRestore();
+  fetchFriendsLovedSpy.mockRestore();
+  watchMovieSpy.mockRestore();
+  unwatchMovieSpy.mockRestore();
+  getMovieTrackingSpy.mockRestore();
+  spies.forEach(s => s.mockRestore());
   cleanup();
-  mockGetUpcomingEpisodes.mockReset();
-  mockWatchEpisode.mockReset();
-  mockUnwatchEpisode.mockReset();
-  mockWatchEpisodesBulk.mockReset();
-  mockBrowseTitles.mockReset();
-  mockGetRecommendations.mockReset();
-  mockFetchFriendsLoved.mockReset();
-  mockWatchMovie.mockReset();
-  mockUnwatchMovie.mockReset();
-  mockGetMovieTracking.mockReset();
 });
 
 const sampleEpisode = {
@@ -123,14 +128,14 @@ const sampleEpisode = {
 
 describe("ReelsPage", () => {
   it("shows loading state initially", () => {
-    mockGetUpcomingEpisodes.mockImplementation(() => new Promise(() => {}));
+    getUpcomingEpisodesSpy.mockImplementation(() => new Promise(() => {}));
     const { container } = render(<ReelsPage />, { wrapper: Wrapper });
     // Skeleton loading UI uses animate-pulse divs instead of text
     expect(container.querySelector(".animate-pulse")).toBeDefined();
   });
 
   it("shows error UI when initial fetch fails", async () => {
-    mockGetUpcomingEpisodes.mockImplementation(() =>
+    getUpcomingEpisodesSpy.mockImplementation(() =>
       Promise.reject(new Error("API error"))
     );
     render(<ReelsPage />, { wrapper: Wrapper });
@@ -138,7 +143,7 @@ describe("ReelsPage", () => {
   });
 
   it("shows empty state when no unwatched episodes", async () => {
-    mockGetUpcomingEpisodes.mockImplementation(() =>
+    getUpcomingEpisodesSpy.mockImplementation(() =>
       Promise.resolve({ today: [], upcoming: [], unwatched: [] })
     );
     render(<ReelsPage />, { wrapper: Wrapper });
@@ -148,10 +153,10 @@ describe("ReelsPage", () => {
   });
 
   it("shows action error banner when markWatched fails", async () => {
-    mockGetUpcomingEpisodes.mockImplementation(() =>
+    getUpcomingEpisodesSpy.mockImplementation(() =>
       Promise.resolve({ today: [], upcoming: [], unwatched: [sampleEpisode] })
     );
-    mockWatchEpisode.mockImplementation(() =>
+    watchEpisodeSpy.mockImplementation(() =>
       Promise.reject(new Error("Watch failed"))
     );
 
@@ -174,26 +179,26 @@ describe("ReelsPage", () => {
 
 describe("ReelsPage source picker", () => {
   it("default (no ?source param) calls getUpcomingEpisodes", async () => {
-    mockGetUpcomingEpisodes.mockImplementation(() =>
+    getUpcomingEpisodesSpy.mockImplementation(() =>
       Promise.resolve({ today: [], upcoming: [], unwatched: [] })
     );
     render(<ReelsPage />, { wrapper: Wrapper });
-    await waitFor(() => expect(mockGetUpcomingEpisodes).toHaveBeenCalled());
-    expect(mockBrowseTitles).not.toHaveBeenCalled();
-    expect(mockGetRecommendations).not.toHaveBeenCalled();
+    await waitFor(() => expect(getUpcomingEpisodesSpy).toHaveBeenCalled());
+    expect(browseTitlesSpy).not.toHaveBeenCalled();
+    expect(getRecommendationsSpy).not.toHaveBeenCalled();
   });
 
   it("?source=coming-soon calls getUpcomingEpisodes not browseTitles", async () => {
-    mockGetUpcomingEpisodes.mockImplementation(() =>
+    getUpcomingEpisodesSpy.mockImplementation(() =>
       Promise.resolve({ today: [], upcoming: [], unwatched: [] })
     );
     render(<ReelsPage />, { wrapper: WrapperWithSearch("?source=coming-soon") });
-    await waitFor(() => expect(mockGetUpcomingEpisodes).toHaveBeenCalled());
-    expect(mockBrowseTitles).not.toHaveBeenCalled();
+    await waitFor(() => expect(getUpcomingEpisodesSpy).toHaveBeenCalled());
+    expect(browseTitlesSpy).not.toHaveBeenCalled();
   });
 
   it("?source=popular calls browseTitles not getUpcomingEpisodes", async () => {
-    mockBrowseTitles.mockImplementation(() =>
+    browseTitlesSpy.mockImplementation(() =>
       Promise.resolve({
         titles: [
           {
@@ -225,16 +230,16 @@ describe("ReelsPage source picker", () => {
         availableLanguages: [],
         regionProviderIds: [],
         priorityLanguageCodes: [],
-      })
+      } as any)
     );
     render(<ReelsPage />, { wrapper: WrapperWithSearch("?source=popular") });
-    await waitFor(() => expect(mockBrowseTitles).toHaveBeenCalled());
+    await waitFor(() => expect(browseTitlesSpy).toHaveBeenCalled());
     await waitFor(() => expect(screen.getAllByText("Popular Movie").length).toBeGreaterThanOrEqual(1));
-    expect(mockGetUpcomingEpisodes).not.toHaveBeenCalled();
+    expect(getUpcomingEpisodesSpy).not.toHaveBeenCalled();
   });
 
   it("?source=from-your-genres calls getRecommendations not getUpcomingEpisodes", async () => {
-    mockGetRecommendations.mockImplementation(() =>
+    getRecommendationsSpy.mockImplementation(() =>
       Promise.resolve({
         recommendations: [
           {
@@ -247,27 +252,27 @@ describe("ReelsPage source picker", () => {
           },
         ],
         count: 1,
-      })
+      } as any)
     );
     render(<ReelsPage />, { wrapper: WrapperWithSearch("?source=from-your-genres") });
-    await waitFor(() => expect(mockGetRecommendations).toHaveBeenCalled());
+    await waitFor(() => expect(getRecommendationsSpy).toHaveBeenCalled());
     await waitFor(() => expect(screen.getAllByText("Rec Movie").length).toBeGreaterThanOrEqual(1));
-    expect(mockGetUpcomingEpisodes).not.toHaveBeenCalled();
+    expect(getUpcomingEpisodesSpy).not.toHaveBeenCalled();
   });
 
   it("?source=friends-loved with empty API response renders empty state", async () => {
-    mockFetchFriendsLoved.mockImplementation(() =>
-      Promise.resolve({ titles: [] })
+    fetchFriendsLovedSpy.mockImplementation(() =>
+      Promise.resolve({ titles: [] } as any)
     );
     render(<ReelsPage />, { wrapper: WrapperWithSearch("?source=friends-loved") });
     await waitFor(() =>
       expect(screen.getByText("Follow some friends to see what they love this week")).toBeDefined()
     );
-    expect(mockGetUpcomingEpisodes).not.toHaveBeenCalled();
+    expect(getUpcomingEpisodesSpy).not.toHaveBeenCalled();
   });
 
   it("?source=friends-loved when endpoint 404s renders empty state", async () => {
-    mockFetchFriendsLoved.mockImplementation(() =>
+    fetchFriendsLovedSpy.mockImplementation(() =>
       Promise.reject(new Error("Not found"))
     );
     render(<ReelsPage />, { wrapper: WrapperWithSearch("?source=friends-loved") });
@@ -277,7 +282,7 @@ describe("ReelsPage source picker", () => {
   });
 
   it("renders source picker chips including Movies", async () => {
-    mockGetUpcomingEpisodes.mockImplementation(() =>
+    getUpcomingEpisodesSpy.mockImplementation(() =>
       Promise.resolve({ today: [], upcoming: [], unwatched: [] })
     );
     render(<ReelsPage />, { wrapper: Wrapper });
@@ -289,12 +294,12 @@ describe("ReelsPage source picker", () => {
   });
 
   it("?source=movies calls getMovieTracking not getUpcomingEpisodes", async () => {
-    mockGetMovieTracking.mockImplementation(() =>
-      Promise.resolve({ to_watch: [], upcoming: [] })
+    getMovieTrackingSpy.mockImplementation(() =>
+      Promise.resolve({ to_watch: [], upcoming: [] } as any)
     );
     render(<ReelsPage />, { wrapper: WrapperWithSearch("?source=movies") });
-    await waitFor(() => expect(mockGetMovieTracking).toHaveBeenCalled());
-    expect(mockGetUpcomingEpisodes).not.toHaveBeenCalled();
+    await waitFor(() => expect(getMovieTrackingSpy).toHaveBeenCalled());
+    expect(getUpcomingEpisodesSpy).not.toHaveBeenCalled();
   });
 });
 
@@ -327,7 +332,7 @@ function simulateSwipeLeft(container: HTMLElement) {
 
 describe("ReelsPage swipe to open season panel", () => {
   async function renderWithShows() {
-    mockGetUpcomingEpisodes.mockImplementation(() =>
+    getUpcomingEpisodesSpy.mockImplementation(() =>
       Promise.resolve({
         today: [],
         upcoming: [],
@@ -386,7 +391,7 @@ describe("ReelsPage swipe to open season panel", () => {
   });
 
   it("swipe does not open panel for caught-up card", async () => {
-    mockGetUpcomingEpisodes.mockImplementation(() =>
+    getUpcomingEpisodesSpy.mockImplementation(() =>
       Promise.resolve({
         today: [],
         upcoming: [],
@@ -431,10 +436,10 @@ describe("ReelsPage progress bar updates after marking watched", () => {
   const ep2 = { ...baseEpisode, id: 502, season_number: 1, episode_number: 2 };
 
   it("advances progress bar when episode is marked watched", async () => {
-    mockGetUpcomingEpisodes.mockImplementation(() =>
+    getUpcomingEpisodesSpy.mockImplementation(() =>
       Promise.resolve({ today: [], upcoming: [], unwatched: [ep1, ep2] })
     );
-    mockWatchEpisode.mockImplementation(() => Promise.resolve());
+    watchEpisodeSpy.mockImplementation(() => Promise.resolve());
 
     render(<ReelsPage />, { wrapper: Wrapper });
 
@@ -451,11 +456,11 @@ describe("ReelsPage progress bar updates after marking watched", () => {
   });
 
   it("rewinds progress bar when undo is clicked", async () => {
-    mockGetUpcomingEpisodes.mockImplementation(() =>
+    getUpcomingEpisodesSpy.mockImplementation(() =>
       Promise.resolve({ today: [], upcoming: [], unwatched: [ep1, ep2] })
     );
-    mockWatchEpisode.mockImplementation(() => Promise.resolve());
-    mockUnwatchEpisode.mockImplementation(() => Promise.resolve());
+    watchEpisodeSpy.mockImplementation(() => Promise.resolve());
+    unwatchEpisodeSpy.mockImplementation(() => Promise.resolve());
 
     render(<ReelsPage />, { wrapper: Wrapper });
 
@@ -475,10 +480,10 @@ describe("ReelsPage progress bar updates after marking watched", () => {
   });
 
   it("rewinds progress bar when watchEpisode API fails", async () => {
-    mockGetUpcomingEpisodes.mockImplementation(() =>
+    getUpcomingEpisodesSpy.mockImplementation(() =>
       Promise.resolve({ today: [], upcoming: [], unwatched: [ep1, ep2] })
     );
-    mockWatchEpisode.mockImplementation(() =>
+    watchEpisodeSpy.mockImplementation(() =>
       Promise.reject(new Error("Network error"))
     );
 
@@ -546,30 +551,30 @@ describe("normalizeMovieToReelItem", () => {
 
 describe("ReelsPage — movies source", () => {
   it("renders the movie title for movies source", async () => {
-    mockGetMovieTracking.mockImplementation(() =>
+    getMovieTrackingSpy.mockImplementation(() =>
       Promise.resolve({
         to_watch: [{ id: "m-1", title: "Inception", release_date: "2024-01-01", release_year: 2024, poster_url: null, offers: [] }],
         upcoming: [],
-      })
+      } as any)
     );
     render(<ReelsPage />, { wrapper: WrapperWithSearch("?source=movies") });
     await waitFor(() => expect(screen.getAllByText("Inception").length).toBeGreaterThanOrEqual(1));
   });
 
   it("calls api.watchMovie (not watchEpisode) when marking a movie as watched", async () => {
-    mockGetMovieTracking.mockImplementation(() =>
+    getMovieTrackingSpy.mockImplementation(() =>
       Promise.resolve({
         to_watch: [{ id: "m-1", title: "Inception", release_date: "2024-01-01", release_year: 2024, poster_url: null, offers: [] }],
         upcoming: [],
-      })
+      } as any)
     );
     render(<ReelsPage />, { wrapper: WrapperWithSearch("?source=movies") });
     const btn = await screen.findByRole("button", { name: /mark as watched/i });
     await act(async () => {
       fireEvent.click(btn);
     });
-    expect(mockWatchMovie).toHaveBeenCalledTimes(1);
-    expect(mockWatchMovie).toHaveBeenCalledWith("m-1");
-    expect(mockWatchEpisode).not.toHaveBeenCalled();
+    expect(watchMovieSpy).toHaveBeenCalledTimes(1);
+    expect(watchMovieSpy).toHaveBeenCalledWith("m-1");
+    expect(watchEpisodeSpy).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/ReelsPage.tsx
+++ b/frontend/src/pages/ReelsPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useLayoutEffect, useRef, useCallback } from "react";
 import { Link, useSearchParams } from "react-router";
+import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 import * as api from "../api";
 import { normalizeSearchTitle } from "../types";
 import type { Episode, RatingValue, SearchTitle, Recommendation } from "../types";
@@ -202,6 +203,7 @@ export default function ReelsPage() {
     ? (rawSource as ReelsSource)
     : "coming-soon";
 
+  const qc = useQueryClient();
   const scrollRef = useRef<HTMLDivElement>(null);
   const [cards, setCards] = useState<ShowCard[]>([]);
   // Ref is always derived from state — never updated independently.
@@ -209,8 +211,6 @@ export default function ReelsPage() {
   // needing to be recreated whenever `cards` changes.
   const cardsRef = useRef(cards);
   useLayoutEffect(() => { cardsRef.current = cards; });
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState("");
   const [friendsLovedEmpty, setFriendsLovedEmpty] = useState(false);
   const [actionError, setActionError] = useState("");
   const actionErrorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -231,35 +231,23 @@ export default function ReelsPage() {
   // Track visible card index for swipe context
   const visibleCardIndexRef = useRef(0);
 
-  // Keep a stable ref to the current source so callbacks can read it without
-  // being recreated.
-  const sourceRef = useRef(source);
-  useLayoutEffect(() => { sourceRef.current = source; });
+  const { data: reelsData, isLoading, isError, error: loadError } = useQuery({
+    queryKey: ["reels", source],
+    queryFn: ({ signal }) => fetchCardsForSource(source, signal),
+    staleTime: 0, // always refetch on mount since user may have watched things elsewhere
+  });
 
+  // Initialize cards from query data.
+  // setState calls here are intentional — they sync local UI state from the query result
+  // so that swipe mutations can update cards independently without re-fetching.
+  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
-    const controller = new AbortController();
-    const { signal } = controller;
-
-    async function load() {
-      setLoading(true);
-      setError("");
-      setFriendsLovedEmpty(false);
-      try {
-        const { cards: c, friendsLovedEmpty: fl } = await fetchCardsForSource(source, signal);
-        if (!signal.aborted) {
-          setCards(c);
-          setFriendsLovedEmpty(fl);
-        }
-      } catch (err: unknown) {
-        if (!signal.aborted) setError(err instanceof Error ? err.message : String(err));
-      } finally {
-        if (!signal.aborted) setLoading(false);
-      }
+    if (reelsData) {
+      setCards(reelsData.cards);
+      setFriendsLovedEmpty(reelsData.friendsLovedEmpty);
     }
-
-    void load();
-    return () => controller.abort();
-  }, [source]);
+  }, [reelsData]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   // Track visible card via scroll position
   useEffect(() => {
@@ -362,7 +350,77 @@ export default function ReelsPage() {
     }
   }, []);
 
-  const markWatched = useCallback(async (titleId: string) => {
+  function showActionError(msg: string) {
+    if (actionErrorTimerRef.current) clearTimeout(actionErrorTimerRef.current);
+    setActionError(msg);
+    actionErrorTimerRef.current = setTimeout(() => setActionError(""), 5000);
+  }
+
+  const watchMutation = useMutation({
+    mutationFn: ({ titleId, episodeId, isMovie }: { titleId: string; episodeId: number; isMovie?: boolean }) =>
+      isMovie ? api.watchMovie(titleId) : api.watchEpisode(episodeId),
+    onError: (err: unknown, { titleId }) => {
+      setCards((prev) =>
+        prev.map((c) => {
+          if (c.titleId !== titleId) return c;
+          const restoredEpisodes = adjustWatchedCount(c.episodes, -1);
+          if (c.caughtUp) {
+            return { ...c, episodes: restoredEpisodes, caughtUp: false, currentIndex: c.episodes.length - 1 };
+          }
+          return { ...c, episodes: restoredEpisodes, currentIndex: Math.max(0, c.currentIndex - 1) };
+        })
+      );
+      setUndoAction(null);
+      showActionError(err instanceof Error ? err.message : "Failed to mark as watched");
+    },
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: ["stats"] });
+      void qc.invalidateQueries({ queryKey: ["activity"] });
+      void qc.invalidateQueries({ queryKey: ["home", "auth"] });
+    },
+  });
+
+  const undoMutation = useMutation({
+    mutationFn: ({ titleId, episodeId, isMovie }: { titleId: string; episodeId: number; isMovie?: boolean }) =>
+      isMovie ? api.unwatchMovie(titleId) : api.unwatchEpisode(episodeId),
+    onError: () => {
+      showActionError("Failed to undo");
+    },
+  });
+
+  const bulkWatchMutation = useMutation({
+    mutationFn: (episodeIds: number[]) => api.watchEpisodesBulk(episodeIds, true),
+    onSuccess: () => {
+      setSeasonPanel(null);
+      void qc.invalidateQueries({ queryKey: ["reels", source] });
+    },
+    onError: () => showActionError("Failed to mark episodes as watched"),
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: ["stats"] });
+      void qc.invalidateQueries({ queryKey: ["activity"] });
+    },
+  });
+
+  const seasonToggleMutation = useMutation({
+    mutationFn: ({ episodeId, currentlyWatched }: { episodeId: number; currentlyWatched: boolean }) =>
+      currentlyWatched ? api.unwatchEpisode(episodeId) : api.watchEpisode(episodeId),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ["reels", source] }),
+    onError: (_err: unknown, { currentlyWatched }: { episodeId: number; currentlyWatched: boolean }) =>
+      showActionError(currentlyWatched ? "Failed to unwatch episode" : "Failed to watch episode"),
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: ["stats"] });
+      void qc.invalidateQueries({ queryKey: ["activity"] });
+    },
+  });
+
+  const rateReelsMutation = useMutation({
+    mutationFn: ({ episodeId, value, isActive }: { episodeId: number; value: RatingValue; isActive: boolean }) =>
+      isActive ? api.unrateEpisode(episodeId) : api.rateEpisode(episodeId, value),
+    onMutate: ({ value, isActive }) => setReelsRating(isActive ? null : value),
+    onError: () => setReelsRating(null),
+  });
+
+  const markWatched = useCallback((titleId: string) => {
     const card = cardsRef.current.find((c) => c.titleId === titleId);
     if (!card || card.caughtUp) return;
     const episode = card.episodes[card.currentIndex];
@@ -377,6 +435,7 @@ export default function ReelsPage() {
       isMovie: card.isMovie,
     };
 
+    // Optimistic update
     setCards((prev) => {
       return prev.map((c) => {
         if (c.titleId !== titleId || c.caughtUp) return c;
@@ -401,48 +460,16 @@ export default function ReelsPage() {
       setCards((prev) => prev.filter((c) => !(c.titleId === titleId && c.caughtUp)));
     }, 5000);
 
-    try {
-      if (card.isMovie) {
-        await api.watchMovie(titleId);
-      } else {
-        await api.watchEpisode(episode.id);
-      }
-    } catch (err: unknown) {
-      // Revert on failure
-      setCards((prev) =>
-        prev.map((c) => {
-          if (c.titleId !== titleId) return c;
-          const restoredEpisodes = adjustWatchedCount(c.episodes, -1);
-          if (c.caughtUp) {
-            return { ...c, episodes: restoredEpisodes, caughtUp: false, currentIndex: c.episodes.length - 1 };
-          }
-          return { ...c, episodes: restoredEpisodes, currentIndex: Math.max(0, c.currentIndex - 1) };
-        })
-      );
-      setUndoAction(null);
-      if (actionErrorTimerRef.current) clearTimeout(actionErrorTimerRef.current);
-      setActionError(err instanceof Error ? err.message : "Failed to mark episode as watched");
-      actionErrorTimerRef.current = setTimeout(() => setActionError(""), 5000);
-    }
-  }, []);
+    watchMutation.mutate({ titleId, episodeId: episode.id, isMovie: card.isMovie });
+  }, [watchMutation]);
 
-  const handleReelsRate = useCallback(async (value: RatingValue) => {
+  const handleReelsRate = useCallback((value: RatingValue) => {
     if (!undoAction) return;
     const isActive = reelsRating === value;
-    try {
-      if (isActive) {
-        await api.unrateEpisode(undoAction.episodeId);
-        setReelsRating(null);
-      } else {
-        await api.rateEpisode(undoAction.episodeId, value);
-        setReelsRating(value);
-      }
-    } catch {
-      // Non-critical: silently ignore rating errors in Reels
-    }
-  }, [undoAction, reelsRating]);
+    rateReelsMutation.mutate({ episodeId: undoAction.episodeId, value, isActive });
+  }, [undoAction, reelsRating, rateReelsMutation]);
 
-  const handleUndo = useCallback(async () => {
+  const handleUndo = useCallback(() => {
     if (!undoAction) return;
     if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
     setUndoAction(null);
@@ -460,53 +487,18 @@ export default function ReelsPage() {
       })
     );
 
-    try {
-      if (undoAction.isMovie) {
-        await api.unwatchMovie(undoAction.titleId);
-      } else {
-        await api.unwatchEpisode(undoAction.episodeId);
-      }
-    } catch (err: unknown) {
-      if (actionErrorTimerRef.current) clearTimeout(actionErrorTimerRef.current);
-      setActionError(err instanceof Error ? err.message : "Failed to undo");
-      actionErrorTimerRef.current = setTimeout(() => setActionError(""), 5000);
-    }
-  }, [undoAction]);
+    undoMutation.mutate({ titleId: undoAction.titleId, episodeId: undoAction.episodeId, isMovie: undoAction.isMovie });
+  }, [undoAction, undoMutation]);
 
   // Season panel: bulk mark watched
-  const handleBulkWatch = useCallback(async (episodeIds: number[]) => {
-    try {
-      await api.watchEpisodesBulk(episodeIds, true);
-      // Reload data for current source
-      const { cards: c, friendsLovedEmpty: fl } = await fetchCardsForSource(sourceRef.current);
-      setCards(c);
-      setFriendsLovedEmpty(fl);
-      setSeasonPanel(null);
-    } catch (err: unknown) {
-      if (actionErrorTimerRef.current) clearTimeout(actionErrorTimerRef.current);
-      setActionError(err instanceof Error ? err.message : "Failed to mark episodes as watched");
-      actionErrorTimerRef.current = setTimeout(() => setActionError(""), 5000);
-    }
-  }, []);
+  const handleBulkWatch = useCallback((episodeIds: number[]) => {
+    bulkWatchMutation.mutate(episodeIds);
+  }, [bulkWatchMutation]);
 
   // Season panel: toggle individual episode watched
-  const handleSeasonToggleWatched = useCallback(async (episodeId: number, currentlyWatched: boolean) => {
-    try {
-      if (currentlyWatched) {
-        await api.unwatchEpisode(episodeId);
-      } else {
-        await api.watchEpisode(episodeId);
-      }
-      // Reload data for current source
-      const { cards: c, friendsLovedEmpty: fl } = await fetchCardsForSource(sourceRef.current);
-      setCards(c);
-      setFriendsLovedEmpty(fl);
-    } catch (err: unknown) {
-      if (actionErrorTimerRef.current) clearTimeout(actionErrorTimerRef.current);
-      setActionError(err instanceof Error ? err.message : "Failed to update watched status");
-      actionErrorTimerRef.current = setTimeout(() => setActionError(""), 5000);
-    }
-  }, []);
+  const handleSeasonToggleWatched = useCallback((episodeId: number, currentlyWatched: boolean) => {
+    seasonToggleMutation.mutate({ episodeId, currentlyWatched });
+  }, [seasonToggleMutation]);
 
   const getUndoInfo = (titleId: string): UndoInfo | undefined => {
     if (!undoAction || undoAction.titleId !== titleId) return undefined;
@@ -533,15 +525,16 @@ export default function ReelsPage() {
     setSearchParams({ source: s }, { replace: true });
   }
 
-  if (loading) {
+  if (isLoading) {
     return <ReelsSkeleton />;
   }
 
-  if (error) {
+  if (isError) {
+    const errorMessage = loadError instanceof Error ? loadError.message : String(loadError);
     return (
       <div className="flex items-center justify-center p-6 safe-top" style={{ minHeight: "calc(100dvh - env(safe-area-inset-top, 0px))" }}>
         <div className="text-center">
-          <p className="text-red-400 mb-4">{error}</p>
+          <p className="text-red-400 mb-4">{errorMessage}</p>
           <Link to="/" className="text-amber-400 hover:text-amber-300">
             Go back
           </Link>

--- a/frontend/src/pages/ReelsPage.tsx
+++ b/frontend/src/pages/ReelsPage.tsx
@@ -374,6 +374,7 @@ export default function ReelsPage() {
       showActionError(err instanceof Error ? err.message : "Failed to mark as watched");
     },
     onSettled: () => {
+      void qc.invalidateQueries({ queryKey: ["reels", source] });
       void qc.invalidateQueries({ queryKey: ["stats"] });
       void qc.invalidateQueries({ queryKey: ["activity"] });
       void qc.invalidateQueries({ queryKey: ["home", "auth"] });
@@ -386,16 +387,17 @@ export default function ReelsPage() {
     onError: () => {
       showActionError("Failed to undo");
     },
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["reels", source] }),
   });
 
   const bulkWatchMutation = useMutation({
     mutationFn: (episodeIds: number[]) => api.watchEpisodesBulk(episodeIds, true),
     onSuccess: () => {
       setSeasonPanel(null);
-      void qc.invalidateQueries({ queryKey: ["reels", source] });
     },
     onError: () => showActionError("Failed to mark episodes as watched"),
     onSettled: () => {
+      void qc.invalidateQueries({ queryKey: ["reels", source] });
       void qc.invalidateQueries({ queryKey: ["stats"] });
       void qc.invalidateQueries({ queryKey: ["activity"] });
     },
@@ -404,10 +406,10 @@ export default function ReelsPage() {
   const seasonToggleMutation = useMutation({
     mutationFn: ({ episodeId, currentlyWatched }: { episodeId: number; currentlyWatched: boolean }) =>
       currentlyWatched ? api.unwatchEpisode(episodeId) : api.watchEpisode(episodeId),
-    onSuccess: () => void qc.invalidateQueries({ queryKey: ["reels", source] }),
     onError: (_err: unknown, { currentlyWatched }: { episodeId: number; currentlyWatched: boolean }) =>
       showActionError(currentlyWatched ? "Failed to unwatch episode" : "Failed to watch episode"),
     onSettled: () => {
+      void qc.invalidateQueries({ queryKey: ["reels", source] });
       void qc.invalidateQueries({ queryKey: ["stats"] });
       void qc.invalidateQueries({ queryKey: ["activity"] });
     },
@@ -418,6 +420,7 @@ export default function ReelsPage() {
       isActive ? api.unrateEpisode(episodeId) : api.rateEpisode(episodeId, value),
     onMutate: ({ value, isActive }) => setReelsRating(isActive ? null : value),
     onError: () => setReelsRating(null),
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["reels", source] }),
   });
 
   const markWatched = useCallback((titleId: string) => {

--- a/frontend/src/pages/SeasonDetailPage.test.tsx
+++ b/frontend/src/pages/SeasonDetailPage.test.tsx
@@ -66,6 +66,8 @@ mock.module("../api", () => ({
   watchEpisode: mockWatchEpisode,
   unwatchEpisode: mockUnwatchEpisode,
   watchEpisodesBulk: mockWatchEpisodesBulk,
+  // stubs to prevent cross-file mock leakage — bun leaks mock.module globally
+  getSubscriptions: mock(() => Promise.resolve({ providerIds: [], onlyMine: false })),
 }));
 
 const { default: SeasonDetailPage } = await import("./SeasonDetailPage");

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, mock, afterEach, beforeEach } from "bun:test";
 import { render, screen, waitFor, cleanup, fireEvent, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 // Initialize i18n before anything else
 import "../i18n";
@@ -125,18 +126,62 @@ mock.module("../api", () => ({
   getMyProfile: mock(() => Promise.resolve({ display_name: null, bio: null, country_code: null, locale: null })),
   updateMyProfile: mock(() => Promise.resolve({ display_name: null, bio: null, country_code: null, locale: null })),
   previewNotifier: mock(() => Promise.resolve({ date: "2026-05-01", episodes: [], movies: [] })),
+  // stubs to prevent cross-file mock leakage — bun leaks mock.module globally
+  getSubscriptions: mock(() => Promise.resolve({ providerIds: [], onlyMine: false })),
+  getSharedWatchlist: mock(() => Promise.resolve({ username: "", titles: [] })),
+  getStats: mock(() => Promise.resolve({})),
+  getMovieDetails: mock(() => Promise.resolve({})),
+  getShowDetails: mock(() => Promise.resolve({})),
+  bulkTrackAction: mock(() => Promise.resolve({ updated: 0 })),
+  trackTitle: mock(() => Promise.resolve()),
+  untrackTitle: mock(() => Promise.resolve()),
+  getCalendarTitles: mock(() => Promise.resolve({ titles: [], episodes: [] })),
+  getUpcomingEpisodes: mock(() => Promise.resolve({ today: [], upcoming: [], unwatched: [] })),
+  watchEpisode: mock(() => Promise.resolve()),
+  unwatchEpisode: mock(() => Promise.resolve()),
+  watchEpisodesBulk: mock(() => Promise.resolve()),
+  watchMovie: mock(() => Promise.resolve()),
+  unwatchMovie: mock(() => Promise.resolve()),
+  getMovieTracking: mock(() => Promise.resolve(null)),
+  browseTitles: mock(() => Promise.resolve({ titles: [], total: 0 })),
+  getRecommendations: mock(() => Promise.resolve({ recommendations: [], suggestions: [], hasMore: false })),
+  fetchFriendsLoved: mock(() => Promise.resolve({ titles: [] })),
+  hideActivityEvent: mock(() => Promise.resolve()),
+  getCollection: mock(() => Promise.resolve({ collection: null, parts: [] })),
+  getTitleSuggestions: mock(() => Promise.resolve({ suggestions: [] })),
+  getActivitySettings: mock(() => Promise.resolve({ enabled: true, kind_visibility: {} })),
+  getNotifierHistory: mock(() => Promise.resolve({ rows: [], successRate: 100 })),
+  getDepartureAlertSettings: mock(() => Promise.resolve({})),
+  getProviders: mock(() => Promise.resolve({ providers: [], regionProviderIds: [] })),
+  updateSubscriptions: mock(() => Promise.resolve({ providerIds: [] })),
+  updateOnlyMine: mock(() => Promise.resolve({ onlyMine: false })),
+  getWatchlistShareToken: mock(() => Promise.resolve({ token: null })),
+  rateEpisode: mock(() => Promise.resolve()),
+  unrateEpisode: mock(() => Promise.resolve()),
 }));
 
 // Import after mocks
 const { default: SettingsPage } = await import("./SettingsPage");
 
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
 function Wrapper({ children }: { children: ReactNode }) {
-  return <MemoryRouter>{children}</MemoryRouter>;
+  return (
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
 }
 
 function WrapperWithPath(path: string) {
   return function ({ children }: { children: ReactNode }) {
-    return <MemoryRouter initialEntries={[path]}>{children}</MemoryRouter>;
+    return (
+      <QueryClientProvider client={newTestClient()}>
+        <MemoryRouter initialEntries={[path]}>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
   };
 }
 

--- a/frontend/src/pages/SharedWatchlistPage.test.tsx
+++ b/frontend/src/pages/SharedWatchlistPage.test.tsx
@@ -39,6 +39,8 @@ const mockGetSharedWatchlist = mock(() =>
 
 mock.module("../api", () => ({
   getSharedWatchlist: mockGetSharedWatchlist,
+  // stubs to prevent cross-file mock leakage — bun leaks mock.module globally
+  getSubscriptions: mock(() => Promise.resolve({ providerIds: [], onlyMine: false })),
 }));
 
 const { default: SharedWatchlistPage } = await import("./SharedWatchlistPage");

--- a/frontend/src/pages/StatsPage.test.tsx
+++ b/frontend/src/pages/StatsPage.test.tsx
@@ -38,6 +38,10 @@ const mockGetStats = mock(() => Promise.resolve(baseStats));
 
 mock.module("../api", () => ({
   getStats: mockGetStats,
+  // stubs to prevent cross-file mock leakage — bun leaks mock.module globally
+  getSubscriptions: mock(() => Promise.resolve({ providerIds: [], onlyMine: false })),
+  getMovieDetails: mock(() => Promise.resolve({})),
+  getShowDetails: mock(() => Promise.resolve({})),
 }));
 
 const { default: StatsPage, formatEta } = await import("./StatsPage");

--- a/frontend/src/pages/TitleDetailPage.test.tsx
+++ b/frontend/src/pages/TitleDetailPage.test.tsx
@@ -1,0 +1,128 @@
+import { describe, test, expect, spyOn, afterEach, beforeEach, mock } from "bun:test";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import * as api from "../api";
+import type { MovieDetailsResponse, ShowDetailsResponse } from "../types";
+
+// Mock AuthContext
+mock.module("../context/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: "u1", username: "me", display_name: "Me", auth_provider: "local", is_admin: false },
+    providers: { local: true, oidc: null },
+    loading: false,
+    sessionStatus: "authenticated",
+    subscriptions: null,
+    refreshSubscriptions: mock(() => Promise.resolve()),
+    login: mock(() => Promise.resolve()),
+    signup: mock(() => Promise.resolve()),
+    logout: mock(() => Promise.resolve()),
+    refresh: mock(() => Promise.resolve()),
+  }),
+  AuthContext: {
+    Provider: ({ children }: { children: ReactNode }) => children,
+  },
+}));
+
+// Mock MovieDetail and ShowDetail to avoid complex data requirements
+mock.module("./title/MovieDetail", () => ({
+  default: () => <div data-testid="movie-detail">MovieDetail</div>,
+}));
+
+mock.module("./title/ShowDetail", () => ({
+  default: () => <div data-testid="show-detail">ShowDetail</div>,
+}));
+
+const { default: TitleDetailPage } = await import("./TitleDetailPage");
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
+function makeWrapper(titleId: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={newTestClient()}>
+        <MemoryRouter initialEntries={[`/title/${titleId}`]}>
+          <Routes>
+            <Route path="/title/:id" element={<>{children}</>} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+const mockMovieTitle = {
+  id: "movie-1",
+  title: "Test Movie",
+  object_type: "MOVIE" as const,
+};
+
+const movieResponse = {
+  title: mockMovieTitle,
+  tmdb: null,
+  country: "US",
+} as unknown as MovieDetailsResponse;
+
+const showResponse = {
+  title: { ...mockMovieTitle, id: "tv-1", title: "Test Show", object_type: "SHOW" },
+  tmdb: null,
+  country: "US",
+} as unknown as ShowDetailsResponse;
+
+let getMovieSpy: ReturnType<typeof spyOn<typeof api, "getMovieDetails">>;
+let getShowSpy: ReturnType<typeof spyOn<typeof api, "getShowDetails">>;
+
+beforeEach(() => {
+  getMovieSpy = spyOn(api, "getMovieDetails");
+  getShowSpy = spyOn(api, "getShowDetails");
+});
+
+afterEach(() => {
+  getMovieSpy.mockRestore();
+  getShowSpy.mockRestore();
+  cleanup();
+});
+
+describe("TitleDetailPage", () => {
+  test("renders skeleton on load", () => {
+    getMovieSpy.mockImplementation(() => new Promise(() => {}));
+    const Wrapper = makeWrapper("movie-1");
+    render(<TitleDetailPage />, { wrapper: Wrapper });
+    // skeleton renders immediately with animate-pulse elements
+    const skeletons = document.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  test("renders MovieDetail for movie id", async () => {
+    getMovieSpy.mockResolvedValue(movieResponse);
+    const Wrapper = makeWrapper("movie-1");
+    render(<TitleDetailPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("movie-detail")).toBeDefined();
+    });
+  });
+
+  test("renders ShowDetail for tv id", async () => {
+    getShowSpy.mockResolvedValue(showResponse);
+    const Wrapper = makeWrapper("tv-1");
+    render(<TitleDetailPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("show-detail")).toBeDefined();
+    });
+  });
+
+  test("renders error message on failure", async () => {
+    getMovieSpy.mockRejectedValue(new Error("Not found"));
+    const Wrapper = makeWrapper("movie-1");
+    render(<TitleDetailPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Not found")).toBeDefined();
+    });
+  });
+});

--- a/frontend/src/pages/TitleDetailPage.test.tsx
+++ b/frontend/src/pages/TitleDetailPage.test.tsx
@@ -6,26 +6,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import * as api from "../api";
 import type { MovieDetailsResponse, ShowDetailsResponse } from "../types";
 
-// Mock AuthContext
-mock.module("../context/AuthContext", () => ({
-  useAuth: () => ({
-    user: { id: "u1", username: "me", display_name: "Me", auth_provider: "local", is_admin: false },
-    providers: { local: true, oidc: null },
-    loading: false,
-    sessionStatus: "authenticated",
-    subscriptions: null,
-    refreshSubscriptions: mock(() => Promise.resolve()),
-    login: mock(() => Promise.resolve()),
-    signup: mock(() => Promise.resolve()),
-    logout: mock(() => Promise.resolve()),
-    refresh: mock(() => Promise.resolve()),
-  }),
-  AuthContext: {
-    Provider: ({ children }: { children: ReactNode }) => children,
-  },
-}));
-
 // Mock MovieDetail and ShowDetail to avoid complex data requirements
+// (component stubs — lower risk than function mocks, kept as mock.module)
 mock.module("./title/MovieDetail", () => ({
   default: () => <div data-testid="movie-detail">MovieDetail</div>,
 }));

--- a/frontend/src/pages/TitleDetailPage.tsx
+++ b/frontend/src/pages/TitleDetailPage.tsx
@@ -1,66 +1,45 @@
-import { useEffect, useState } from "react";
 import { useParams } from "react-router";
+import { useQuery } from "@tanstack/react-query";
 import * as api from "../api";
 import type { MovieDetailsResponse, ShowDetailsResponse } from "../types";
 import { DetailPageSkeleton } from "../components/SkeletonComponents";
 import MovieDetail from "./title/MovieDetail";
 import ShowDetail from "./title/ShowDetail";
 
+type TitleDetailData = MovieDetailsResponse | ShowDetailsResponse;
+
 export default function TitleDetailPage() {
   const { id } = useParams<{ id: string }>();
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [movieData, setMovieData] = useState<MovieDetailsResponse | null>(null);
-  const [showData, setShowData] = useState<ShowDetailsResponse | null>(null);
 
-  useEffect(() => {
-    if (!id) return;
-    const titleId = id;
-    const controller = new AbortController();
-    const { signal } = controller;
+  const { isLoading, isError, error, data } = useQuery<TitleDetailData>({
+    queryKey: ["title-detail", id],
+    enabled: !!id,
+    queryFn: ({ signal }) => {
+      const isShow = id!.startsWith("tv-");
+      return isShow ? api.getShowDetails(id!, signal) : api.getMovieDetails(id!, signal);
+    },
+  });
 
-    // Determine type from the ID prefix (e.g. "movie-123" or "tv-456")
-    // to avoid making two API calls for shows.
-    const isShow = titleId.startsWith("tv-");
-
-    async function load() {
-      setLoading(true);
-      setError(null);
-      try {
-        if (isShow) {
-          const data = await api.getShowDetails(titleId, signal);
-          if (!signal.aborted) setShowData(data);
-        } else {
-          const data = await api.getMovieDetails(titleId, signal);
-          if (!signal.aborted) setMovieData(data);
-        }
-      } catch (e: unknown) {
-        if (!signal.aborted) setError(e instanceof Error ? e.message : "Failed to load details");
-      } finally {
-        if (!signal.aborted) setLoading(false);
-      }
-    }
-
-    load();
-    return () => {
-      controller.abort();
-    };
-  }, [id]);
-
-  if (loading) {
+  if (isLoading) {
     return <DetailPageSkeleton />;
   }
 
-  if (error) {
+  if (isError) {
     return (
       <div className="flex items-center justify-center py-20">
-        <div className="text-red-400 select-text">{error}</div>
+        <div className="text-red-400 select-text">
+          {error instanceof Error ? error.message : "Failed to load details"}
+        </div>
       </div>
     );
   }
 
-  if (movieData) return <MovieDetail data={movieData} />;
-  if (showData) return <ShowDetail data={showData} />;
+  if (data && data.title.object_type === "MOVIE") {
+    return <MovieDetail data={data as MovieDetailsResponse} />;
+  }
+  if (data && data.title.object_type === "SHOW") {
+    return <ShowDetail data={data as ShowDetailsResponse} />;
+  }
 
   return <div className="text-zinc-400 text-center py-20">Title not found</div>;
 }

--- a/frontend/src/pages/TrackedPage.test.tsx
+++ b/frontend/src/pages/TrackedPage.test.tsx
@@ -38,6 +38,8 @@ mock.module("../api", () => ({
   trackTitle: mock(() => Promise.resolve()),
   untrackTitle: mock(() => Promise.resolve()),
   bulkTrackAction: mockBulkTrackAction,
+  // stubs to prevent cross-file mock leakage — bun leaks mock.module globally
+  getSubscriptions: mock(() => Promise.resolve({ providerIds: [], onlyMine: false })),
 }));
 
 const { default: TrackedPage } = await import("./TrackedPage");

--- a/frontend/src/pages/UpcomingPage.test.tsx
+++ b/frontend/src/pages/UpcomingPage.test.tsx
@@ -17,6 +17,28 @@ mock.module("../api", () => ({
   watchEpisode: mockWatchEpisode,
   unwatchEpisode: mockUnwatchEpisode,
   getCalendarTitles: mock(() => Promise.resolve({ titles: [], episodes: [] })),
+  // stubs to prevent cross-file mock leakage — bun leaks mock.module globally
+  getSubscriptions: mock(() => Promise.resolve({ providerIds: [], onlyMine: false })),
+  hideActivityEvent: mock(() => Promise.resolve()),
+  getCollection: mock(() => Promise.resolve({ collection: null, parts: [] })),
+  getTitleSuggestions: mock(() => Promise.resolve({ suggestions: [] })),
+  getMyProfile: mock(() => Promise.resolve({ display_name: null, bio: null, country_code: null, locale: null })),
+  getTrackedTitles: mock(() => Promise.resolve({ titles: [], count: 0, profile_public: false })),
+  getActivitySettings: mock(() => Promise.resolve({ enabled: true, kind_visibility: {} })),
+  getJobs: mock(() => Promise.resolve({ crons: [], stats: {}, recentJobs: [] })),
+  getAdminSettings: mock(() => Promise.resolve({ oidc_configured: false, oidc: {} })),
+  getAdminConfig: mock(() => Promise.resolve({ safe: [], secrets: [] })),
+  getAdminLogs: mock(() => Promise.resolve({ entries: [], count: 0 })),
+  getIntegrations: mock(() => Promise.resolve({ integrations: [] })),
+  getFeedToken: mock(() => Promise.resolve({ token: null })),
+  getKioskToken: mock(() => Promise.resolve({ token: null })),
+  getWatchlistShareToken: mock(() => Promise.resolve({ token: null })),
+  getNotifiers: mock(() => Promise.resolve({ notifiers: [] })),
+  getNotifierProviders: mock(() => Promise.resolve({ providers: [] })),
+  getDepartureAlertSettings: mock(() => Promise.resolve({})),
+  getProviders: mock(() => Promise.resolve({ providers: [], regionProviderIds: [] })),
+  updateSubscriptions: mock(() => Promise.resolve({ providerIds: [] })),
+  updateOnlyMine: mock(() => Promise.resolve({ onlyMine: false })),
 }));
 
 mock.module("../hooks/useIsMobile", () => ({

--- a/frontend/src/pages/settings/AccountTab.test.tsx
+++ b/frontend/src/pages/settings/AccountTab.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, mock, beforeEach, afterEach, spyOn } from "bun:test";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import type { ReactNode } from "react";
+import "../../i18n";
+import * as api from "../../api";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
+function wrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <MemoryRouter>
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      </MemoryRouter>
+    );
+  };
+}
+
+mock.module("../../context/AuthContext", () => ({
+  useAuth: () => ({
+    user: {
+      id: "u1",
+      username: "testuser",
+      display_name: null,
+      auth_provider: "local",
+      is_admin: false,
+    },
+    loading: false,
+    sessionStatus: "authenticated",
+  }),
+}));
+
+mock.module("../../lib/auth-client", () => ({
+  authClient: {
+    changePassword: mock(() => Promise.resolve({ error: null })),
+    passkey: {
+      listUserPasskeys: mock(() => Promise.resolve({ data: [] })),
+      addPasskey: mock(() => Promise.resolve({ error: null })),
+      deletePasskey: mock(() => Promise.resolve({ error: null })),
+      updatePasskey: mock(() => Promise.resolve({ error: null })),
+    },
+  },
+}));
+
+const { default: AccountTab } = await import("./AccountTab");
+
+let spies: ReturnType<typeof spyOn>[] = [];
+
+beforeEach(() => {
+  spies = [
+    spyOn(api, "getMyProfile").mockResolvedValue({
+      display_name: "Test User",
+      bio: null,
+      country_code: null,
+    } as any),
+    spyOn(api, "getTrackedTitles").mockResolvedValue({
+      titles: [],
+      count: 0,
+      profile_public: false,
+      profile_visibility: "private",
+    } as any),
+    spyOn(api, "getActivitySettings").mockResolvedValue({
+      enabled: false,
+      kind_visibility: {},
+    } as any),
+  ];
+});
+
+afterEach(() => {
+  cleanup();
+  for (const spy of spies) spy.mockRestore();
+  spies = [];
+});
+
+describe("AccountTab", () => {
+  it("renders without crashing", async () => {
+    const client = newTestClient();
+    render(<AccountTab />, { wrapper: wrapper(client) });
+
+    // The UserSection renders immediately from AuthContext data — username appears in multiple inputs
+    await waitFor(() => {
+      expect(screen.getAllByDisplayValue("testuser").length).toBeGreaterThan(0);
+    });
+  });
+
+  it("renders profile visibility section after data loads", async () => {
+    const client = newTestClient();
+    render(<AccountTab />, { wrapper: wrapper(client) });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("visibility-selector")).toBeDefined();
+    });
+  });
+
+  it("renders activity stream section", async () => {
+    const client = newTestClient();
+    render(<AccountTab />, { wrapper: wrapper(client) });
+
+    await waitFor(() => {
+      expect(screen.getByText("Activity stream")).toBeDefined();
+    });
+  });
+});

--- a/frontend/src/pages/settings/AccountTab.test.tsx
+++ b/frontend/src/pages/settings/AccountTab.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from "react-router";
 import type { ReactNode } from "react";
 import "../../i18n";
 import * as api from "../../api";
+import * as AuthContextModule from "../../context/AuthContext";
 
 function newTestClient() {
   return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
@@ -20,20 +21,8 @@ function wrapper(client: QueryClient) {
   };
 }
 
-mock.module("../../context/AuthContext", () => ({
-  useAuth: () => ({
-    user: {
-      id: "u1",
-      username: "testuser",
-      display_name: null,
-      auth_provider: "local",
-      is_admin: false,
-    },
-    loading: false,
-    sessionStatus: "authenticated",
-  }),
-}));
-
+// Keep auth-client mock as mock.module — it's a complex external lib (better-auth)
+// and cannot be easily spyOn'd
 mock.module("../../lib/auth-client", () => ({
   authClient: {
     changePassword: mock(() => Promise.resolve({ error: null })),
@@ -52,6 +41,24 @@ let spies: ReturnType<typeof spyOn>[] = [];
 
 beforeEach(() => {
   spies = [
+    spyOn(AuthContextModule, "useAuth").mockReturnValue({
+      user: {
+        id: "u1",
+        username: "testuser",
+        display_name: null,
+        auth_provider: "local",
+        is_admin: false,
+      },
+      providers: { local: true, oidc: null },
+      loading: false,
+      sessionStatus: "authenticated",
+      subscriptions: null,
+      refreshSubscriptions: mock(() => Promise.resolve()),
+      login: mock(() => Promise.resolve()),
+      signup: mock(() => Promise.resolve()),
+      logout: mock(() => Promise.resolve()),
+      refresh: mock(() => Promise.resolve()),
+    }),
     spyOn(api, "getMyProfile").mockResolvedValue({
       display_name: "Test User",
       bio: null,

--- a/frontend/src/pages/settings/AccountTab.tsx
+++ b/frontend/src/pages/settings/AccountTab.tsx
@@ -53,30 +53,14 @@ const COUNTRIES = [
   { code: "ZA", name: "South Africa" },
 ];
 
-function ProfileEditSection() {
+function ProfileEditForm({ profile }: { profile: api.MyProfile }) {
   const { user } = useAuth();
   const { t } = useTranslation();
-  const [displayName, setDisplayName] = useState("");
-  const [bio, setBio] = useState("");
-  const [countryCode, setCountryCode] = useState("");
+  const [displayName, setDisplayName] = useState(profile.display_name ?? "");
+  const [bio, setBio] = useState(profile.bio ?? "");
+  const [countryCode, setCountryCode] = useState(profile.country_code ?? "");
   const [msg, setMsg] = useState("");
   const { run, error: saveErr, pending: saving } = useAsyncError();
-
-  const { data, isLoading } = useQuery({
-    queryKey: ["my-profile"],
-    queryFn: ({ signal }) => api.getMyProfile(signal),
-  });
-
-  /* eslint-disable react-hooks/set-state-in-effect */
-  useEffect(() => {
-    // syncing server-backed initial values into controlled form fields
-    if (data) {
-      setDisplayName(data.display_name ?? "");
-      setBio(data.bio ?? "");
-      setCountryCode(data.country_code ?? "");
-    }
-  }, [data]);
-  /* eslint-enable react-hooks/set-state-in-effect */
 
   async function handleSave(e: React.FormEvent) {
     e.preventDefault();
@@ -90,8 +74,6 @@ function ProfileEditSection() {
       setMsg(t("profile.profileSaved"));
     });
   }
-
-  if (isLoading) return null;
 
   return (
     <SCard
@@ -140,6 +122,18 @@ function ProfileEditSection() {
       </form>
     </SCard>
   );
+}
+
+function ProfileEditSection() {
+  const { data, isLoading } = useQuery({
+    queryKey: ["my-profile"],
+    queryFn: ({ signal }) => api.getMyProfile(signal),
+  });
+
+  if (isLoading) return null;
+  if (!data) return null;
+
+  return <ProfileEditForm profile={data} />;
 }
 
 function passwordStrength(pw: string): number {

--- a/frontend/src/pages/settings/AccountTab.tsx
+++ b/frontend/src/pages/settings/AccountTab.tsx
@@ -1,10 +1,12 @@
-import { useState, useEffect, useCallback, useReducer } from "react";
+import { useState, useEffect, useReducer } from "react";
 import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { SUPPORTED_LANGUAGES, setLanguage } from "../../i18n";
 import { useAuth } from "../../context/AuthContext";
 import * as api from "../../api";
-import type { Title, ActivitySettings, ActivityType, ActivityKindVisibility } from "../../types";
+import type { ActivitySettings, ActivityType, ActivityKindVisibility } from "../../types";
 import { authClient } from "../../lib/auth-client";
 import { UserPlus } from "lucide-react";
 import { useAsyncError } from "../../hooks/useAsyncError";
@@ -57,22 +59,24 @@ function ProfileEditSection() {
   const [displayName, setDisplayName] = useState("");
   const [bio, setBio] = useState("");
   const [countryCode, setCountryCode] = useState("");
-  const [loaded, setLoaded] = useState(false);
   const [msg, setMsg] = useState("");
   const { run, error: saveErr, pending: saving } = useAsyncError();
 
+  const { data, isLoading } = useQuery({
+    queryKey: ["my-profile"],
+    queryFn: ({ signal }) => api.getMyProfile(signal),
+  });
+
+  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
-    let mounted = true;
-    const controller = new AbortController();
-    api.getMyProfile(controller.signal).then((data) => {
-      if (!mounted) return;
+    // syncing server-backed initial values into controlled form fields
+    if (data) {
       setDisplayName(data.display_name ?? "");
       setBio(data.bio ?? "");
       setCountryCode(data.country_code ?? "");
-      setLoaded(true);
-    }).catch(() => { if (mounted) setLoaded(true); });
-    return () => { mounted = false; controller.abort(); };
-  }, []);
+    }
+  }, [data]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   async function handleSave(e: React.FormEvent) {
     e.preventDefault();
@@ -87,7 +91,7 @@ function ProfileEditSection() {
     });
   }
 
-  if (!loaded) return null;
+  if (isLoading) return null;
 
   return (
     <SCard
@@ -525,40 +529,42 @@ function PasskeySection() {
 
 function ProfileVisibilitySection() {
   const { t } = useTranslation();
-  const [loading, setLoading] = useState(true);
-  const [visibility, setVisibility] = useState<string>("private");
-  const [titles, setTitles] = useState<(Title & { public: boolean })[]>([]);
+  const qc = useQueryClient();
   const [updatingGlobal, setUpdatingGlobal] = useState(false);
   const [updatingAll, setUpdatingAll] = useState(false);
   const [err, setErr] = useState("");
 
-  const refresh = useCallback(async (signal?: AbortSignal) => {
-    try {
-      const data = await api.getTrackedTitles(signal);
-      if (signal?.aborted) return;
-      setVisibility(data.profile_visibility || (data.profile_public ? "public" : "private"));
-      setTitles(data.titles);
-    } catch {
-      // ignore
-    } finally {
-      if (!signal?.aborted) setLoading(false);
-    }
-  }, []);
+  const { data, isLoading: loading } = useQuery({
+    queryKey: ["tracked"],
+    queryFn: ({ signal }) => api.getTrackedTitles(signal),
+  });
 
-  useEffect(() => {
-    const controller = new AbortController();
-    refresh(controller.signal);
-    return () => controller.abort();
-  }, [refresh]);
+  const visibility = data?.profile_visibility ?? (data?.profile_public ? "public" : "private");
+  const titles = data?.titles ?? [];
+
+  const updateVisibilityMutation = useMutation({
+    mutationFn: (newVisibility: string) => api.updateProfileVisibility(newVisibility),
+    onError: (e: unknown) => {
+      setErr(e instanceof Error ? e.message : String(e));
+      toast.error("Failed to update visibility");
+    },
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["tracked"] }),
+  });
+
+  const bulkVisibilityMutation = useMutation({
+    mutationFn: (isPublic: boolean) => api.updateAllTitleVisibility(isPublic),
+    onError: (e: unknown) => {
+      setErr(e instanceof Error ? e.message : String(e));
+      toast.error("Failed to update visibility");
+    },
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["tracked"] }),
+  });
 
   async function handleVisibilityChange(newVisibility: string) {
     setErr("");
     setUpdatingGlobal(true);
     try {
-      await api.updateProfileVisibility(newVisibility);
-      setVisibility(newVisibility);
-    } catch (e: unknown) {
-      setErr(e instanceof Error ? e.message : String(e));
+      await updateVisibilityMutation.mutateAsync(newVisibility);
     } finally {
       setUpdatingGlobal(false);
     }
@@ -568,10 +574,7 @@ function ProfileVisibilitySection() {
     setErr("");
     setUpdatingAll(true);
     try {
-      await api.updateAllTitleVisibility(isPublic);
-      setTitles((prev) => prev.map((x) => ({ ...x, public: isPublic })));
-    } catch (e: unknown) {
-      setErr(e instanceof Error ? e.message : String(e));
+      await bulkVisibilityMutation.mutateAsync(isPublic);
     } finally {
       setUpdatingAll(false);
     }
@@ -682,7 +685,6 @@ const KIND_VIS_OPTIONS: Array<{ value: "public" | "friends_only" | "private"; la
 ];
 
 function ActivityStreamSection() {
-  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [settings, setSettings] = useState<ActivitySettings>({
     enabled: false,
@@ -690,23 +692,16 @@ function ActivityStreamSection() {
   });
   const [err, setErr] = useState("");
 
-  const refresh = useCallback(async (signal?: AbortSignal) => {
-    try {
-      const data = await api.getActivitySettings(signal);
-      if (signal?.aborted) return;
-      setSettings(data);
-    } catch {
-      // ignore
-    } finally {
-      if (!signal?.aborted) setLoading(false);
-    }
-  }, []);
+  const { data, isLoading: loading } = useQuery({
+    queryKey: ["activity-settings"],
+    queryFn: ({ signal }) => api.getActivitySettings(signal),
+  });
 
   useEffect(() => {
-    const controller = new AbortController();
-    refresh(controller.signal);
-    return () => controller.abort();
-  }, [refresh]);
+    if (data) {
+      setSettings(data);
+    }
+  }, [data]);
 
   async function handleToggle(next: boolean) {
     setSaving(true);

--- a/frontend/src/pages/settings/AdminTab.test.tsx
+++ b/frontend/src/pages/settings/AdminTab.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import type { ReactNode } from "react";
+import "../../i18n";
+import * as api from "../../api";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
+function wrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <MemoryRouter>
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      </MemoryRouter>
+    );
+  };
+}
+
+const { default: AdminTab } = await import("./AdminTab");
+
+let spies: ReturnType<typeof spyOn>[] = [];
+
+beforeEach(() => {
+  spies = [
+    spyOn(api, "getJobs").mockResolvedValue({
+      crons: [],
+      stats: {},
+      recentJobs: [],
+    } as any),
+    spyOn(api, "getAdminSettings").mockResolvedValue({
+      oidc_configured: false,
+      oidc: {
+        issuer_url: { source: "unset", value: "" },
+        client_id: { source: "unset", value: "" },
+        client_secret: { source: "unset", value: "" },
+        redirect_uri: { source: "unset", value: "" },
+      },
+    } as any),
+    spyOn(api, "getAdminConfig").mockResolvedValue({
+      safe: [],
+      secrets: [],
+    } as any),
+    spyOn(api, "getAdminLogs").mockResolvedValue({
+      entries: [],
+    } as any),
+  ];
+});
+
+afterEach(() => {
+  cleanup();
+  for (const spy of spies) spy.mockRestore();
+  spies = [];
+});
+
+describe("AdminTab", () => {
+  it("renders without crashing", async () => {
+    const client = newTestClient();
+    render(<AdminTab />, { wrapper: wrapper(client) });
+
+    await waitFor(() => {
+      expect(screen.getByText("Background jobs")).toBeDefined();
+    });
+  });
+
+  it("shows empty jobs message when no crons configured", async () => {
+    const client = newTestClient();
+    render(<AdminTab />, { wrapper: wrapper(client) });
+
+    await waitFor(() => {
+      expect(screen.getByText("No scheduled jobs configured.")).toBeDefined();
+    });
+  });
+
+  it("shows OIDC config section", async () => {
+    const client = newTestClient();
+    render(<AdminTab />, { wrapper: wrapper(client) });
+
+    await waitFor(() => {
+      expect(screen.getByText("OpenID Connect")).toBeDefined();
+    });
+  });
+
+  it("shows maintenance section", async () => {
+    const client = newTestClient();
+    render(<AdminTab />, { wrapper: wrapper(client) });
+
+    await waitFor(() => {
+      expect(screen.getByText("Maintenance")).toBeDefined();
+    });
+  });
+});

--- a/frontend/src/pages/settings/AdminTab.tsx
+++ b/frontend/src/pages/settings/AdminTab.tsx
@@ -1,8 +1,8 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect } from "react";
 import { Link } from "react-router";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import * as api from "../../api";
-import type { JobsResponse, AdminConfigResponse, AdminLogEntry } from "../../api";
-import type { AdminSettings } from "../../types";
 import {
   SCard,
   SStatusPill,
@@ -39,41 +39,25 @@ function JobStatusBadge({ status }: { status: string }) {
 }
 
 function BackgroundJobsSection() {
-  const [data, setData] = useState<JobsResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [triggering, setTriggering] = useState<string | null>(null);
+  const qc = useQueryClient();
   const [msg, setMsg] = useState("");
   const [err, setErr] = useState("");
 
-  const refresh = useCallback((signal?: AbortSignal) => {
-    api.getJobs(signal).then((d) => {
-      if (signal?.aborted) return;
-      setData(d);
-      setLoading(false);
-    }).catch(() => { if (!signal?.aborted) setLoading(false); });
-  }, []);
+  const { data, isLoading: loading } = useQuery({
+    queryKey: ["admin-jobs"],
+    queryFn: ({ signal }) => api.getJobs(signal),
+    refetchInterval: 15_000,
+  });
 
-  useEffect(() => {
-    const controller = new AbortController();
-    refresh(controller.signal);
-    const interval = setInterval(() => refresh(), 15000);
-    return () => { controller.abort(); clearInterval(interval); };
-  }, [refresh]);
-
-  async function handleTrigger(name: string) {
-    setMsg("");
-    setErr("");
-    setTriggering(name);
-    try {
-      await api.triggerJob(name);
-      setMsg(`Job "${formatJobName(name)}" queued successfully`);
-      refresh();
-    } catch (e: unknown) {
+  const triggerJobMutation = useMutation({
+    mutationFn: (name: string) => api.triggerJob(name),
+    onSuccess: (_data, name) => setMsg(`Job "${formatJobName(name)}" queued successfully`),
+    onError: (e: unknown) => {
       setErr(e instanceof Error ? e.message : String(e));
-    } finally {
-      setTriggering(null);
-    }
-  }
+      toast.error("Failed to trigger job");
+    },
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["admin-jobs"] }),
+  });
 
   if (loading) {
     return (
@@ -152,10 +136,10 @@ function BackgroundJobsSection() {
                       <SButton
                         variant="ghost"
                         small
-                        onClick={() => handleTrigger(cron.name)}
-                        disabled={triggering === cron.name}
+                        onClick={() => triggerJobMutation.mutate(cron.name)}
+                        disabled={triggerJobMutation.isPending && triggerJobMutation.variables === cron.name}
                       >
-                        {triggering === cron.name ? "Queuing..." : "Run now"}
+                        {triggerJobMutation.isPending && triggerJobMutation.variables === cron.name ? "Queuing..." : "Run now"}
                       </SButton>
                     </div>
                   </div>
@@ -245,8 +229,7 @@ function SettingField({
 }
 
 function AdminSection() {
-  const [settings, setSettings] = useState<AdminSettings | null>(null);
-  const [loading, setLoading] = useState(true);
+  const qc = useQueryClient();
   const [saving, setSaving] = useState(false);
   const [msg, setMsg] = useState("");
   const [err, setErr] = useState("");
@@ -256,23 +239,23 @@ function AdminSection() {
   const [clientSecret, setClientSecret] = useState("");
   const [redirectUri, setRedirectUri] = useState("");
 
+  const { data: settings, isLoading: loading } = useQuery({
+    queryKey: ["admin-settings"],
+    queryFn: ({ signal }) => api.getAdminSettings(signal),
+  });
+
   useEffect(() => {
-    const controller = new AbortController();
-    api.getAdminSettings(controller.signal).then((data) => {
-      if (controller.signal.aborted) return;
-      setSettings(data);
-      setIssuerUrl(data.oidc.issuer_url.source !== "env" ? data.oidc.issuer_url.value : "");
-      setClientId(data.oidc.client_id.source !== "env" ? data.oidc.client_id.value : "");
+    if (settings) {
+      setIssuerUrl(settings.oidc.issuer_url.source !== "env" ? settings.oidc.issuer_url.value : "");
+      setClientId(settings.oidc.client_id.source !== "env" ? settings.oidc.client_id.value : "");
       setClientSecret("");
       setRedirectUri(
-        data.oidc.redirect_uri.source !== "env"
-          ? data.oidc.redirect_uri.value || `${window.location.origin}/api/auth/oidc/callback`
+        settings.oidc.redirect_uri.source !== "env"
+          ? settings.oidc.redirect_uri.value || `${window.location.origin}/api/auth/oidc/callback`
           : ""
       );
-      setLoading(false);
-    }).catch(() => { if (!controller.signal.aborted) setLoading(false); });
-    return () => controller.abort();
-  }, []);
+    }
+  }, [settings]);
 
   async function handleSave(e: React.FormEvent) {
     e.preventDefault();
@@ -290,8 +273,7 @@ function AdminSection() {
       }
       const result = await api.updateAdminSettings(body);
       setMsg(result.oidc_configured ? "OIDC configured successfully" : "Settings saved");
-      const data = await api.getAdminSettings();
-      setSettings(data);
+      void qc.invalidateQueries({ queryKey: ["admin-settings"] });
     } catch (e: unknown) {
       setErr(e instanceof Error ? e.message : String(e));
     } finally {
@@ -374,16 +356,10 @@ function AdminSection() {
 }
 
 function RuntimeConfigSection() {
-  const [config, setConfig] = useState<AdminConfigResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const controller = new AbortController();
-    api.getAdminConfig(controller.signal)
-      .then((d) => { if (!controller.signal.aborted) { setConfig(d); setLoading(false); } })
-      .catch(() => { if (!controller.signal.aborted) setLoading(false); });
-    return () => controller.abort();
-  }, []);
+  const { data: config, isLoading: loading } = useQuery({
+    queryKey: ["admin-config"],
+    queryFn: ({ signal }) => api.getAdminConfig(signal),
+  });
 
   return (
     <SCard title="Runtime configuration" subtitle="Current server config. Secret values show only whether they are set.">
@@ -434,24 +410,15 @@ const LOG_LEVEL_COLORS: Record<string, string> = {
 };
 
 function LogTailSection() {
-  const [entries, setEntries] = useState<AdminLogEntry[]>([]);
-  const [loading, setLoading] = useState(true);
   const [levelFilter, setLevelFilter] = useState<string>("");
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const fetchLogs = useCallback((signal?: AbortSignal) => {
-    api.getAdminLogs({ limit: 50, level: levelFilter || undefined }, signal)
-      .then((d) => { if (!signal?.aborted) { setEntries(d.entries); setLoading(false); } })
-      .catch(() => { if (!signal?.aborted) setLoading(false); });
-  }, [levelFilter]);
+  const { data, isLoading: loading } = useQuery({
+    queryKey: ["admin-logs", levelFilter],
+    queryFn: ({ signal }) => api.getAdminLogs({ limit: 50, level: levelFilter || undefined }, signal),
+    refetchInterval: 5_000,
+  });
 
-  // Initial load + polling. Loading state resets via fetchLogs callback results.
-  useEffect(() => {
-    const controller = new AbortController();
-    fetchLogs(controller.signal);
-    intervalRef.current = setInterval(() => fetchLogs(), 5000);
-    return () => { controller.abort(); if (intervalRef.current) clearInterval(intervalRef.current); };
-  }, [fetchLogs]);
+  const entries = data?.entries ?? [];
 
   return (
     <SCard

--- a/frontend/src/pages/settings/AppearanceTab.test.tsx
+++ b/frontend/src/pages/settings/AppearanceTab.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, mock, beforeEach, afterEach, spyOn } from "bun:test";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import "../../i18n";
+import * as api from "../../api";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
+function wrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+mock.module("../../hooks/useTheme", () => ({
+  useTheme: () => ({
+    theme: "dark",
+    setTheme: mock(() => {}),
+  }),
+}));
+
+mock.module("../../hooks/useAppearance", () => ({
+  applyAppearance: mock(() => {}),
+}));
+
+mock.module("../../components/ThemePicker", () => ({
+  default: () => <div data-testid="theme-picker">ThemePicker</div>,
+}));
+
+mock.module("../../components/AccentPicker", () => ({
+  default: ({ onChange }: any) => (
+    <div data-testid="accent-picker" onClick={() => onChange("amber")}>AccentPicker</div>
+  ),
+}));
+
+mock.module("../../components/DensityPicker", () => ({
+  default: ({ onChange }: any) => (
+    <div data-testid="density-picker" onClick={() => onChange("comfortable")}>DensityPicker</div>
+  ),
+}));
+
+const { default: AppearanceTab } = await import("./AppearanceTab");
+
+let spies: ReturnType<typeof spyOn>[] = [];
+
+beforeEach(() => {
+  spies = [
+    spyOn(api, "getAppearanceSettings").mockResolvedValue({
+      themeVariant: "dark",
+      accentColor: "amber",
+      density: "comfortable",
+      reduceMotion: 0,
+      highContrast: 0,
+      hideEpisodeSpoilers: 0,
+      autoplayTrailers: 0,
+    } as any),
+    spyOn(api, "getHomepageLayout").mockResolvedValue({
+      homepage_layout: [
+        { id: "up_next", enabled: true },
+        { id: "unwatched", enabled: true },
+      ],
+    } as any),
+    spyOn(api, "getCrowdedWeekSettings").mockResolvedValue({
+      crowdedWeekBadgeEnabled: 1,
+      crowdedWeekThreshold: 5,
+    } as any),
+  ];
+});
+
+afterEach(() => {
+  cleanup();
+  for (const spy of spies) spy.mockRestore();
+  spies = [];
+});
+
+describe("AppearanceTab", () => {
+  it("renders without crashing", async () => {
+    const client = newTestClient();
+    render(<AppearanceTab />, { wrapper: wrapper(client) });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("theme-picker")).toBeDefined();
+    });
+  });
+
+  it("shows homepage layout section", async () => {
+    const client = newTestClient();
+    render(<AppearanceTab />, { wrapper: wrapper(client) });
+
+    await waitFor(() => {
+      // Check that the layout sections rendered (at least one section item)
+      expect(screen.getAllByRole("button").length).toBeGreaterThan(0);
+    });
+  });
+
+  it("shows crowded week section", async () => {
+    const client = newTestClient();
+    render(<AppearanceTab />, { wrapper: wrapper(client) });
+
+    await waitFor(() => {
+      // crowded week toggle renders an aria-pressed button
+      expect(screen.getAllByRole("button", { pressed: true }).length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/frontend/src/pages/settings/AppearanceTab.tsx
+++ b/frontend/src/pages/settings/AppearanceTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
 import * as api from "../../api";
@@ -28,16 +28,6 @@ const SECTION_LABELS: Record<string, string> = {
   streak: "settings.homepage.sections.streak",
 };
 
-const DEFAULT_APPEARANCE: AppearanceSettings = {
-  themeVariant: "dark",
-  accentColor: "amber",
-  density: "comfortable",
-  reduceMotion: 0,
-  highContrast: 0,
-  hideEpisodeSpoilers: 0,
-  autoplayTrailers: 0,
-};
-
 function ThemeSection() {
   const { t } = useTranslation();
 
@@ -51,31 +41,21 @@ function ThemeSection() {
   );
 }
 
-function AppearanceSection() {
+function AppearanceControls({ initialData }: { initialData: AppearanceSettings }) {
   const { t } = useTranslation();
   const { setTheme } = useTheme();
-  const [settings, setSettings] = useState<AppearanceSettings>(DEFAULT_APPEARANCE);
+  const [settings, setSettings] = useState<AppearanceSettings>(initialData);
   const [saved, setSaved] = useState(false);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const { data } = useQuery({
-    queryKey: ["appearance-settings"],
-    queryFn: ({ signal }) => api.getAppearanceSettings(signal),
-  });
-
-  /* eslint-disable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps */
+  // Apply appearance and theme on mount from server-fetched data
   useEffect(() => {
-    // syncing server-backed initial values into controlled appearance state
-    if (data) {
-      setSettings(data);
-      applyAppearance(data);
-      if (data.themeVariant) setTheme(data.themeVariant as Parameters<typeof setTheme>[0]);
-    }
-  // mount-only load — setTheme identity not tracked intentionally
-  }, [data]);
-  /* eslint-enable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps */
+    applyAppearance(initialData);
+    if (initialData.themeVariant) setTheme(initialData.themeVariant as Parameters<typeof setTheme>[0]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // mount-only — initialData is stable on first render; setTheme identity not tracked
 
-  async function save(patch: Partial<AppearanceSettings>) {
+  const save = useCallback(async (patch: Partial<AppearanceSettings>) => {
     const next = { ...settings, ...patch };
     setSettings(next);
     applyAppearance(next);
@@ -89,7 +69,7 @@ function AppearanceSection() {
     } catch {
       // silently ignore
     }
-  }
+  }, [settings]);
 
   function handleAccentChange(accent: AccentColor) {
     save({ accentColor: accent });
@@ -151,6 +131,17 @@ function AppearanceSection() {
       </SCard>
     </>
   );
+}
+
+function AppearanceSection() {
+  const { data } = useQuery({
+    queryKey: ["appearance-settings"],
+    queryFn: ({ signal }) => api.getAppearanceSettings(signal),
+  });
+
+  if (!data) return null;
+
+  return <AppearanceControls initialData={data} />;
 }
 
 function HomepageLayoutSection() {

--- a/frontend/src/pages/settings/AppearanceTab.tsx
+++ b/frontend/src/pages/settings/AppearanceTab.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import { useQuery } from "@tanstack/react-query";
 import * as api from "../../api";
 import type { HomepageSection, AppearanceSettings, AccentColor, Density } from "../../types";
 import { DEFAULT_HOMEPAGE_LAYOUT } from "../../types";
@@ -57,29 +58,31 @@ function AppearanceSection() {
   const [saved, setSaved] = useState(false);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const { data } = useQuery({
+    queryKey: ["appearance-settings"],
+    queryFn: ({ signal }) => api.getAppearanceSettings(signal),
+  });
+
+  /* eslint-disable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps */
   useEffect(() => {
-    const controller = new AbortController();
-    api.getAppearanceSettings(controller.signal)
-      .then((data) => {
-        if (!controller.signal.aborted) {
-          setSettings(data);
-          applyAppearance(data);
-          if (data.themeVariant) setTheme(data.themeVariant as Parameters<typeof setTheme>[0]);
-        }
-      })
-      .catch(() => {});
-    return () => controller.abort();
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only load
-  }, []);
+    // syncing server-backed initial values into controlled appearance state
+    if (data) {
+      setSettings(data);
+      applyAppearance(data);
+      if (data.themeVariant) setTheme(data.themeVariant as Parameters<typeof setTheme>[0]);
+    }
+  // mount-only load — setTheme identity not tracked intentionally
+  }, [data]);
+  /* eslint-enable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps */
 
   async function save(patch: Partial<AppearanceSettings>) {
     const next = { ...settings, ...patch };
     setSettings(next);
     applyAppearance(next);
     try {
-      const saved = await api.updateAppearanceSettings(patch);
-      setSettings(saved);
-      applyAppearance(saved);
+      const updated = await api.updateAppearanceSettings(patch);
+      setSettings(updated);
+      applyAppearance(updated);
       setSaved(true);
       if (saveTimer.current) clearTimeout(saveTimer.current);
       saveTimer.current = setTimeout(() => setSaved(false), 2000);
@@ -157,13 +160,16 @@ function HomepageLayoutSection() {
   const [saved, setSaved] = useState(false);
   const dragIndexRef = useRef<number | null>(null);
 
+  const { data } = useQuery({
+    queryKey: ["homepage-layout"],
+    queryFn: ({ signal }) => api.getHomepageLayout(signal),
+  });
+
   useEffect(() => {
-    const controller = new AbortController();
-    api.getHomepageLayout(controller.signal)
-      .then((res) => { if (!controller.signal.aborted) setLayout(res.homepage_layout); })
-      .catch(() => {});
-    return () => controller.abort();
-  }, []);
+    if (data) {
+      setLayout(data.homepage_layout);
+    }
+  }, [data]);
 
   async function save(newLayout: HomepageSection[]) {
     setSaving(true);
@@ -265,18 +271,17 @@ function CrowdedWeekSection() {
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
 
+  const { data } = useQuery({
+    queryKey: ["crowded-week-settings"],
+    queryFn: ({ signal }) => api.getCrowdedWeekSettings(signal),
+  });
+
   useEffect(() => {
-    const controller = new AbortController();
-    api.getCrowdedWeekSettings(controller.signal)
-      .then((res) => {
-        if (!controller.signal.aborted) {
-          setEnabled(res.crowdedWeekBadgeEnabled !== 0);
-          setThreshold(res.crowdedWeekThreshold);
-        }
-      })
-      .catch(() => {});
-    return () => controller.abort();
-  }, []);
+    if (data) {
+      setEnabled(data.crowdedWeekBadgeEnabled !== 0);
+      setThreshold(data.crowdedWeekThreshold);
+    }
+  }, [data]);
 
   async function save(updates: { crowdedWeekBadgeEnabled?: number; crowdedWeekThreshold?: number }) {
     setSaving(true);

--- a/frontend/src/pages/settings/IntegrationsTab.test.tsx
+++ b/frontend/src/pages/settings/IntegrationsTab.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import "../../i18n";
+import * as api from "../../api";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
+function wrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+const { default: IntegrationsTab } = await import("./IntegrationsTab");
+
+let spies: ReturnType<typeof spyOn>[] = [];
+
+beforeEach(() => {
+  spies = [
+    spyOn(api, "getIntegrations").mockResolvedValue({ integrations: [] } as any),
+    spyOn(api, "getFeedToken").mockResolvedValue({ token: null } as any),
+    spyOn(api, "getKioskToken").mockResolvedValue({ token: null } as any),
+    spyOn(api, "getWatchlistShareToken").mockResolvedValue({ token: null } as any),
+  ];
+});
+
+afterEach(() => {
+  cleanup();
+  for (const spy of spies) spy.mockRestore();
+  spies = [];
+});
+
+describe("IntegrationsTab", () => {
+  it("renders without crashing", async () => {
+    const client = newTestClient();
+    render(<IntegrationsTab />, { wrapper: wrapper(client) });
+
+    // PlexSection returns null while loading, then renders Connect button
+    await waitFor(() => {
+      expect(screen.getByText("Connect Plex")).toBeDefined();
+    });
+  });
+
+  it("shows feed generate button when no feed token", async () => {
+    const client = newTestClient();
+    render(<IntegrationsTab />, { wrapper: wrapper(client) });
+
+    await waitFor(() => {
+      // "Generate Feed URL" is the translated text for feed.generate
+      expect(screen.getByText("Generate Feed URL")).toBeDefined();
+    });
+  });
+
+  it("shows watchlist section", async () => {
+    const client = newTestClient();
+    render(<IntegrationsTab />, { wrapper: wrapper(client) });
+
+    await waitFor(() => {
+      // "Watchlist" is the translated text for profile.watchlist
+      expect(screen.getByText("Watchlist")).toBeDefined();
+    });
+  });
+});

--- a/frontend/src/pages/settings/IntegrationsTab.tsx
+++ b/frontend/src/pages/settings/IntegrationsTab.tsx
@@ -478,7 +478,6 @@ function KioskSection() {
     queryFn: ({ signal }) => api.getKioskToken(signal),
   });
   const token = data?.token ?? null;
-  const kioskUrl = token ? `${window.location.origin}/kiosk/${token}` : null;
 
   const regenerateMutation = useMutation({
     mutationFn: () => api.regenerateKioskToken(),
@@ -492,9 +491,8 @@ function KioskSection() {
     onSettled: () => void qc.invalidateQueries({ queryKey: ["kiosk-token"] }),
   });
 
-  async function handleCopy() {
-    if (!kioskUrl) return;
-    await navigator.clipboard.writeText(kioskUrl);
+  async function handleCopy(url: string) {
+    await navigator.clipboard.writeText(url);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }
@@ -507,13 +505,13 @@ function KioskSection() {
         <div className="space-y-3">
           <div className="flex flex-col sm:flex-row gap-2">
             <SInput
-              value={kioskUrl!}
+              value={`${window.location.origin}/kiosk/${token}`}
               mono
               readOnly
               aria-label={t("kiosk.title")}
             />
             <div className="flex gap-2 shrink-0">
-              <SButton variant="ghost" small onClick={handleCopy}>
+              <SButton variant="ghost" small onClick={() => handleCopy(`${window.location.origin}/kiosk/${token}`)}>
                 {copied ? t("kiosk.copied") : t("kiosk.copyUrl")}
               </SButton>
               <SButton
@@ -555,7 +553,6 @@ function WatchlistShareSection() {
     queryFn: ({ signal }) => api.getWatchlistShareToken(signal),
   });
   const token = data?.token ?? null;
-  const shareUrl = token ? `${window.location.origin}/share/watchlist/${token}` : null;
 
   const regenerateMutation = useMutation({
     mutationFn: () => api.regenerateWatchlistShareToken(),
@@ -569,9 +566,8 @@ function WatchlistShareSection() {
     onSettled: () => void qc.invalidateQueries({ queryKey: ["watchlist-share-token"] }),
   });
 
-  async function handleCopy() {
-    if (!shareUrl) return;
-    await navigator.clipboard.writeText(shareUrl);
+  async function handleCopy(url: string) {
+    await navigator.clipboard.writeText(url);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }
@@ -584,13 +580,13 @@ function WatchlistShareSection() {
         <div className="space-y-3">
           <div className="flex flex-col sm:flex-row gap-2">
             <SInput
-              value={shareUrl!}
+              value={`${window.location.origin}/share/watchlist/${token}`}
               mono
               readOnly
               aria-label={t("share.title")}
             />
             <div className="flex gap-2 shrink-0">
-              <SButton variant="ghost" small onClick={handleCopy}>
+              <SButton variant="ghost" small onClick={() => handleCopy(`${window.location.origin}/share/watchlist/${token}`)}>
                 {copied ? t("share.copied") : t("share.copyUrl")}
               </SButton>
               <SButton

--- a/frontend/src/pages/settings/IntegrationsTab.tsx
+++ b/frontend/src/pages/settings/IntegrationsTab.tsx
@@ -1,5 +1,7 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import * as api from "../../api";
 import type { Integration, PlexServer } from "../../api";
 import {
@@ -22,8 +24,7 @@ const PLEX_POPUP_FEATURES = "width=800,height=700,menubar=no,toolbar=no,location
 const PIN_POLL_INTERVAL_MS = 2000;
 
 function PlexSection() {
-  const [integrations, setIntegrations] = useState<Integration[]>([]);
-  const [loading, setLoading] = useState(true);
+  const qc = useQueryClient();
   const [step, setStep] = useState<ConnectStep>({ type: "idle" });
   const [saving, setSaving] = useState(false);
   const [syncing, setSyncing] = useState<string | null>(null);
@@ -37,21 +38,22 @@ function PlexSection() {
   const [syncMovies, setSyncMovies] = useState(true);
   const [syncEpisodes, setSyncEpisodes] = useState(true);
 
-  const refresh = useCallback((signal?: AbortSignal) => {
-    api.getIntegrations(signal)
-      .then((r) => {
-        if (signal?.aborted) return;
-        setIntegrations(r.integrations.filter((i) => i.provider === "plex"));
-        setLoading(false);
-      })
-      .catch(() => { if (!signal?.aborted) setLoading(false); });
-  }, []);
+  const { data, isLoading: loading } = useQuery({
+    queryKey: ["integrations"],
+    queryFn: ({ signal }) => api.getIntegrations(signal),
+  });
 
-  useEffect(() => {
-    const controller = new AbortController();
-    refresh(controller.signal);
-    return () => controller.abort();
-  }, [refresh]);
+  const integrations = (data?.integrations ?? []).filter((i) => i.provider === "plex");
+
+  const deleteIntegrationMutation = useMutation({
+    mutationFn: (id: string) => api.deleteIntegration(id),
+    onSuccess: () => setMsg("Plex integration disconnected."),
+    onError: () => {
+      setErr("Failed to disconnect integration.");
+      toast.error("Failed to disconnect integration");
+    },
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["integrations"] }),
+  });
 
   useEffect(() => {
     if (step.type !== "waiting") return;
@@ -140,7 +142,7 @@ function PlexSection() {
       });
       setStep({ type: "idle" });
       setMsg("Plex server connected successfully.");
-      refresh();
+      void qc.invalidateQueries({ queryKey: ["integrations"] });
     } catch (e: unknown) {
       setErr(e instanceof Error ? e.message : "Failed to save integration.");
     } finally {
@@ -159,7 +161,7 @@ function PlexSection() {
       } else {
         setErr(result.error ?? "Sync failed.");
       }
-      refresh();
+      void qc.invalidateQueries({ queryKey: ["integrations"] });
     } catch {
       setErr("Sync failed.");
     } finally {
@@ -173,7 +175,7 @@ function PlexSection() {
     setToggling(integration.id);
     try {
       await api.updateIntegration(integration.id, { enabled: !integration.enabled });
-      refresh();
+      void qc.invalidateQueries({ queryKey: ["integrations"] });
     } catch {
       setErr("Failed to update integration.");
     } finally {
@@ -184,13 +186,7 @@ function PlexSection() {
   async function handleDelete(id: string) {
     setMsg("");
     setErr("");
-    try {
-      await api.deleteIntegration(id);
-      setMsg("Plex integration disconnected.");
-      refresh();
-    } catch {
-      setErr("Failed to disconnect integration.");
-    }
+    deleteIntegrationMutation.mutate(id);
   }
 
   function formatSyncTime(iso: string | null) {
@@ -403,28 +399,20 @@ const FEED_FLAVORS: FeedFlavor[] = [
 
 function CalendarFeedSection() {
   const { t } = useTranslation();
-  const [token, setToken] = useState<string | null>(null);
-  const [loadingToken, setLoadingToken] = useState(true);
-  const [regenerating, setRegenerating] = useState(false);
+  const qc = useQueryClient();
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
 
-  useEffect(() => {
-    const controller = new AbortController();
-    api.getFeedToken(controller.signal)
-      .then(({ token: tok }) => { if (!controller.signal.aborted) { setToken(tok); setLoadingToken(false); } })
-      .catch(() => { if (!controller.signal.aborted) setLoadingToken(false); });
-    return () => controller.abort();
-  }, []);
+  const { data, isLoading: loadingToken } = useQuery({
+    queryKey: ["feed-token"],
+    queryFn: ({ signal }) => api.getFeedToken(signal),
+  });
+  const token = data?.token ?? null;
 
-  async function handleRegenerate() {
-    setRegenerating(true);
-    try {
-      const { token: newToken } = await api.regenerateFeedToken();
-      setToken(newToken);
-    } finally {
-      setRegenerating(false);
-    }
-  }
+  const regenerateMutation = useMutation({
+    mutationFn: () => api.regenerateFeedToken(),
+    onError: () => toast.error("Failed to regenerate feed token"),
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["feed-token"] }),
+  });
 
   async function handleCopy(key: string, url: string) {
     await navigator.clipboard.writeText(url);
@@ -463,17 +451,17 @@ function CalendarFeedSection() {
             <SButton
               variant="ghost"
               small
-              onClick={handleRegenerate}
-              disabled={regenerating}
+              onClick={() => regenerateMutation.mutate()}
+              disabled={regenerateMutation.isPending}
             >
-              {regenerating ? t("feed.regenerating") : t("feed.regenerate")}
+              {regenerateMutation.isPending ? t("feed.regenerating") : t("feed.regenerate")}
             </SButton>
           </div>
           <SHint kind="info">{t("feed.warning")}</SHint>
         </div>
       ) : (
-        <SButton onClick={handleRegenerate} disabled={regenerating}>
-          {regenerating ? t("feed.generating") : t("feed.generate")}
+        <SButton onClick={() => regenerateMutation.mutate()} disabled={regenerateMutation.isPending}>
+          {regenerateMutation.isPending ? t("feed.generating") : t("feed.generate")}
         </SButton>
       )}
     </SCard>
@@ -482,41 +470,27 @@ function CalendarFeedSection() {
 
 function KioskSection() {
   const { t } = useTranslation();
-  const [token, setToken] = useState<string | null>(null);
-  const [loadingToken, setLoadingToken] = useState(true);
-  const [regenerating, setRegenerating] = useState(false);
-  const [revoking, setRevoking] = useState(false);
+  const qc = useQueryClient();
   const [copied, setCopied] = useState(false);
 
-  useEffect(() => {
-    const controller = new AbortController();
-    api.getKioskToken(controller.signal)
-      .then(({ token: tok }) => { if (!controller.signal.aborted) { setToken(tok); setLoadingToken(false); } })
-      .catch(() => { if (!controller.signal.aborted) setLoadingToken(false); });
-    return () => controller.abort();
-  }, []);
-
+  const { data, isLoading: loadingToken } = useQuery({
+    queryKey: ["kiosk-token"],
+    queryFn: ({ signal }) => api.getKioskToken(signal),
+  });
+  const token = data?.token ?? null;
   const kioskUrl = token ? `${window.location.origin}/kiosk/${token}` : null;
 
-  async function handleRegenerate() {
-    setRegenerating(true);
-    try {
-      const { token: newToken } = await api.regenerateKioskToken();
-      setToken(newToken);
-    } finally {
-      setRegenerating(false);
-    }
-  }
+  const regenerateMutation = useMutation({
+    mutationFn: () => api.regenerateKioskToken(),
+    onError: () => toast.error("Failed to regenerate kiosk token"),
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["kiosk-token"] }),
+  });
 
-  async function handleRevoke() {
-    setRevoking(true);
-    try {
-      await api.revokeKioskToken();
-      setToken(null);
-    } finally {
-      setRevoking(false);
-    }
-  }
+  const revokeMutation = useMutation({
+    mutationFn: () => api.revokeKioskToken(),
+    onError: () => toast.error("Failed to revoke kiosk token"),
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["kiosk-token"] }),
+  });
 
   async function handleCopy() {
     if (!kioskUrl) return;
@@ -545,26 +519,26 @@ function KioskSection() {
               <SButton
                 variant="ghost"
                 small
-                onClick={handleRegenerate}
-                disabled={regenerating}
+                onClick={() => regenerateMutation.mutate()}
+                disabled={regenerateMutation.isPending}
               >
-                {regenerating ? t("kiosk.regenerating") : t("kiosk.regenerate")}
+                {regenerateMutation.isPending ? t("kiosk.regenerating") : t("kiosk.regenerate")}
               </SButton>
               <SButton
                 variant="ghost"
                 small
-                onClick={handleRevoke}
-                disabled={revoking}
+                onClick={() => revokeMutation.mutate()}
+                disabled={revokeMutation.isPending}
               >
-                {revoking ? t("kiosk.revoking") : t("kiosk.revoke")}
+                {revokeMutation.isPending ? t("kiosk.revoking") : t("kiosk.revoke")}
               </SButton>
             </div>
           </div>
           <SHint kind="info">{t("kiosk.warning")}</SHint>
         </div>
       ) : (
-        <SButton onClick={handleRegenerate} disabled={regenerating}>
-          {regenerating ? t("kiosk.generating") : t("kiosk.generate")}
+        <SButton onClick={() => regenerateMutation.mutate()} disabled={regenerateMutation.isPending}>
+          {regenerateMutation.isPending ? t("kiosk.generating") : t("kiosk.generate")}
         </SButton>
       )}
     </SCard>
@@ -573,41 +547,27 @@ function KioskSection() {
 
 function WatchlistShareSection() {
   const { t } = useTranslation();
-  const [token, setToken] = useState<string | null>(null);
-  const [loadingToken, setLoadingToken] = useState(true);
-  const [regenerating, setRegenerating] = useState(false);
-  const [revoking, setRevoking] = useState(false);
+  const qc = useQueryClient();
   const [copied, setCopied] = useState(false);
 
-  useEffect(() => {
-    const controller = new AbortController();
-    api.getWatchlistShareToken(controller.signal)
-      .then(({ token: tok }) => { if (!controller.signal.aborted) { setToken(tok); setLoadingToken(false); } })
-      .catch(() => { if (!controller.signal.aborted) setLoadingToken(false); });
-    return () => controller.abort();
-  }, []);
-
+  const { data, isLoading: loadingToken } = useQuery({
+    queryKey: ["watchlist-share-token"],
+    queryFn: ({ signal }) => api.getWatchlistShareToken(signal),
+  });
+  const token = data?.token ?? null;
   const shareUrl = token ? `${window.location.origin}/share/watchlist/${token}` : null;
 
-  async function handleRegenerate() {
-    setRegenerating(true);
-    try {
-      const { token: newToken } = await api.regenerateWatchlistShareToken();
-      setToken(newToken);
-    } finally {
-      setRegenerating(false);
-    }
-  }
+  const regenerateMutation = useMutation({
+    mutationFn: () => api.regenerateWatchlistShareToken(),
+    onError: () => toast.error("Failed to regenerate watchlist share token"),
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["watchlist-share-token"] }),
+  });
 
-  async function handleRevoke() {
-    setRevoking(true);
-    try {
-      await api.revokeWatchlistShareToken();
-      setToken(null);
-    } finally {
-      setRevoking(false);
-    }
-  }
+  const revokeMutation = useMutation({
+    mutationFn: () => api.revokeWatchlistShareToken(),
+    onError: () => toast.error("Failed to revoke watchlist share token"),
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["watchlist-share-token"] }),
+  });
 
   async function handleCopy() {
     if (!shareUrl) return;
@@ -636,26 +596,26 @@ function WatchlistShareSection() {
               <SButton
                 variant="ghost"
                 small
-                onClick={handleRegenerate}
-                disabled={regenerating}
+                onClick={() => regenerateMutation.mutate()}
+                disabled={regenerateMutation.isPending}
               >
-                {regenerating ? t("share.regenerating") : t("share.regenerate")}
+                {regenerateMutation.isPending ? t("share.regenerating") : t("share.regenerate")}
               </SButton>
               <SButton
                 variant="ghost"
                 small
-                onClick={handleRevoke}
-                disabled={revoking}
+                onClick={() => revokeMutation.mutate()}
+                disabled={revokeMutation.isPending}
               >
-                {revoking ? t("share.revoking") : t("share.revoke")}
+                {revokeMutation.isPending ? t("share.revoking") : t("share.revoke")}
               </SButton>
             </div>
           </div>
           <SHint kind="info">{t("share.warning")}</SHint>
         </div>
       ) : (
-        <SButton onClick={handleRegenerate} disabled={regenerating}>
-          {regenerating ? t("share.generating") : t("share.generate")}
+        <SButton onClick={() => regenerateMutation.mutate()} disabled={regenerateMutation.isPending}>
+          {regenerateMutation.isPending ? t("share.generating") : t("share.generate")}
         </SButton>
       )}
     </SCard>

--- a/frontend/src/pages/settings/NotificationsTab.test.tsx
+++ b/frontend/src/pages/settings/NotificationsTab.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, mock, beforeEach, afterEach, spyOn } from "bun:test";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import "../../i18n";
+import * as api from "../../api";
+
+function newTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
+function wrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+// Mock push support as unsupported so PushNotificationsSection is skipped in tests
+mock.module("../../lib/push", () => ({
+  isPushSupported: () => false,
+  subscribeToPush: mock(() => Promise.resolve({})),
+  unsubscribeFromPush: mock(() => Promise.resolve()),
+  getExistingSubscription: mock(() => Promise.resolve(null)),
+}));
+
+const { default: NotificationsTab } = await import("./NotificationsTab");
+
+let spies: ReturnType<typeof spyOn>[] = [];
+
+beforeEach(() => {
+  spies = [
+    spyOn(api, "getNotifiers").mockResolvedValue({ notifiers: [] } as any),
+    spyOn(api, "getNotifierProviders").mockResolvedValue({ providers: ["discord"] } as any),
+    spyOn(api, "getDepartureAlertSettings").mockResolvedValue({
+      streamingDeparturesEnabled: true,
+      departureAlertLeadDays: 7,
+    } as any),
+  ];
+});
+
+afterEach(() => {
+  cleanup();
+  for (const spy of spies) spy.mockRestore();
+  spies = [];
+});
+
+describe("NotificationsTab", () => {
+  it("renders without crashing and shows notifiers section", async () => {
+    const client = newTestClient();
+    render(<NotificationsTab />, { wrapper: wrapper(client) });
+
+    await waitFor(() => {
+      expect(screen.getByText("Notifiers")).toBeDefined();
+    });
+  });
+
+  it("shows departure alerts section", async () => {
+    const client = newTestClient();
+    render(<NotificationsTab />, { wrapper: wrapper(client) });
+
+    await waitFor(() => {
+      expect(screen.getByText("Streaming departure alerts")).toBeDefined();
+    });
+  });
+
+  it("shows empty notifiers message when no notifiers configured", async () => {
+    const client = newTestClient();
+    render(<NotificationsTab />, { wrapper: wrapper(client) });
+
+    await waitFor(() => {
+      expect(screen.getByText("No notifiers configured.")).toBeDefined();
+    });
+  });
+});

--- a/frontend/src/pages/settings/NotificationsTab.tsx
+++ b/frontend/src/pages/settings/NotificationsTab.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import * as api from "../../api";
 import type { Notifier } from "../../api";
-import type { NotificationLogRow } from "../../types";
 import { isPushSupported, subscribeToPush, unsubscribeFromPush, getExistingSubscription } from "../../lib/push";
 import {
   SCard,
@@ -251,11 +252,6 @@ function PushNotificationsSection() {
   );
 }
 
-type NotifierHistoryState = {
-  rows: NotificationLogRow[];
-  successRate: number;
-} | null;
-
 function statusPillKind(rate: number): "ok" | "warning" | "error" {
   if (rate >= 90) return "ok";
   if (rate >= 60) return "warning";
@@ -275,26 +271,11 @@ function formatAttemptedAt(ts: number): string {
   }
 }
 
-function NotifierDeliveryHistory({ notifierId, refreshKey }: { notifierId: string; refreshKey?: number }) {
-  const [history, setHistory] = useState<NotifierHistoryState>(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    let cancelled = false;
-    const load = async () => {
-      try {
-        const data = await api.getNotifierHistory(notifierId);
-        if (!cancelled) {
-          setHistory(data);
-          setLoading(false);
-        }
-      } catch {
-        if (!cancelled) setLoading(false);
-      }
-    };
-    load();
-    return () => { cancelled = true; };
-  }, [notifierId, refreshKey]);
+function NotifierDeliveryHistory({ notifierId }: { notifierId: string }) {
+  const { data: history, isLoading: loading } = useQuery({
+    queryKey: ["notifier-history", notifierId],
+    queryFn: () => api.getNotifierHistory(notifierId),
+  });
 
   if (loading) {
     return <div className="text-zinc-500 text-xs font-mono mt-3">Loading history...</div>;
@@ -339,16 +320,13 @@ function NotifierDeliveryHistory({ notifierId, refreshKey }: { notifierId: strin
 }
 
 function NotificationsSection() {
-  const [notifiers, setNotifiers] = useState<Notifier[]>([]);
-  const [providers, setProviders] = useState<string[]>([]);
-  const [loading, setLoading] = useState(true);
+  const qc = useQueryClient();
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [msg, setMsg] = useState("");
   const [err, setErr] = useState("");
   const [testing, setTesting] = useState<string | null>(null);
   const [toggling, setToggling] = useState<string | null>(null);
-  const [historyKeys, setHistoryKeys] = useState<Record<string, number>>({});
   const [previewing, setPreviewing] = useState<string | null>(null);
   const [previewContent, setPreviewContent] = useState<Record<string, import("../../api").NotificationContent>>({});
 
@@ -372,22 +350,25 @@ function NotificationsSection() {
   const [formAchievements, setFormAchievements] = useState(false);
   const [saving, setSaving] = useState(false);
 
-  const refresh = useCallback((signal?: AbortSignal) => {
-    Promise.all([api.getNotifiers(signal), api.getNotifierProviders(signal)])
-      .then(([n, p]) => {
-        if (signal?.aborted) return;
-        setNotifiers(n.notifiers.filter((x) => x.provider !== "webpush"));
-        setProviders(p.providers.filter((x) => x !== "webpush"));
-        setLoading(false);
-      })
-      .catch(() => { if (!signal?.aborted) setLoading(false); });
-  }, []);
+  const { data: notifiersData, isLoading: notifiersLoading } = useQuery({
+    queryKey: ["notifiers"],
+    queryFn: ({ signal }) => api.getNotifiers(signal),
+  });
 
-  useEffect(() => {
-    const controller = new AbortController();
-    refresh(controller.signal);
-    return () => controller.abort();
-  }, [refresh]);
+  const { data: providersData, isLoading: providersLoading } = useQuery({
+    queryKey: ["notifier-providers"],
+    queryFn: ({ signal }) => api.getNotifierProviders(signal),
+  });
+
+  const notifiers = (notifiersData?.notifiers ?? []).filter((x) => x.provider !== "webpush");
+  const providers = (providersData?.providers ?? []).filter((x) => x !== "webpush");
+  const loading = notifiersLoading || providersLoading;
+
+  const deleteNotifierMutation = useMutation({
+    mutationFn: (id: string) => api.deleteNotifier(id),
+    onError: () => toast.error("Failed to delete notifier"),
+    onSettled: () => void qc.invalidateQueries({ queryKey: ["notifiers"] }),
+  });
 
   function resetForm() {
     setFormProvider("discord");
@@ -497,7 +478,7 @@ function NotificationsSection() {
         setMsg("Notifier created");
       }
       resetForm();
-      refresh();
+      void qc.invalidateQueries({ queryKey: ["notifiers"] });
     } catch (e: unknown) {
       setErr(e instanceof Error ? e.message : String(e));
     } finally {
@@ -508,13 +489,9 @@ function NotificationsSection() {
   async function handleDelete(id: string) {
     setMsg("");
     setErr("");
-    try {
-      await api.deleteNotifier(id);
-      setMsg("Notifier deleted");
-      refresh();
-    } catch (e: unknown) {
-      setErr(e instanceof Error ? e.message : String(e));
-    }
+    deleteNotifierMutation.mutate(id, {
+      onSuccess: () => setMsg("Notifier deleted"),
+    });
   }
 
   async function handleTest(id: string) {
@@ -532,7 +509,7 @@ function NotificationsSection() {
       setErr(e instanceof Error ? e.message : String(e));
     } finally {
       setTesting(null);
-      setHistoryKeys((prev) => ({ ...prev, [id]: (prev[id] ?? 0) + 1 }));
+      void qc.invalidateQueries({ queryKey: ["notifier-history", id] });
     }
   }
 
@@ -556,7 +533,7 @@ function NotificationsSection() {
     setToggling(n.id);
     try {
       await api.updateNotifier(n.id, { enabled: !n.enabled });
-      refresh();
+      void qc.invalidateQueries({ queryKey: ["notifiers"] });
     } catch (e: unknown) {
       setErr(e instanceof Error ? e.message : String(e));
     } finally {
@@ -672,7 +649,7 @@ function NotificationsSection() {
                     </button>
                   </div>
                 )}
-                <NotifierDeliveryHistory notifierId={n.id} refreshKey={historyKeys[n.id] ?? 0} />
+                <NotifierDeliveryHistory notifierId={n.id} />
               </div>
             );
           })}
@@ -947,23 +924,23 @@ const DEPARTURE_LEAD_DAY_OPTIONS = [1, 3, 7, 14, 30];
 function DepartureAlertsSection() {
   const [departuresEnabled, setDeparturesEnabled] = useState(true);
   const [leadDays, setLeadDays] = useState(7);
-  const [loading, setLoading] = useState(true);
   const [msg, setMsg] = useState("");
   const [err, setErr] = useState("");
 
+  const { data, isLoading: loading } = useQuery({
+    queryKey: ["departure-alert-settings"],
+    queryFn: ({ signal }) => api.getDepartureAlertSettings(signal),
+  });
+
+  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
-    let cancelled = false;
-    api.getDepartureAlertSettings().then((s) => {
-      if (!cancelled) {
-        setDeparturesEnabled(s.streamingDeparturesEnabled);
-        setLeadDays(s.departureAlertLeadDays);
-        setLoading(false);
-      }
-    }).catch(() => {
-      if (!cancelled) setLoading(false);
-    });
-    return () => { cancelled = true; };
-  }, []);
+    // syncing server-backed initial values into controlled toggles
+    if (data) {
+      setDeparturesEnabled(data.streamingDeparturesEnabled);
+      setLeadDays(data.departureAlertLeadDays);
+    }
+  }, [data]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   async function handleToggle(val: boolean) {
     setMsg("");

--- a/frontend/src/pages/settings/NotificationsTab.tsx
+++ b/frontend/src/pages/settings/NotificationsTab.tsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import * as api from "../../api";
 import type { Notifier } from "../../api";
+import type { UserSettings } from "../../types";
 import { isPushSupported, subscribeToPush, unsubscribeFromPush, getExistingSubscription } from "../../lib/push";
 import {
   SCard,
@@ -274,7 +275,7 @@ function formatAttemptedAt(ts: number): string {
 function NotifierDeliveryHistory({ notifierId }: { notifierId: string }) {
   const { data: history, isLoading: loading } = useQuery({
     queryKey: ["notifier-history", notifierId],
-    queryFn: () => api.getNotifierHistory(notifierId),
+    queryFn: ({ signal }) => api.getNotifierHistory(notifierId, signal),
   });
 
   if (loading) {
@@ -921,26 +922,11 @@ function NotificationsSection() {
 
 const DEPARTURE_LEAD_DAY_OPTIONS = [1, 3, 7, 14, 30];
 
-function DepartureAlertsSection() {
-  const [departuresEnabled, setDeparturesEnabled] = useState(true);
-  const [leadDays, setLeadDays] = useState(7);
+function DepartureAlertsControls({ initialData }: { initialData: UserSettings }) {
+  const [departuresEnabled, setDeparturesEnabled] = useState(initialData.streamingDeparturesEnabled);
+  const [leadDays, setLeadDays] = useState(initialData.departureAlertLeadDays);
   const [msg, setMsg] = useState("");
   const [err, setErr] = useState("");
-
-  const { data, isLoading: loading } = useQuery({
-    queryKey: ["departure-alert-settings"],
-    queryFn: ({ signal }) => api.getDepartureAlertSettings(signal),
-  });
-
-  /* eslint-disable react-hooks/set-state-in-effect */
-  useEffect(() => {
-    // syncing server-backed initial values into controlled toggles
-    if (data) {
-      setDeparturesEnabled(data.streamingDeparturesEnabled);
-      setLeadDays(data.departureAlertLeadDays);
-    }
-  }, [data]);
-  /* eslint-enable react-hooks/set-state-in-effect */
 
   async function handleToggle(val: boolean) {
     setMsg("");
@@ -966,14 +952,6 @@ function DepartureAlertsSection() {
     } catch (e: unknown) {
       setErr(e instanceof Error ? e.message : String(e));
     }
-  }
-
-  if (loading) {
-    return (
-      <SCard title="Streaming departure alerts" subtitle="Get notified when a tracked title is leaving a streaming service.">
-        <div className="text-zinc-500 text-sm">Loading...</div>
-      </SCard>
-    );
   }
 
   return (
@@ -1008,6 +986,25 @@ function DepartureAlertsSection() {
       </div>
     </SCard>
   );
+}
+
+function DepartureAlertsSection() {
+  const { data, isLoading: loading } = useQuery({
+    queryKey: ["departure-alert-settings"],
+    queryFn: ({ signal }) => api.getDepartureAlertSettings(signal),
+  });
+
+  if (loading) {
+    return (
+      <SCard title="Streaming departure alerts" subtitle="Get notified when a tracked title is leaving a streaming service.">
+        <div className="text-zinc-500 text-sm">Loading...</div>
+      </SCard>
+    );
+  }
+
+  if (!data) return null;
+
+  return <DepartureAlertsControls initialData={data} />;
 }
 
 export default function NotificationsTab() {


### PR DESCRIPTION
## Summary

Completes the phased TanStack Query adoption started in #823. Migrates all remaining `useEffect`+`setState` server fetches to `useQuery`/`useMutation` across the entire frontend, and documents the rule in the agent instructions.

- **Docs**: Adds "Data fetching (TanStack Query)" section to `frontend/CLAUDE.md` — the authoritative rule for when to use Query vs raw `api.ts` calls
- **Batch A**: `TitleDetailPage`, `AdminUsersPage`, `InvitePage`, `SuggestionsRow`, `AgendaCalendar`, `EpisodeRatingButtons`, `RatingButtons`, `RecommendButton`, `UserSearchDropdown` → `useQuery`
- **Batch B**: `TrackButton`, `PinButton`, `FollowButton`, `VisibilityButton`, `StatusPicker`, `SnoozePicker`, `TagList`, `NotificationModePicker`, `MovieRow` → `useMutation` with optimistic updates + invalidation
- **Batch C**: `ReelsPage`, `AdminUsersPage` (writes), `InvitePage` (writes) → `useMutation`
- **Batch D**: `NotificationsTab`, `AccountTab`, `AdminTab`, `IntegrationsTab`, `AppearanceTab` → `useQuery` for reads + `useMutation` for action writes; form-value submit handlers deferred to the planned react-hook-form work

## What was explicitly deferred

Settings-tab **form-value submit handlers** (`updateMyProfile`, `updateAdminSettings`, `updateAppearanceSettings`, `updateActivitySettings`, `updateHomepageLayout`, `updateCrowdedWeekSettings`, `updateDepartureAlertSettings`) wait for the planned react-hook-form migration.

## Test plan

- [ ] `bun run check` passes (server + frontend tsc, ESLint zero warnings, 1080 frontend tests pass, build, wrangler dry-run, bundle budget)
- [ ] Title detail page loads (movie + show); track/untrack reflects immediately and persists on reload
- [ ] Rating a title/episode updates and survives navigation away and back (cache hit)
- [ ] Reels: watch/rate an item updates correctly
- [ ] Admin users: ban/unban works; role toggle works
- [ ] Invites: create/revoke works
- [ ] A settings tab (e.g. Notifications) loads its data and a delete/test action works; form saves still work (unchanged)
- [ ] React Query Devtools (DEV) shows new query keys populating and invalidating

Part of #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)