### PR TITLE
feat(e2e): add home page spec (TC-01 to TC-06)

### DIFF
--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,0 +1,197 @@
+import { test, expect } from "@playwright/test";
+import {
+  mockLoggedIn,
+  mockLoggedOut,
+  MOCK_EPISODE,
+  MOCK_UPCOMING_EPISODE,
+  MOCK_SEARCH_TITLE,
+} from "./helpers";
+import { HomePage } from "./pages/home-page";
+
+test.describe("Home", () => {
+  test.skip(
+    ({ browserName }) => browserName !== "chromium",
+    "chromium only — desktop layout requires a stable viewport",
+  );
+
+  // ── TC-01: Authenticated user sees the home page ──────────────────────────
+  test("TC-01: authenticated user sees the home page", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const home = new HomePage(page);
+    await mockLoggedIn(page);
+    await home.mockHomeDataEndpoints();
+    await home.gotoHome();
+
+    await expect(page).toHaveTitle(/remindarr/i);
+    // Unauthenticated hero should NOT be visible
+    await expect(
+      page.getByRole("heading", { name: /track movies.*tv shows/i }),
+    ).not.toBeVisible();
+    // Main content area should be present
+    await expect(page.locator("main")).toBeVisible();
+    // Top nav has a Home link
+    await expect(
+      page
+        .getByRole("navigation", { name: /main navigation/i })
+        .getByRole("link", { name: /home/i }),
+    ).toBeVisible();
+    // No error banner
+    await expect(page.locator(".bg-red-900\\/50")).not.toBeVisible();
+  });
+
+  // ── TC-02: Home page shows tracked titles list (upcoming episodes) ────────
+  test("TC-02: shows today's airing episode", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const home = new HomePage(page);
+    await mockLoggedIn(page);
+    // Register base mocks first (includes empty episodes fallback)
+    await home.mockHomeDataEndpoints();
+    // Override episodes with today's episode — registered AFTER so it wins (LIFO)
+    await page.route("**/api/episodes/upcoming", (route) =>
+      route.fulfill({
+        json: { today: [MOCK_EPISODE], upcoming: [], unwatched: [] },
+      }),
+    );
+    await home.gotoHome();
+
+    await expect(page.locator("main")).toBeVisible();
+    // "Today" section heading from t("home.today")
+    await expect(page.getByRole("heading", { name: /today/i })).toBeVisible();
+    // Show title appears
+    await expect(page.getByText(MOCK_EPISODE.show_title)).toBeVisible();
+    // Episode code chip e.g. "S01·E01"
+    await expect(page.getByText(/S01[·\s]?E01/)).toBeVisible();
+  });
+
+  // ── TC-03: Home page shows upcoming episodes section ──────────────────────
+  test("TC-03: shows upcoming episodes section", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const home = new HomePage(page);
+    await mockLoggedIn(page);
+    await home.mockHomeDataEndpoints();
+    // Override episodes with upcoming episode — registered AFTER so it wins (LIFO)
+    await page.route("**/api/episodes/upcoming", (route) =>
+      route.fulfill({
+        json: { today: [], upcoming: [MOCK_UPCOMING_EPISODE], unwatched: [] },
+      }),
+    );
+    await home.gotoHome();
+
+    await expect(page.locator("main")).toBeVisible();
+    // "Coming Up" section heading from t("home.comingUp")
+    await expect(
+      page.getByRole("heading", { name: /coming up/i }),
+    ).toBeVisible();
+    // Show title appears
+    await expect(
+      page.getByText(MOCK_UPCOMING_EPISODE.show_title),
+    ).toBeVisible();
+    // Episode code chip e.g. "S01·E02"
+    await expect(page.getByText(/S01[·\s]?E02/)).toBeVisible();
+  });
+
+  // ── TC-04: Empty state — no tracked titles ────────────────────────────────
+  test("TC-04: empty state shows no episodes message", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const home = new HomePage(page);
+    await mockLoggedIn(page);
+    // mockHomeDataEndpoints stubs episodes/upcoming with empty arrays
+    await home.mockHomeDataEndpoints();
+    await home.gotoHome();
+
+    await expect(page.locator("main")).toBeVisible();
+    // "Today" section kicker "Airing tonight" is rendered as a div (Kicker component)
+    await expect(page.getByText(/airing tonight/i)).toBeVisible();
+    // Empty state message — t("home.noEpisodes") when all lists empty
+    await expect(page.getByText(/no upcoming episodes/i)).toBeVisible();
+    // No JS error banner
+    await expect(page.locator(".bg-red-900\\/50")).not.toBeVisible();
+  });
+
+  // ── TC-05: Unauthenticated user sees the landing page ────────────────────
+  test("TC-05: unauthenticated user sees landing page", async ({ page }) => {
+    const home = new HomePage(page);
+    await mockLoggedOut(page);
+    // Browse endpoint for Popular Right Now section
+    await page.route("**/api/browse**", (route) =>
+      route.fulfill({
+        json: {
+          titles: [MOCK_SEARCH_TITLE],
+          page: 1,
+          totalPages: 1,
+          totalResults: 1,
+          availableGenres: [],
+          availableProviders: [],
+          availableLanguages: [],
+        },
+      }),
+    );
+    await home.gotoHome();
+
+    // Hero heading visible
+    await expect(
+      page.getByRole("heading", { name: /track movies.*tv shows/i }),
+    ).toBeVisible();
+    // Sign In link in main content area (scoped to avoid strict mode with nav link)
+    await expect(
+      page.locator("#main-content").getByRole("link", { name: /sign in/i }),
+    ).toBeVisible();
+    // Create Account link to /signup
+    await expect(
+      page.getByRole("link", { name: /create account/i }),
+    ).toBeVisible();
+    // Popular Right Now section
+    await expect(
+      page.getByRole("heading", { name: /popular right now/i }),
+    ).toBeVisible();
+    // URL remains /
+    await expect(page).toHaveURL("/");
+  });
+
+  // ── TC-06: Navigation — home is accessible from the nav bar ──────────────
+  test("TC-06: Home nav link navigates to home", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const home = new HomePage(page);
+    await mockLoggedIn(page);
+    await home.mockHomeDataEndpoints();
+    // Stub browse so /browse can render without hitting real backend
+    await page.route("**/api/browse**", (route) =>
+      route.fulfill({
+        json: {
+          titles: [],
+          page: 1,
+          totalPages: 0,
+          totalResults: 0,
+          availableGenres: [],
+          availableProviders: [],
+          availableLanguages: [],
+        },
+      }),
+    );
+    await page.route("**/api/titles/genres", (route) =>
+      route.fulfill({ json: { genres: [] } }),
+    );
+    await page.route("**/api/titles/providers", (route) =>
+      route.fulfill({ json: { providers: [], regionProviderIds: [] } }),
+    );
+    await page.route("**/api/titles/languages", (route) =>
+      route.fulfill({ json: { languages: [], priorityLanguageCodes: [] } }),
+    );
+
+    // Navigate away from home first
+    await page.goto("/browse");
+    await expect(page.getByRole("heading", { name: "Browse" })).toBeVisible();
+
+    // Click Home nav link
+    const nav = page.getByRole("navigation", { name: /main navigation/i });
+    await nav.getByRole("link", { name: /home/i }).click();
+    await page.waitForURL("/");
+
+    await expect(page).toHaveURL("/");
+    // Main content visible (authenticated home, not landing)
+    await expect(page.locator("main")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /track movies.*tv shows/i }),
+    ).not.toBeVisible();
+  });
+});

--- a/e2e/pages/home-page.ts
+++ b/e2e/pages/home-page.ts
@@ -1,0 +1,120 @@
+import type { Page } from "@playwright/test";
+import { BasePage } from "./base-page";
+
+/**
+ * Home page POM.
+ *
+ * Non-DOM notes:
+ * - The home route renders `HomePage` which shows an unauthenticated landing
+ *   hero when no session is present, or the authenticated sections layout when
+ *   logged in.
+ * - On desktop (≥ 640 px) the desktop layout renders; on mobile an entirely
+ *   different `MobileFeedHome` component is shown and may redirect to `/reels`.
+ *   Tests that use this POM should set viewport to 1280x720.
+ * - The authenticated home fetches several endpoints in parallel (episodes,
+ *   recommendations, homepage-layout, up-next, friends-loved, streak, movies).
+ *   All must be mocked to avoid network calls.
+ */
+export class HomePage extends BasePage {
+  async gotoHome(): Promise<void> {
+    await this.goto("/");
+  }
+
+  /**
+   * Stub all authenticated home data endpoints with empty/valid responses.
+   * Stubs GET /api/episodes/upcoming with empty arrays by default.
+   * To override, register your own episodes/upcoming route AFTER calling this
+   * method — Playwright processes routes LIFO so the last registration wins.
+   */
+  async mockHomeDataEndpoints(): Promise<void> {
+    await this.page.route("**/api/episodes/upcoming", (route) =>
+      route.fulfill({
+        json: { today: [], upcoming: [], unwatched: [] },
+      }),
+    );
+    await this.page.route("**/api/recommendations**", (route) =>
+      route.fulfill({ json: { recommendations: [], count: 0 } }),
+    );
+    // Real URL: /api/user/settings/homepage-layout
+    await this.page.route("**/api/user/settings/homepage-layout**", (route) =>
+      route.fulfill({
+        json: {
+          homepage_layout: [
+            { id: "today", enabled: true },
+            { id: "upcoming", enabled: true },
+            { id: "up_next", enabled: true },
+            { id: "friends_loved", enabled: true },
+            { id: "movies_to_watch", enabled: true },
+            { id: "upcoming_movies", enabled: true },
+            { id: "streak", enabled: true },
+          ],
+        },
+      }),
+    );
+    // Real URL: /api/up-next?limit=12
+    await this.page.route("**/api/up-next**", (route) =>
+      route.fulfill({ json: { items: [] } }),
+    );
+    // Real URL: /api/social/friends-loved?limit=20
+    await this.page.route("**/api/social/friends-loved**", (route) =>
+      route.fulfill({ json: { items: [] } }),
+    );
+    // Real URL: /api/streak/me
+    await this.page.route("**/api/streak/me**", (route) =>
+      route.fulfill({ json: null }),
+    );
+    // Real URL: /api/movies/tracking
+    await this.page.route("**/api/movies/tracking**", (route) =>
+      route.fulfill({ json: { to_watch: [], upcoming: [] } }),
+    );
+    // AuthContext calls getSubscriptions() after auth succeeds.
+    // If unmocked it hits the real server with a fake userId and gets 401,
+    // which triggers the auth:unauthorized event and logs the user out.
+    await this.page.route("**/api/user/settings/subscriptions**", (route) =>
+      route.fulfill({ json: { providerIds: [] } }),
+    );
+    // AchievementToast polls achievements in the background. Without this mock
+    // it returns 401 and triggers auth:unauthorized (even though the component
+    // catches the error, fetchJson dispatches the event first).
+    await this.page.route("**/api/achievements/me**", (route) =>
+      route.fulfill({ json: [] }),
+    );
+    // Catch-all for any remaining authenticated API calls that return 401.
+    // This prevents unexpected logouts from unmocked background requests.
+    await this.page.route("**/api/recommendations/count**", (route) =>
+      route.fulfill({ json: { count: 0 } }),
+    );
+    // SuggestedForYouRow is always rendered at the bottom of HomePage and
+    // calls /api/suggestions. Without this mock it returns 401 from the real
+    // backend (fake userId), firing auth:unauthorized and logging the user out.
+    await this.page.route("**/api/suggestions**", (route) =>
+      route.fulfill({ json: { flat: [], bySource: {} } }),
+    );
+  }
+
+  mainContent() {
+    return this.page.locator("main");
+  }
+
+  heroHeading() {
+    return this.page.getByRole("heading", {
+      name: /track movies.*tv shows/i,
+    });
+  }
+
+  signInLink() {
+    return this.page.getByRole("link", { name: /sign in/i });
+  }
+
+  createAccountLink() {
+    return this.page.getByRole("link", { name: /create account/i });
+  }
+
+  popularNowHeading() {
+    return this.page.getByRole("heading", { name: /popular right now/i });
+  }
+
+  homeNavLink() {
+    return this.page.getByRole("link", { name: /^home$/i });
+  }
+}

--- a/e2e/test-cases/home.md
+++ b/e2e/test-cases/home.md
@@ -1,0 +1,204 @@
+# Test cases: home
+
+## Preconditions (shared)
+
+- The Remindarr dev server is running (Bun on `:3000`, Vite dev server on `:5173`, Vite proxies `/api` to `:3000`).
+- The home page is served at `/` (`HomeRoute` renders `HomePage` for desktop, redirects to `/reels` for authenticated mobile users).
+- Unless stated otherwise, all API calls are mocked via `page.route()`.
+
+---
+
+## TC-01: Authenticated user sees the home page
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: Verifies that an authenticated session causes `HomePage` to render its
+content area rather than the unauthenticated landing hero. A mock is sufficient — no
+real DB state is needed to confirm the session-gated branch renders.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` stubs `/api/auth/get-session` with a valid session.
+- `page.route()` stubs all auth-home data endpoints with empty-but-valid responses:
+  - `GET **/api/episodes/upcoming` → `{ today: [], upcoming: [], unwatched: [] }`
+  - `GET **/api/recommendations**` → `{ recommendations: [], count: 0 }`
+  - `GET **/api/homepage-layout**` → omit or return the default layout
+  - `GET **/api/up-next**` → `{ items: [] }`
+  - `GET **/api/friends-loved**` → `{ items: [] }`
+  - `GET **/api/streak**` → `null`
+  - `GET **/api/movies/tracking**` → `{ to_watch: [], upcoming: [] }`
+- Viewport is set to desktop width (≥ 640 px) to avoid the mobile redirect to `/reels`.
+
+**Steps**:
+
+1. Call `mockLoggedIn(page)` and set up all data stubs listed in preconditions.
+2. Navigate to `/`.
+3. Wait for the page to finish loading (skeleton disappears).
+
+**Expected**:
+
+- The page title is `Remindarr`.
+- The unauthenticated hero heading ("Track movies & TV shows you love") is **not** visible.
+- The main content area (`<main>`) is present and visible.
+- The top navigation shows a "Home" link (`getByRole("link", { name: /home/i })`).
+- No error banner is shown.
+
+---
+
+## TC-02: Home page shows tracked titles list (upcoming episodes)
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: Validates that episode data returned from `/api/episodes/upcoming` is
+rendered on screen. Mocking the endpoint makes the test deterministic and fast.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` called.
+- `GET **/api/episodes/upcoming` returns `MOCK_EPISODE` (from `e2e/helpers.ts`) in the
+  `today` array: `{ today: [MOCK_EPISODE], upcoming: [], unwatched: [] }`.
+- All other home data endpoints return empty/null responses (same stubs as TC-01).
+- Viewport is desktop width (≥ 640 px).
+
+**Steps**:
+
+1. Set up mocks as described in preconditions.
+2. Navigate to `/`.
+3. Wait for the main content area to appear.
+4. Locate the "Airing tonight" section heading.
+
+**Expected**:
+
+- `getByRole("heading", { name: /today/i })` (or the translated equivalent) is visible.
+- The show title `"Test Show"` (from `MOCK_EPISODE.show_title`) is visible on screen.
+- Episode information `"S01·E01"` is rendered within the episode card.
+
+---
+
+## TC-03: Home page shows upcoming episodes section
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: Confirms that `upcoming` episodes (air date in the future) are rendered in
+the "Coming Up" / "This week" section. Stubbing the endpoint keeps the air dates stable.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` called.
+- `GET **/api/episodes/upcoming` returns `MOCK_UPCOMING_EPISODE` (from `e2e/helpers.ts`)
+  in the `upcoming` array:
+  `{ today: [], upcoming: [MOCK_UPCOMING_EPISODE], unwatched: [] }`.
+- All other home data endpoints return empty/null responses.
+- Viewport is desktop width (≥ 640 px).
+
+**Steps**:
+
+1. Set up mocks as described in preconditions.
+2. Navigate to `/`.
+3. Wait for the main content area to appear.
+4. Locate the upcoming-episodes section heading.
+
+**Expected**:
+
+- A heading matching "Coming Up" or "Airing Soon" (translated equivalent) is visible,
+  **or** a "This week" section heading is present.
+- The show title `"Test Show"` (from `MOCK_UPCOMING_EPISODE.show_title`) appears within
+  the upcoming section.
+- The episode label `"S01·E02"` is rendered in the card.
+
+---
+
+## TC-04: Empty state — no tracked titles
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: Confirms the empty-state message is shown when all episode lists are empty.
+A real account with no tracked titles would also work, but mocking is faster and avoids
+DB setup.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` called.
+- `GET **/api/episodes/upcoming` returns `{ today: [], upcoming: [], unwatched: [] }`.
+- All other home data endpoints return empty/null responses.
+- Viewport is desktop width (≥ 640 px).
+
+**Steps**:
+
+1. Set up mocks as described in preconditions.
+2. Navigate to `/`.
+3. Wait for the main content area to appear.
+
+**Expected**:
+
+- The "Today" section (kicker "Airing tonight") is present in the layout.
+- Within that section, the empty-state text is shown — `getByText(/no episodes/i)` or
+  the translated equivalent (e.g. "No episodes today").
+- No episode cards are rendered.
+- No JavaScript error is thrown (error banner absent).
+
+---
+
+## TC-05: Unauthenticated user sees the landing page (not redirected)
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: The unauthenticated branch of `HomePage` is a pure frontend render that
+depends only on the session state. `mockLoggedOut(page)` stubs the session endpoint to
+return `null`; no real auth state is required.
+
+**Preconditions**:
+
+- `mockLoggedOut(page)` called (stubs `GET /api/auth/get-session` → `null`).
+- `GET **/api/browse**` returns a list containing at least one title (e.g. `MOCK_SEARCH_TITLE`
+  from `e2e/helpers.ts`) so the "Popular Right Now" grid has content.
+
+**Steps**:
+
+1. Call `mockLoggedOut(page)` and stub the browse endpoint.
+2. Navigate to `/`.
+3. Wait for the main content area to render.
+
+**Expected**:
+
+- The hero heading `getByRole("heading", { name: /track movies.*tv shows/i })` is visible.
+- A `getByRole("link", { name: /sign in/i })` link pointing to `/login` is present.
+- A `getByRole("link", { name: /create account/i })` link pointing to `/signup` is present.
+- The "Popular Right Now" section heading is visible.
+- The URL remains `/` (no redirect occurs).
+
+---
+
+## TC-06: Navigation — home is accessible from the nav bar
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: This test exercises the shell navigation only. Session state controls which
+nav links are rendered; mocking the session is sufficient.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` called.
+- All home data endpoints return empty responses (same stubs as TC-01).
+- Viewport is desktop width (≥ 640 px).
+
+**Steps**:
+
+1. Set up mocks as described in preconditions.
+2. Navigate to `/browse` (a page other than home).
+3. Locate the "Home" nav link: `getByRole("navigation", { name: /main navigation/i })`
+   → `getByRole("link", { name: /home/i })`.
+4. Click the "Home" link.
+5. Wait for navigation to complete.
+
+**Expected**:
+
+- The URL changes to `/`.
+- The main content area is visible (authenticated home layout, not the landing hero).
+- The "Home" nav link has an active/current style (aria-current or highlighted).


### PR DESCRIPTION
## Summary

- Adds `e2e/pages/home-page.ts` — Page Object with `gotoHome()`, `mockHomeDataEndpoints()`, and semantic locators for the home page
- Adds `e2e/home.spec.ts` — 6 Playwright tests (TC-01 to TC-06) covering authenticated home, episode sections, empty state, unauthenticated landing, and nav link navigation
- Adds `e2e/test-cases/home.md` — human-reviewed test-case spec

`mockHomeDataEndpoints()` stubs all 10+ endpoints that the authenticated home page calls in parallel, preventing 401s from background components (`AchievementToast`, `SuggestedForYouRow`, `AuthContext.getSubscriptions`) from triggering `auth:unauthorized` and logging the test user out.

## Test plan

- [x] TC-01: authenticated user sees the home page (no hero, main content visible, Home nav link visible)
- [x] TC-02: shows today's airing episode (`MOCK_EPISODE` in `today` array → "Today" heading + show title + episode chip)
- [x] TC-03: shows upcoming episodes section (`MOCK_UPCOMING_EPISODE` in `upcoming` array → "Coming Up" heading + show title + episode chip)
- [x] TC-04: empty state shows no episodes message (empty arrays → "Airing tonight" kicker + "No upcoming episodes" paragraph)
- [x] TC-05: unauthenticated user sees landing page (hero heading, Sign In link scoped to `#main-content`, Create Account link, Popular Right Now section)
- [x] TC-06: Home nav link navigates to home (navigate to `/browse` → click Home → URL is `/` and authenticated home renders)
- [x] All 6 tests pass locally: `bun run test:e2e -- --project=chromium e2e/home.spec.ts` → 6 passed

Part of #853

🤖 Generated with [Claude Code](https://claude.com/claude-code)