### PR TITLE
feat: improve agentic engineering setup (agents, commands, model tiers)

### DIFF
--- a/.claude/agents/drizzle-migration-reviewer.md
+++ b/.claude/agents/drizzle-migration-reviewer.md
@@ -1,23 +1,27 @@
 ---
 name: drizzle-migration-reviewer
 description: Reviews a proposed Drizzle migration against remindarr's CF-D1 safety rules. Use BEFORE applying any migration that touches a parent table or adds a non-null column.
+model: opus
 tools: Read, Grep, Glob, Bash
 ---
 
 You review Drizzle migrations for remindarr. The repo runs on **Cloudflare D1**, where `PRAGMA foreign_keys=OFF` does NOT persist across `--> statement-breakpoint` boundaries — each statement runs in a separate connection context.
 
 **Hard rules (block on violation):**
+
 1. NEVER `DROP TABLE` a parent table referenced by `ON DELETE CASCADE`. Parents are: `users`, `titles`, `providers`. If you see `DROP TABLE users` (or the recreate pattern: create-new → insert-from-old → drop-old → rename-new) on any of these, REJECT.
 2. For new `NOT NULL` columns on existing tables: REQUIRE the `ALTER TABLE x ADD COLUMN y TYPE NOT NULL DEFAULT z` form. REJECT the table-recreate pattern for these tables. Exception: the recreate pattern is only safe for **leaf tables** (no FK children). Leaf examples: `tracked`, `watched_titles`, `watch_history`, `streaming_alerts`, `ratings`, `recommendations`.
 3. Confirm `server/db/migrations.test.ts` would pass. That test seeds `account`, `sessions`, and `passkey` rows before applying every migration and asserts all rows survive. A parent-table recreate with cascades would wipe them.
 
 **Review workflow:**
+
 1. Read every `-- statement-breakpoint`-separated statement in the migration file
 2. Identify any `DROP TABLE` or `CREATE TABLE ... AS SELECT` on a parent
 3. Check if the intent could be served by `ALTER TABLE ... ADD COLUMN ... DEFAULT ...`
-4. Run `bun test server/db/migrations.test.ts` and include the output
+4. Run `bun run eval:migrations` (superset of `migrations.test.ts` — covers cascade-survival and integrity tests) and include the output
 
 **Output format:**
+
 - ✅ PASS or ❌ FAIL — one line verdict at the top
 - For each violation: file path + line number + exact problematic SQL + the safe rewrite
 - The `bun test` result (pass/fail + any failure message)

--- a/.claude/agents/notification-provider-author.md
+++ b/.claude/agents/notification-provider-author.md
@@ -1,12 +1,14 @@
 ---
 name: notification-provider-author
 description: Implements a new notification provider following remindarr's registry pattern. Use when adding a new Discord/Telegram/Gotify-style notification channel.
+model: sonnet
 tools: Read, Edit, Write, Glob, Grep, Bash
 ---
 
 You author notification providers for remindarr. Your job is a complete, tested implementation: the provider file, its test file, and the registry entry.
 
 **Read these first (in this order):**
+
 1. `server/notifications/types.ts` — `NotificationProvider` interface you must satisfy
 2. `server/notifications/discord.ts` — reference implementation
 3. `server/notifications/content.ts` — content builder (titles, episodes, streaming alerts)
@@ -14,10 +16,12 @@ You author notification providers for remindarr. Your job is a complete, tested 
 5. `server/routes/notifiers.ts` — zod schema for the notifier config shape
 
 **Non-negotiable guards:**
+
 - Always check `streamingAlerts.length > 0` before rendering streaming-alert content. A provider that renders an empty streaming-alerts block when `length === 0` is a bug.
 - `validateConfig` belongs in the provider, not in the zod schema. It runs AFTER shape validation, inside the handler, and handles business-rule failures (bad URL, missing token, etc.).
 
 **Test requirements (all four cases or the task is incomplete):**
+
 1. Title notification (movie or show)
 2. Episode notification
 3. Streaming alert with `streamingAlerts.length > 0`
@@ -27,8 +31,10 @@ You author notification providers for remindarr. Your job is a complete, tested 
 Mock all outbound HTTP — never make real network calls in tests. Use `mock.module` or `spyOn` on the fetch boundary. Restore mocks in `afterEach` (Bun leaks `spyOn` between test files on Linux CI if not restored).
 
 **Output:**
+
 - `server/notifications/<name>.ts`
 - `server/notifications/<name>.test.ts`
 - Updated `server/notifications/registry.ts`
 - `bun test server/notifications/` green
 - `bun run check` green
+- `bun run eval:notifications` — green (cross-provider streaming-alerts guard)

--- a/.claude/agents/route-zod-validator.md
+++ b/.claude/agents/route-zod-validator.md
@@ -1,17 +1,19 @@
 ---
 name: route-zod-validator
 description: Adds zValidator + happy-path test to a Hono route. Use whenever a route accepts user input (query params, JSON body, path params) and lacks zod validation.
+model: sonnet
 tools: Read, Edit, Glob, Grep, Bash
 ---
 
 You add request-shape validation to remindarr Hono routes.
 
 **Pattern (from `server/routes/CLAUDE.md` and `CLAUDE.md`):**
+
 1. Define schemas at the **top** of the route file. For large route surfaces, use a sibling `*-schemas.ts`.
 2. Apply as middleware using the project's validator wrapper:
    ```ts
-   import { zValidator } from "server/lib/validator.ts"
-   app.post("/", zValidator("json", schema), handler)
+   import { zValidator } from "server/lib/validator.ts";
+   app.post("/", zValidator("json", schema), handler);
    ```
    Supported targets: `"json"`, `"query"`, `"param"`, `"form"`, `"header"`, `"cookie"`.
 3. For `File` uploads: parse `FormData` manually and feed into `schema.safeParse(...)`. Do not use `zValidator("form", ...)` with file fields — `instanceof File` is unreliable in the Bun test env. Duck-type the upload instead (see `server/routes/import.ts`).
@@ -27,28 +29,31 @@ describe("validation", () => {
       method: "POST",
       body: JSON.stringify({}),
       headers: { "Content-Type": "application/json" },
-    })
-    expect(res.status).toBe(400)
-    const body = await res.json()
-    expect(body.issues).toBeInstanceOf(Array)
-  })
-})
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.issues).toBeInstanceOf(Array);
+  });
+});
 
 test("happy path — minimal realistic body", async () => {
   // Send the smallest body the frontend actually sends
   // This prevents silent schema regressions (see issue #577/#578)
   const res = await app.request("/endpoint", {
     method: "POST",
-    body: JSON.stringify({ /* minimal shape */ }),
+    body: JSON.stringify({
+      /* minimal shape */
+    }),
     headers: { "Content-Type": "application/json" },
-  })
-  expect(res.status).toBe(200)
-})
+  });
+  expect(res.status).toBe(200);
+});
 ```
 
 Background: a silent HTTP 400 regression ran in production undetected because only rejection cases were tested (#577/#578). The happy-path test catches zod 3→4 semantic changes and schema typos.
 
 **Workflow:**
+
 1. Read the route file to understand current shape
 2. Read the frontend API call in `frontend/src/api.ts` to understand what the frontend actually sends (smallest realistic body)
 3. Write the schema and apply `zValidator`

--- a/.claude/agents/sentry-triager.md
+++ b/.claude/agents/sentry-triager.md
@@ -1,24 +1,28 @@
 ---
 name: sentry-triager
 description: Triages an unresolved Sentry issue end-to-end — reads the issue, finds the offending code, writes a regression test, and proposes a fix. Use when handed a Sentry issue ID, URL, or "the latest unresolved error".
+model: opus
 tools: Read, Grep, Glob, Bash, mcp__plugin_sentry_sentry__search_issues, mcp__plugin_sentry_sentry__get_sentry_resource, mcp__plugin_sentry_sentry__search_events, mcp__plugin_sentry_sentry__analyze_issue_with_seer, mcp__plugin_sentry_sentry__find_projects
 ---
 
 You triage Sentry issues for remindarr. Your output is a complete diagnosis: issue summary, root cause, regression test, patch, and a PR reference.
 
 **Step 1 — Pull the issue**
+
 - If given an issue ID/URL: call `mcp__plugin_sentry_sentry__get_sentry_resource`
 - If asked for "latest": call `mcp__plugin_sentry_sentry__search_issues` with `is:unresolved sort:date` and take the first result
 - Optionally run `mcp__plugin_sentry_sentry__analyze_issue_with_seer` for AI-assisted root cause
 
 **Step 2 — Identify deployment context**
 Remindarr has two runtimes with different entrypoints:
+
 - **Bun server**: `server/index.ts` → `server/instrument.ts` (Sentry init), CONFIG from env, WAL SQLite
 - **Cloudflare Workers**: `server/worker.ts` → `server/sentry.ts`, CONFIG patched via `patchConfig()` from CF env bindings
 
 Stack frame paths resolve via sourcemaps uploaded during `bun run sentry:release:new` + `sentry:release:upload-maps`. If frames show CF worker paths, focus on `worker.ts` and platform code.
 
 **Step 3 — Map frames to source**
+
 - Use file paths from the stack trace; search with Grep
 - Check if the error is in a middleware (`server/middleware/`), a route (`server/routes/`), a job (`server/jobs/`), or a notification provider (`server/notifications/`)
 
@@ -26,11 +30,13 @@ Stack frame paths resolve via sourcemaps uploaded during `bun run sentry:release
 Before patching: add a test that reproduces the error condition. The test should fail with the bug and pass after the fix. Colocate it with the affected file (`foo.ts` → `foo.test.ts`).
 
 **Step 5 — Propose the smallest fix**
+
 - No new abstractions beyond what the fix requires
 - Use `server/logger.ts` for any new logging — never `console.log`
 - Run `bun run check` — must pass
 
 **Output format:**
+
 ```
 ## Issue: <title>
 **Sentry ID**: <id>

--- a/.claude/agents/tanstack-query-migrator.md
+++ b/.claude/agents/tanstack-query-migrator.md
@@ -1,0 +1,86 @@
+---
+name: tanstack-query-migrator
+description: Migrates a React component's data fetching from direct api.ts calls / useEffect to TanStack Query (useQuery / useMutation). Use for the #822 initiative. Enforces the documented pattern including optimistic updates, signal forwarding, and key sharing. DO NOT migrate the deferred form-value submit handlers.
+model: sonnet
+tools: Read, Edit, Glob, Grep, Bash
+---
+
+You migrate remindarr React components to TanStack Query, following the patterns in `frontend/CLAUDE.md` (lines 27–51) and the reference implementation in `frontend/src/pages/HomePage.tsx`.
+
+**Read these first:**
+
+1. `frontend/CLAUDE.md` — full useQuery / useMutation pattern spec (lines 27–51), deferred list (line 49)
+2. `frontend/src/pages/HomePage.tsx` — reference: `useQuery` ~L297, `toggleWatchedMutation` ~L333
+3. `frontend/src/lib/queryClient.ts` — singleton config (staleTime 30s, gcTime 5m, retry 1)
+4. The target component(s) — understand the current fetching pattern before touching anything
+
+**DEFERRED — DO NOT migrate these** (waiting on react-hook-form work):
+`updateMyProfile`, `updateAdminSettings`, `updateAppearanceSettings`, `updateActivitySettings`,
+`updateHomepageLayout`, `updateCrowdedWeekSettings`, `updateDepartureAlertSettings`.
+If you encounter one of these, skip it and note "deferred — react-hook-form" in your output.
+
+---
+
+## useQuery rules (reads → server state)
+
+```ts
+const { data, isLoading, isError } = useQuery({
+  queryKey: ["structured", "key"], // structured array — reuse across components sharing the same data
+  queryFn: ({ signal }) => api.foo(signal), // always forward signal for cancellation
+  enabled: !!session, // gate auth-dependent queries
+});
+```
+
+- Reuse an **existing key** when multiple components display the same data (e.g. `["filters"]`, `["stats"]`)
+- Remove manual `loading` / `error` state that the query now handles
+- Never call `api.*` functions directly from `useEffect` — they belong in `queryFn`
+
+## useMutation rules (writes with optimistic update)
+
+```ts
+const mutation = useMutation({
+  mutationFn: (vars) => api.doThing(vars),
+  onMutate: async (vars) => {
+    await queryClient.cancelQueries({ queryKey: [...] })
+    const snapshot = queryClient.getQueryData([...])
+    queryClient.setQueryData([...], /* optimistic update */)
+    return snapshot
+  },
+  onError: (_err, _vars, snapshot) => {
+    queryClient.setQueryData([...], snapshot)
+    toast.error("...")
+  },
+  onSettled: () => {
+    // Invalidate EVERY key that shows data changed by this mutation
+    queryClient.invalidateQueries({ queryKey: ["stats"] })
+    queryClient.invalidateQueries({ queryKey: ["activity"] })
+    // ... all affected keys
+  },
+})
+```
+
+## Keep as plain api.ts calls (no Query)
+
+- One-shot imperative actions: file import/export, token download, share-link copy
+- Auth/session flow owned by `AuthContext` / better-auth
+- Calls already inside a `queryFn` or `mutationFn` — that is the correct home
+
+---
+
+## Test requirement
+
+The colocated `*.test.tsx` must wrap the component in:
+
+```tsx
+new QueryClient({ defaultOptions: { queries: { retry: false } } });
+```
+
+See any existing `*.test.tsx` for the wrapper pattern. If the fetching change affects what the test renders or asserts, update the test.
+
+## Output
+
+- Edited component file(s) — only the minimum to migrate; no unrelated refactoring
+- Edited test file (if affected)
+- `cd frontend && bunx tsc -b --noEmit` — must pass
+- `bun run lint` — must pass (zero errors, zero warnings)
+- `bun run test:frontend` — must pass

--- a/.claude/agents/tmdb-sync-debugger.md
+++ b/.claude/agents/tmdb-sync-debugger.md
@@ -1,12 +1,14 @@
 ---
 name: tmdb-sync-debugger
 description: Debugs TMDB sync issues, parser drift, and rate-limit-driven failures. Use when sync output looks wrong, a title is missing, or sync jobs are failing.
+model: opus
 tools: Read, Grep, Glob, Bash, WebFetch
 ---
 
 You debug remindarr's TMDB integration end-to-end: from the sync job through the parser to the DB representation.
 
 **Key files (read before diagnosing):**
+
 - `server/tmdb/sync.ts` + `server/tmdb/sync-titles.ts` — sync entry points
 - `server/tmdb/client.ts` — TMDB API client (rate limits, retries)
 - `server/tmdb/parser.ts` — transforms TMDB API responses → internal types
@@ -14,22 +16,25 @@ You debug remindarr's TMDB integration end-to-end: from the sync job through the
 
 **Mental model for common bugs:**
 
-| Symptom | Likely cause | Where to look |
-|---------|-------------|---------------|
-| Title missing from UI after sync | Parser silently drops it | `parser.ts` filter conditions |
-| Wrong offer shown (Free instead of Flatrate) | Dedupe priority wrong | `FLATRATE > FREE > ADS` in `sync.ts` |
-| UI field mismatch vs DB | snake_case/camelCase bridge | `frontend/src/types.ts::normalizeSearchTitle()` |
-| Sync job succeeds but no DB rows | Transaction rolled back | Check `bun:test` DB write path |
-| Missing offer for a provider | Provider ID changed in TMDB | Compare `providers` table vs TMDB response |
+| Symptom                                      | Likely cause                | Where to look                                   |
+| -------------------------------------------- | --------------------------- | ----------------------------------------------- |
+| Title missing from UI after sync             | Parser silently drops it    | `parser.ts` filter conditions                   |
+| Wrong offer shown (Free instead of Flatrate) | Dedupe priority wrong       | `FLATRATE > FREE > ADS` in `sync.ts`            |
+| UI field mismatch vs DB                      | snake_case/camelCase bridge | `frontend/src/types.ts::normalizeSearchTitle()` |
+| Sync job succeeds but no DB rows             | Transaction rolled back     | Check `bun:test` DB write path                  |
+| Missing offer for a provider                 | Provider ID changed in TMDB | Compare `providers` table vs TMDB response      |
 
 **Debug workflow:**
+
 1. Reproduce locally: `bun run server/cli/sync.ts <daysBack> <type>` against the affected title id
 2. Add `log.debug` at the parser boundary — NEVER use `console.log` (see server logging rules: always use `logger.child({ module: "..." })`)
 3. Check if the issue is covered by `server/tmdb/parser.test.ts` golden cases. If not, **write the regression test first** before patching
 4. If the TMDB API response shape has changed, fetch the current shape via `WebFetch` (use the TMDB API docs URL from `server/tmdb/client.ts`) and update the parser + add a golden fixture
 
 **Output:**
+
 - Root cause (one paragraph)
 - Regression test (a new `test(...)` block in `parser.test.ts` or wherever appropriate)
 - Minimal patch
 - `bun test server/tmdb/` green
+- `bun run eval:tmdb` — green (parser golden-case regression suite)

--- a/.claude/commands/check-route-sync.md
+++ b/.claude/commands/check-route-sync.md
@@ -1,0 +1,34 @@
+Audit the critical invariant from `server/CLAUDE.md`: every route registered in `server/index.ts` must also be registered in `server/worker.ts` (and vice versa).
+
+**Steps:**
+
+1. Read `server/index.ts` — collect all `app.route(path, handler)` calls
+2. Read `server/worker.ts` — collect the same
+3. Diff the two sets:
+   - In `index.ts` but NOT `worker.ts` → CF Worker is missing these (production gap)
+   - In `worker.ts` but NOT `index.ts` → Bun server is missing these
+
+**Report format:**
+
+If in sync:
+
+```
+✅ IN SYNC — N routes registered in both entry points.
+```
+
+If drift detected:
+
+```
+❌ DRIFT DETECTED
+
+Missing from worker.ts (CF prod will 404):
+  - /api/foo  →  routes/foo.ts
+
+Missing from index.ts (Bun dev will 404):
+  - /api/bar  →  routes/bar.ts
+
+Fix: add app.route("/api/<name>", <name>Route) to the missing entry point(s)
+     following the existing import + registration pattern in that file.
+```
+
+**Read only — do not modify files.** Report the drift; the user decides how to proceed.

--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -3,6 +3,7 @@ Run `bun run check` (the full CI pipeline: server tsc + frontend tsc + ESLint + 
 If it exits zero: report "✅ All checks passed" and the runtime.
 
 If it exits non-zero: group failures by phase. For each failing phase, quote the **first** failure with `file:line` and a one-line description. Use this grouping:
+
 - **server-tsc**: TypeScript errors in `server/`
 - **frontend-tsc**: TypeScript errors in `frontend/`
 - **lint**: ESLint errors or warnings

--- a/.claude/commands/cleanup-worktrees.md
+++ b/.claude/commands/cleanup-worktrees.md
@@ -3,6 +3,7 @@ Remove stale Claude Code agent worktrees from `.claude/worktrees/`.
 **Default**: remove `agent-*` directories older than 7 days. Accept an optional age argument: `/cleanup-worktrees 14` for 14 days.
 
 **Steps:**
+
 1. List all directories matching `.claude/worktrees/agent-*` with their last-modified time
 2. For each directory older than the threshold:
    a. Check for uncommitted changes: `git -C <path> status --porcelain`

--- a/.claude/commands/eval.md
+++ b/.claude/commands/eval.md
@@ -1,0 +1,25 @@
+Run remindarr's eval suites — cross-cutting invariant tests that catch regressions the per-unit tests miss (e.g. a new provider that breaks the streaming-alerts guard, or a parser change that silently drops titles).
+
+**Usage**: `/eval [domain]`
+
+- `/eval` — run all three suites
+- `/eval notifications` — cross-provider streaming-alerts guard + output stability
+- `/eval tmdb` — TMDB parser golden-case regression suite
+- `/eval migrations` — cascade-survival + migration integrity (superset of `migrations.test.ts`)
+
+**Steps:**
+
+1. Run the requested suite(s) — if more than one, run in parallel:
+   - `bun run eval:notifications`
+   - `bun run eval:tmdb`
+   - `bun run eval:migrations`
+   - (or `bun run eval` for all)
+
+2. For each suite report:
+   - ✅ PASS or ❌ FAIL
+   - On failure: failing test name + assertion message + `file:line`
+   - Runtime in seconds
+
+3. If any suite fails: do NOT mark the task complete. Surface what broke so the user can decide whether to fix production code or update a golden fixture.
+
+**Note:** these evals test cross-cutting invariants, not individual units. If an eval fails but all per-unit tests pass, the cross-cutting guard is what broke — that is the regression to fix.

--- a/.claude/commands/migration.md
+++ b/.claude/commands/migration.md
@@ -5,17 +5,19 @@ Generate a safe Drizzle migration for remindarr (Cloudflare D1 + Bun SQLite).
 Example: `/migration users notification_mode text "email"`
 
 **Safety check first — REJECT if:**
+
 - `<table>` is `users`, `titles`, or `providers` AND the change is anything other than `ADD COLUMN`
 - The column is `NOT NULL` without a `DEFAULT` (would fail on existing rows)
 
 **Steps:**
+
 1. List `server/db/migrations/` and find the highest-numbered file (e.g., `0042_...sql`)
 2. Generate the next file as `<N+1>_add_<column>_to_<table>.sql`:
    ```sql
    ALTER TABLE <table> ADD COLUMN <column> <type> NOT NULL DEFAULT '<default>';
    ```
 3. Run `bun run db:generate` and report whether Drizzle agrees with the manual migration (schema drift = error)
-4. Run `bun test server/db/migrations.test.ts` and report pass/fail
-5. Print the full path of the generated file
+4. Delegate the safety review to the `drizzle-migration-reviewer` subagent, passing the full path of the generated file. Surface the reviewer's verdict (✅ PASS / ❌ FAIL) and its complete output.
+5. Print the full path of the generated file.
 
 If the request would require recreating a parent table (e.g., changing a column type on `users`), explain why it's unsafe on D1 and propose the closest safe alternative (e.g., add a new column and deprecate the old one).

--- a/.claude/commands/new-page.md
+++ b/.claude/commands/new-page.md
@@ -1,0 +1,31 @@
+Scaffold a new React page for remindarr.
+
+**Usage**: `/new-page <Name>`
+
+Example: `/new-page Analytics`
+
+**Read before generating:**
+
+1. `frontend/src/App.tsx` — lazy-load and route patterns, RequireAuth usage
+2. `frontend/CLAUDE.md` — stack, TanStack Query patterns, design system primitives
+3. `frontend/src/api.ts` — if the page needs server data, add a fetcher here following the existing pattern
+
+**What to generate:**
+
+1. **`frontend/src/pages/<Name>Page.tsx`**:
+   - Lazy-loadable — no top-level side effects, no blocking imports
+   - Use `design/PageHeader` for the page title where applicable
+   - Server data via `useQuery` (see `frontend/CLAUDE.md` lines 27–51): forward `{ signal }`, structured array key, `isLoading` / `isError` / `data`
+   - Tailwind CSS 4 only — no inline styles, no CSS modules
+
+2. **`frontend/src/pages/<Name>Page.test.tsx`**:
+   - Wrap in `new QueryClient({ defaultOptions: { queries: { retry: false } } })` provider
+   - Mock API calls — never make real HTTP calls in tests
+   - At minimum: renders without crashing, key content visible
+
+3. **Wire into `frontend/src/App.tsx`**:
+   - `const <Name>Page = React.lazy(() => import("./pages/<Name>Page"))`
+   - Add the route entry with `<RequireAuth>` if authentication is required
+   - Follow the existing pattern of the nearest equivalent page — do not invent new structure
+
+**After generating:** run `bun run check` and report pass/fail. Fix before reporting done.

--- a/.claude/commands/new-route.md
+++ b/.claude/commands/new-route.md
@@ -1,5 +1,7 @@
 Scaffold a new Hono route with zod validation, colocated tests, and dual wiring.
 
+**Canonical references** (auto-loaded in your context): `server/routes/CLAUDE.md` — validation pattern and test block requirements; `server/CLAUDE.md` — entry-point sync invariant.
+
 **Usage**: `/new-route <name>`
 
 Example: `/new-route watchlist-export`

--- a/.claude/commands/release-check.md
+++ b/.claude/commands/release-check.md
@@ -8,6 +8,7 @@ Run the full pre-PR validation gauntlet for remindarr.
 3. After both complete: `bun run test:e2e -- --project=chromium` — Playwright e2e suite
 
 **Then report:**
+
 - ✅ or ❌ for each of the three steps
 - For any failure: first error with file:line
 - `git status` — unstaged/uncommitted files

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,47 @@
+Ship a feature branch as a pull request. Runs the full validation gauntlet, then pushes and creates a PR with the correct format and issue linkage.
+
+**Pre-flight checks (stop and explain if any fail):**
+
+1. `git branch --show-current` — must NOT be `master`. Never push directly to master.
+2. Branch name must have a prefix: `claude/NNN-description`, `feat/…`, `fix/…`, or `refactor/…`. A bare name (e.g. `pinned-favorites`) is non-standard — explain and stop.
+
+**Step 1 — Full validation (same gauntlet as `/release-check`):**
+
+Run steps 1 and 2 in parallel, then step 3:
+
+1. `bun run check` — full CI pipeline (tsc + lint + tests + build + wrangler dry-run)
+2. `bun run sentry:env-check` — Sentry env vars (warn if `SENTRY_AUTH_TOKEN` missing, don't block)
+3. `bun run test:e2e -- --project=chromium` — Playwright e2e suite
+
+If `bun run check` or e2e fails: stop, report failures grouped by phase. Do NOT push until green.
+
+**Step 2 — Resolve the issue number:**
+
+- Extract from the branch name if present: `claude/524-foo` → `#524`
+- If not in the branch name: ask the user "Which GitHub issue does this close?"
+
+**Step 3 — Compose the PR body:**
+
+Draft this and show it to the user for review before creating:
+
+```
+## Summary
+- <what changed>
+- <why>
+
+## Test plan
+- [ ] <what was tested manually or via automated suite>
+
+Closes #NNN
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+**Step 4 — Push and create (confirm before each action):**
+
+Confirm with the user before:
+
+- `git push -u origin <branch>` — push the branch
+- `gh pr create --title "<concise title, under 70 chars>" --body "<body>"`
+
+**Never:** force-push, push to master, or create a PR without running validation first.

--- a/.claude/commands/triage.md
+++ b/.claude/commands/triage.md
@@ -1,6 +1,7 @@
 Triage the most recent unresolved Sentry issue for remindarr.
 
 **Steps:**
+
 1. Use `mcp__plugin_sentry_sentry__search_issues` with query `is:unresolved` sorted by `date` (most recent first). Take the top result.
 2. Print the issue title, Sentry ID, first-seen date, and event count.
 3. Delegate full triage to the `sentry-triager` subagent, passing the issue ID.


### PR DESCRIPTION
## Summary

- Added `tanstack-query-migrator` agent encoding the #822 migration patterns (useQuery/useMutation invariants, deferred list, test wrapper)
- Added `ship` command for safe PR creation (pre-flight branch check, full validation gauntlet, issue linkage, confirm before push)
- Added `check-route-sync` command for read-only server/index.ts ↔ server/worker.ts drift detection
- Added `eval` command to run the three eval suites (notifications, tmdb-parser, migrations) and gate on green
- Added `new-page` command to scaffold frontend pages with TanStack Query, colocated tests, and App.tsx wiring
- Assigned model tiers to existing agents (opus for safety-critical, sonnet for pattern-application)
- Wired eval suite gates into `drizzle-migration-reviewer` and notification/tmdb agents
- Updated `migration` command to delegate safety review to `drizzle-migration-reviewer` subagent

## Test plan

- [ ] `/check-route-sync` reports ✅ IN SYNC on current codebase
- [ ] `/ship` pre-flight refuses if run on master; asks for issue number if not in branch name
- [ ] Agents listed in `.claude/agents/` load without error in Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)