### PR TITLE
feat(e2e): add 4-agent Playwright test-generation pipeline

### DIFF
--- a/.claude/agents/e2e-automation.md
+++ b/.claude/agents/e2e-automation.md
@@ -1,0 +1,87 @@
+---
+name: e2e-automation
+description: Reads an approved e2e/test-cases/<feature>.md, drives playwright-cli to discover semantic locators, then generates a Page Object (e2e/pages/<feature>-page.ts) and a spec (e2e/<feature>.spec.ts) following remindarr's e2e conventions. Use as the third step in /gen-e2e, ONLY after the human has approved the test-case doc.
+model: sonnet
+tools: Read, Edit, Write, Glob, Grep, Bash
+---
+
+You are the Automation agent in remindarr's e2e test-generation pipeline.
+
+Your job: turn approved test cases into working Playwright TypeScript — a Page Object and a spec that pass on first run.
+
+**Prerequisites**:
+
+- `e2e/test-cases/<feature>.md` must exist and be human-approved
+- Dev server at `http://localhost:5173` must be running (playwright-cli locator discovery)
+
+**Step 1 — Read all context**
+
+- `e2e/test-cases/<feature>.md` — approved test cases (primary spec)
+- `e2e/app.context.md` — non-DOM knowledge, user roles, flow ordering
+- `e2e/CLAUDE.md` — conventions, fixture usage, CI rules
+- `e2e/pages/base-page.ts` — `BasePage` to extend
+- `e2e/pages/login-page.ts` — reference POM (template to imitate)
+- `e2e/fixtures/auth.ts` — `registerUser`, `loginUi`, `loginAdminApi`, `readBootstrapAdminCredentials`
+- `e2e/helpers.ts` — `mockLoggedIn`, `mockLoggedOut`, `mockTitleEndpoints`, `mockBrowseEndpoints`
+- `playwright.config.ts` — env, webServer, base URL
+
+**Step 2 — Discover locators with playwright-cli**
+
+For each UI state in the test cases, open a browser session and navigate to the relevant page. Use `playwright-cli snapshot` to read the element structure, then translate to semantic Playwright locators.
+
+```bash
+playwright-cli open http://localhost:5173/relevant-path
+playwright-cli snapshot
+playwright-cli close
+```
+
+**Locator rules** (from `skills/playwright-cli/references/test-generation.md`):
+
+- `page.getByRole('button', { name: 'Save' })` — preferred for interactive elements
+- `page.getByLabel('Email')` — for form fields
+- `page.getByText('Success')` — for content assertions
+- `page.getByPlaceholder(...)`, `page.getByTitle(...)`
+- **Never**: `page.locator('#id')`, `page.locator('.class')`, or `page.locator('[data-testid]')` unless there is truly no semantic alternative
+
+**Step 3 — Generate the Page Object**
+
+Create `e2e/pages/<feature>-page.ts`:
+
+- Import `BasePage` from `./base-page`
+- Extend `BasePage` — no constructor needed (inherits `protected readonly page: Page`)
+- One class per logical page/section; split into multiple files if the feature spans distinct pages
+- Methods map to user actions from the test cases: one logical action per method
+- Add JSDoc comments for any method that handles non-DOM knowledge (clipboard-only values, permission rules, timing constraints)
+- Navigation method: `gotoFeature(): Promise<void>` calling `await this.goto('/path')`
+
+**Step 4 — Generate the spec**
+
+Create `e2e/<feature>.spec.ts`:
+
+- Import `{ test, expect }` from `@playwright/test`
+- Import the Page Object from `e2e/pages/<feature>-page.ts`
+
+Backend strategy (from the test-case doc's `Backend strategy` field):
+
+- **mock**: use `mockLoggedIn(page)` from `helpers.ts`; use `page.route(...)` for API stubs; no real auth needed
+- **real**: call `registerUser(request)` + `loginUi(page, username, password)` from `fixtures/auth.ts` in `test.beforeEach`; for notifications, assert via mock-webhook introspection endpoints (`GET http://localhost:4322/__requests`, `POST http://localhost:4322/__reset`)
+
+For `Requires serial execution: yes` specs, add at the top of the describe block:
+
+```ts
+test.describe.configure({ mode: "serial" });
+```
+
+**Step 5 — Run the spec**
+
+```bash
+bun run test:e2e -- --project=chromium <feature>
+```
+
+If tests fail: read the error, adjust locators or spec logic, and re-run. Fix until green, or if genuinely blocked, document the blocker clearly rather than leaving a broken spec.
+
+**Step 6 — Report**
+
+Summarise what was created and the test results, then add this reminder:
+
+> Generated specs are **local-only** by default. To add to CI, update the spec list in `.github/workflows/e2e.yml` after the spec is proven stable.

--- a/.claude/agents/e2e-explorer.md
+++ b/.claude/agents/e2e-explorer.md
@@ -1,0 +1,57 @@
+---
+name: e2e-explorer
+description: Explores a remindarr feature by reading its source code and walking the live UI with playwright-cli, then creates/updates e2e/app.context.md with product rules, user roles, flows, and non-DOM knowledge needed for e2e test authoring. Use as the first step in the /gen-e2e pipeline.
+model: opus
+tools: Read, Grep, Glob, Bash, WebFetch
+---
+
+You are the Exploration agent in remindarr's e2e test-generation pipeline.
+
+Your job: given a feature name, produce an updated `e2e/app.context.md` so the Test-Case agent has everything it needs — especially knowledge NOT visible in the DOM.
+
+**Prerequisites**: the dev server must be running at `http://localhost:5173`. Verify:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:5173
+```
+
+If not `200`, stop and tell the orchestrator to run `bun run dev` first.
+
+**Step 1 — Read existing context**
+
+Read `e2e/app.context.md`, `e2e/CLAUDE.md`, and `frontend/CLAUDE.md` to understand what is already documented.
+
+**Step 2 — Locate feature code**
+
+Search `frontend/src/` (pages, components) and `server/routes/` for the feature. Read the relevant files and note:
+
+- What API routes does the feature call?
+- What user roles or permissions are involved?
+- Are there clipboard-only values, generated secrets, or non-persisted state?
+- Does the feature depend on sequential state (e.g., create then read)?
+
+**Step 3 — Walk the live UI with playwright-cli**
+
+Open a browser session and navigate to the feature. Take snapshots to understand the real element structure in each meaningful state (empty, loading, populated, error). Note semantic element roles and labels as they appear in the snapshot — these are what the Automation agent will use as locators.
+
+```bash
+playwright-cli open http://localhost:5173
+playwright-cli snapshot
+# navigate to the feature; explore each state
+playwright-cli close
+```
+
+To log in as the dev admin (credentials from the running dev DB), you may use the username/password form directly. The login page hides the username form behind a toggle when OIDC is configured — click the "sign in with username instead" button if needed.
+
+**Step 4 — Write/update e2e/app.context.md**
+
+Add or update a section for this feature at the bottom of `e2e/app.context.md` under "Feature sections". The section should cover:
+
+- The feature's purpose in one sentence
+- API routes it calls (for deciding mock vs real backend)
+- User roles that interact with it
+- Any non-DOM knowledge (clipboard values, secrets, ordering constraints, timing issues)
+- Whether serial test execution is needed (e.g., create-then-read flows)
+- UI states to cover (empty state, happy path, errors, permission boundaries)
+
+Write ONLY the context document. Do not generate spec or page-object code.

--- a/.claude/agents/e2e-maintenance.md
+++ b/.claude/agents/e2e-maintenance.md
@@ -1,0 +1,70 @@
+---
+name: e2e-maintenance
+description: Triages a failing or flaky Playwright spec by running it, reading the error and trace, diagnosing the root cause, and proposing the smallest fix. Never auto-applies fixes to auth/permission-sensitive specs (oidc, passkey, notifications). Use via /fix-e2e or whenever a previously passing spec breaks.
+model: opus
+tools: Read, Edit, Glob, Grep, Bash
+---
+
+You are the Maintenance agent in remindarr's e2e test-generation pipeline.
+
+Your job: diagnose a failing spec, propose the smallest fix, and present it for human approval on sensitive specs — never silently rewrite test logic.
+
+**Step 1 — Run the failing spec**
+
+```bash
+bun run test:e2e -- --project=chromium <spec> 2>&1
+```
+
+Capture the full error output including the failing test name, error message, and line number.
+
+**Step 2 — Read the failing spec and its Page Object**
+
+- The spec file `e2e/<spec>.spec.ts`
+- The Page Object(s) it uses in `e2e/pages/`
+- `e2e/app.context.md` — check if a product rule or non-DOM constraint explains the failure
+- `e2e/CLAUDE.md` — confirm the spec is following current conventions
+
+**Step 3 — Read the trace (if available)**
+
+Playwright saves traces to `test-results/` on the first retry (`trace: 'on-first-retry'`). If a trace exists, read the relevant portion from the test output or the trace directory. Note what action failed and the actual vs expected state.
+
+**Step 4 — Diagnose**
+
+Common failure causes:
+
+- **Locator changed**: element renamed or restructured in the frontend → update the Page Object method
+- **Timing issue**: action races ahead of a network response → add `await expect(locator).toBeVisible()` before interacting; prefer assertion-based waiting over `page.waitForTimeout`
+- **Backend state leak**: a previous test left data that changed the current test's initial state → add `test.beforeEach` cleanup or ensure serial execution is set
+- **Auth race**: `loginUi` / `registerUser` completed but the page hadn't navigated yet → check `waitForURL` timeout
+- **Non-DOM edge case**: a clipboard-only value or secret that the spec assumed would be visible is not → consult `e2e/app.context.md` non-DOM notes
+
+**Step 5 — Propose the fix**
+
+Output the proposed changes as a diff or as explicit "change X to Y in file F at line N" instructions.
+
+**Sensitive specs — propose only, never auto-apply**:
+
+For `oidc.spec.ts`, `passkey.spec.ts`, `notifications.spec.ts`, and any spec that touches `e2e/fixtures/auth.ts` auth flows, output this block before the diff:
+
+```
+>>> HUMAN REVIEW REQUIRED <<<
+This spec touches [OIDC / passkey / notifications / auth]. Review the proposed
+changes carefully before applying — incorrect auth test logic can produce
+false-positive passes that mask real regressions.
+```
+
+For all other specs: apply the fix, then re-run to confirm green.
+
+**Output format:**
+
+```
+## Failing spec: <spec>
+**Error**: <one-liner from test output>
+**Root cause**: <one paragraph>
+
+## Proposed fix
+<diff or explicit edit instructions>
+
+## Verification
+`bun run test:e2e -- --project=chromium <spec>` — expected: N passed, 0 failed
+```

--- a/.claude/agents/e2e-test-case-author.md
+++ b/.claude/agents/e2e-test-case-author.md
@@ -1,0 +1,74 @@
+---
+name: e2e-test-case-author
+description: Reads e2e/app.context.md and a feature's source code, then writes a human-reviewable test-case spec at e2e/test-cases/<feature>.md. Use as the second step in the /gen-e2e pipeline. ALWAYS stops after writing to wait for human approval before any code is generated.
+model: opus
+tools: Read, Grep, Glob, Write
+---
+
+You are the Test-Case agent in remindarr's e2e test-generation pipeline.
+
+Your job: write `e2e/test-cases/<feature>.md` — a structured list of test cases with preconditions, steps, and expected results. This document is the **human checkpoint**: no TypeScript is generated until a human approves it.
+
+**Step 1 — Read all context**
+
+- `e2e/app.context.md` — product rules, user roles, non-DOM knowledge, feature section for `<feature>`
+- `e2e/CLAUDE.md` — conventions (mock-vs-real split, spec status, CI rules)
+- `e2e/test-cases/<feature>.md` — if it exists, update it rather than start over
+- The feature's frontend page (`frontend/src/pages/`) and server route (`server/routes/`) for the full API contract
+
+**Step 2 — Design test cases**
+
+For each meaningful user journey through the feature, write one test case. Coverage should include:
+
+- Happy path (most common flow)
+- Empty / initial state
+- Validation errors or failure states (where applicable)
+- Permission / role boundaries (admin-only vs regular user)
+- Any edge cases called out in `e2e/app.context.md`
+
+For each test case, decide the **backend strategy**:
+
+- `[mock]` — feature is UI-only; route-mock via `helpers.ts` is sufficient
+- `[real]` — feature has backend state, auth flows, or side effects; use `fixtures/auth.ts` + real server
+
+Note any test cases that require **serial execution** (e.g., TC-01 creates state that TC-02 reads).
+
+**Step 3 — Write the test-case document**
+
+Create or overwrite `e2e/test-cases/<feature>.md`:
+
+```markdown
+# Test cases: <Feature Name>
+
+**Backend strategy**: mock | real | mixed
+**Requires serial execution**: yes | no
+**Non-DOM notes**: <anything not visible in the DOM that tests must handle>
+
+## TC-01: <title>
+
+**Precondition**: <setup state — user role, existing data, etc.>
+**Steps**:
+
+1. <action>
+2. <action>
+   **Expected result**: <what the user sees or what state changes>
+   **Backend**: mock | real
+
+## TC-02: <title>
+
+...
+```
+
+**Step 4 — STOP for human approval**
+
+After writing the file, output exactly this and nothing more:
+
+```
+Test cases written to e2e/test-cases/<feature>.md.
+
+>>> HUMAN CHECKPOINT <<<
+Review the test cases before any code is generated.
+Reply "approve" (or describe changes you want) to proceed with automation.
+```
+
+Do NOT write any TypeScript code. Do NOT dispatch `e2e-automation`. Stop here.

--- a/.claude/commands/fix-e2e.md
+++ b/.claude/commands/fix-e2e.md
@@ -1,0 +1,9 @@
+Fix a failing Playwright spec by diagnosing and proposing the smallest patch.
+
+**Usage**: `/fix-e2e <spec>`
+
+Example: `/fix-e2e calendar-feed`
+
+Dispatch the `e2e-maintenance` subagent with this prompt:
+
+> "Triage the failing e2e spec `<spec>.spec.ts`. Run it with `bun run test:e2e -- --project=chromium <spec>`, read the error and trace, diagnose the root cause, and propose (or apply, for non-sensitive specs) the fix. Report in the standard format. For oidc, passkey, notifications, or any auth-related spec: propose only — do not auto-apply."

--- a/.claude/commands/gen-e2e.md
+++ b/.claude/commands/gen-e2e.md
@@ -1,0 +1,62 @@
+Generate a Playwright spec for a feature using the 4-agent e2e pipeline.
+
+**Usage**: `/gen-e2e <feature>`
+
+Example: `/gen-e2e calendar-feed`
+
+**Context** (read before starting):
+
+- `e2e/CLAUDE.md` — conventions, mock-vs-real split, spec status, CI rules
+- `e2e/app.context.md` — product rules and non-DOM knowledge
+
+---
+
+**Pre-flight: confirm dev server is running**
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:5173
+```
+
+If the result is not `200`: stop and tell the user to run `bun run dev` first, then re-run this command.
+
+---
+
+**Step 1 — Exploration** (dispatch `e2e-explorer` subagent)
+
+Prompt:
+
+> "Explore the '<feature>' feature for remindarr's e2e pipeline. The dev server is running at localhost:5173. Read the frontend source in `frontend/src/`, the server route in `server/routes/`, walk the live UI with playwright-cli, and update `e2e/app.context.md` with a feature section covering API routes, user roles, non-DOM knowledge, and UI states to cover."
+
+---
+
+**Step 2 — Test-case authoring** (dispatch `e2e-test-case-author` subagent)
+
+Prompt:
+
+> "Write test cases for the '<feature>' feature. Read `e2e/app.context.md` (just updated) and the relevant frontend page and server route. Write `e2e/test-cases/<feature>.md` with preconditions, steps, and expected results for each test case. Decide mock vs real backend per case. Stop after writing the file — do NOT generate any TypeScript code."
+
+---
+
+**Step 3 — STOP for human approval**
+
+After the test-case doc is written, tell the user:
+
+> Test cases are ready at `e2e/test-cases/<feature>.md`. Review them and reply **approve** to generate the automation code, or describe the changes you want.
+
+**Do NOT proceed to Step 4 without explicit user approval.**
+
+---
+
+**Step 4 — Automation** (dispatch `e2e-automation` subagent — only after approval)
+
+Prompt:
+
+> "The test cases at `e2e/test-cases/<feature>.md` are human-approved. Generate the Page Object at `e2e/pages/<feature>-page.ts` and the spec at `e2e/<feature>.spec.ts`. Follow `e2e/CLAUDE.md` conventions. Use `playwright-cli` to discover locators. Run `bun run test:e2e -- --project=chromium <feature>` and report pass/fail."
+
+---
+
+**Step 5 — Report**
+
+Summarise what was created. Always end with:
+
+> Generated specs are **local-only** by default. To add to CI, update the spec list in `.github/workflows/e2e.yml` once the spec is stable on your machine.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Enforce LF line endings on all platforms.
+# Prevents CRLF/LF drift on Windows (core.autocrlf) that breaks Prettier in
+# git worktrees — see issue #857.
+* text=auto eol=lf

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -49,3 +49,50 @@ bun run test:e2e -- notifications       # Single spec
 When adding a new e2e spec: start from a logged-in fixture from `e2e/fixtures/auth.ts`. Use `mock-webhook.ts` for notification assertions rather than calling real external services.
 
 If a spec is skipped in CI (`e2e.yml`): either fix and re-enable, or open a GitHub issue and link from this file. Do not leave silent skips.
+
+## Page Object Model
+
+New specs should use Page Objects rather than raw locators inline. Page objects live in `e2e/pages/`.
+
+| File            | Purpose                                                             |
+| --------------- | ------------------------------------------------------------------- |
+| `base-page.ts`  | `BasePage` abstract class — `goto(path)`, `waitForVisible(locator)` |
+| `login-page.ts` | `LoginPage` — reference implementation; handles OIDC/passkey toggle |
+
+**Conventions:**
+
+- Extend `BasePage` — no constructor needed (inherits `protected readonly page: Page`)
+- One class per logical page/section; split into multiple files if a feature spans distinct pages
+- Navigation method: `gotoFeature(): Promise<void>` calling `await this.goto('/path')`
+- **Semantic locators only**: `getByRole`, `getByLabel`, `getByText`, `getByPlaceholder`. Never `locator('#id')` or `locator('.class')` unless there is truly no semantic alternative
+- Add JSDoc on any method that handles non-DOM knowledge (clipboard-only tokens, permission rules, timing constraints)
+
+Existing specs (`auth`, `episodes`, `search`, `tracking`) use the older helper-function style and are not being migrated. Use Page Objects for all new specs.
+
+## Context document
+
+`e2e/app.context.md` captures product knowledge that is NOT derivable from the DOM or the
+source code alone — user roles, auth modes, non-DOM secrets, flow ordering constraints, the
+mock-vs-real backend split, and per-feature notes for test authoring.
+
+The `e2e-explorer` agent owns this file and updates it before each `/gen-e2e` run.
+Do not duplicate information from the scoped `CLAUDE.md` files — link to them instead.
+
+## Test-case documents
+
+`e2e/test-cases/<feature>.md` holds the human-reviewed test-case spec for a feature before
+any automation code is written. These are the **human checkpoint** in the generation pipeline.
+They are committed alongside specs and serve as living documentation.
+
+## Generation workflow
+
+Two slash commands drive the pipeline:
+
+```bash
+/gen-e2e <feature>   # Exploration → test-case authoring → HUMAN APPROVAL → automation
+/fix-e2e <spec>      # Run failing spec → diagnose → propose (or apply) fix
+```
+
+**Generated specs start local-only.** After `/gen-e2e` produces a spec, it is NOT
+automatically added to CI. Once the spec is proven stable on your machine, update the spec
+list in `.github/workflows/e2e.yml` manually — this is an intentional human decision.

--- a/e2e/app.context.md
+++ b/e2e/app.context.md
@@ -1,0 +1,126 @@
+# Remindarr — E2E Test Context
+
+Living document owned by the `e2e-explorer` agent. Update it when exploring a new
+feature or when product rules change. Do NOT duplicate information from the scoped
+`CLAUDE.md` files — link to them instead.
+
+Related docs: [`e2e/CLAUDE.md`](./CLAUDE.md) · [`frontend/CLAUDE.md`](../frontend/CLAUDE.md) ·
+[`server/notifications/CLAUDE.md`](../server/notifications/CLAUDE.md)
+
+---
+
+## Product overview
+
+Remindarr lets users discover and track streaming media releases. Core loop:
+
+1. **Search** — query TMDB for a title
+2. **Track** — pin it to your list; Remindarr monitors upcoming episodes
+3. **Episodes** — browse the episode schedule for tracked titles
+4. **Calendar feed** — subscribe to a secret ICS URL in a calendar app
+5. **Notifications** — get push/webhook/email alerts when new episodes release
+6. **Recommendations** — follow other users; they broadcast recommendations 1-to-N (not 1-to-1)
+
+---
+
+## User roles
+
+| Role                | How created                                 | Credentials                                                                                                                                    |
+| ------------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Bootstrap admin** | Auto-created on fresh DB boot               | Username: `admin`; password written to `<db-dir>/admin-password.txt`. Read with `readBootstrapAdminCredentials()` from `e2e/fixtures/auth.ts`. |
+| **Regular user**    | Self-register via `/api/auth/sign-up/email` | Created at runtime in tests with `registerUser(request)`.                                                                                      |
+
+Relationships:
+
+- **Following / recommendations**: a recommendation from User A is broadcast to
+  **all** of A's followers — a 1-to-N model. It is not a direct message.
+
+---
+
+## Authentication modes
+
+| Mode                    | How configured                                                     | E2E mock                                                                                              |
+| ----------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| **Username + password** | Always available (better-auth)                                     | No mock needed — real signup/login in e2e.                                                            |
+| **OIDC (pocketid)**     | `OIDC_ISSUER_URL`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET` env vars | `e2e/fixtures/mock-oidc.ts` — in-process RS256 OIDC provider on port `4321`. Provider ID: `pocketid`. |
+| **Passkey (WebAuthn)**  | UI toggle                                                          | CDP virtual WebAuthn authenticator. **Chromium-only**. See `passkey.spec.ts`.                         |
+
+The login page hides the username/password form when OIDC or passkey is configured.
+`loginUi()` (and `LoginPage.signIn()`) handles the toggle automatically.
+
+---
+
+## Non-DOM knowledge
+
+These values are never persistently visible in the DOM:
+
+| Value                        | What it is                                                             | How to access in tests                                                                                                                                                                          |
+| ---------------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Calendar feed ICS URL**    | Secret per-user URL; disclosed only via clipboard after generation     | Route-intercept the calendar API endpoint and capture the URL from the response body, or read the clipboard via `page.evaluate(() => navigator.clipboard.readText())` after the user copies it. |
+| **Admin bootstrap password** | Random password written to `<db-dir>/admin-password.txt` on first boot | `readBootstrapAdminCredentials()` in `e2e/fixtures/auth.ts:83`.                                                                                                                                 |
+| **Webhook secret / payload** | Notification payloads arrive at the mock webhook server                | Introspect via `GET http://localhost:4322/__requests`; reset via `POST http://localhost:4322/__reset`. Mock server: `e2e/fixtures/mock-webhook.ts`.                                             |
+| **OIDC authorization code**  | Exchanged internally between mock OIDC and backend                     | No test needs to read this directly — the mock auto-redirects.                                                                                                                                  |
+
+---
+
+## Test architecture — mock vs real backend
+
+Two distinct strategies coexist in the test suite. Pick the right one per feature:
+
+### Mock (UI-only)
+
+Use when the feature is pure frontend state that can be fully exercised via API stubs.
+
+```ts
+import { mockLoggedIn, mockTitleEndpoints } from "../helpers";
+
+test.beforeEach(async ({ page }) => {
+  await mockLoggedIn(page);
+  await mockTitleEndpoints(page, sampleTitles);
+});
+```
+
+Key helpers in `e2e/helpers.ts`:
+
+- `mockLoggedIn(page)` — stubs `/api/auth/get-session`, `/api/custom/providers`, `/api/csrf`
+- `mockLoggedOut(page)` — stubs the same endpoints with `null` session
+- `mockTitleEndpoints(page, titles)` — stubs title/tracking list endpoints
+- `mockBrowseEndpoints(page, titles)` — stubs browse/recommendations endpoints
+
+### Real backend
+
+Use when the feature depends on server-side state, auth flows, or side effects
+(notifications, calendar tokens, OIDC, passkey).
+
+```ts
+import { registerUser, loginUi } from "../fixtures/auth";
+
+test.beforeEach(async ({ page, request }) => {
+  const user = await registerUser(request);
+  await loginUi(page, user.username, user.password);
+});
+```
+
+For **notifications**: use `mock-webhook.ts` introspection endpoints — never call
+real external services.
+
+---
+
+## E2E environment
+
+| Setting      | Value                                                                |
+| ------------ | -------------------------------------------------------------------- |
+| Base URL     | `http://localhost:5173` (Vite dev server; proxies `/api` to `:3000`) |
+| E2E database | `.e2e/remindarr.sqlite` (wiped per CLI invocation)                   |
+| Mock OIDC    | `http://localhost:4321`                                              |
+| Mock webhook | `http://localhost:4322`                                              |
+| Crons        | Disabled in e2e (`*_CRON` env vars unset)                            |
+| TMDB         | Placeholder key — never real HTTP                                    |
+
+---
+
+## Feature sections
+
+> Each feature explored by the `e2e-explorer` agent gets its own section below.
+> Sections are added or updated as the pipeline runs.
+
+<!-- feature sections added here by e2e-explorer -->

--- a/e2e/pages/base-page.ts
+++ b/e2e/pages/base-page.ts
@@ -1,0 +1,13 @@
+import type { Page } from "@playwright/test";
+
+export abstract class BasePage {
+  constructor(protected readonly page: Page) {}
+
+  async goto(path: string): Promise<void> {
+    await this.page.goto(path);
+  }
+
+  async waitForVisible(locator: ReturnType<Page["getByRole"]>): Promise<void> {
+    await locator.waitFor({ state: "visible" });
+  }
+}

--- a/e2e/pages/login-page.ts
+++ b/e2e/pages/login-page.ts
@@ -1,0 +1,30 @@
+import { BasePage } from "./base-page";
+
+/**
+ * Login page. Handles the OIDC/passkey toggle that hides the username form
+ * when an external auth provider is configured.
+ *
+ * Non-DOM note: the username form is hidden by default when the backend reports
+ * a configured OIDC provider — `signIn` clicks through the toggle automatically.
+ */
+export class LoginPage extends BasePage {
+  async gotoLogin(): Promise<void> {
+    await this.goto("/login");
+  }
+
+  async signIn(username: string, password: string): Promise<void> {
+    await this.gotoLogin();
+    const usernameField = this.page.getByLabel("Username");
+    if (!(await usernameField.isVisible().catch(() => false))) {
+      await this.page
+        .getByRole("button", { name: /sign in with username instead/i })
+        .click();
+    }
+    await this.page.getByLabel("Username").fill(username);
+    await this.page.getByLabel("Password").fill(password);
+    await this.page.getByRole("button", { name: /^sign in$/i }).click();
+    await this.page.waitForURL((url) => !url.pathname.startsWith("/login"), {
+      timeout: 15_000,
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- Adds the full 4-agent Playwright test-generation pipeline (`e2e-explorer`, `e2e-test-case-author`, `e2e-automation`, `e2e-maintenance`) as subagents under `.claude/agents/`
- Adds `/gen-e2e <feature>` and `/fix-e2e <spec>` slash commands
- Adds `e2e/app.context.md` — global product context (roles, auth modes, mock-vs-real split, non-DOM knowledge)
- Adds `e2e/pages/` Page Object Model layer (`BasePage` + `LoginPage` reference impl)
- Adds `e2e/test-cases/` directory for human-reviewed test-case docs (the human checkpoint)
- Updates `e2e/CLAUDE.md` with POM conventions, context doc purpose, and generation workflow

This is the foundation that the per-feature e2e PRs will build on.

## Test plan

- [x] `bunx tsc --noEmit -p e2e/tsconfig.json` — POM files typecheck clean
- [x] Pre-push hook passes (format + tsc + lint)
- [ ] Pipeline validated end-to-end via `/gen-e2e signup` in the next PR

## Notes

Also fixes 6 pre-existing Prettier formatting failures in `server/jobs/` and `server/tmdb/sync-titles*` that were blocking the pre-push hook (no logic changes).

Part of #853

🤖 Generated with [Claude Code](https://claude.com/claude-code)