### PR TITLE
feat(e2e): Admin users page E2E tests (TC-01–TC-08)

### DIFF
--- a/e2e/admin-users.spec.ts
+++ b/e2e/admin-users.spec.ts
@@ -1,0 +1,352 @@
+import { test, expect } from "@playwright/test";
+import { mockLoggedIn, mockLoggedOut } from "./helpers";
+import { AdminUsersPage } from "./pages/admin-users-page";
+
+test.describe.configure({ mode: "serial" });
+
+// Admin session — MOCK_SESSION does NOT have admin role; construct inline.
+const MOCK_ADMIN_SESSION = {
+  session: {
+    id: "session-1",
+    userId: "user-1",
+    expiresAt: "2099-01-01T00:00:00Z",
+    token: "mock-session-token",
+  },
+  user: {
+    id: "user-1",
+    name: "Admin User",
+    email: "admin@example.com",
+    username: "admin",
+    role: "admin",
+    is_admin: true,
+  },
+};
+
+const ADMIN_USER = {
+  id: "user-1",
+  username: "admin",
+  name: "Admin User",
+  email: "admin@example.com",
+  role: "admin",
+  is_admin: 1,
+  auth_provider: "credential",
+  banned: false,
+  ban_reason: null,
+  ban_expires: null,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+};
+
+const REGULAR_USER = {
+  id: "user-2",
+  username: "regularuser",
+  name: "Regular User",
+  email: "regular@example.com",
+  role: "user",
+  is_admin: 0,
+  auth_provider: "credential",
+  banned: false,
+  ban_reason: null,
+  ban_expires: null,
+  created_at: "2024-02-01T00:00:00Z",
+  updated_at: "2024-02-01T00:00:00Z",
+};
+
+const TWO_USER_LIST = {
+  users: [ADMIN_USER, REGULAR_USER],
+  total: 2,
+  page: 1,
+  page_size: 25,
+  total_pages: 1,
+};
+
+async function mockAdminSession(page: AdminUsersPage["page"]) {
+  await page.route("**/api/auth/get-session", (route) =>
+    route.fulfill({ json: MOCK_ADMIN_SESSION }),
+  );
+  await page.route("**/api/auth/custom/providers", (route) =>
+    route.fulfill({ json: { local: true, oidc: null } }),
+  );
+}
+
+async function mockBackgroundApis(page: AdminUsersPage["page"]) {
+  await page.route("**/api/achievements/me**", (route) =>
+    route.fulfill({ json: [] }),
+  );
+  await page.route("**/api/recommendations/count**", (route) =>
+    route.fulfill({ json: { count: 0 } }),
+  );
+  await page.route("**/api/user/settings/subscriptions**", (route) =>
+    route.fulfill({ json: { providerIds: [], onlyMine: false } }),
+  );
+}
+
+test.describe("Admin users page", () => {
+  test.skip(
+    ({ browserName }) => browserName !== "chromium",
+    "Running on chromium only",
+  );
+
+  test("TC-01: Admin users page loads and shows user list", async ({
+    page,
+  }) => {
+    const aup = new AdminUsersPage(page);
+    await mockAdminSession(page);
+    await mockBackgroundApis(page);
+    await page.route("**/api/admin/users**", (route) =>
+      route.fulfill({ json: TWO_USER_LIST }),
+    );
+
+    await aup.gotoAdminUsers();
+    await aup.waitForVisible(aup.heading());
+
+    // Heading "User Management"
+    await expect(aup.heading()).toContainText("User Management");
+
+    // Both usernames visible
+    await expect(page.getByText("admin").first()).toBeVisible();
+    await expect(page.getByText("regularuser").first()).toBeVisible();
+
+    // Back to settings link
+    await expect(aup.backToSettingsLink()).toBeVisible();
+
+    // Total count
+    await expect(page.getByText("2 users")).toBeVisible();
+  });
+
+  test("TC-02: Non-admin user sees access-denied message", async ({ page }) => {
+    const aup = new AdminUsersPage(page);
+    await mockLoggedIn(page);
+    await mockBackgroundApis(page);
+    // Mock admin/users so the query doesn't 401 → redirect to login
+    await page.route("**/api/admin/users**", (route) =>
+      route.fulfill({
+        json: { users: [], total: 0, page: 1, page_size: 25, total_pages: 0 },
+      }),
+    );
+
+    await aup.gotoAdminUsers();
+    await page.waitForURL("**/admin/users**", { waitUntil: "commit" });
+
+    await expect(page.getByText(/access denied/i)).toBeVisible();
+    await expect(page.getByRole("table")).not.toBeVisible();
+  });
+
+  test("TC-03: Unauthenticated user is redirected to /login", async ({
+    page,
+  }) => {
+    const aup = new AdminUsersPage(page);
+    await mockLoggedOut(page);
+
+    await aup.gotoAdminUsers();
+    await page.waitForURL("**/login**", { waitUntil: "commit" });
+
+    expect(page.url()).toContain("/login");
+    await expect(page.getByRole("button", { name: /sign in/i })).toBeVisible();
+  });
+
+  test("TC-04: Role badges shown for admin and regular users", async ({
+    page,
+  }) => {
+    const aup = new AdminUsersPage(page);
+    await mockAdminSession(page);
+    await mockBackgroundApis(page);
+    await page.route("**/api/admin/users**", (route) =>
+      route.fulfill({ json: TWO_USER_LIST }),
+    );
+
+    await aup.gotoAdminUsers();
+    await aup.waitForVisible(aup.heading());
+
+    // "Admin" badge in admin's row (last = sm:table-cell td, visible on desktop)
+    await expect(aup.userRow("admin").getByText("Admin").last()).toBeVisible();
+    // "User" badge in regularuser's row (last = sm:table-cell td, visible on desktop)
+    await expect(
+      aup.userRow("regularuser").getByText("User").last(),
+    ).toBeVisible();
+
+    // Admin row (currently signed-in user) shows "you" label, not action buttons
+    await expect(aup.userRow("admin").getByText("you")).toBeVisible();
+
+    // Regularuser row has action buttons
+    await expect(aup.promoteButton("regularuser")).toBeVisible();
+    await expect(aup.deleteButton("regularuser")).toBeVisible();
+  });
+
+  test("TC-05: Promoting a regular user to admin updates their role badge", async ({
+    page,
+  }) => {
+    const aup = new AdminUsersPage(page);
+    await mockAdminSession(page);
+    await mockBackgroundApis(page);
+
+    // Stateful handler: after PUT /role, GET returns promoted user
+    let regularUserRole = "user";
+    let regularUserIsAdmin = 0;
+
+    await page.route("**/api/admin/users**", (route) => {
+      const url = route.request().url();
+      const method = route.request().method();
+
+      if (method === "PUT" && url.includes("/user-2/role")) {
+        regularUserRole = "admin";
+        regularUserIsAdmin = 1;
+        return route.fulfill({ json: { message: "Role updated" } });
+      }
+
+      return route.fulfill({
+        json: {
+          users: [
+            ADMIN_USER,
+            {
+              ...REGULAR_USER,
+              role: regularUserRole,
+              is_admin: regularUserIsAdmin,
+            },
+          ],
+          total: 2,
+          page: 1,
+          page_size: 25,
+          total_pages: 1,
+        },
+      });
+    });
+
+    await aup.gotoAdminUsers();
+    await aup.waitForVisible(page.getByText("regularuser").first());
+
+    // Click promote button
+    await aup.promoteButton("regularuser").click();
+
+    // After refetch, "Admin" badge appears in regularuser's row (last = sm:table-cell, visible)
+    await expect(
+      aup.userRow("regularuser").getByText("Admin").last(),
+    ).toBeVisible();
+    // Demote button is now shown
+    await expect(aup.demoteButton("regularuser")).toBeVisible();
+  });
+
+  test("TC-06: Deleting a user removes them from the table", async ({
+    page,
+  }) => {
+    const aup = new AdminUsersPage(page);
+    await mockAdminSession(page);
+    await mockBackgroundApis(page);
+
+    let deleted = false;
+
+    await page.route("**/api/admin/users**", (route) => {
+      const url = route.request().url();
+      const method = route.request().method();
+
+      if (method === "DELETE" && url.includes("/user-2")) {
+        deleted = true;
+        return route.fulfill({ json: { message: "User deleted" } });
+      }
+
+      return route.fulfill({
+        json: deleted
+          ? {
+              users: [ADMIN_USER],
+              total: 1,
+              page: 1,
+              page_size: 25,
+              total_pages: 1,
+            }
+          : TWO_USER_LIST,
+      });
+    });
+
+    await aup.gotoAdminUsers();
+    await aup.waitForVisible(page.getByText("regularuser").first());
+
+    // Click delete and confirm
+    await aup.deleteButton("regularuser").click();
+    await aup.waitForVisible(aup.confirmDeleteButton());
+    await aup.confirmDeleteButton().click();
+
+    // regularuser row is gone
+    await expect(page.getByText("regularuser")).not.toBeVisible();
+    await expect(page.getByText("1 users")).toBeVisible();
+  });
+
+  test("TC-07: Banning a user shows the ban dialog and updates the banned badge", async ({
+    page,
+  }) => {
+    const aup = new AdminUsersPage(page);
+    await mockAdminSession(page);
+    await mockBackgroundApis(page);
+
+    let banned = false;
+
+    await page.route("**/api/admin/users**", (route) => {
+      const url = route.request().url();
+      const method = route.request().method();
+
+      if (method === "PUT" && url.includes("/user-2/ban")) {
+        banned = true;
+        return route.fulfill({ json: { message: "User banned" } });
+      }
+
+      return route.fulfill({
+        json: {
+          users: [ADMIN_USER, { ...REGULAR_USER, banned: banned }],
+          total: 2,
+          page: 1,
+          page_size: 25,
+          total_pages: 1,
+        },
+      });
+    });
+
+    await aup.gotoAdminUsers();
+    await aup.waitForVisible(page.getByText("regularuser").first());
+
+    // Open ban dialog
+    await aup.banButton("regularuser").click();
+
+    // Dialog is visible
+    await expect(page.getByText("Ban User").first()).toBeVisible();
+
+    // Confirm ban
+    await aup.confirmBanButton().click();
+
+    // regularuser row now shows "Banned" badge
+    await expect(aup.userRow("regularuser").getByText("Banned")).toBeVisible();
+  });
+
+  test("TC-08: Search filters the user list", async ({ page }) => {
+    const aup = new AdminUsersPage(page);
+    await mockAdminSession(page);
+    await mockBackgroundApis(page);
+
+    await page.route("**/api/admin/users**", (route) => {
+      const url = route.request().url();
+      if (url.includes("search=regular")) {
+        return route.fulfill({
+          json: {
+            users: [REGULAR_USER],
+            total: 1,
+            page: 1,
+            page_size: 25,
+            total_pages: 1,
+          },
+        });
+      }
+      return route.fulfill({ json: TWO_USER_LIST });
+    });
+
+    await aup.gotoAdminUsers();
+    await aup.waitForVisible(page.getByText("regularuser").first());
+
+    // Type into search
+    await aup.searchInput().fill("regular");
+
+    // Only regularuser visible; admin username not visible in table body
+    await expect(page.getByText("regularuser").first()).toBeVisible();
+    // Wait for admin row to disappear from table
+    await expect(
+      page.getByRole("row", { name: /admin user/i }),
+    ).not.toBeVisible();
+  });
+});

--- a/e2e/pages/admin-users-page.ts
+++ b/e2e/pages/admin-users-page.ts
@@ -1,0 +1,61 @@
+import type { Page } from "@playwright/test";
+import { BasePage } from "./base-page";
+
+export class AdminUsersPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async gotoAdminUsers(): Promise<void> {
+    await super.goto("/admin/users");
+  }
+
+  heading() {
+    return this.page.getByRole("heading", { level: 1 });
+  }
+
+  searchInput() {
+    return this.page.getByRole("textbox", {
+      name: /search by username or name/i,
+    });
+  }
+
+  backToSettingsLink() {
+    return this.page.getByRole("link", { name: /back to settings/i });
+  }
+
+  /** Row for a given username — finds the username cell in the table */
+  userRow(username: string) {
+    return this.page.getByRole("row").filter({ hasText: username });
+  }
+
+  promoteButton(username: string) {
+    return this.userRow(username).getByRole("button", {
+      name: /promote to admin/i,
+    });
+  }
+
+  demoteButton(username: string) {
+    return this.userRow(username).getByRole("button", {
+      name: /demote to user/i,
+    });
+  }
+
+  banButton(username: string) {
+    return this.userRow(username).getByRole("button", { name: /ban user/i });
+  }
+
+  deleteButton(username: string) {
+    return this.userRow(username).getByRole("button", { name: /delete user/i });
+  }
+
+  /** Confirmation dialog delete button */
+  confirmDeleteButton() {
+    return this.page.getByRole("button", { name: /delete permanently/i });
+  }
+
+  /** Confirmation dialog ban button */
+  confirmBanButton() {
+    return this.page.getByRole("button", { name: /ban user/i }).last();
+  }
+}

--- a/e2e/test-cases/admin-users.md
+++ b/e2e/test-cases/admin-users.md
@@ -1,0 +1,345 @@
+# Test cases: admin users page
+
+## Preconditions (shared)
+
+- The Remindarr dev server is running (Bun on `:3000`, Vite proxy on `:5173`).
+- The admin users page is at `/admin/users`.
+- The page requires an authenticated session where `user.is_admin === true`.
+  Construct the admin session inline (or via a shared `MOCK_ADMIN_SESSION` helper):
+
+```json
+{
+  "session": {
+    "id": "session-1",
+    "userId": "user-1",
+    "expiresAt": "<future ISO>",
+    "token": "mock-session-token"
+  },
+  "user": {
+    "id": "user-1",
+    "name": "Admin User",
+    "email": "admin@example.com",
+    "username": "admin",
+    "role": "admin",
+    "is_admin": true
+  }
+}
+```
+
+- `GET **/api/auth/custom/providers` returns `{ "local": true, "oidc": null }`.
+- A canonical **two-user list** response for `GET **/api/admin/users**`:
+
+```json
+{
+  "users": [
+    {
+      "id": "user-1",
+      "username": "admin",
+      "name": "Admin User",
+      "email": "admin@example.com",
+      "role": "admin",
+      "is_admin": 1,
+      "auth_provider": "credential",
+      "banned": false,
+      "ban_reason": null,
+      "ban_expires": null,
+      "created_at": "2024-01-01T00:00:00Z",
+      "updated_at": "2024-01-01T00:00:00Z"
+    },
+    {
+      "id": "user-2",
+      "username": "regularuser",
+      "name": "Regular User",
+      "email": "regular@example.com",
+      "role": "user",
+      "is_admin": 0,
+      "auth_provider": "credential",
+      "banned": false,
+      "ban_reason": null,
+      "ban_expires": null,
+      "created_at": "2024-02-01T00:00:00Z",
+      "updated_at": "2024-02-01T00:00:00Z"
+    }
+  ],
+  "total": 2,
+  "page": 1,
+  "page_size": 25,
+  "total_pages": 1
+}
+```
+
+---
+
+## TC-01: Admin users page loads and shows user list
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: The user table is a pure render of `GET /api/admin/users`. Mocking the
+response lets us assert exact rows without a seeded database.
+
+**Preconditions**:
+
+- Admin session mock (as in shared preconditions).
+- `GET **/api/admin/users**` returns the canonical two-user list.
+
+**Steps**:
+
+1. Set up all route intercepts above.
+2. Navigate to `/admin/users`.
+3. Wait for `getByRole("heading", { level: 1 })` to be visible.
+
+**Expected**:
+
+- `getByRole("heading", { level: 1 })` text contains `"Users"` (translation key
+  `admin.users.title`).
+- `getByText("admin")` (username) is visible in the table.
+- `getByText("regularuser")` is visible in the table.
+- Two rows appear in the `<tbody>`.
+- The `"← Back to settings"` link is visible and points to `/settings`.
+- A total count label is visible (`"2 users"` or similar).
+
+---
+
+## TC-02: Non-admin user sees access-denied message
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: The access-denied guard is `if (!me?.is_admin) return <div>…</div>`.
+Mocking the session with a non-admin user fully exercises this branch.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` stubs the session with `MOCK_SESSION` (role `"user"`,
+  `is_admin` false).
+
+**Steps**:
+
+1. Call `mockLoggedIn(page)`.
+2. Navigate to `/admin/users`.
+3. Wait for the page to render.
+
+**Expected**:
+
+- `getByText(/access denied/i)` or the translated `admin.accessDenied` message is
+  visible.
+- No user table is rendered (`getByRole("table")` is absent).
+
+---
+
+## TC-03: Unauthenticated user is redirected to /login
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: The `RequireAuth` wrapper redirects unauthenticated sessions before the
+page component even mounts.
+
+**Preconditions**:
+
+- `mockLoggedOut(page)` stubs `GET /api/auth/get-session` with `null`.
+
+**Steps**:
+
+1. Call `mockLoggedOut(page)`.
+2. Navigate to `/admin/users`.
+3. Wait for the URL to change away from `/admin/users`.
+
+**Expected**:
+
+- The browser is redirected to `/login`.
+- The login form is visible (`getByRole("button", { name: /sign in/i })` is present).
+
+---
+
+## TC-04: Role badges are shown for admin and regular users
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: Badge rendering depends on `user.role === "admin"` and
+`user.is_admin === 1`. Both states are present in the canonical two-user list.
+
+**Preconditions**:
+
+- Admin session mock.
+- `GET **/api/admin/users**` returns the canonical two-user list.
+
+**Steps**:
+
+1. Set up all route intercepts.
+2. Navigate to `/admin/users`.
+3. Wait for the user table to appear.
+
+**Expected**:
+
+- An `"Admin"` role badge is visible in the `admin` user's row (amber styling).
+- A `"User"` role badge is visible in the `regularuser` row (neutral/zinc styling).
+- The `admin` row (which is the currently-signed-in user) shows a `"You"` label
+  instead of action buttons.
+- The `regularuser` row shows action buttons (role toggle, ban, delete icons).
+
+---
+
+## TC-05: Promoting a regular user to admin updates their role badge
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: The promote action is `PUT /api/admin/users/:id/role` followed by a
+`GET /api/admin/users` refetch. Both can be mocked to assert the badge updates.
+
+**Preconditions**:
+
+- Admin session mock.
+- `GET **/api/admin/users**` initially returns the canonical two-user list.
+- `PUT **/api/admin/users/user-2/role` returns `{ "message": "Role updated" }`.
+- After the PUT, `GET **/api/admin/users**` returns the same list with `user-2`
+  promoted (`"role": "admin"`, `"is_admin": 1`).
+
+**Steps**:
+
+1. Set up all route intercepts.
+2. Navigate to `/admin/users`.
+3. Wait for `getByText("regularuser")` to be visible.
+4. Identify the role-toggle button in `regularuser`'s row:
+   `getByRole("button", { name: /promote/i })` (aria-label is the translation of
+   `admin.users.promote`).
+5. Click the promote button.
+6. Wait for the refetch to complete.
+
+**Expected**:
+
+- The `regularuser` row now displays an `"Admin"` badge (amber styling).
+- The role-toggle button aria-label changes to the `"Demote"` translation.
+- No error toast is shown.
+
+---
+
+## TC-06: Deleting a user removes them from the table
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: Delete is `DELETE /api/admin/users/:id` + refetch. Mocking both lets
+us assert the row disappears without touching a real database.
+
+**Preconditions**:
+
+- Admin session mock.
+- `GET **/api/admin/users**` initially returns the canonical two-user list.
+- `DELETE **/api/admin/users/user-2` returns `{ "message": "User deleted" }`.
+- After the DELETE, `GET **/api/admin/users**` returns only the admin user:
+
+```json
+{
+  "users": [
+    {
+      "id": "user-1",
+      "username": "admin",
+      "name": "Admin User",
+      "email": "admin@example.com",
+      "role": "admin",
+      "is_admin": 1,
+      "auth_provider": "credential",
+      "banned": false,
+      "ban_reason": null,
+      "ban_expires": null,
+      "created_at": "2024-01-01T00:00:00Z",
+      "updated_at": "2024-01-01T00:00:00Z"
+    }
+  ],
+  "total": 1,
+  "page": 1,
+  "page_size": 25,
+  "total_pages": 1
+}
+```
+
+**Steps**:
+
+1. Set up all route intercepts.
+2. Navigate to `/admin/users`.
+3. Wait for `getByText("regularuser")` to be visible.
+4. Click the delete button in `regularuser`'s row:
+   `getByRole("button", { name: /delete user/i })` (aria-label `admin.users.delete`).
+5. A confirmation dialog appears — click the `"Delete"` confirmation button
+   (`getByRole("button", { name: /delete/i })` inside the dialog, translation key
+   `admin.users.deleteConfirmButton`).
+6. Wait for the dialog to close and refetch to complete.
+
+**Expected**:
+
+- The confirmation dialog closes.
+- `getByText("regularuser")` is no longer in the DOM.
+- Only the `admin` row remains in the table.
+- The total-count label updates to reflect `1 user`.
+
+---
+
+## TC-07: Banning a user shows the ban confirmation dialog
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: The ban flow opens an `AlertDialog` with an optional reason input.
+Exercising the dialog open/close state only requires a mock for the ban API response.
+
+**Preconditions**:
+
+- Admin session mock.
+- `GET **/api/admin/users**` returns the canonical two-user list.
+- `PUT **/api/admin/users/user-2/ban` returns `{ "message": "User banned" }`.
+- After the PUT, `GET **/api/admin/users**` returns the list with `user-2` banned
+  (`"banned": true`).
+
+**Steps**:
+
+1. Set up all route intercepts.
+2. Navigate to `/admin/users`.
+3. Wait for `getByText("regularuser")` to be visible.
+4. Click the ban button in `regularuser`'s row:
+   `getByRole("button", { name: /ban user/i })` (aria-label `admin.users.ban`).
+5. The ban dialog appears — optionally fill in a ban reason.
+6. Click the `"Ban"` confirmation button (translation key `admin.users.banConfirm`).
+7. Wait for the dialog to close and refetch to complete.
+
+**Expected**:
+
+- The ban dialog opens (`getByText(/ban/i)` dialog title is visible).
+- After confirming, the dialog closes.
+- `regularuser`'s row now shows a `"Banned"` badge (red styling).
+- The ban button icon changes to an `"Unban"` button (aria-label `admin.users.unban`).
+
+---
+
+## TC-08: Search filters the user list
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: The search input triggers a query-param change on
+`GET /api/admin/users?search=…`. Mocking the filtered response verifies the UI
+re-renders correctly.
+
+**Preconditions**:
+
+- Admin session mock.
+- `GET **/api/admin/users**` (no search param) returns the canonical two-user list.
+- `GET **/api/admin/users?search=regular**` returns only the `regularuser` entry
+  (`total: 1`, `total_pages: 1`).
+
+**Steps**:
+
+1. Set up both route intercepts.
+2. Navigate to `/admin/users`.
+3. Wait for both user rows to appear.
+4. Type `"regular"` into the search input
+   (`getByPlaceholder(...)` / `getByRole("textbox")` for the search field).
+5. Wait for the table to re-render.
+
+**Expected**:
+
+- Only `getByText("regularuser")` is visible in the table.
+- `getByText("admin")` (username) is **not** visible in the table body.


### PR DESCRIPTION
## Summary

- Adds 8 Playwright E2E tests for the `/admin/users` page covering user list rendering, role badges, access guard (non-admin + unauthenticated), promote/demote, delete with confirmation, ban with dialog, and search filtering
- Adds `AdminUsersPage` page object in `e2e/pages/admin-users-page.ts`
- Adds test-case specification in `e2e/test-cases/admin-users.md`

Part of #853

## Test plan

- [x] TC-01: Page loads and shows user list (usernames, total count, back link)
- [x] TC-02: Non-admin user sees access-denied message
- [x] TC-03: Unauthenticated user redirected to /login
- [x] TC-04: Role badges shown for admin and regular users; "you" label on self
- [x] TC-05: Promote regular user → Admin badge updates
- [x] TC-06: Delete user → row removed from table
- [x] TC-07: Ban user → dialog opens, Banned badge appears after confirm
- [x] TC-08: Search input filters the user list

🤖 Generated with [Claude Code](https://claude.com/claude-code)