### PR TITLE
feat(e2e): Shared Watchlist page tests (TC-01–TC-06)

### DIFF
--- a/e2e/pages/shared-watchlist-page.ts
+++ b/e2e/pages/shared-watchlist-page.ts
@@ -1,0 +1,34 @@
+import type { Page } from "@playwright/test";
+import { BasePage } from "./base-page";
+
+export class SharedWatchlistPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async gotoWatchlist(token: string): Promise<void> {
+    await super.goto(`/share/watchlist/${token}`);
+  }
+
+  heading() {
+    return this.page.getByRole("heading", { level: 1 });
+  }
+
+  errorHeading() {
+    return this.page.getByText("This link is invalid or has been revoked", {
+      exact: true,
+    });
+  }
+
+  emptyState() {
+    return this.page.getByText("This watchlist is empty", { exact: true });
+  }
+
+  poweredByLink() {
+    return this.page.getByRole("link", { name: "Remindarr" }).last();
+  }
+
+  goToRemindarrLink() {
+    return this.page.getByRole("link", { name: "Go to Remindarr" });
+  }
+}

--- a/e2e/shared-watchlist.spec.ts
+++ b/e2e/shared-watchlist.spec.ts
@@ -1,0 +1,203 @@
+import { test, expect } from "@playwright/test";
+import { mockLoggedOut } from "./helpers";
+import { SharedWatchlistPage } from "./pages/shared-watchlist-page";
+
+test.describe.configure({ mode: "serial" });
+
+const MOCK_TITLE = {
+  id: "tt1234567",
+  object_type: "MOVIE",
+  title: "Test Movie",
+  original_title: "Test Movie",
+  release_year: 2024,
+  release_date: "2024-01-15",
+  runtime_minutes: 120,
+  short_description: "A test movie",
+  genres: ["Action"],
+  imdb_id: "tt1234567",
+  tmdb_id: 12345,
+  poster_url: null,
+  age_certification: "PG-13",
+  original_language: "en",
+  tmdb_url: "https://www.themoviedb.org/movie/12345",
+  imdb_score: 7.5,
+  imdb_votes: 10000,
+  tmdb_score: 7.8,
+  is_tracked: false,
+  offers: [],
+};
+
+const STANDARD_WATCHLIST = {
+  username: "alice",
+  titles: [MOCK_TITLE],
+};
+
+async function setupPublicShellMocks(page: SharedWatchlistPage["page"]) {
+  // Auth shell — public page, no session required.
+  await page.route("**/api/auth/get-session", (route) =>
+    route.fulfill({ json: null }),
+  );
+  await page.route("**/api/auth/custom/providers", (route) =>
+    route.fulfill({ json: { local: true, oidc: null } }),
+  );
+}
+
+test.describe("Shared Watchlist page", () => {
+  test.skip(
+    ({ browserName }) => browserName !== "chromium",
+    "Running on chromium only",
+  );
+
+  test("TC-01: Page loads and shows the owner's titles", async ({ page }) => {
+    const swp = new SharedWatchlistPage(page);
+    await setupPublicShellMocks(page);
+    await page.route("**/api/share/watchlist/valid-token-abc**", (route) =>
+      route.fulfill({ json: STANDARD_WATCHLIST }),
+    );
+
+    await swp.gotoWatchlist("valid-token-abc");
+    await swp.waitForVisible(swp.heading());
+
+    // Heading with count and username
+    await expect(swp.heading()).toContainText("1 title");
+    await expect(swp.heading()).toContainText("shared by");
+    await expect(page.getByText("@alice")).toBeVisible();
+
+    // Read-only subtitle
+    await expect(
+      page.getByText("Read-only view — sign in to track these titles"),
+    ).toBeVisible();
+
+    // Title card for Test Movie
+    await expect(page.getByText("Test Movie").first()).toBeVisible();
+    await expect(page.getByText("2024")).toBeVisible();
+
+    // Footer
+    await expect(swp.poweredByLink()).toBeVisible();
+
+    // No error state
+    await expect(swp.errorHeading()).not.toBeVisible();
+  });
+
+  test("TC-02: Page is accessible without authentication", async ({ page }) => {
+    const swp = new SharedWatchlistPage(page);
+    await mockLoggedOut(page);
+    await page.route("**/api/share/watchlist/public-token**", (route) =>
+      route.fulfill({ json: STANDARD_WATCHLIST }),
+    );
+
+    await swp.gotoWatchlist("public-token");
+    await swp.waitForVisible(swp.heading());
+
+    // URL remains on the watchlist page — no redirect to /login
+    expect(page.url()).toContain("/share/watchlist/public-token");
+
+    // Owner username visible
+    await expect(page.getByText("@alice")).toBeVisible();
+
+    // Sign In link visible (unauthenticated nav)
+    await expect(
+      page.getByRole("link", { name: /sign in/i }).first(),
+    ).toBeVisible();
+  });
+
+  test("TC-03: Invalid or revoked token shows the error state", async ({
+    page,
+  }) => {
+    const swp = new SharedWatchlistPage(page);
+    await setupPublicShellMocks(page);
+    await page.route("**/api/share/watchlist/bad-token**", (route) =>
+      route.fulfill({ status: 404, json: { error: "Not found" } }),
+    );
+
+    await swp.gotoWatchlist("bad-token");
+    await swp.waitForVisible(swp.errorHeading());
+
+    await expect(swp.errorHeading()).toBeVisible();
+    await expect(
+      page.getByText(
+        "The watchlist you are looking for is no longer available.",
+      ),
+    ).toBeVisible();
+    await expect(swp.goToRemindarrLink()).toBeVisible();
+    await expect(swp.goToRemindarrLink()).toHaveAttribute("href", "/");
+
+    // No title grid
+    await expect(page.getByText("@alice")).not.toBeVisible();
+  });
+
+  test("TC-04: Empty watchlist shows the empty-state message", async ({
+    page,
+  }) => {
+    const swp = new SharedWatchlistPage(page);
+    await setupPublicShellMocks(page);
+    await page.route("**/api/share/watchlist/empty-token**", (route) =>
+      route.fulfill({ json: { username: "bob", titles: [] } }),
+    );
+
+    await swp.gotoWatchlist("empty-token");
+    await swp.waitForVisible(swp.heading());
+
+    // Heading shows 0 titles and @bob
+    await expect(swp.heading()).toContainText("0 title");
+    await expect(page.getByText("@bob")).toBeVisible();
+
+    // Empty state message
+    await expect(swp.emptyState()).toBeVisible();
+
+    // No title cards
+    await expect(page.getByText("Test Movie")).not.toBeVisible();
+
+    // Footer still present
+    await expect(swp.poweredByLink()).toBeVisible();
+  });
+
+  test("TC-05: Clicking a title card navigates to the title detail page", async ({
+    page,
+  }) => {
+    const swp = new SharedWatchlistPage(page);
+    await setupPublicShellMocks(page);
+    await page.route("**/api/share/watchlist/nav-token**", (route) =>
+      route.fulfill({ json: STANDARD_WATCHLIST }),
+    );
+
+    await swp.gotoWatchlist("nav-token");
+    await swp.waitForVisible(swp.heading());
+
+    // Title card link is present with href to /title/tt1234567
+    const titleLink = page.getByRole("link", { name: "Test Movie" }).first();
+    await expect(titleLink).toBeVisible();
+    await expect(titleLink).toHaveAttribute("href", "/title/tt1234567");
+
+    // Navigate via click and check URL
+    await titleLink.click();
+    await page.waitForURL("**/title/tt1234567**", { waitUntil: "commit" });
+    expect(page.url()).toContain("/title/tt1234567");
+  });
+
+  test("TC-06: Loading skeleton is shown while the API request is in flight", async ({
+    page,
+  }) => {
+    const swp = new SharedWatchlistPage(page);
+    await setupPublicShellMocks(page);
+
+    // Delayed mock to keep the loading state visible
+    await page.route("**/api/share/watchlist/slow-token**", async (route) => {
+      await new Promise((r) => setTimeout(r, 800));
+      await route.fulfill({ json: STANDARD_WATCHLIST });
+    });
+
+    // Start navigation without waiting
+    void swp.gotoWatchlist("slow-token");
+
+    // While loading: skeleton pulse element visible, heading not yet present
+    await expect(page.locator(".animate-pulse").first()).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(swp.heading()).not.toBeVisible();
+
+    // After loading: heading appears and skeleton gone
+    await swp.waitForVisible(swp.heading());
+    await expect(swp.heading()).toContainText("1 title");
+  });
+});

--- a/e2e/test-cases/shared-watchlist.md
+++ b/e2e/test-cases/shared-watchlist.md
@@ -1,0 +1,228 @@
+# Test cases: shared-watchlist
+
+## Preconditions (shared)
+
+- The Remindarr dev server is running (Bun on `:3000`, Vite proxy on `:5173`).
+- The shared watchlist page is at `/share/watchlist/:token` — this is a **public** route
+  with no `<RequireAuth>` wrapper. Authentication is not required to view it.
+- The page fetches `GET /api/share/watchlist/:token`. The backend looks up the share token;
+  if found it returns `{ username, titles[] }`; if not found it returns HTTP 404.
+- All test cases use `page.route()` mocks unless explicitly marked **Real**.
+- No session or auth mock is strictly required (the page is public), but apply
+  `GET **/api/auth/get-session` → `null` and
+  `GET **/api/auth/custom/providers` → `{ local: true, oidc: null }` to prevent spurious
+  auth requests from the shell from erroring.
+
+### Standard watchlist fixture
+
+```json
+{
+  "username": "alice",
+  "titles": [
+    {
+      "id": "tt1234567",
+      "object_type": "MOVIE",
+      "title": "Test Movie",
+      "original_title": "Test Movie",
+      "release_year": 2024,
+      "release_date": "2024-01-15",
+      "runtime_minutes": 120,
+      "short_description": "A test movie",
+      "genres": ["Action"],
+      "imdb_id": "tt1234567",
+      "tmdb_id": 12345,
+      "poster_url": null,
+      "age_certification": "PG-13",
+      "original_language": "en",
+      "tmdb_url": "https://www.themoviedb.org/movie/12345",
+      "imdb_score": 7.5,
+      "imdb_votes": 10000,
+      "tmdb_score": 7.8,
+      "is_tracked": false,
+      "offers": []
+    }
+  ]
+}
+```
+
+---
+
+## TC-01: Page loads and shows the owner's titles
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: Verifies the complete initial render — heading with owner username, title count,
+read-only subtitle, and the title grid — without a real user account or share token. A mock
+response guarantees a stable fixture for assertion.
+
+**Preconditions**:
+
+- Auth shell mocks applied (`get-session` → `null`, `providers` → local only).
+- `GET **/api/share/watchlist/valid-token-abc` → the standard watchlist fixture
+  (`username: "alice"`, 1 title: `"Test Movie"`).
+
+**Steps**:
+
+1. Apply route mocks for the auth shell and the watchlist endpoint.
+2. Navigate to `/share/watchlist/valid-token-abc`.
+3. Wait for the `h1` heading to be visible.
+
+**Expected**:
+
+- The heading (level 1) reads `"1 title shared by"` and contains `"@alice"` in amber/yellow
+  text.
+- A subtitle reads `"Read-only view — sign in to track these titles"`.
+- A title card for `"Test Movie"` is present in the grid (rendered as a `<Link>` to
+  `/title/tt1234567`).
+- The card shows the title text `"Test Movie"` and the year `"2024"`.
+- A footer `"Powered by Remindarr"` link pointing to `/` is visible at the bottom.
+- No error state (`"This link is invalid or has been revoked"`) is shown.
+
+---
+
+## TC-02: Page is accessible without authentication
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: Confirms that `/share/watchlist/:token` is not guarded by `RequireAuth`. An
+unauthenticated visitor must reach the page without being redirected to `/login`.
+
+**Preconditions**:
+
+- `GET **/api/auth/get-session` → `null` (explicitly no session).
+- `GET **/api/auth/custom/providers` → `{ local: true, oidc: null }`.
+- `GET **/api/share/watchlist/public-token` → the standard watchlist fixture.
+
+**Steps**:
+
+1. Apply unauthenticated session mock (`get-session` → `null`).
+2. Apply the watchlist mock.
+3. Navigate to `/share/watchlist/public-token`.
+4. Wait for the heading to appear.
+
+**Expected**:
+
+- The browser URL remains `/share/watchlist/public-token` — no redirect to `/login`.
+- The heading with `"@alice"` is visible.
+- The top navigation bar shows a `"Sign In"` link (unauthenticated state).
+
+---
+
+## TC-03: Invalid or revoked token shows the error state
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: Tests the error branch: when the API returns a non-OK response (404), the page
+must show the link-invalid message instead of a title grid.
+
+**Preconditions**:
+
+- Auth shell mocks applied.
+- `GET **/api/share/watchlist/bad-token` → HTTP 404 with body `{ "error": "Not found" }`.
+
+**Steps**:
+
+1. Apply route mocks (auth shell + the 404 response for the watchlist endpoint).
+2. Navigate to `/share/watchlist/bad-token`.
+3. Wait for the error heading to appear.
+
+**Expected**:
+
+- The heading reads `"This link is invalid or has been revoked"`.
+- The sub-paragraph reads `"The watchlist you are looking for is no longer available."`.
+- A link reading `"Go to Remindarr"` is present and points to `/`.
+- No title grid or `"@username"` heading is shown.
+
+---
+
+## TC-04: Empty watchlist shows the empty-state message
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: Tests the zero-titles branch within a valid share link. The heading still
+renders with the owner's name but the grid area shows the empty-state copy.
+
+**Preconditions**:
+
+- Auth shell mocks applied.
+- `GET **/api/share/watchlist/empty-token` → HTTP 200:
+  ```json
+  { "username": "bob", "titles": [] }
+  ```
+
+**Steps**:
+
+1. Apply route mocks.
+2. Navigate to `/share/watchlist/empty-token`.
+3. Wait for the heading.
+
+**Expected**:
+
+- The heading reads `"0 titles shared by"` with `"@bob"` in amber text.
+- No title link cards are present in the page body.
+- The empty-state paragraph `"This watchlist is empty"` is visible.
+- The footer `"Powered by Remindarr"` is still present.
+
+---
+
+## TC-05: Clicking a title card navigates to the title detail page
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: Navigation is a frontend concern. The shared watchlist renders each title as a
+`<Link to="/title/:id">`. We only need to verify the link href; no detail-page data needs
+to load.
+
+**Preconditions**:
+
+- Auth shell mocks applied.
+- `GET **/api/share/watchlist/nav-token` → the standard watchlist fixture (title id
+  `"tt1234567"`, title `"Test Movie"`).
+- `GET **/api/details/**` → left unrouted (we only assert URL change, not page render).
+
+**Steps**:
+
+1. Apply route mocks.
+2. Navigate to `/share/watchlist/nav-token` and wait for the heading.
+3. Wait for the title card link for `"Test Movie"` to be visible.
+4. Click `getByRole("link", { name: "Test Movie" })`.
+5. Wait for the URL to change.
+
+**Expected**:
+
+- The browser URL changes to `/title/tt1234567`.
+
+---
+
+## TC-06: Loading skeleton is shown while the API request is in flight
+
+**Priority**: P2
+**Backend**: Mock
+
+**Why mock**: Verifies the loading state branch. By delaying the mock response we can assert
+that the skeleton placeholder renders before the data arrives.
+
+**Preconditions**:
+
+- Auth shell mocks applied.
+- `GET **/api/share/watchlist/slow-token` → the standard watchlist fixture, but the
+  `page.route()` handler uses `await new Promise(r => setTimeout(r, 800))` before
+  calling `route.fulfill(...)` to simulate a slow response.
+
+**Steps**:
+
+1. Apply route mocks with the artificial delay.
+2. Navigate to `/share/watchlist/slow-token` (do NOT await the heading yet).
+3. Immediately assert the loading state.
+4. Then wait for the heading to appear.
+
+**Expected**:
+
+- While loading: an animated skeleton placeholder element is visible (from
+  `TitleGridSkeleton`) and the heading is not yet present.
+- After loading: the heading `"1 title shared by @alice"` appears and the skeleton is gone.


### PR DESCRIPTION
## Summary

- Adds 6 E2E tests for the public `/share/watchlist/:token` page
- Covers: page load with owner titles, public access without auth, invalid token error state, empty watchlist, title card navigation, and loading skeleton
- No auth background mocks needed — `AchievementToast` is gated on `{user && ...}` and `BottomTabBar` recommendation count has `enabled: !!user`

Part of #853

## Test plan

- [x] All 6 TCs pass locally on chromium: `bun run test:e2e -- shared-watchlist --project=chromium`
- [x] Pre-push hook passes (types + lint + format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)