### PR TITLE
feat(e2e): Settings admin tab E2E tests (TC-01–TC-06)

### DIFF
--- a/e2e/pages/settings-admin-page.ts
+++ b/e2e/pages/settings-admin-page.ts
@@ -1,0 +1,40 @@
+import type { Page } from "@playwright/test";
+import { BasePage } from "./base-page";
+
+export class SettingsAdminPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async gotoAdminTab(): Promise<void> {
+    await super.goto("/settings?tab=admin");
+  }
+
+  backgroundJobsSection() {
+    return this.page.getByText("Background jobs").first();
+  }
+
+  oidcSection() {
+    return this.page.getByText("OpenID Connect").first();
+  }
+
+  runtimeConfigSection() {
+    return this.page.getByText("Runtime configuration").first();
+  }
+
+  serverLogsSection() {
+    return this.page.getByText("Server logs").first();
+  }
+
+  maintenanceSection() {
+    return this.page.getByText("Maintenance").first();
+  }
+
+  manageUsersLink() {
+    return this.page.getByRole("link", { name: /manage users/i });
+  }
+
+  saveOidcButton() {
+    return this.page.getByRole("button", { name: /save oidc settings/i });
+  }
+}

--- a/e2e/settings-admin.spec.ts
+++ b/e2e/settings-admin.spec.ts
@@ -1,0 +1,268 @@
+import { test, expect } from "@playwright/test";
+import { mockLoggedIn } from "./helpers";
+import { SettingsAdminPage } from "./pages/settings-admin-page";
+
+test.describe.configure({ mode: "serial" });
+
+// Admin session — MOCK_SESSION does NOT have admin role; construct inline.
+const MOCK_ADMIN_SESSION = {
+  session: {
+    id: "session-1",
+    userId: "user-1",
+    expiresAt: "2099-01-01T00:00:00Z",
+    token: "mock-session-token",
+  },
+  user: {
+    id: "user-1",
+    name: "Admin User",
+    email: "admin@example.com",
+    username: "admin",
+    role: "admin",
+    is_admin: true,
+  },
+};
+
+async function mockAdminSession(page: SettingsAdminPage["page"]) {
+  await page.route("**/api/auth/get-session", (route) =>
+    route.fulfill({ json: MOCK_ADMIN_SESSION }),
+  );
+  await page.route("**/api/auth/custom/providers", (route) =>
+    route.fulfill({ json: { local: true, oidc: null } }),
+  );
+}
+
+const UNCONFIGURED_SETTINGS = {
+  oidc: {
+    issuer_url: { value: "", source: "unset" },
+    client_id: { value: "", source: "unset" },
+    client_secret: { value: "", source: "unset" },
+    redirect_uri: { value: "", source: "unset" },
+    admin_claim: { value: "", source: "unset" },
+    admin_value: { value: "", source: "unset" },
+  },
+  oidc_configured: false,
+};
+
+async function mockAdminApis(page: SettingsAdminPage["page"]) {
+  await page.route("**/api/jobs**", (route) =>
+    route.fulfill({
+      json: { crons: [], stats: {}, recentJobs: [] },
+    }),
+  );
+  await page.route("**/api/admin/settings**", (route) =>
+    route.fulfill({ json: UNCONFIGURED_SETTINGS }),
+  );
+  await page.route("**/api/admin/config**", (route) =>
+    route.fulfill({ json: { safe: [], secrets: [] } }),
+  );
+  await page.route("**/api/admin/logs**", (route) =>
+    route.fulfill({ json: { entries: [], count: 0 } }),
+  );
+}
+
+// Background mocks required for all authenticated pages.
+async function mockBackgroundApis(page: SettingsAdminPage["page"]) {
+  await page.route("**/api/achievements/me**", (route) =>
+    route.fulfill({ json: [] }),
+  );
+  await page.route("**/api/recommendations/count**", (route) =>
+    route.fulfill({ json: { count: 0 } }),
+  );
+  await page.route("**/api/user/settings/subscriptions**", (route) =>
+    route.fulfill({ json: { providerIds: [], onlyMine: false } }),
+  );
+}
+
+test.describe("Settings — admin tab", () => {
+  test.skip(
+    ({ browserName }) => browserName !== "chromium",
+    "Running on chromium only",
+  );
+
+  test("TC-01: Admin tab is accessible to admin users and shows all sections", async ({
+    page,
+  }) => {
+    const sap = new SettingsAdminPage(page);
+    await mockAdminSession(page);
+    await mockBackgroundApis(page);
+    await mockAdminApis(page);
+
+    await sap.gotoAdminTab();
+    await sap.waitForVisible(sap.backgroundJobsSection());
+
+    // All five sections
+    await expect(sap.backgroundJobsSection()).toBeVisible();
+    await expect(sap.oidcSection()).toBeVisible();
+    await expect(sap.runtimeConfigSection()).toBeVisible();
+    await expect(sap.serverLogsSection()).toBeVisible();
+    await expect(sap.maintenanceSection()).toBeVisible();
+
+    // "Manage users →" link
+    await expect(sap.manageUsersLink()).toBeVisible();
+  });
+
+  test("TC-02: Non-admin user cannot access the admin tab — falls back to account tab", async ({
+    page,
+  }) => {
+    const sap = new SettingsAdminPage(page);
+    await mockLoggedIn(page);
+    await mockBackgroundApis(page);
+
+    // Mock account tab API calls
+    await page.route("**/api/user/profile**", (route) =>
+      route.fulfill({ json: {} }),
+    );
+
+    // Mock account tab API calls so AccountTab loads cleanly
+    await page.route("**/api/user/me/profile**", (route) =>
+      route.fulfill({
+        json: {
+          id: "user-1",
+          username: "testuser",
+          name: "Test User",
+          email: "test@example.com",
+          display_name: null,
+          bio: null,
+          image: null,
+        },
+      }),
+    );
+
+    await sap.gotoAdminTab();
+    await page.waitForURL("**/settings**", { waitUntil: "commit" });
+
+    // tab=admin param stays in the URL but admin content is NOT rendered
+    // (SettingsPage coerces activeTab to "account" without updating the URL param)
+    await expect(page.getByText("Background jobs")).not.toBeVisible();
+    await expect(page.getByText("OpenID Connect")).not.toBeVisible();
+  });
+
+  test("TC-03: OIDC 'Not configured' status pill shown when OIDC is unconfigured", async ({
+    page,
+  }) => {
+    const sap = new SettingsAdminPage(page);
+    await mockAdminSession(page);
+    await mockBackgroundApis(page);
+    await mockAdminApis(page);
+
+    await sap.gotoAdminTab();
+    await sap.waitForVisible(sap.oidcSection());
+
+    // Status pill
+    await expect(page.getByText("Not configured").first()).toBeVisible();
+
+    // All four main OIDC inputs rendered as editable fields
+    await expect(
+      page.getByPlaceholder("https://auth.example.com"),
+    ).toBeVisible();
+    await expect(page.getByPlaceholder("my-client-id")).toBeVisible();
+
+    // Save button visible and enabled
+    await expect(sap.saveOidcButton()).toBeVisible();
+    await expect(sap.saveOidcButton()).toBeEnabled();
+  });
+
+  test("TC-04: OIDC fields locked when values are set via environment variable", async ({
+    page,
+  }) => {
+    const sap = new SettingsAdminPage(page);
+    await mockAdminSession(page);
+    await mockBackgroundApis(page);
+
+    // Override admin/settings with env-sourced fields
+    await page.route("**/api/jobs**", (route) =>
+      route.fulfill({ json: { crons: [], stats: {}, recentJobs: [] } }),
+    );
+    await page.route("**/api/admin/settings**", (route) =>
+      route.fulfill({
+        json: {
+          oidc: {
+            issuer_url: { value: "https://auth.example.com", source: "env" },
+            client_id: { value: "my-client-id", source: "env" },
+            client_secret: { value: "***", source: "env" },
+            redirect_uri: { value: "", source: "unset" },
+            admin_claim: { value: "", source: "unset" },
+            admin_value: { value: "", source: "unset" },
+          },
+          oidc_configured: true,
+        },
+      }),
+    );
+    await page.route("**/api/admin/config**", (route) =>
+      route.fulfill({ json: { safe: [], secrets: [] } }),
+    );
+    await page.route("**/api/admin/logs**", (route) =>
+      route.fulfill({ json: { entries: [], count: 0 } }),
+    );
+
+    await sap.gotoAdminTab();
+    await sap.waitForVisible(sap.oidcSection());
+
+    // "Configured" pill
+    await expect(page.getByText("Configured").first()).toBeVisible();
+
+    // ENV value displayed as static text
+    await expect(
+      page.getByText("https://auth.example.com").first(),
+    ).toBeVisible();
+
+    // "(set via environment variable)" label present for env fields
+    await expect(
+      page.getByText("(set via environment variable)").first(),
+    ).toBeVisible();
+
+    // Amber ENV badge visible
+    await expect(page.getByText("ENV").first()).toBeVisible();
+
+    // Redirect URI still an editable input (source "unset")
+    await expect(page.getByPlaceholder(/localhost.*callback/i)).toBeVisible();
+  });
+
+  test("TC-05: Saving OIDC settings calls the API and shows success message", async ({
+    page,
+  }) => {
+    const sap = new SettingsAdminPage(page);
+    await mockAdminSession(page);
+    await mockBackgroundApis(page);
+    await mockAdminApis(page);
+
+    // Register PUT handler AFTER mockAdminApis (LIFO: last registered = first matched)
+    await page.route("**/api/admin/settings**", (route) => {
+      if (route.request().method() === "PUT") {
+        return route.fulfill({
+          json: { success: true, oidc_configured: true },
+        });
+      }
+      return route.fulfill({ json: UNCONFIGURED_SETTINGS });
+    });
+
+    await sap.gotoAdminTab();
+    await sap.waitForVisible(sap.oidcSection());
+
+    // Fill in OIDC fields
+    await page
+      .getByPlaceholder("https://auth.example.com")
+      .fill("https://sso.example.com");
+    await page.getByPlaceholder("my-client-id").fill("test-client");
+
+    await sap.saveOidcButton().click();
+
+    await expect(
+      page.getByText("OIDC configured successfully").first(),
+    ).toBeVisible();
+  });
+
+  test("TC-06: Background jobs section shows 'No scheduled jobs configured.' empty state", async ({
+    page,
+  }) => {
+    const sap = new SettingsAdminPage(page);
+    await mockAdminSession(page);
+    await mockBackgroundApis(page);
+    await mockAdminApis(page);
+
+    await sap.gotoAdminTab();
+    await sap.waitForVisible(sap.backgroundJobsSection());
+
+    await expect(page.getByText("No scheduled jobs configured.")).toBeVisible();
+  });
+});

--- a/e2e/test-cases/settings-admin.md
+++ b/e2e/test-cases/settings-admin.md
@@ -1,0 +1,264 @@
+# Test cases: settings — admin tab
+
+## Preconditions (shared)
+
+- The Remindarr dev server is running (Bun on `:3000`, Vite proxy on `:5173`).
+- The admin tab is at `/settings?tab=admin`.
+- The admin tab is only rendered when `user.is_admin === true` in the session.
+  `MOCK_SESSION` (from `e2e/helpers.ts`) has `role: "user"` — for admin tests a
+  custom session override is needed (see individual preconditions).
+- An **admin session mock** is defined as `MOCK_SESSION` with `user.role = "admin"`
+  and `user.is_admin = true` (construct inline or export `MOCK_ADMIN_SESSION` from
+  a shared helper).
+
+---
+
+## TC-01: Admin tab is accessible to admin users and shows all sections
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: All four sections (Background jobs, OpenID Connect, Runtime config,
+Server logs, Maintenance) each fetch their own API endpoint. Mocking all of them
+lets us assert every section heading is present without a running backend.
+
+**Preconditions**:
+
+- `page.route()` stubs `GET **/api/auth/get-session` with an admin session:
+
+```json
+{
+  "session": {
+    "id": "session-1",
+    "userId": "user-1",
+    "expiresAt": "<future ISO>",
+    "token": "mock-session-token"
+  },
+  "user": {
+    "id": "user-1",
+    "name": "Admin User",
+    "email": "admin@example.com",
+    "username": "admin",
+    "role": "admin",
+    "is_admin": true
+  }
+}
+```
+
+- `page.route()` stubs `GET **/api/auth/custom/providers` with `{ "local": true, "oidc": null }`.
+- `page.route()` stubs `GET **/api/admin/jobs` with:
+
+```json
+{
+  "crons": [],
+  "stats": {},
+  "recentJobs": []
+}
+```
+
+- `page.route()` stubs `GET **/api/admin/settings` with a fully unconfigured OIDC payload:
+
+```json
+{
+  "oidc": {
+    "issuer_url": { "value": "", "source": "unset" },
+    "client_id": { "value": "", "source": "unset" },
+    "client_secret": { "value": "", "source": "unset" },
+    "redirect_uri": { "value": "", "source": "unset" },
+    "admin_claim": { "value": "", "source": "unset" },
+    "admin_value": { "value": "", "source": "unset" }
+  },
+  "oidc_configured": false
+}
+```
+
+- `page.route()` stubs `GET **/api/admin/config` with `{ "safe": [], "secrets": [] }`.
+- `page.route()` stubs `GET **/api/admin/logs**` with `{ "entries": [], "count": 0 }`.
+
+**Steps**:
+
+1. Set up all route intercepts above.
+2. Navigate to `/settings?tab=admin`.
+3. Wait for `getByText("Background jobs")` to be visible.
+
+**Expected**:
+
+- The settings page heading (`"Settings"`) is visible.
+- The breadcrumb includes `admin` (the active tab label).
+- `getByText("Background jobs")` section is visible.
+- `getByText("OpenID Connect")` section heading is visible.
+- `getByText("Runtime configuration")` section heading is visible.
+- `getByText("Server logs")` section heading is visible.
+- `getByText("Maintenance")` section heading is visible.
+- The `"Manage users →"` link is visible and points to `/admin/users`.
+
+---
+
+## TC-02: Non-admin user cannot access the admin tab — falls back to account tab
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: Tab visibility is a frontend guard in `SettingsPage.tsx`. When
+`user.is_admin` is false the `"admin"` tab is omitted from `TABS` and the URL
+parameter is silently coerced to `"account"`.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` stubs the session with `MOCK_SESSION` (role `"user"`,
+  `is_admin` not set / `false`).
+
+**Steps**:
+
+1. Call `mockLoggedIn(page)`.
+2. Navigate to `/settings?tab=admin`.
+3. Wait for the settings page to render.
+
+**Expected**:
+
+- The URL resolves to `/settings` (the `tab=admin` parameter is removed because the
+  active tab falls back to `"account"`).
+- The account tab content is shown (e.g. `getByText("Account")` heading or account
+  form fields are visible).
+- `getByText("Background jobs")` is **not** visible.
+- `getByText("OpenID Connect")` is **not** visible.
+- The admin tab link does **not** appear in the sidebar.
+
+---
+
+## TC-03: OIDC "Not configured" status pill shown when OIDC is unconfigured
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: The status pill (`"Not configured"` vs `"Configured"`) is driven
+entirely by `oidc_configured` in the `GET /api/admin/settings` response.
+
+**Preconditions**:
+
+- Admin session mock (as in TC-01).
+- `GET **/api/admin/settings` returns `{ ..., "oidc_configured": false }` (same
+  payload as TC-01).
+- Other admin API mocks from TC-01 are also active.
+
+**Steps**:
+
+1. Set up all route intercepts.
+2. Navigate to `/settings?tab=admin`.
+3. Wait for `getByText("OpenID Connect")` to be visible.
+
+**Expected**:
+
+- A `"Not configured"` status pill is visible next to the `"OpenID Connect"` heading.
+- The four OIDC fields (`"Issuer URL"`, `"Client ID"`, `"Client Secret"`,
+  `"Redirect URI"`) are rendered as editable inputs (since all sources are `"unset"`).
+- `getByRole("button", { name: /Save OIDC settings/i })` is visible and enabled.
+
+---
+
+## TC-04: OIDC fields locked when values are set via environment variable
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: The ENV-locked display is controlled by `source === "env"` in the API
+response. A mock is the cleanest way to exercise this branch.
+
+**Preconditions**:
+
+- Admin session mock (as in TC-01).
+- `GET **/api/admin/settings` returns OIDC fields sourced from env:
+
+```json
+{
+  "oidc": {
+    "issuer_url": { "value": "https://auth.example.com", "source": "env" },
+    "client_id": { "value": "my-client-id", "source": "env" },
+    "client_secret": { "value": "***", "source": "env" },
+    "redirect_uri": { "value": "", "source": "unset" },
+    "admin_claim": { "value": "", "source": "unset" },
+    "admin_value": { "value": "", "source": "unset" }
+  },
+  "oidc_configured": true
+}
+```
+
+- Other admin API mocks from TC-01 active.
+
+**Steps**:
+
+1. Set up all route intercepts.
+2. Navigate to `/settings?tab=admin`.
+3. Wait for `getByText("OpenID Connect")` to be visible.
+
+**Expected**:
+
+- A `"Configured"` status pill is visible.
+- `getByText("https://auth.example.com")` is visible (ENV display, not an `<input>`).
+- `getByText("(set via environment variable)")` appears for the env-sourced fields.
+- An `"ENV"` amber status pill is visible for each locked field.
+- The `"Redirect URI"` field is still an editable input (source is `"unset"`).
+
+---
+
+## TC-05: Saving OIDC settings calls the API and shows success message
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: The save path is `PUT /api/admin/settings`. Mocking the response lets
+us verify the success message without a running backend.
+
+**Preconditions**:
+
+- Admin session mock (as in TC-01).
+- `GET **/api/admin/settings` returns the unconfigured payload from TC-01.
+- Other admin API mocks from TC-01 active.
+- `page.route()` intercepts `PUT **/api/admin/settings` and returns:
+
+```json
+{ "success": true, "oidc_configured": true }
+```
+
+**Steps**:
+
+1. Set up all route intercepts.
+2. Navigate to `/settings?tab=admin`.
+3. Wait for `getByLabel("Issuer URL")` (or `getByPlaceholder("https://auth.example.com")`) to be visible.
+4. Fill in `getByPlaceholder("https://auth.example.com")` with `"https://sso.example.com"`.
+5. Fill in `getByPlaceholder("my-client-id")` with `"test-client"`.
+6. Click `getByRole("button", { name: /Save OIDC settings/i })`.
+7. Wait for the success message.
+
+**Expected**:
+
+- `getByText("OIDC configured successfully")` is visible.
+- No error message is shown.
+
+---
+
+## TC-06: Background jobs section — "No scheduled jobs configured" empty state
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: The empty-state branch renders when `data.crons.length === 0`. Returning
+an empty crons array from the mock exercises it without a real job queue.
+
+**Preconditions**:
+
+- Admin session mock (as in TC-01).
+- `GET **/api/admin/jobs` returns `{ "crons": [], "stats": {}, "recentJobs": [] }`.
+- Other admin API mocks from TC-01 active.
+
+**Steps**:
+
+1. Set up all route intercepts.
+2. Navigate to `/settings?tab=admin`.
+3. Wait for `getByText("Background jobs")` to be visible.
+
+**Expected**:
+
+- `getByText("No scheduled jobs configured.")` is visible within the background jobs
+  card.
+- No job row / table is rendered.


### PR DESCRIPTION
## Summary

- Adds 6 Playwright E2E tests for the Settings admin tab covering tab access guard, OIDC status display (unconfigured/env-locked), OIDC save success, background jobs empty state, and non-admin fallback
- Adds `SettingsAdminPage` page object in `e2e/pages/settings-admin-page.ts`
- Adds test-case specification in `e2e/test-cases/settings-admin.md`

Part of #853

## Test plan

- [x] TC-01: Admin tab accessible to admin users — all 5 sections visible
- [x] TC-02: Non-admin user — admin tab content not rendered
- [x] TC-03: OIDC "Not configured" pill when unconfigured
- [x] TC-04: OIDC fields locked (ENV badge + static text) when set via environment variable
- [x] TC-05: Save OIDC settings shows success message
- [x] TC-06: Background jobs empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)