### PR TITLE
feat(e2e): add browse page spec (TC-01 to TC-06)

### DIFF
--- a/e2e/browse.spec.ts
+++ b/e2e/browse.spec.ts
@@ -1,0 +1,237 @@
+import { test, expect } from "@playwright/test";
+import { mockLoggedOut } from "./helpers";
+import {
+  BrowsePage,
+  MOCK_BROWSE_TITLE,
+  MOCK_ACTION_TITLE,
+  MOCK_NETFLIX_TITLE,
+} from "./pages/browse-page";
+
+test.describe("Browse", () => {
+  test.skip(
+    ({ browserName }) => browserName !== "chromium",
+    "chromium only — desktop filter layout requires a stable viewport",
+  );
+
+  // ── TC-01: Browse page loads with header, category tabs, filter bar, title cards ──
+  test("TC-01: browse page loads with header, category tabs, filter bar, and title cards", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const browse = new BrowsePage(page);
+    await mockLoggedOut(page);
+    await browse.mockBrowseDataEndpoints();
+    await page.goto("/browse");
+
+    await expect(browse.browseHeading()).toBeVisible();
+
+    // Kicker text above heading
+    await expect(page.getByText(/Catalog/i)).toBeVisible();
+
+    // Search bar
+    await expect(
+      page.getByPlaceholder(/Search titles or paste IMDB link/i),
+    ).toBeVisible();
+
+    // Category tab buttons
+    await expect(browse.categoryButton("Popular")).toBeVisible();
+    await expect(browse.categoryButton("Upcoming")).toBeVisible();
+    await expect(browse.categoryButton("Top Rated")).toBeVisible();
+    await expect(browse.categoryButton("Now Playing")).toBeVisible();
+
+    // Filter dropdowns
+    await expect(browse.genreDropdownButton()).toBeVisible();
+    await expect(browse.providerDropdownButton()).toBeVisible();
+    await expect(page.getByRole("button", { name: /Any year/i })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Any rating/i }),
+    ).toBeVisible();
+
+    // Content type group: All (pressed by default)
+    const typeGroup = browse.contentTypeGroup();
+    await expect(typeGroup).toBeVisible();
+    await expect(
+      typeGroup.getByRole("button", { name: /^All$/i }),
+    ).toHaveAttribute("aria-pressed", "true");
+    await expect(
+      typeGroup.getByRole("button", { name: /Movies/i }),
+    ).toBeVisible();
+    await expect(
+      typeGroup.getByRole("button", { name: /Shows/i }),
+    ).toBeVisible();
+
+    // Title card for the mocked title
+    await expect(browse.titleCard("Test Movie")).toBeVisible();
+
+    // "Popular" heading above the title grid
+    await expect(
+      page.getByRole("heading", { name: "Popular", level: 2 }),
+    ).toBeVisible();
+  });
+
+  // ── TC-02: Genre filter selects Action and updates results ──────────────────
+  test("TC-02: genre filter re-queries API and updates results", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const browse = new BrowsePage(page);
+    await mockLoggedOut(page);
+    await browse.mockBrowseDataEndpoints();
+    // Override browse for genre=Action — registered AFTER so it wins (LIFO)
+    await page.route("**/api/browse**", (route) => {
+      const url = new URL(route.request().url());
+      if (url.searchParams.get("genre") === "Action") {
+        return route.fulfill({
+          json: {
+            titles: [MOCK_ACTION_TITLE],
+            page: 1,
+            totalPages: 1,
+            totalResults: 1,
+          },
+        });
+      }
+      return route.continue();
+    });
+    await page.goto("/browse");
+    await expect(browse.browseHeading()).toBeVisible();
+
+    // Open Genre dropdown
+    await browse.genreDropdownButton().click();
+    // Checklist should appear — click the Action checkbox
+    await page.getByRole("checkbox", { name: "Action" }).click();
+    // Close the dropdown
+    await page.keyboard.press("Escape");
+
+    // Active filter chip appears in the active-filters row (× is Unicode U+00D7)
+    await expect(browse.activeFilterChip("Action ×")).toBeVisible();
+
+    // New title appears; old title gone
+    await expect(browse.titleCard("Action Movie")).toBeVisible();
+    await expect(browse.titleCard("Test Movie")).not.toBeVisible();
+  });
+
+  // ── TC-03: Provider filter selects Netflix and updates results ──────────────
+  test("TC-03: provider filter re-queries API and updates results", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const browse = new BrowsePage(page);
+    await mockLoggedOut(page);
+    await browse.mockBrowseDataEndpoints();
+    // Override browse for provider=8 — registered AFTER so it wins (LIFO)
+    await page.route("**/api/browse**", (route) => {
+      const url = new URL(route.request().url());
+      if (url.searchParams.get("provider") === "8") {
+        return route.fulfill({
+          json: {
+            titles: [MOCK_NETFLIX_TITLE],
+            page: 1,
+            totalPages: 1,
+            totalResults: 1,
+          },
+        });
+      }
+      return route.continue();
+    });
+    await page.goto("/browse");
+    await expect(browse.browseHeading()).toBeVisible();
+
+    // Open Provider dropdown
+    await browse.providerDropdownButton().click();
+    // Click the Netflix checkbox
+    await page.getByRole("checkbox", { name: "Netflix" }).click();
+    // Close the dropdown
+    await page.keyboard.press("Escape");
+
+    // Active filter chip appears in the active-filters row (× is Unicode U+00D7)
+    await expect(browse.activeFilterChip("Netflix ×")).toBeVisible();
+
+    // Netflix Movie appears; Test Movie gone
+    await expect(browse.titleCard("Netflix Movie")).toBeVisible();
+    await expect(browse.titleCard("Test Movie")).not.toBeVisible();
+  });
+
+  // ── TC-04: Empty results show no-titles message ─────────────────────────────
+  test("TC-04: empty results show no titles message", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const browse = new BrowsePage(page);
+    await mockLoggedOut(page);
+    await browse.mockBrowseDataEndpoints();
+    // Override browse with empty results — registered AFTER so it wins (LIFO)
+    await page.route("**/api/browse**", (route) =>
+      route.fulfill({
+        json: { titles: [], page: 1, totalPages: 0, totalResults: 0 },
+      }),
+    );
+    await page.goto("/browse");
+
+    await expect(browse.browseHeading()).toBeVisible();
+
+    // No article elements in the grid
+    await expect(page.getByRole("article")).toHaveCount(0);
+
+    // Empty state message from TitleList
+    await expect(page.getByText("No titles found.")).toBeVisible();
+
+    // Filter bar still rendered
+    await expect(browse.categoryButton("Popular")).toBeVisible();
+    await expect(browse.genreDropdownButton()).toBeVisible();
+
+    // No error banner
+    await expect(page.locator(".bg-red-900\\/50")).not.toBeVisible();
+  });
+
+  // ── TC-05: Unauthenticated user can access /browse (public page) ────────────
+  test("TC-05: unauthenticated user can access /browse without redirect", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const browse = new BrowsePage(page);
+    await mockLoggedOut(page);
+    await browse.mockBrowseDataEndpoints();
+    await page.goto("/browse");
+
+    // URL stays at /browse — no redirect to /login
+    await expect(page).toHaveURL("/browse");
+    await expect(browse.browseHeading()).toBeVisible();
+
+    // Top nav shows "Sign In" link (not a user avatar)
+    await expect(
+      page
+        .getByRole("navigation", { name: /main navigation/i })
+        .getByRole("link", { name: /sign in/i }),
+    ).toBeVisible();
+
+    // Title grid renders the mocked title
+    await expect(browse.titleCard("Test Movie")).toBeVisible();
+  });
+
+  // ── TC-06: Clicking a title navigates to the title detail page ──────────────
+  test("TC-06: clicking a title card navigates to the title detail page", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const browse = new BrowsePage(page);
+    await mockLoggedOut(page);
+    await browse.mockBrowseDataEndpoints();
+    // Stub details endpoint so the page doesn't get a 404/error (optional)
+    await page.route("**/api/details/**", (route) =>
+      route.fulfill({ json: null }),
+    );
+    await page.goto("/browse");
+    await expect(browse.titleCard("Test Movie")).toBeVisible();
+
+    // Click the title link inside the article
+    await browse
+      .titleCard("Test Movie")
+      .getByRole("link", { name: "Test Movie" })
+      .first()
+      .click();
+
+    await page.waitForURL(/\/title\/movie-12345/);
+    await expect(page).toHaveURL(/\/title\/movie-12345/);
+
+    // Browse heading and category tabs are no longer visible
+    await expect(browse.browseHeading()).not.toBeVisible();
+  });
+});

--- a/e2e/pages/browse-page.ts
+++ b/e2e/pages/browse-page.ts
@@ -1,0 +1,148 @@
+import type { Page } from "@playwright/test";
+import { BasePage } from "./base-page";
+
+/**
+ * Browse page POM.
+ *
+ * Non-DOM notes:
+ * - The browse page at `/browse` is publicly accessible — no RequireAuth wrapper.
+ * - CategoryBrowse calls GET /api/browse?category=popular&page=1 on load.
+ *   The glob pattern catches all variants (with query params).
+ * - loadFilters calls genres/providers/languages in parallel on mount.
+ * - Filter dropdowns (Genre, Provider) are FilterField components: clicking the
+ *   summary button toggles an absolutely-positioned checklist panel.
+ *   Each option is a label wrapping an input[type=checkbox].
+ * - Active filter chips are button elements with text like "Action x".
+ * - Category tabs use the Pill component which renders as a button.
+ * - Title cards render as article[aria-label={title.title}].
+ * - The BrowseFilterCard type group uses role="group" aria-label="Content type".
+ */
+export class BrowsePage extends BasePage {
+  async gotoBrowse(): Promise<void> {
+    await this.goto("/browse");
+  }
+
+  /**
+   * Mock all filter-data endpoints (genres, providers, languages) and the
+   * browse results endpoint with a single title: "Test Movie" (id "movie-12345").
+   * Call this before navigating. Register more specific browse route mocks AFTER
+   * this call so they win (Playwright applies routes LIFO).
+   */
+  async mockBrowseDataEndpoints(): Promise<void> {
+    await this.page.route("**/api/titles/genres", (route) =>
+      route.fulfill({
+        json: { genres: ["Action", "Drama", "Comedy"] },
+      }),
+    );
+    await this.page.route("**/api/titles/providers", (route) =>
+      route.fulfill({
+        json: {
+          providers: [
+            {
+              id: 8,
+              name: "Netflix",
+              technical_name: "netflix",
+              icon_url: "",
+            },
+          ],
+          regionProviderIds: [8],
+        },
+      }),
+    );
+    await this.page.route("**/api/titles/languages", (route) =>
+      route.fulfill({
+        json: { languages: ["en", "es"], priorityLanguageCodes: ["en"] },
+      }),
+    );
+    await this.page.route("**/api/browse**", (route) =>
+      route.fulfill({
+        json: {
+          titles: [MOCK_BROWSE_TITLE],
+          page: 1,
+          totalPages: 1,
+          totalResults: 1,
+        },
+      }),
+    );
+  }
+
+  browseHeading() {
+    return this.page.getByRole("heading", { name: "Browse" });
+  }
+
+  categoryButton(name: string) {
+    return this.page.getByRole("button", { name, exact: true });
+  }
+
+  genreDropdownButton() {
+    return this.page.getByRole("button", { name: /All genres/i });
+  }
+
+  providerDropdownButton() {
+    return this.page.getByRole("button", { name: /All providers/i });
+  }
+
+  contentTypeGroup() {
+    return this.page.getByRole("group", { name: /Content type/i });
+  }
+
+  titleCard(name: string) {
+    return this.page.getByRole("article", { name });
+  }
+
+  /**
+   * Active filter chips have aria-label="Remove X filter" but display text "X x".
+   * Use getByText for the visible label (the "x" is the Unicode multiplication sign).
+   */
+  activeFilterChip(displayText: string) {
+    return this.page.getByText(displayText, { exact: true });
+  }
+}
+
+/** Standard browse fixture — matches the camelCase SearchTitle shape returned by /api/browse. */
+export const MOCK_BROWSE_TITLE = {
+  id: "movie-12345",
+  objectType: "MOVIE",
+  title: "Test Movie",
+  originalTitle: "Test Movie",
+  releaseYear: 2024,
+  releaseDate: "2024-06-15",
+  runtimeMinutes: 120,
+  shortDescription: "A test movie",
+  genres: ["Action"],
+  imdbId: "tt1234567",
+  tmdbId: 12345,
+  posterUrl: null,
+  ageCertification: "PG-13",
+  originalLanguage: "en",
+  tmdbUrl: "https://www.themoviedb.org/movie/12345",
+  offers: [],
+  scores: { imdbScore: 7.5, imdbVotes: 10000, tmdbScore: 7.8 },
+  isTracked: false,
+};
+
+/** Browse fixture for an Action-genre filter result. */
+export const MOCK_ACTION_TITLE = {
+  ...MOCK_BROWSE_TITLE,
+  id: "movie-99999",
+  title: "Action Movie",
+  originalTitle: "Action Movie",
+};
+
+/** Browse fixture for a Netflix provider filter result. */
+export const MOCK_NETFLIX_TITLE = {
+  ...MOCK_BROWSE_TITLE,
+  id: "movie-88888",
+  title: "Netflix Movie",
+  originalTitle: "Netflix Movie",
+  offers: [
+    {
+      provider_id: 8,
+      provider_name: "Netflix",
+      provider_technical_name: "netflix",
+      provider_icon_url: "",
+      monetization_type: "FLATRATE",
+      url: "https://netflix.com",
+    },
+  ],
+};

--- a/e2e/test-cases/browse.md
+++ b/e2e/test-cases/browse.md
@@ -1,0 +1,267 @@
+# Test cases: browse
+
+## Preconditions (shared)
+
+- The Remindarr dev server is running (Bun on `:3000`, Vite proxy on `:5173`).
+- Unless stated otherwise, the browser is unauthenticated (no active session cookie).
+- The browse page is at `/browse`.
+- All test cases use `page.route()` mocks unless explicitly marked **Real**.
+- Before navigating, mock the following base endpoints so the page renders without hitting
+  the real backend:
+  - `GET **/api/auth/get-session` → `null` (logged-out)
+  - `GET **/api/auth/custom/providers` → `{ local: true, oidc: null }`
+  - `GET **/api/titles/genres` → `{ genres: ["Action", "Drama", "Comedy"] }`
+  - `GET **/api/titles/providers` → `{ providers: [{ id: 8, name: "Netflix", technical_name: "netflix", icon_url: "" }], regionProviderIds: [8] }`
+  - `GET **/api/titles/languages` → `{ languages: ["en", "es"], priorityLanguageCodes: ["en"] }`
+  - `GET **/api/titles/languages` (also used by the advanced search language dropdown)
+  - `GET **/api/browse**` → a standard `browseTitlesResponse` fixture (see below)
+
+### Standard `browseTitlesResponse` fixture
+
+```json
+{
+  "titles": [
+    {
+      "id": "movie-12345",
+      "objectType": "MOVIE",
+      "title": "Test Movie",
+      "originalTitle": "Test Movie",
+      "releaseYear": 2024,
+      "releaseDate": "2024-06-15",
+      "runtimeMinutes": 120,
+      "shortDescription": "A test movie",
+      "genres": ["Action"],
+      "imdbId": "tt1234567",
+      "tmdbId": 12345,
+      "posterUrl": null,
+      "ageCertification": "PG-13",
+      "originalLanguage": "en",
+      "tmdbUrl": "https://www.themoviedb.org/movie/12345",
+      "offers": [],
+      "scores": { "imdbScore": 7.5, "imdbVotes": 10000, "tmdbScore": 7.8 },
+      "isTracked": false
+    }
+  ],
+  "page": 1,
+  "totalPages": 1,
+  "totalResults": 1
+}
+```
+
+---
+
+## TC-01: Browse page loads with category tabs, filter bar, and title cards visible
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: Verifies the complete initial render — page header, category tabs, filter
+dropdowns, and title grid — without touching the real TMDB-backed browse endpoint. A mock
+response guarantees a stable title list for assertion.
+
+**Preconditions**:
+
+- All shared mocks applied (see shared preconditions above).
+- `GET **/api/browse**` returns the standard `browseTitlesResponse` fixture (1 title:
+  `"Test Movie"`).
+
+**Steps**:
+
+1. Apply all shared route mocks.
+2. Navigate to `/browse`.
+3. Wait for `getByRole("heading", { name: "Browse" })` to be visible.
+
+**Expected**:
+
+- Heading `"Browse"` (level 1) is visible.
+- The kicker text above the heading contains `"Catalog"` and a title count (e.g.
+  `"Catalog · 1 titles"`).
+- A search bar with placeholder `"Search titles or paste IMDB link..."` is present.
+- The category bar shows four buttons: `"Popular"`, `"Upcoming"`, `"Top Rated"`,
+  `"Now Playing"`. The `"Popular"` button is active by default.
+- The filter card shows four dropdown buttons: `"All genres"`, `"All providers"`,
+  `"Any year"`, `"Any rating"`.
+- The content-type group (role `group`, `aria-label="Content type"`) shows three
+  buttons: `"All"` (pressed), `"Movies"`, `"Shows"`.
+- `getByRole("article", { name: "Test Movie" })` is visible in the title grid.
+- `getByRole("heading", { name: "Popular", level: 2 })` is visible above the title grid.
+
+---
+
+## TC-02: Genre filter — selecting a genre re-queries the API and updates results
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: Verifies that picking a genre adds a `genre=Action` query param to the
+`/api/browse` request and that the updated results render correctly. Mocking lets us assert
+the exact URL sent to the backend.
+
+**Preconditions**:
+
+- All shared mocks applied.
+- Initial `GET **/api/browse**` (no genre param) returns the standard `browseTitlesResponse`
+  fixture.
+- A second `page.route()` intercepts `GET **/api/browse?*genre=Action*` and returns a
+  fixture with one title: `"Action Movie"` (genre `["Action"]`).
+
+**Steps**:
+
+1. Apply all shared route mocks including the genre-specific intercept.
+2. Navigate to `/browse` and wait for `getByRole("heading", { name: "Browse" })`.
+3. Click `getByRole("button", { name: /All genres/i })` to open the Genre dropdown.
+4. Wait for the genre checklist to appear.
+5. Click the checkbox labelled `"Action"` inside the genre dropdown.
+6. Wait for the title grid to update.
+
+**Expected**:
+
+- The `GET /api/browse` request includes `genre=Action` in the query string.
+- The Genre dropdown button now shows `"Action"` as its summary (not `"All genres"`).
+- An active filter chip with the text `"Action ×"` appears in the active-filters row.
+- `getByRole("article", { name: "Action Movie" })` is visible in the title grid.
+- `getByRole("article", { name: "Test Movie" })` is no longer visible (replaced by the
+  genre-filtered result).
+
+---
+
+## TC-03: Provider filter — selecting a provider updates results
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: Same reasoning as TC-02 — validates that the provider param is forwarded to
+the API and the results re-render.
+
+**Preconditions**:
+
+- All shared mocks applied.
+- Initial `GET **/api/browse**` (no provider param) returns the standard
+  `browseTitlesResponse`.
+- A second route intercept matches `GET **/api/browse?*provider=8*` and returns a fixture
+  with one title: `"Netflix Movie"` whose `offers` array includes a Netflix offer.
+
+**Steps**:
+
+1. Apply all shared route mocks including the provider-specific intercept.
+2. Navigate to `/browse` and wait for `getByRole("heading", { name: "Browse" })`.
+3. Click `getByRole("button", { name: /All providers/i })` to open the Provider dropdown.
+4. Wait for the provider checklist to appear.
+5. Click the checkbox labelled `"Netflix"` inside the provider dropdown.
+6. Wait for the title grid to update.
+
+**Expected**:
+
+- The `GET /api/browse` request includes `provider=8` (or `provider=netflix`) in the query
+  string.
+- The Provider dropdown button summary changes from `"All providers"` to `"Netflix"`.
+- An active filter chip with the text `"Netflix ×"` appears.
+- `getByRole("article", { name: "Netflix Movie" })` is visible.
+
+---
+
+## TC-04: Empty results — no titles match filters
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: Tests the empty-state UI branch; we force zero results by returning an empty
+`titles` array from the browse endpoint.
+
+**Preconditions**:
+
+- All shared mocks applied.
+- `GET **/api/browse**` returns:
+  ```json
+  { "titles": [], "page": 1, "totalPages": 0, "totalResults": 0 }
+  ```
+
+**Steps**:
+
+1. Apply all shared route mocks with the empty-results response.
+2. Navigate to `/browse`.
+3. Wait for `getByRole("heading", { name: "Browse" })`.
+4. Wait for the title grid area to settle (no loading spinner).
+
+**Expected**:
+
+- No `<article>` elements are present in the title grid.
+- The empty-state message `"No titles found."` is visible (rendered by `TitleList`).
+- The filter bar is still rendered (category tabs and filter dropdowns remain visible).
+- No error banner is shown.
+
+---
+
+## TC-05: Unauthenticated user can access /browse (public page)
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: Confirms that `/browse` is not guarded by `RequireAuth` — an unauthenticated
+visitor must reach the page without being redirected to `/login`. The route in `App.tsx`
+confirms this: `/browse` has no `<RequireAuth>` wrapper.
+
+**Preconditions**:
+
+- `GET **/api/auth/get-session` → `null` (explicitly no session).
+- `GET **/api/auth/custom/providers` → `{ local: true, oidc: null }`.
+- `GET **/api/titles/genres` → `{ genres: [] }`.
+- `GET **/api/titles/providers` → `{ providers: [], regionProviderIds: [] }`.
+- `GET **/api/titles/languages` → `{ languages: [], priorityLanguageCodes: [] }`.
+- `GET **/api/browse**` → standard `browseTitlesResponse` fixture.
+
+**Steps**:
+
+1. Apply unauthenticated session mock (`get-session` → `null`).
+2. Apply remaining mocks listed above.
+3. Navigate to `/browse`.
+4. Wait for `getByRole("heading", { name: "Browse" })`.
+
+**Expected**:
+
+- The browser URL remains `/browse` — no redirect to `/login` occurs.
+- `getByRole("heading", { name: "Browse" })` is visible.
+- The top navigation bar shows a `"Sign In"` link (not a user avatar or logout button),
+  confirming the unauthenticated state is correctly reflected.
+- The title grid renders the mocked title.
+
+> **Note**: The `"On my services"` toggle chip does **not** appear for unauthenticated
+> users (it requires `subscriptions.providerIds.length > 0` from the auth context).
+
+---
+
+## TC-06: Clicking a title navigates to the title detail page
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: Navigation is a frontend concern. We only need to verify that the `<Link>`
+element on each title card routes to `/title/<id>`. No detail-page data needs to load.
+
+**Preconditions**:
+
+- All shared mocks applied.
+- `GET **/api/browse**` returns the standard `browseTitlesResponse` (title id
+  `"movie-12345"`, title `"Test Movie"`).
+- `GET **/api/details/**` → any minimal valid response (or left unrouted — we only
+  assert URL change, not detail-page render).
+
+**Steps**:
+
+1. Apply all shared route mocks.
+2. Navigate to `/browse` and wait for `getByRole("heading", { name: "Browse" })`.
+3. Wait for `getByRole("article", { name: "Test Movie" })` to be visible.
+4. Click the `getByRole("link", { name: "Test Movie" })` inside that article (the poster
+   or title heading link — both point to the same URL).
+5. Wait for the URL to change.
+
+**Expected**:
+
+- The browser URL changes to `/title/movie-12345`.
+- The page no longer shows the browse heading or the category tab bar.
+
+> **Implementation note**: Each `TitleCard` renders two `<Link to="/title/${title.id}">`
+> elements — one wrapping the poster image and one wrapping the heading. Either is a valid
+> click target. Prefer `getByRole("link", { name: "Test Movie" })` which matches both; if
+> Playwright finds multiple, scope to the article: `getByRole("article", { name: "Test Movie"
+}).getByRole("link", { name: "Test Movie" }).first()`.


### PR DESCRIPTION
## Summary

- Adds `e2e/pages/browse-page.ts` — Page Object with `mockBrowseDataEndpoints()`, category/filter locators, and fixture data (`MOCK_BROWSE_TITLE`, `MOCK_ACTION_TITLE`, `MOCK_NETFLIX_TITLE`)
- Adds `e2e/browse.spec.ts` — 6 Playwright tests (TC-01 to TC-06) covering initial load, genre/provider filter interactions, empty state, unauthenticated access, and title click navigation
- Adds `e2e/test-cases/browse.md` — human-reviewed test-case spec

Key implementation notes:
- `BrowseFilterCard` filter dropdowns close on Escape; tests close them after checking the checkbox so the active-filter chip row becomes visible
- Active filter chip text uses Unicode × (U+00D7); matched via `getByText()` rather than `getByRole()` since the chip's accessible name is "Remove X filter"
- Genre/provider filter routes use a conditional handler to match only when the specific query param is present

## Test plan

- [x] TC-01: browse page loads with heading, category tabs (Popular/Upcoming/Top Rated/Now Playing), filter dropdowns, Content type group, title card, and Popular h2
- [x] TC-02: selecting Action genre → API re-queried → "Action ×" chip appears → "Action Movie" card visible, "Test Movie" gone
- [x] TC-03: selecting Netflix provider → "Netflix ×" chip appears → "Netflix Movie" visible, "Test Movie" gone
- [x] TC-04: empty results → no article elements, "No titles found." visible, filter bar still rendered
- [x] TC-05: unauthenticated visit → URL stays `/browse`, "Sign In" in nav, title card renders
- [x] TC-06: clicking title card link → URL changes to `/title/movie-12345`, browse heading gone
- [x] All 6 tests pass locally: `bun run test:e2e -- --project=chromium e2e/browse.spec.ts` → 6 passed

Part of #853

🤖 Generated with [Claude Code](https://claude.com/claude-code)