### PR TITLE
feat(e2e): Invite / Accept flow tests (TC-01–TC-07)

### DIFF
--- a/e2e/invite-accept.spec.ts
+++ b/e2e/invite-accept.spec.ts
@@ -1,0 +1,279 @@
+import { test, expect } from "@playwright/test";
+import { mockLoggedOut, mockLoggedIn } from "./helpers";
+import { InvitePage } from "./pages/invite-page";
+
+test.describe.configure({ mode: "serial" });
+
+const MOCK_INVITATION_PENDING = {
+  id: "inv-001",
+  code: "ABCD1234",
+  created_at: "2026-05-20T10:00:00Z",
+  expires_at: "2026-06-20T10:00:00Z",
+  used_at: null,
+  used_by: null,
+};
+
+const MOCK_INVITATION_USED = {
+  id: "inv-002",
+  code: "EFGH5678",
+  created_at: "2026-05-01T08:00:00Z",
+  expires_at: "2026-06-01T08:00:00Z",
+  used_at: "2026-05-10T14:00:00Z",
+  used_by: {
+    id: "user-2",
+    username: "alice",
+    display_name: "Alice",
+    image: null,
+  },
+};
+
+async function setupInviteMocks(
+  page: InvitePage["page"],
+  invitations: object[] = [],
+) {
+  // Background shell components — must mock to prevent auth:unauthorized.
+  await page.route("**/api/achievements/me**", (route) =>
+    route.fulfill({ json: [] }),
+  );
+  await page.route("**/api/recommendations/count**", (route) =>
+    route.fulfill({ json: { count: 0 } }),
+  );
+  await page.route("**/api/user/settings/subscriptions**", (route) =>
+    route.fulfill({ json: { providerIds: [], onlyMine: false } }),
+  );
+  // Invitations endpoint
+  await page.route("**/api/invitations**", (route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({ json: { invitations } });
+    }
+    return route.fulfill({ json: {} });
+  });
+}
+
+test.describe("Invite / Accept flow", () => {
+  test.skip(
+    ({ browserName }) => browserName !== "chromium",
+    "Running on chromium only",
+  );
+
+  test("TC-01: Page loads with heading, generate button, and empty invitation list", async ({
+    page,
+  }) => {
+    const ip = new InvitePage(page);
+    await setupInviteMocks(page);
+    await mockLoggedIn(page);
+    await ip.gotoInvite();
+    await ip.waitForVisible(ip.heading());
+
+    await expect(ip.heading()).toBeVisible();
+    await expect(ip.createButton()).toBeVisible();
+    await expect(ip.createButton()).toBeEnabled();
+    await expect(ip.emptyState()).toBeVisible();
+
+    expect(page.url()).toContain("/invite");
+  });
+
+  test("TC-02: Generating an invitation link adds it to the list", async ({
+    page,
+  }) => {
+    const ip = new InvitePage(page);
+    await setupInviteMocks(page);
+    await mockLoggedIn(page);
+
+    let postCalled = 0;
+    // Stateful: after POST, GET returns the new invitation
+    let invitations: object[] = [];
+    await page.route("**/api/invitations**", async (route) => {
+      if (route.request().method() === "POST") {
+        postCalled++;
+        invitations = [MOCK_INVITATION_PENDING];
+        await route.fulfill({
+          status: 201,
+          json: {
+            id: "inv-001",
+            code: "ABCD1234",
+            expires_at: "2026-06-20T10:00:00Z",
+          },
+        });
+      } else {
+        await route.fulfill({ json: { invitations } });
+      }
+    });
+
+    await ip.gotoInvite();
+    await ip.waitForVisible(ip.createButton());
+
+    await ip.createButton().click();
+
+    // Wait for invitation card to appear
+    await expect(page.getByText("ABCD1234")).toBeVisible({ timeout: 10000 });
+
+    expect(postCalled).toBe(1);
+
+    // Status badge shows "Pending"
+    await expect(page.getByText("Pending")).toBeVisible();
+
+    // Code in monospace element
+    await expect(
+      page.locator("code").filter({ hasText: "ABCD1234" }),
+    ).toBeVisible();
+
+    // Revoke button visible (pending-only)
+    await expect(page.getByRole("button", { name: /revoke/i })).toBeVisible();
+
+    // Empty-state gone
+    await expect(ip.emptyState()).not.toBeVisible();
+  });
+
+  test("TC-03: Auto-redeeming a valid invite code shows a success banner", async ({
+    page,
+  }) => {
+    const ip = new InvitePage(page);
+    await setupInviteMocks(page);
+    await mockLoggedIn(page);
+
+    await page.route("**/api/invitations/redeem/VALIDCODE**", (route) =>
+      route.fulfill({
+        json: {
+          success: true,
+          inviter: { id: "user-99", username: "bob", display_name: "Bob" },
+        },
+      }),
+    );
+
+    await ip.gotoInviteWithCode("VALIDCODE");
+    await ip.waitForVisible(ip.heading());
+
+    // Wait for success banner containing Bob's name
+    await expect(page.getByText(/bob/i, { exact: false }).first()).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Green success banner rendered
+    await expect(ip.redeemBanner()).toBeVisible();
+
+    // No error banner
+    await expect(ip.errorBanner()).not.toBeVisible();
+
+    // Code removed from URL
+    await page.waitForURL("**/invite", { waitUntil: "commit" });
+    expect(page.url()).not.toContain("code=");
+  });
+
+  test("TC-04: Auto-redeeming an expired/invalid code shows an error banner", async ({
+    page,
+  }) => {
+    const ip = new InvitePage(page);
+    await setupInviteMocks(page);
+    await mockLoggedIn(page);
+
+    await page.route("**/api/invitations/redeem/BADCODE**", (route) =>
+      route.fulfill({
+        status: 410,
+        json: { error: "Invitation has expired" },
+      }),
+    );
+
+    await ip.gotoInviteWithCode("BADCODE");
+    await ip.waitForVisible(ip.heading());
+
+    // Wait for error banner
+    await expect(page.getByText("Invitation has expired").first()).toBeVisible({
+      timeout: 10000,
+    });
+
+    await expect(ip.errorBanner()).toBeVisible();
+
+    // No success banner
+    await expect(ip.redeemBanner()).not.toBeVisible();
+
+    // Code removed from URL
+    await page.waitForURL("**/invite", { waitUntil: "commit" });
+    expect(page.url()).not.toContain("code=");
+  });
+
+  test("TC-05: Revoking a pending invitation removes it", async ({ page }) => {
+    const ip = new InvitePage(page);
+    await setupInviteMocks(page, [MOCK_INVITATION_PENDING]);
+    await mockLoggedIn(page);
+
+    let deleteCalled = 0;
+    let currentInvitations: object[] = [MOCK_INVITATION_PENDING];
+
+    // Single stateful handler covers both GET /invitations and DELETE /invitations/:id
+    // Registered after setupInviteMocks so it has higher priority (LIFO).
+    await page.route("**/api/invitations**", async (route) => {
+      const method = route.request().method();
+      const url = route.request().url();
+      if (method === "DELETE" && url.includes("/inv-001")) {
+        deleteCalled++;
+        currentInvitations = [];
+        await route.fulfill({ json: {} });
+      } else if (method === "GET" && !url.includes("/inv-")) {
+        await route.fulfill({
+          json: { invitations: currentInvitations },
+        });
+      } else {
+        await route.fulfill({ json: {} });
+      }
+    });
+
+    await ip.gotoInvite();
+    await ip.waitForVisible(page.getByText("ABCD1234"));
+
+    await page.getByRole("button", { name: /revoke/i }).click();
+
+    // Wait for empty state after list refetch
+    await expect(ip.emptyState()).toBeVisible({ timeout: 10000 });
+
+    expect(deleteCalled).toBe(1);
+
+    // Invitation card is gone
+    await expect(page.getByText("ABCD1234")).not.toBeVisible();
+  });
+
+  test("TC-06: Unauthenticated user is redirected to /login", async ({
+    page,
+  }) => {
+    const ip = new InvitePage(page);
+    await mockLoggedOut(page);
+    await ip.gotoInvite();
+    await page.waitForURL("**/login**", { waitUntil: "commit" });
+
+    expect(page.url()).toContain("/login");
+    await expect(ip.heading()).not.toBeVisible();
+    await expect(ip.createButton()).not.toBeVisible();
+  });
+
+  test("TC-07: Used invitation card shows who redeemed it and links to their profile", async ({
+    page,
+  }) => {
+    const ip = new InvitePage(page);
+    await setupInviteMocks(page, [MOCK_INVITATION_USED]);
+    await mockLoggedIn(page);
+
+    await ip.gotoInvite();
+    await ip.waitForVisible(ip.heading());
+
+    // Wait for invitation card
+    await expect(page.getByText("EFGH5678")).toBeVisible({ timeout: 10000 });
+
+    // Status badge shows "Used by @Alice"
+    await expect(
+      page.getByText(/used by/i, { exact: false }).first(),
+    ).toBeVisible();
+
+    // Link to @alice's profile
+    const aliceLink = page.getByRole("link", { name: "@alice" });
+    await expect(aliceLink).toBeVisible();
+    await expect(aliceLink).toHaveAttribute("href", "/user/alice");
+
+    // No Revoke or Share buttons (used-only hides pending actions)
+    await expect(
+      page.getByRole("button", { name: /revoke/i }),
+    ).not.toBeVisible();
+
+    // Green tinted card
+    await expect(page.locator(".bg-green-900\\/20").first()).toBeVisible();
+  });
+});

--- a/e2e/pages/invite-page.ts
+++ b/e2e/pages/invite-page.ts
@@ -1,0 +1,36 @@
+import type { Page } from "@playwright/test";
+import { BasePage } from "./base-page";
+
+export class InvitePage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async gotoInvite(): Promise<void> {
+    await super.goto("/invite");
+  }
+
+  async gotoInviteWithCode(code: string): Promise<void> {
+    await super.goto(`/invite?code=${code}`);
+  }
+
+  heading() {
+    return this.page.getByRole("heading", { level: 1 });
+  }
+
+  createButton() {
+    return this.page.getByRole("button", { name: /create invite link/i });
+  }
+
+  emptyState() {
+    return this.page.getByText(/no invitations yet/i);
+  }
+
+  redeemBanner() {
+    return this.page.locator(".bg-green-900\\/20");
+  }
+
+  errorBanner() {
+    return this.page.locator(".bg-red-900\\/20");
+  }
+}

--- a/e2e/test-cases/invite-accept.md
+++ b/e2e/test-cases/invite-accept.md
@@ -1,0 +1,291 @@
+# Test cases: invite-accept
+
+## Preconditions (shared)
+
+- The Remindarr dev server is running (Bun on `:3000`, Vite proxy on `:5173`).
+- The invite page is at `/invite` (wrapped in `<RequireAuth>` — the user must be logged in).
+- When a share link is visited (`/invite?code=<code>`), the page auto-redeems the code via
+  `POST /api/invitations/redeem/:code` immediately after mount.
+- All test cases use `page.route()` mocks unless explicitly marked **Real**.
+- Before navigating, apply the following base mocks so the page shell renders without hitting
+  the real backend:
+  - `GET **/api/auth/get-session` → `MOCK_SESSION` (logged-in user, from `e2e/helpers.ts`)
+  - `GET **/api/auth/custom/providers` → `{ local: true, oidc: null }`
+  - `GET **/api/invitations` → `{ invitations: [] }` (empty list by default)
+
+### Standard invitation fixture
+
+```json
+{
+  "invitations": [
+    {
+      "id": "inv-001",
+      "code": "ABCD1234",
+      "created_at": "2026-05-20T10:00:00Z",
+      "expires_at": "2026-06-20T10:00:00Z",
+      "used_at": null,
+      "used_by": null
+    }
+  ]
+}
+```
+
+### Standard used-invitation fixture
+
+```json
+{
+  "invitations": [
+    {
+      "id": "inv-002",
+      "code": "EFGH5678",
+      "created_at": "2026-05-01T08:00:00Z",
+      "expires_at": "2026-06-01T08:00:00Z",
+      "used_at": "2026-05-10T14:00:00Z",
+      "used_by": {
+        "id": "user-2",
+        "username": "alice",
+        "display_name": "Alice",
+        "image": null
+      }
+    }
+  ]
+}
+```
+
+---
+
+## TC-01: Page loads with heading, generate button, and empty invitation list
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: Verifies the initial render of the invite management UI — heading, generate
+button, and empty-state message — without touching the real invitation store.
+
+**Preconditions**:
+
+- All shared mocks applied (`get-session` → `MOCK_SESSION`).
+- `GET **/api/invitations` → `{ invitations: [] }`.
+
+**Steps**:
+
+1. Apply all shared route mocks.
+2. Navigate to `/invite`.
+3. Wait for the `h1` heading to be visible.
+
+**Expected**:
+
+- The page heading (level 1) is visible and contains the invite page title (e.g. `"Invite"`
+  or similar i18n key rendered as a heading with a `UserPlus` icon beside it).
+- A prominent amber/yellow button labelled `"Create invite link"` (or similar) is visible and
+  enabled.
+- The empty-state paragraph (`"No invitations yet"` or similar) is visible because the
+  invitations list is empty.
+- No error banner is shown.
+- The URL remains `/invite` — no redirect occurred (confirming `RequireAuth` let the logged-in
+  user through).
+
+---
+
+## TC-02: Generating an invitation link adds it to the list
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: Validates the create-invitation mutation: the button click fires
+`POST /api/invitations`, the list re-fetches, and the new invitation card renders with a
+pending status badge and copy/share actions.
+
+**Preconditions**:
+
+- All shared mocks applied.
+- `GET **/api/invitations` (initial fetch) → `{ invitations: [] }`.
+- `POST **/api/invitations` → `{ id: "inv-001", code: "ABCD1234", expires_at: "2026-06-20T10:00:00Z" }` (HTTP 201).
+- `GET **/api/invitations` (re-fetch after mutation) → the standard invitation fixture
+  containing one pending invitation with code `"ABCD1234"`.
+
+**Steps**:
+
+1. Apply all shared route mocks.
+2. Navigate to `/invite` and wait for the heading to appear.
+3. Click the `getByRole("button", { name: /create invite link/i })`.
+4. Wait for the invitation list to update.
+
+**Expected**:
+
+- The `POST /api/invitations` request was made.
+- A success toast (Sonner) appears briefly.
+- The invitation card for `"ABCD1234"` is visible.
+- The status badge on the card reads `"Pending"` (pending clock icon).
+- The card shows the code `"ABCD1234"` in a monospace `<code>` element.
+- A `"Share"` (or copy) button and a `"Revoke"` button are visible in the card actions.
+- The empty-state message is no longer visible.
+
+---
+
+## TC-03: Auto-redeeming a valid invite code shows a success banner
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: The redeem flow is triggered by the `?code=` query parameter on mount. Mocking
+`POST /api/invitations/redeem/:code` lets us verify the success banner renders with the
+inviter's name without needing a real invitation in the DB.
+
+**Preconditions**:
+
+- All shared mocks applied.
+- `GET **/api/invitations` → standard invitation fixture (or empty — not the focus here).
+- `POST **/api/invitations/redeem/VALIDCODE` → HTTP 200:
+  ```json
+  {
+    "success": true,
+    "inviter": { "id": "user-99", "username": "bob", "display_name": "Bob" }
+  }
+  ```
+
+**Steps**:
+
+1. Apply all shared route mocks including the redeem intercept.
+2. Navigate to `/invite?code=VALIDCODE`.
+3. Wait for the heading to appear.
+4. Wait for the redeem banner to become visible (the `redeeming` spinner disappears and
+   `redeemResult` is set).
+
+**Expected**:
+
+- While redeeming, a loading message (e.g. `"Redeeming..."`) is briefly visible.
+- After success, a green banner is visible containing the inviter's name `"Bob"` (the
+  `t("invite.redeemSuccess", { name: "Bob" })` message).
+- A success toast also appears.
+- The URL is updated to `/invite` (the `?code=` param is removed via `setSearchParams({},
+{ replace: true })`).
+- No red error banner is shown.
+
+---
+
+## TC-04: Auto-redeeming an expired/invalid code shows an error banner
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: Tests the error branch: the backend returns a 4xx and the page should show a
+red error banner with the server's error message.
+
+**Preconditions**:
+
+- All shared mocks applied.
+- `POST **/api/invitations/redeem/BADCODE` → HTTP 410 with body:
+  ```json
+  { "error": "Invitation has expired" }
+  ```
+  (Trigger the rejection by having `page.route()` call
+  `route.fulfill({ status: 410, json: { error: "Invitation has expired" } })`. The api
+  client will throw, and the `.catch` block in the `useEffect` will set `redeemResult` to
+  `{ status: "error", message: "Invitation has expired" }`.)
+
+**Steps**:
+
+1. Apply all shared route mocks including the failing redeem intercept.
+2. Navigate to `/invite?code=BADCODE`.
+3. Wait for the heading to appear.
+4. Wait for the error banner to become visible.
+
+**Expected**:
+
+- A red error banner is visible containing the message `"Invitation has expired"`.
+- An error toast also appears.
+- The URL is updated to `/invite` (code param removed).
+- No green success banner is shown.
+
+---
+
+## TC-05: Revoking a pending invitation removes it (or marks it revoked)
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: Validates the revoke mutation: clicking the revoke button fires
+`DELETE /api/invitations/:id`, the list re-fetches, and the card disappears (or is removed
+from the pending state).
+
+**Preconditions**:
+
+- All shared mocks applied.
+- `GET **/api/invitations` (initial) → standard invitation fixture (1 pending invitation,
+  id `"inv-001"`).
+- `DELETE **/api/invitations/inv-001` → `{ success: true }` (HTTP 200).
+- `GET **/api/invitations` (re-fetch) → `{ invitations: [] }`.
+
+**Steps**:
+
+1. Apply all shared route mocks.
+2. Navigate to `/invite` and wait for the invitation card with code `"ABCD1234"` to appear.
+3. Click the `getByRole("button", { name: /revoke/i })` within the invitation card.
+4. Wait for the list to update.
+
+**Expected**:
+
+- The `DELETE /api/invitations/inv-001` request was made.
+- A success toast appears.
+- The invitation card for `"ABCD1234"` is no longer visible.
+- The empty-state message reappears.
+
+---
+
+## TC-06: Unauthenticated user is redirected to /login
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: Confirms that `/invite` is guarded by `<RequireAuth>`. An unauthenticated
+visitor must be redirected to `/login`, never reaching the invite UI.
+
+**Preconditions**:
+
+- `GET **/api/auth/get-session` → `null` (no session).
+- `GET **/api/auth/custom/providers` → `{ local: true, oidc: null }`.
+
+**Steps**:
+
+1. Apply unauthenticated mocks (`get-session` → `null`).
+2. Navigate to `/invite`.
+3. Wait for the URL to change.
+
+**Expected**:
+
+- The browser URL changes to `/login` (or `/login?redirect=/invite`) — `RequireAuth`
+  redirected the visitor.
+- The invite heading and the generate-invitation button are **not** visible.
+
+---
+
+## TC-07: Used invitation card shows who redeemed it and links to their profile
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: Tests the `"used"` status branch of `InvitationCard`. A used invitation renders
+a green card with a `"Used by Alice"` label and a link to `@alice`'s profile page.
+
+**Preconditions**:
+
+- All shared mocks applied.
+- `GET **/api/invitations` → the standard used-invitation fixture (code `"EFGH5678"`,
+  used by `{ username: "alice", display_name: "Alice" }`).
+
+**Steps**:
+
+1. Apply all shared route mocks.
+2. Navigate to `/invite` and wait for the heading.
+3. Wait for an invitation card to appear.
+
+**Expected**:
+
+- The status badge shows a green `"Used"` state (CheckCircle2 icon).
+- The card body contains text matching `"Used by Alice"` or similar.
+- A link with text `"@alice"` is present and its `href` equals `/user/alice`.
+- No `"Revoke"` or `"Share"` button is visible (pending-only actions are hidden for used
+  invitations).
+- The card has a green tinted background/border (CSS classes `bg-green-900/20`,
+  `border-green-900/40`).


### PR DESCRIPTION
## Summary

- Adds 7 E2E tests for the `/invite` page (create invitation, auto-redeem via `?code=`, revoke, auth guard, used invitation card)
- Covers: page load + empty state, create invitation POST, successful code redeem banner, failed code redeem error banner, revoke DELETE + list update, auth redirect, used invitation card with profile link
- Uses a single stateful `**/api/invitations**` route handler to correctly reflect DELETE/GET state changes without route priority conflicts

Part of #853

## Test plan

- [x] All 7 TCs pass locally on chromium: `bun run test:e2e -- invite-accept --project=chromium`
- [x] Pre-push hook passes (types + lint + format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)