### PR TITLE
feat(e2e): add stats spec (TC-01 to TC-04)

### DIFF
--- a/e2e/pages/stats-page.ts
+++ b/e2e/pages/stats-page.ts
@@ -1,0 +1,135 @@
+import type { Page } from "@playwright/test";
+import { BasePage } from "./base-page";
+
+/**
+ * Stats page POM.
+ *
+ * Non-DOM notes:
+ * - Stats are accessed via the Tracked page at /tracked by clicking the
+ *   "Stats" Pill button. The route /stats redirects to /tracked?view=stats
+ *   but TrackedPage does NOT read the ?view=stats query param — the pill
+ *   must be clicked to switch views.
+ * - TrackedPage calls GET /api/track on mount (getTrackedTitles).
+ * - StatsView calls GET /api/stats when mounted (after clicking the pill).
+ * - The app shell background components (AchievementToast, SuggestedForYouRow,
+ *   AuthContext.getSubscriptions) call additional endpoints that must be mocked
+ *   to prevent auth:unauthorized events from logging the test user out.
+ */
+export class StatsPage extends BasePage {
+  async gotoTracked(): Promise<void> {
+    await this.goto("/tracked");
+  }
+
+  /**
+   * Click the "Stats" pill on the Tracked page to switch to the stats view.
+   * Call gotoTracked() and wait for the page to load before calling this.
+   */
+  async clickStatsPill(): Promise<void> {
+    await this.page.getByRole("button", { name: /^Stats$/i }).click();
+  }
+
+  /**
+   * Stub all endpoints needed for an authenticated visit to /tracked,
+   * excluding GET /api/stats and GET /api/track which tests set up themselves.
+   * Call before navigating. Register stats/track mocks AFTER this call so
+   * they win (Playwright applies routes LIFO).
+   */
+  async mockTrackedShellEndpoints(): Promise<void> {
+    // AuthContext calls getSubscriptions() after auth succeeds.
+    await this.page.route("**/api/user/settings/subscriptions**", (route) =>
+      route.fulfill({ json: { providerIds: [] } }),
+    );
+    // AchievementToast polls /api/achievements/me in the background.
+    await this.page.route("**/api/achievements/me**", (route) =>
+      route.fulfill({ json: [] }),
+    );
+    // SuggestedForYouRow is always rendered on HomePage, but not on TrackedPage.
+    // Still safe to stub in case any lazy-loaded component requests it.
+    await this.page.route("**/api/suggestions**", (route) =>
+      route.fulfill({ json: { flat: [], bySource: {} } }),
+    );
+    // RecommendationsCount badge in the nav shell calls /api/recommendations/count.
+    // Without this mock it returns 401 and fires auth:unauthorized.
+    await this.page.route("**/api/recommendations/count**", (route) =>
+      route.fulfill({ json: { count: 0 } }),
+    );
+  }
+
+  statsHeading() {
+    return this.page.getByText("Stats").first();
+  }
+
+  overviewCard(label: string) {
+    return this.page.getByText(label);
+  }
+
+  sectionHeading(name: string) {
+    return this.page.getByText(name);
+  }
+}
+
+// ── Standard stats fixture ────────────────────────────────────────────────────
+
+export const MOCK_STATS_FULL = {
+  overview: {
+    watched_movies: 12,
+    watched_episodes: 84,
+    tracked_shows: 5,
+    tracked_movies: 7,
+    watch_time_minutes: 3720,
+    watch_time_minutes_shows: 1260,
+    watch_time_minutes_movies: 2460,
+  },
+  genres: [
+    { genre: "Drama", count: 30 },
+    { genre: "Action", count: 18 },
+  ],
+  languages: [
+    { language: "en", count: 45 },
+    { language: "ja", count: 10 },
+  ],
+  monthly: [{ month: "2026-05", movies_watched: 3, episodes_watched: 12 }],
+  shows_by_status: {
+    watching: 3,
+    caught_up: 1,
+    not_started: 0,
+    completed: 1,
+    on_hold: 0,
+    dropped: 0,
+    plan_to_watch: 0,
+    unreleased: 0,
+  },
+  pace: {
+    minutesPerDay: 62,
+    watchlistEtaDays: 14,
+  },
+};
+
+export const MOCK_STATS_EMPTY = {
+  overview: {
+    watched_movies: 0,
+    watched_episodes: 0,
+    tracked_shows: 0,
+    tracked_movies: 0,
+    watch_time_minutes: 0,
+    watch_time_minutes_shows: 0,
+    watch_time_minutes_movies: 0,
+  },
+  genres: [],
+  languages: [],
+  monthly: [],
+  shows_by_status: {
+    watching: 0,
+    caught_up: 0,
+    not_started: 0,
+    completed: 0,
+    on_hold: 0,
+    dropped: 0,
+    plan_to_watch: 0,
+    unreleased: 0,
+  },
+  pace: {
+    minutesPerDay: 0,
+    watchlistEtaDays: null,
+  },
+};

--- a/e2e/stats.spec.ts
+++ b/e2e/stats.spec.ts
@@ -1,0 +1,177 @@
+import { test, expect } from "@playwright/test";
+import { mockLoggedIn, mockLoggedOut } from "./helpers";
+import {
+  StatsPage,
+  MOCK_STATS_FULL,
+  MOCK_STATS_EMPTY,
+} from "./pages/stats-page";
+
+const EMPTY_TRACKED = {
+  titles: [],
+  count: 0,
+  profile_public: false,
+  profile_visibility: "private",
+};
+
+test.describe("Stats", () => {
+  test.skip(
+    ({ browserName }) => browserName !== "chromium",
+    "chromium only — desktop layout requires a stable viewport",
+  );
+
+  // ── TC-01: Stats page loads with all sections visible ──────────────────────
+  test("TC-01: stats page loads with all sections visible", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const stats = new StatsPage(page);
+    await mockLoggedIn(page);
+    await stats.mockTrackedShellEndpoints();
+    await page.route("**/api/track**", (route) =>
+      route.fulfill({ json: EMPTY_TRACKED }),
+    );
+    await page.route("**/api/stats**", (route) =>
+      route.fulfill({ json: MOCK_STATS_FULL }),
+    );
+
+    await stats.gotoTracked();
+    await stats.clickStatsPill();
+
+    // Overview section cards
+    await expect(page.getByText("Movies Watched")).toBeVisible();
+    await expect(page.getByText("Episodes Watched")).toBeVisible();
+    await expect(page.getByText("Shows Tracked")).toBeVisible();
+    await expect(page.getByText("Movies Tracked")).toBeVisible();
+    await expect(page.getByText("Watch Time", { exact: true })).toBeVisible();
+    await expect(page.getByText("Watchlist ETA")).toBeVisible();
+
+    // Monthly Activity section (legend items use exact: true to avoid
+    // matching "Episodes Watched" / "Movies Watched" overview card labels)
+    await expect(page.getByText("Monthly Activity")).toBeVisible();
+    await expect(page.getByText("Episodes", { exact: true })).toBeVisible();
+    await expect(page.getByText("Movies", { exact: true })).toBeVisible();
+
+    // Genre, Language, Status sections
+    await expect(page.getByText("Top Genres")).toBeVisible();
+    await expect(page.getByText("Top Languages")).toBeVisible();
+    await expect(page.getByText("Shows by Status")).toBeVisible();
+
+    // Watch time breakdown cards
+    await expect(page.getByText("TV Watch Time")).toBeVisible();
+    await expect(page.getByText("Movie Watch Time")).toBeVisible();
+  });
+
+  // ── TC-02: Stats show correct counts from mock data ─────────────────────────
+  test("TC-02: stats show correct counts", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const stats = new StatsPage(page);
+    await mockLoggedIn(page);
+    await stats.mockTrackedShellEndpoints();
+    await page.route("**/api/track**", (route) =>
+      route.fulfill({ json: EMPTY_TRACKED }),
+    );
+    await page.route("**/api/stats**", (route) =>
+      route.fulfill({ json: MOCK_STATS_FULL }),
+    );
+
+    await stats.gotoTracked();
+    await stats.clickStatsPill();
+
+    // Wait for stats to render (skeleton disappears)
+    await expect(page.getByText("Movies Watched")).toBeVisible();
+
+    // Overview card values
+    await expect(page.getByText("12").first()).toBeVisible(); // watched_movies
+    await expect(page.getByText("84").first()).toBeVisible(); // watched_episodes
+    await expect(page.getByText("5").first()).toBeVisible(); // tracked_shows
+    await expect(page.getByText("7").first()).toBeVisible(); // tracked_movies
+    await expect(page.getByText("62h")).toBeVisible(); // 3720 min = 62h
+    await expect(page.getByText("~2w")).toBeVisible(); // 14 days ≈ 2 weeks
+
+    // Watch-time breakdown
+    await expect(page.getByText("21h")).toBeVisible(); // 1260 min = 21h
+    await expect(page.getByText("84 episodes")).toBeVisible();
+    await expect(page.getByText("41h")).toBeVisible(); // 2460 min = 41h
+    await expect(page.getByText("12 movies")).toBeVisible();
+
+    // Top Genres
+    await expect(page.getByText("Drama")).toBeVisible();
+    await expect(page.getByText("Action")).toBeVisible();
+
+    // Top Languages (language codes mapped to display names)
+    await expect(page.getByText("English")).toBeVisible();
+    await expect(page.getByText("Japanese")).toBeVisible();
+
+    // Shows by Status — only non-zero entries rendered.
+    // "Watching" also appears in TrackedStatsBand as "Currently watching" but exact:true
+    // avoids that. "Completed" appears in both TrackedStatsBand and ShowStatusGrid;
+    // scope to the Shows by Status section heading's sibling grid.
+    await expect(page.getByText("Watching", { exact: true })).toBeVisible();
+    await expect(page.getByText("Caught Up", { exact: true })).toBeVisible();
+    await expect(
+      page.getByText("Shows by Status").locator("..").getByText("Completed"),
+    ).toBeVisible();
+    // Zero-count entries are NOT rendered
+    await expect(
+      page.getByText("Not Started", { exact: true }),
+    ).not.toBeVisible();
+    await expect(page.getByText("On Hold", { exact: true })).not.toBeVisible();
+    await expect(page.getByText("Dropped", { exact: true })).not.toBeVisible();
+  });
+
+  // ── TC-03: Empty stats — new user with no watch history ─────────────────────
+  test("TC-03: empty stats show zeros and hide empty sections", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const stats = new StatsPage(page);
+    await mockLoggedIn(page);
+    await stats.mockTrackedShellEndpoints();
+    await page.route("**/api/track**", (route) =>
+      route.fulfill({ json: EMPTY_TRACKED }),
+    );
+    await page.route("**/api/stats**", (route) =>
+      route.fulfill({ json: MOCK_STATS_EMPTY }),
+    );
+
+    await stats.gotoTracked();
+    await stats.clickStatsPill();
+
+    // Wait for stats to render
+    await expect(page.getByText("Movies Watched")).toBeVisible();
+
+    // Overview cards show zero values
+    await expect(page.getByText("0h").first()).toBeVisible();
+    // Watchlist ETA is null → displayed as "—" (use first() since TrackedStatsBand
+    // also shows "—" for avg score when there are no rated titles)
+    await expect(page.getByText("—").first()).toBeVisible();
+
+    // Monthly Activity section is always rendered
+    await expect(page.getByText("Monthly Activity")).toBeVisible();
+
+    // Empty array sections are hidden
+    await expect(page.getByText("Top Genres")).not.toBeVisible();
+    await expect(page.getByText("Top Languages")).not.toBeVisible();
+    // tracked_shows === 0 → Shows by Status hidden
+    await expect(page.getByText("Shows by Status")).not.toBeVisible();
+
+    // No error banner
+    await expect(page.locator(".bg-red-900\\/50")).not.toBeVisible();
+  });
+
+  // ── TC-04: Unauthenticated user is redirected to /login ─────────────────────
+  test("TC-04: unauthenticated user is redirected to /login", async ({
+    page,
+  }) => {
+    await mockLoggedOut(page);
+    await page.goto("/stats");
+
+    // RequireAuth redirects to /login
+    await page.waitForURL(/\/login/);
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.getByRole("heading", { name: /sign in/i })).toBeVisible();
+
+    // Stats content is not visible
+    await expect(page.getByText("Monthly Activity")).not.toBeVisible();
+  });
+});

--- a/e2e/test-cases/stats.md
+++ b/e2e/test-cases/stats.md
@@ -1,0 +1,239 @@
+# Test cases: stats
+
+## Preconditions (shared)
+
+- The Remindarr dev server is running (Bun on `:3000`, Vite proxy on `:5173`).
+- The stats view is reached via the **Tracked** page at `/tracked` — the route `/stats`
+  is a redirect alias to `/tracked?view=stats`, and the Stats view is activated by clicking
+  the **Stats** pill on that page. Note: `TrackedPage` does **not** read `?view=stats`
+  from the URL query param; the pill must be clicked to switch views.
+- `GET /api/stats` is the backing endpoint (requires auth).
+- Unless stated otherwise, the browser is authenticated via `mockLoggedIn(page)`.
+
+---
+
+## TC-01: Stats page loads with stats sections visible
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: The stats layout and section headings are pure frontend concerns. Mocking
+`GET /api/stats` with a realistic payload lets the test assert that all six sections render
+correctly without depending on a seeded database.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` has been called.
+- `page.route()` intercepts `GET **/api/stats` and returns HTTP 200 with a payload
+  containing non-zero overview counts, at least one genre, at least one language, 13
+  monthly entries, and non-zero `shows_by_status` values.
+- `page.route()` intercepts `GET **/api/titles**` and returns `{ titles: [], count: 0 }`.
+
+**Steps**:
+
+1. Set up route intercepts as described in preconditions.
+2. Navigate to `/tracked`.
+3. `getByText("Stats")` (the Stats pill) → click.
+4. Wait for the stats content to appear (skeleton disappears).
+
+**Expected**:
+
+- The heading `getByText("Stats")` is visible on the page.
+- The overview grid is visible, containing cards labelled:
+  - `getByText("Movies Watched")`
+  - `getByText("Episodes Watched")`
+  - `getByText("Shows Tracked")`
+  - `getByText("Movies Tracked")`
+  - `getByText("Watch Time")`
+  - `getByText("Watchlist ETA")`
+- The section heading `getByText("Monthly Activity")` is visible.
+- The legend items `getByText("Episodes")` and `getByText("Movies")` are visible.
+- The section heading `getByText("Top Genres")` is visible.
+- The section heading `getByText("Top Languages")` is visible.
+- The section heading `getByText("Shows by Status")` is visible.
+- The watch-time breakdown cards `getByText("TV Watch Time")` and
+  `getByText("Movie Watch Time")` are visible.
+
+---
+
+## TC-02: Stats show correct counts
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: The displayed values come directly from the API response. Mocking the
+response with specific numbers lets the test assert exact rendered values without
+seeding a database.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` has been called.
+- `page.route()` intercepts `GET **/api/stats` and returns:
+
+  ```json
+  {
+    "overview": {
+      "watched_movies": 12,
+      "watched_episodes": 84,
+      "tracked_shows": 5,
+      "tracked_movies": 7,
+      "watch_time_minutes": 3720,
+      "watch_time_minutes_shows": 1260,
+      "watch_time_minutes_movies": 2460
+    },
+    "genres": [
+      { "genre": "Drama", "count": 30 },
+      { "genre": "Action", "count": 18 }
+    ],
+    "languages": [
+      { "language": "en", "count": 45 },
+      { "language": "ja", "count": 10 }
+    ],
+    "monthly": [
+      { "month": "2026-05", "movies_watched": 3, "episodes_watched": 12 }
+    ],
+    "shows_by_status": {
+      "watching": 3,
+      "caught_up": 1,
+      "not_started": 0,
+      "completed": 1,
+      "on_hold": 0,
+      "dropped": 0,
+      "plan_to_watch": 0,
+      "unreleased": 0
+    },
+    "pace": {
+      "minutesPerDay": 62,
+      "watchlistEtaDays": 14
+    }
+  }
+  ```
+
+- `page.route()` intercepts `GET **/api/titles**` and returns `{ titles: [], count: 0 }`.
+
+**Steps**:
+
+1. Set up route intercepts as described in preconditions.
+2. Navigate to `/tracked`.
+3. `getByText("Stats")` (the Stats pill) → click.
+4. Wait for the stats content to render (no skeleton visible).
+
+**Expected**:
+
+- The Movies Watched card displays the value `12`.
+- The Episodes Watched card displays the value `84`.
+- The Shows Tracked card displays the value `5`.
+- The Movies Tracked card displays the value `7`.
+- The Watch Time card displays `62h` (3720 min = 62h exactly).
+- The Watchlist ETA card displays `~2w` (14 days formatted as approximately 2 weeks).
+- The TV Watch Time breakdown card displays `21h` and sub-label containing `84 episodes`.
+- The Movie Watch Time breakdown card displays `41h` and sub-label containing `12 movies`.
+- `getByText("Drama")` is visible in the Top Genres section with count `30`.
+- `getByText("Action")` is visible in the Top Genres section with count `18`.
+- `getByText("English")` is visible in the Top Languages section with count `45`.
+- `getByText("Japanese")` is visible in the Top Languages section with count `10`.
+- In the Shows by Status grid, a cell shows `3` with label `Watching`.
+- In the Shows by Status grid, a cell shows `1` with label `Caught Up`.
+- In the Shows by Status grid, a cell shows `1` with label `Completed`.
+- Status entries with count `0` (`Not Started`, `On Hold`, `Dropped`, `Plan to Watch`,
+  `Unreleased`) are **not** rendered (the component returns `null` for zero-count entries).
+
+---
+
+## TC-03: Empty stats — new user with no watch history
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: A zero-state user is trivial to reproduce via a mock response. This test
+verifies that the page does not crash or show broken UI when all counts are zero, genre
+and language arrays are empty, and monthly activity has no data.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` has been called.
+- `page.route()` intercepts `GET **/api/stats` and returns:
+
+  ```json
+  {
+    "overview": {
+      "watched_movies": 0,
+      "watched_episodes": 0,
+      "tracked_shows": 0,
+      "tracked_movies": 0,
+      "watch_time_minutes": 0,
+      "watch_time_minutes_shows": 0,
+      "watch_time_minutes_movies": 0
+    },
+    "genres": [],
+    "languages": [],
+    "monthly": [],
+    "shows_by_status": {
+      "watching": 0,
+      "caught_up": 0,
+      "not_started": 0,
+      "completed": 0,
+      "on_hold": 0,
+      "dropped": 0,
+      "plan_to_watch": 0,
+      "unreleased": 0
+    },
+    "pace": {
+      "minutesPerDay": 0,
+      "watchlistEtaDays": null
+    }
+  }
+  ```
+
+- `page.route()` intercepts `GET **/api/titles**` and returns `{ titles: [], count: 0 }`.
+
+**Steps**:
+
+1. Set up route intercepts as described in preconditions.
+2. Navigate to `/tracked`.
+3. `getByText("Stats")` (the Stats pill) → click.
+4. Wait for the stats content to render.
+
+**Expected**:
+
+- The six overview cards are visible with value `0` for counts and `0h` for watch time.
+- The Watchlist ETA card displays `—` (the null ETA sentinel).
+- The TV Watch Time card displays `0h` with sub-label `0 episodes`.
+- The Movie Watch Time card displays `0h` with sub-label `0 movies`.
+- The `Top Genres` section heading is **not** rendered (empty array → section hidden).
+- The `Top Languages` section heading is **not** rendered (empty array → section hidden).
+- The `Shows by Status` section heading is **not** rendered
+  (`tracked_shows === 0` guards the entire block).
+- The Monthly Activity section **is** still rendered (the chart container is always shown,
+  but all bar columns are flat/empty).
+- No error banner or crash is visible.
+
+---
+
+## TC-04: Unauthenticated user is redirected to /login
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: The auth guard is a frontend `RequireAuth` component that reads the session
+from `GET /api/auth/get-session`. Using `mockLoggedOut(page)` (from `e2e/helpers.ts`) to
+return `null` is sufficient to trigger the redirect without a real server.
+
+**Preconditions**:
+
+- `mockLoggedOut(page)` has been called (stubs `GET /api/auth/get-session` → `null` and
+  `GET /api/auth/custom/providers` → `{ local: true, oidc: null }`).
+
+**Steps**:
+
+1. Call `mockLoggedOut(page)` to inject a mock logged-out session.
+2. Navigate to `/stats`.
+3. Wait for navigation to settle.
+
+**Expected**:
+
+- The browser first redirects to `/tracked?view=stats` (the alias redirect from `App.tsx`).
+- Then the `RequireAuth` guard on the Tracked page redirects to `/login`.
+- The final URL is `/login` (or `/login?redirect=...`).
+- The login form is visible: `getByRole("heading", { name: /sign in/i })`.
+- The stats page content (overview cards, Monthly Activity heading) is **not** visible.


### PR DESCRIPTION
## Summary

- Adds `e2e/pages/stats-page.ts` — Page Object with `gotoTracked()`, `clickStatsPill()`, `mockTrackedShellEndpoints()`, and fixtures `MOCK_STATS_FULL` / `MOCK_STATS_EMPTY`
- Adds `e2e/stats.spec.ts` — 4 Playwright tests (TC-01 to TC-04) covering stats sections visibility, correct count rendering, empty-state behavior, and unauthenticated redirect
- Adds `e2e/test-cases/stats.md` — human-reviewed test-case spec

Key implementation notes:
- Stats are accessed by navigating to `/tracked` and clicking the "Stats" pill button (the `/stats` route redirects there but `TrackedPage` ignores `?view=stats`)
- `mockTrackedShellEndpoints()` stubs `subscriptions`, `achievements/me`, `suggestions`, and `recommendations/count` — the last being the critical 401 source that triggers `auth:unauthorized` and logs the test user out
- Several `getByText` assertions use `{ exact: true }` or parent-scoped locators to avoid strict-mode violations from overlapping labels in `TrackedStatsBand` vs `StatsView`

## Test plan

- [x] TC-01: all stats sections visible (overview cards, Monthly Activity legend, Top Genres/Languages/Shows by Status headings, watch-time breakdown)
- [x] TC-02: correct counts rendered (12 movies, 84 episodes, 62h total, ~2w ETA, 21h TV/41h movie breakdown, Drama/Action genres, English/Japanese languages, Watching=3/Caught Up=1/Completed=1, zero-count statuses hidden)
- [x] TC-03: empty stats — zeros, "—" for null ETA, Monthly Activity always shown, Top Genres/Languages/Shows by Status hidden
- [x] TC-04: unauthenticated visit to `/stats` redirects to `/login`
- [x] All 4 tests pass locally: `bun run test:e2e -- --project=chromium e2e/stats.spec.ts` → 4 passed

Part of #853

🤖 Generated with [Claude Code](https://claude.com/claude-code)