### PR TITLE
feat(e2e): add push.ts fixture for web-push notification tests

### DIFF
--- a/e2e/fixtures/push.ts
+++ b/e2e/fixtures/push.ts
@@ -1,0 +1,43 @@
+/**
+ * Web-push helpers for e2e tests.
+ *
+ * Browser-side push notifications require:
+ *   1. The `notifications` permission to be granted up-front.
+ *   2. A service worker with a Push subscription — not possible in Playwright
+ *      without a real VAPID key exchange. Instead, specs that test the
+ *      notification UI (enable/disable toggles, provider settings) should use
+ *      the API route-mock path rather than end-to-end push delivery.
+ *
+ * Use `grantNotificationsPermission` in a `test.use({ ... })` block or
+ * directly in a `beforeEach` to pre-grant the permission so the browser
+ * does not show a permission prompt during the test.
+ */
+import type { BrowserContext } from "@playwright/test";
+
+/**
+ * Grants the `notifications` permission on the given context.
+ *
+ * Call from a fixture or `test.beforeEach` before navigating to any page that
+ * triggers a permission prompt. The origin must match the app's base URL.
+ *
+ * @example
+ * test.beforeEach(async ({ context }) => {
+ *   await grantNotificationsPermission(context, "http://localhost:5173");
+ * });
+ */
+export async function grantNotificationsPermission(
+  context: BrowserContext,
+  origin = "http://localhost:5173",
+): Promise<void> {
+  await context.grantPermissions(["notifications"], { origin });
+}
+
+/**
+ * Revokes the `notifications` permission, restoring prompt behaviour.
+ * Useful in `afterEach` when a test explicitly checks the denied state.
+ */
+export async function revokeNotificationsPermission(
+  context: BrowserContext,
+): Promise<void> {
+  await context.clearPermissions();
+}


### PR DESCRIPTION
## Summary

- Adds `e2e/fixtures/push.ts` — helpers to grant/revoke the `notifications` browser permission so specs that test notification UI flows don't trigger the browser permission prompt
- Exports `grantNotificationsPermission(context, origin?)` and `revokeNotificationsPermission(context)`

The notifications settings spec and any push-related spec will call `grantNotificationsPermission` in `test.beforeEach` before navigating to pages that could trigger the permission prompt.

## Test plan

- [x] `bunx tsc --noEmit -p e2e/tsconfig.json` — typechecks clean
- [x] Pre-push hook passes

Part of #853

🤖 Generated with [Claude Code](https://claude.com/claude-code)