### PR TITLE
feat(e2e): leaderboard spec (TC-01 to TC-05)

### DIFF
--- a/e2e/leaderboard.spec.ts
+++ b/e2e/leaderboard.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from "@playwright/test";
+import { mockLoggedIn, mockLoggedOut } from "./helpers";
+import {
+  LeaderboardPage,
+  MOCK_LEADERBOARD_FOUR_ENTRIES,
+  MOCK_LEADERBOARD_WITH_ME,
+} from "./pages/leaderboard-page";
+
+test.describe("Leaderboard", () => {
+  test.skip(
+    ({ browserName }) => browserName !== "chromium",
+    "chromium only — desktop layout requires a stable viewport",
+  );
+
+  // ── TC-01: Leaderboard loads and shows ranked users ──────────────────────────
+  test("TC-01: leaderboard loads with podium and ranked list", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const lb = new LeaderboardPage(page);
+    await mockLoggedIn(page);
+    await lb.mockLeaderboardShellEndpoints();
+    await page.route("**/api/leaderboard**", (route) =>
+      route.fulfill({ json: MOCK_LEADERBOARD_FOUR_ENTRIES }),
+    );
+
+    await lb.gotoLeaderboard();
+    await expect(lb.pageHeading()).toBeVisible();
+
+    // Subtitle
+    await expect(page.getByText("Among people you follow")).toBeVisible();
+
+    // Podium: ranks 1–3 visible
+    await expect(page.getByText("#1")).toBeVisible();
+    await expect(page.getByText("#2")).toBeVisible();
+    await expect(page.getByText("#3")).toBeVisible();
+
+    // Podium entries: Alice (rank 1, shown center), Bob (rank 2, left), Charlie (rank 3, right)
+    await expect(page.getByText("Alice", { exact: true })).toBeVisible();
+    await expect(page.getByText("Bob", { exact: true })).toBeVisible();
+    await expect(page.getByText("Charlie", { exact: true })).toBeVisible();
+
+    // XP visible for podium entries
+    await expect(page.getByText("500 XP")).toBeVisible();
+
+    // Ranked list shows Diana at #4
+    await expect(page.getByText("#4")).toBeVisible();
+    await expect(page.getByText("Diana", { exact: true })).toBeVisible();
+
+    // No error banner
+    await expect(page.locator(".bg-red-900\\/40")).not.toBeVisible();
+  });
+
+  // ── TC-02: Current user's entry is highlighted ───────────────────────────────
+  test("TC-02: current user podium card has amber highlight", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const lb = new LeaderboardPage(page);
+    await mockLoggedIn(page);
+    await lb.mockLeaderboardShellEndpoints();
+    await page.route("**/api/leaderboard**", (route) =>
+      route.fulfill({ json: MOCK_LEADERBOARD_WITH_ME }),
+    );
+
+    await lb.gotoLeaderboard();
+    await expect(lb.pageHeading()).toBeVisible();
+
+    // Current user is rank 2 (in podium). Locate the @testuser text, then
+    // walk up to the podium card container and verify amber highlight class.
+    const usernameEl = page.getByText("@testuser");
+    await expect(usernameEl).toBeVisible();
+
+    // The PodiumSpot div is the first ancestor div with border-amber-400/40
+    const podiumCard = usernameEl
+      .locator("xpath=ancestor::div[contains(@class,'border-amber')]")
+      .first();
+    await expect(podiumCard).toBeVisible();
+    await expect(podiumCard).toHaveClass(/border-amber/);
+
+    // Other podium cards (Alice, Bob) do not have amber border
+    const aliceCard = page
+      .getByText("@alice")
+      .locator("xpath=ancestor::div[contains(@class,'rounded-xl')]")
+      .first();
+    await expect(aliceCard).not.toHaveClass(/border-amber/);
+  });
+
+  // ── TC-03: Empty leaderboard shows empty state message ───────────────────────
+  test("TC-03: empty leaderboard shows follow prompt", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const lb = new LeaderboardPage(page);
+    await mockLoggedIn(page);
+    await lb.mockLeaderboardShellEndpoints();
+    await page.route("**/api/leaderboard**", (route) =>
+      route.fulfill({ json: { entries: [] } }),
+    );
+
+    await lb.gotoLeaderboard();
+
+    // Heading and subtitle visible in empty state
+    await expect(lb.pageHeading()).toBeVisible();
+    await expect(page.getByText("Among people you follow")).toBeVisible();
+
+    // Empty state message
+    await expect(
+      page.getByText(/follow people to see them on the leaderboard/i),
+    ).toBeVisible();
+
+    // No podium rank labels
+    await expect(page.getByText("#1")).not.toBeVisible();
+    await expect(page.getByText("#2")).not.toBeVisible();
+    await expect(page.getByText("#3")).not.toBeVisible();
+  });
+
+  // ── TC-05: Unauthenticated user is redirected to /login ──────────────────────
+  test("TC-05: unauthenticated user is redirected to /login", async ({
+    page,
+  }) => {
+    await mockLoggedOut(page);
+    await page.goto("/leaderboard");
+
+    await page.waitForURL(/\/login/);
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.getByRole("heading", { name: /sign in/i })).toBeVisible();
+
+    // Leaderboard content not visible
+    await expect(
+      page.getByRole("heading", { name: /leaderboard/i }),
+    ).not.toBeVisible();
+  });
+});

--- a/e2e/pages/leaderboard-page.ts
+++ b/e2e/pages/leaderboard-page.ts
@@ -1,0 +1,122 @@
+import type { Page } from "@playwright/test";
+import { BasePage } from "./base-page";
+
+/**
+ * Leaderboard page POM.
+ *
+ * Non-DOM notes:
+ * - LeaderboardPage at /leaderboard calls GET /api/leaderboard.
+ * - The podium reorders entries for visual display: 2nd left, 1st center, 3rd right.
+ * - Current user's podium card has amber border/bg; list row also has amber styling.
+ * - Empty state condition: entries.length <= 1 (not just 0).
+ * - App shell endpoints must be mocked to prevent auth:unauthorized logout events.
+ */
+export class LeaderboardPage extends BasePage {
+  async gotoLeaderboard(): Promise<void> {
+    await this.goto("/leaderboard");
+  }
+
+  /**
+   * Stub all shell endpoints needed for authenticated visits to the leaderboard page.
+   * Does NOT mock /api/leaderboard — tests register that themselves.
+   */
+  async mockLeaderboardShellEndpoints(): Promise<void> {
+    await this.page.route("**/api/user/settings/subscriptions**", (route) =>
+      route.fulfill({ json: { providerIds: [] } }),
+    );
+    await this.page.route("**/api/recommendations/count**", (route) =>
+      route.fulfill({ json: { count: 0 } }),
+    );
+    await this.page.route("**/api/achievements/me**", (route) =>
+      route.fulfill({ json: { achievements: [] } }),
+    );
+  }
+
+  pageHeading() {
+    return this.page.getByRole("heading", { name: /leaderboard/i });
+  }
+}
+
+// ── Leaderboard fixtures ──────────────────────────────────────────────────────
+
+export const MOCK_LEADERBOARD_FOUR_ENTRIES = {
+  entries: [
+    {
+      userId: "user-2",
+      username: "alice",
+      name: "Alice",
+      image: null,
+      xp: 500,
+      badgeCount: 3,
+      rank: 1,
+    },
+    {
+      userId: "user-3",
+      username: "bob",
+      name: "Bob",
+      image: null,
+      xp: 420,
+      badgeCount: 2,
+      rank: 2,
+    },
+    {
+      userId: "user-4",
+      username: "charlie",
+      name: "Charlie",
+      image: null,
+      xp: 310,
+      badgeCount: 1,
+      rank: 3,
+    },
+    {
+      userId: "user-5",
+      username: "diana",
+      name: "Diana",
+      image: null,
+      xp: 200,
+      badgeCount: 0,
+      rank: 4,
+    },
+  ],
+};
+
+export const MOCK_LEADERBOARD_WITH_ME = {
+  entries: [
+    {
+      userId: "user-2",
+      username: "alice",
+      name: "Alice",
+      image: null,
+      xp: 600,
+      badgeCount: 4,
+      rank: 1,
+    },
+    {
+      userId: "user-1",
+      username: "testuser",
+      name: "Test User",
+      image: null,
+      xp: 500,
+      badgeCount: 3,
+      rank: 2,
+    },
+    {
+      userId: "user-3",
+      username: "bob",
+      name: "Bob",
+      image: null,
+      xp: 400,
+      badgeCount: 2,
+      rank: 3,
+    },
+    {
+      userId: "user-4",
+      username: "charlie",
+      name: "Charlie",
+      image: null,
+      xp: 200,
+      badgeCount: 0,
+      rank: 4,
+    },
+  ],
+};

--- a/e2e/test-cases/leaderboard.md
+++ b/e2e/test-cases/leaderboard.md
@@ -1,0 +1,259 @@
+# Test cases: leaderboard
+
+## Preconditions (shared)
+
+- The Remindarr dev server is running (Bun on `:3000`, Vite dev server on `:5173`).
+- The leaderboard page is at `/leaderboard`.
+- The leaderboard API endpoint is `GET /api/leaderboard` (requires auth; returns
+  `{ entries: LeaderboardEntry[] }` where each entry has `userId`, `username`, `name`,
+  `image`, `xp`, `badgeCount`, `rank`).
+- Unless stated otherwise, `mockLoggedIn(page)` is called before each test so the
+  `RequireAuth` guard passes.
+
+---
+
+## TC-01: Leaderboard loads and shows ranked users
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: The leaderboard data is deterministic once stubbed — mocking keeps the test
+hermetic, avoids a real DB with follow relationships, and lets us assert exact text.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` is called with `MOCK_SESSION` (current user id `"user-1"`).
+- `page.route()` intercepts `GET **/api/leaderboard` and returns:
+  ```json
+  {
+    "entries": [
+      {
+        "userId": "user-2",
+        "username": "alice",
+        "name": "Alice",
+        "image": null,
+        "xp": 500,
+        "badgeCount": 3,
+        "rank": 1
+      },
+      {
+        "userId": "user-3",
+        "username": "bob",
+        "name": "Bob",
+        "image": null,
+        "xp": 420,
+        "badgeCount": 2,
+        "rank": 2
+      },
+      {
+        "userId": "user-4",
+        "username": "charlie",
+        "name": "Charlie",
+        "image": null,
+        "xp": 310,
+        "badgeCount": 1,
+        "rank": 3
+      },
+      {
+        "userId": "user-5",
+        "username": "diana",
+        "name": "Diana",
+        "image": null,
+        "xp": 200,
+        "badgeCount": 0,
+        "rank": 4
+      }
+    ]
+  }
+  ```
+
+**Steps**:
+
+1. Call `mockLoggedIn(page)`.
+2. Set up `page.route()` intercept on `**/api/leaderboard` as described above.
+3. Navigate to `/leaderboard`.
+4. Wait for the heading to appear: `getByRole("heading", { name: /leaderboard/i })`.
+
+**Expected**:
+
+- The page heading `"Leaderboard"` is visible.
+- The subtitle `"Among people you follow"` is visible.
+- The podium section shows exactly three entries (ranks 1–3): `"Alice"`, `"Bob"`,
+  `"Charlie"` with their rank labels `#1`, `#2`, `#3`.
+- Rank labels use `#` prefix (e.g. `getByText("#1")` is visible).
+- XP values are visible for podium entries (e.g. `"500 XP"` for Alice).
+- The ranked-list section below the podium shows `"Diana"` at `#4`.
+- No error banner is rendered.
+
+---
+
+## TC-02: Current user's entry is highlighted
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: The highlight is a purely client-side comparison of `entry.userId` against the
+session's user id. A mocked session and mocked leaderboard response are sufficient.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` is called. `MOCK_SESSION.user.id` is `"user-1"`.
+- `page.route()` intercepts `GET **/api/leaderboard` and returns an entry for the current
+  user in both the podium and the list:
+  ```json
+  {
+    "entries": [
+      {
+        "userId": "user-2",
+        "username": "alice",
+        "name": "Alice",
+        "image": null,
+        "xp": 600,
+        "badgeCount": 4,
+        "rank": 1
+      },
+      {
+        "userId": "user-1",
+        "username": "testuser",
+        "name": "Test User",
+        "image": null,
+        "xp": 500,
+        "badgeCount": 3,
+        "rank": 2
+      },
+      {
+        "userId": "user-3",
+        "username": "bob",
+        "name": "Bob",
+        "image": null,
+        "xp": 400,
+        "badgeCount": 2,
+        "rank": 3
+      },
+      {
+        "userId": "user-4",
+        "username": "charlie",
+        "name": "Charlie",
+        "image": null,
+        "xp": 200,
+        "badgeCount": 0,
+        "rank": 4
+      }
+    ]
+  }
+  ```
+  (Current user is rank 2 — in the podium.)
+
+**Steps**:
+
+1. Call `mockLoggedIn(page)`.
+2. Set up `page.route()` intercept as described above.
+3. Navigate to `/leaderboard`.
+4. Wait for `getByRole("heading", { name: /leaderboard/i })` to be visible.
+5. Locate the podium card containing `"Test User"` / `"@testuser"`.
+
+**Expected**:
+
+- The current user's podium card has a visually distinct highlight (amber border/background).
+  Assert by checking that the card container has an amber highlight class or `aria` attribute
+  distinguishable from the other cards — use `getByText("@testuser").locator("..")` to
+  reach the card's parent and assert it has `class` containing `amber` or equivalent.
+- The other podium cards (Alice, Bob) do not carry the same highlight styling.
+- If the current user appears in the ranked list (rank 4+), that row is similarly
+  highlighted compared to adjacent rows.
+
+---
+
+## TC-03: Empty leaderboard — no entries (or only the user themselves)
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: The empty state is a client-side branch (`entries.length <= 1`). A mocked
+empty array response exercises this path without any DB state.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` is called.
+- `page.route()` intercepts `GET **/api/leaderboard` and returns `{ "entries": [] }`.
+
+**Steps**:
+
+1. Call `mockLoggedIn(page)`.
+2. Set up `page.route()` intercept returning `{ "entries": [] }`.
+3. Navigate to `/leaderboard`.
+4. Wait for the page to finish loading (no skeleton/pulse elements visible).
+
+**Expected**:
+
+- The heading `"Leaderboard"` and subtitle `"Among people you follow"` are visible.
+- The empty-state message `"Follow people to see them on the leaderboard."` is visible
+  (`getByText(/follow people to see them on the leaderboard/i)`).
+- No podium cards are rendered.
+- No ranked-list rows are rendered.
+- A trophy icon is present alongside the empty-state message.
+
+---
+
+## TC-04: Clicking a user navigates to their profile
+
+**Priority**: P2
+**Backend**: Mock
+
+**Why P2 / design note**: The current `LeaderboardPage.tsx` renders names and usernames as
+plain text — there are no `<a>` or `<Link>` elements wrapping the user cards. This TC
+documents the **expected navigation behaviour** so that when clickable profiles are added the
+test can be promoted to P1 and automated.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` is called.
+- `page.route()` intercepts `GET **/api/leaderboard` and returns at least three entries
+  (same payload as TC-01).
+
+**Steps** (manual / future automation):
+
+1. Call `mockLoggedIn(page)`.
+2. Set up `page.route()` intercept with a multi-entry payload.
+3. Navigate to `/leaderboard`.
+4. Wait for the leaderboard entries to render.
+5. Click the podium card or list row for username `"alice"`.
+
+**Expected** (target behaviour once implemented):
+
+- The browser navigates to `/user/alice`.
+- The user profile page for Alice is rendered (heading or username `"alice"` visible).
+
+**Current state**: This navigation is not yet implemented. The TC is recorded so it can
+be automated once the feature ships. When automating, add a `page.route()` stub for
+`**/api/user/alice` returning a minimal profile payload to keep the test hermetic.
+
+---
+
+## TC-05: Auth requirement — unauthenticated access redirects to login
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: The `RequireAuth` guard in `App.tsx` is a client-side route check. Stubbing
+`GET /api/auth/get-session` with a null session via `mockLoggedOut(page)` is sufficient;
+no real session or DB state is required.
+
+**Preconditions**:
+
+- `mockLoggedOut(page)` is called to stub the session endpoint with `null`.
+- No `mockLoggedIn(page)` call is made.
+
+**Steps**:
+
+1. Call `mockLoggedOut(page)` to inject a null session.
+2. Navigate directly to `/leaderboard`.
+3. Wait for any client-side redirect to resolve.
+
+**Expected**:
+
+- The browser is redirected away from `/leaderboard` to `/login` (or equivalent auth
+  entry point).
+- The leaderboard content (`getByRole("heading", { name: /leaderboard/i })`) is never
+  rendered.
+- The login form (or login page) is visible.


### PR DESCRIPTION
Part of #853

## Summary
- Adds `e2e/pages/leaderboard-page.ts` — `LeaderboardPage` POM with `mockLeaderboardShellEndpoints()` (stubs subscriptions, recommendations/count, achievements/me) and fixture exports
- Adds `e2e/leaderboard.spec.ts` — 4 Playwright tests covering page load with podium/ranked list, current-user amber highlight, empty-state follow prompt, and unauthenticated redirect
- Adds `e2e/test-cases/leaderboard.md` — human-reviewed test-case spec
- TC-04 (click-to-profile navigation) is not automated — the feature is not yet implemented in the component (documented in the test-case spec)

## Test plan
- [ ] TC-01: leaderboard loads with podium (ranks 1–3) and ranked list (rank 4+)
- [ ] TC-02: current user's podium card has amber border/background highlight
- [ ] TC-03: empty leaderboard (no entries) shows "Follow people to see them on the leaderboard."
- [ ] TC-05: unauthenticated user is redirected to /login

🤖 Generated with [Claude Code](https://claude.com/claude-code)