### PR TITLE
feat(e2e): settings-integrations spec

### DIFF
--- a/e2e/pages/settings-integrations-page.ts
+++ b/e2e/pages/settings-integrations-page.ts
@@ -1,0 +1,40 @@
+import type { Page } from "@playwright/test";
+import { BasePage } from "./base-page";
+
+export class SettingsIntegrationsPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async gotoIntegrationsTab(): Promise<void> {
+    await super.goto("/settings?tab=integrations");
+  }
+
+  plexSection() {
+    return this.page.getByText("Plex").first();
+  }
+
+  connectPlexButton() {
+    return this.page.getByRole("button", { name: /connect plex/i });
+  }
+
+  disconnectButton() {
+    return this.page.getByRole("button", { name: /disconnect/i });
+  }
+
+  syncNowButton() {
+    return this.page.getByRole("button", { name: /sync now/i });
+  }
+
+  disableButton() {
+    return this.page.getByRole("button", { name: /^disable$/i });
+  }
+
+  cancelConnectButton() {
+    return this.page.getByRole("button", { name: /^cancel$/i });
+  }
+
+  openAuthLink() {
+    return this.page.getByRole("link", { name: /open authorization page/i });
+  }
+}

--- a/e2e/settings-integrations.spec.ts
+++ b/e2e/settings-integrations.spec.ts
@@ -1,0 +1,228 @@
+import { test, expect } from "@playwright/test";
+import { mockLoggedIn, mockLoggedOut } from "./helpers";
+import { SettingsIntegrationsPage } from "./pages/settings-integrations-page";
+
+test.describe.configure({ mode: "serial" });
+
+const PLEX_INTEGRATION = {
+  id: "integ-1",
+  user_id: "user-1",
+  provider: "plex",
+  name: "My Plex Server",
+  config: {
+    serverUrl: "http://192.168.1.10:32400",
+    serverId: "abc123",
+    serverName: "My Plex Server",
+    plexUsername: "plexuser",
+    syncMovies: true,
+    syncEpisodes: true,
+  },
+  enabled: true,
+  last_sync_at: "2024-03-01T12:00:00Z",
+  last_sync_error: null,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-03-01T12:00:00Z",
+};
+
+// Mock all token endpoints that IntegrationsTab sections query.
+async function mockTokenApis(page: SettingsIntegrationsPage["page"]) {
+  await page.route("**/api/feed/token**", (route) =>
+    route.fulfill({ json: { token: null } }),
+  );
+  await page.route("**/api/kiosk/token**", (route) =>
+    route.fulfill({ json: { token: null } }),
+  );
+  await page.route("**/api/share/token**", (route) =>
+    route.fulfill({ json: { token: null } }),
+  );
+}
+
+// Background mocks required for all authenticated pages.
+async function mockBackgroundApis(page: SettingsIntegrationsPage["page"]) {
+  await page.route("**/api/achievements/me**", (route) =>
+    route.fulfill({ json: [] }),
+  );
+  await page.route("**/api/recommendations/count**", (route) =>
+    route.fulfill({ json: { count: 0 } }),
+  );
+  await page.route("**/api/user/settings/subscriptions**", (route) =>
+    route.fulfill({ json: { providerIds: [], onlyMine: false } }),
+  );
+}
+
+test.describe("Settings — integrations tab", () => {
+  test.skip(
+    ({ browserName }) => browserName !== "chromium",
+    "Running on chromium only",
+  );
+
+  test("TC-01: Integrations tab loads and shows Plex section", async ({
+    page,
+  }) => {
+    const sip = new SettingsIntegrationsPage(page);
+    await mockLoggedIn(page);
+    await mockBackgroundApis(page);
+    await mockTokenApis(page);
+    await page.route("**/api/integrations**", (route) =>
+      route.fulfill({ json: { integrations: [] } }),
+    );
+
+    await sip.gotoIntegrationsTab();
+    await sip.waitForVisible(sip.plexSection());
+
+    // Plex section is visible
+    await expect(sip.plexSection()).toBeVisible();
+    await expect(
+      page.getByText(
+        "Connect your Plex server to automatically sync your watched history.",
+      ),
+    ).toBeVisible();
+
+    // Connect Plex button shown (no existing integration)
+    await expect(sip.connectPlexButton()).toBeVisible();
+  });
+
+  test("TC-02: Unauthenticated user is redirected to /login", async ({
+    page,
+  }) => {
+    const sip = new SettingsIntegrationsPage(page);
+    await mockLoggedOut(page);
+
+    await sip.gotoIntegrationsTab();
+    await page.waitForURL("**/login**", { waitUntil: "commit" });
+
+    expect(page.url()).toContain("/login");
+    await expect(page.getByText("Plex")).not.toBeVisible();
+  });
+
+  test("TC-03: Connect Plex button is visible when no integration exists", async ({
+    page,
+  }) => {
+    const sip = new SettingsIntegrationsPage(page);
+    await mockLoggedIn(page);
+    await mockBackgroundApis(page);
+    await mockTokenApis(page);
+    await page.route("**/api/integrations**", (route) =>
+      route.fulfill({ json: { integrations: [] } }),
+    );
+
+    await sip.gotoIntegrationsTab();
+    await sip.waitForVisible(sip.plexSection());
+
+    // Connect Plex button present
+    await expect(sip.connectPlexButton()).toBeVisible();
+    // No Disconnect button
+    await expect(sip.disconnectButton()).not.toBeVisible();
+  });
+
+  test("TC-04: Clicking 'Connect Plex' opens the PIN-waiting state", async ({
+    page,
+  }) => {
+    const sip = new SettingsIntegrationsPage(page);
+    await mockLoggedIn(page);
+    await mockBackgroundApis(page);
+    await mockTokenApis(page);
+    await page.route("**/api/integrations**", (route) => {
+      if (route.request().method() === "POST") {
+        return route.fulfill({
+          json: {
+            pinId: 42,
+            authUrl: "https://app.plex.tv/auth#?clientID=mock&code=mock-pin",
+          },
+        });
+      }
+      return route.fulfill({ json: { integrations: [] } });
+    });
+
+    // Suppress any popup that opens
+    page.on("popup", (popup) => void popup.close());
+
+    await sip.gotoIntegrationsTab();
+    await sip.waitForVisible(sip.connectPlexButton());
+
+    await sip.connectPlexButton().click();
+
+    // Waiting state is shown
+    await expect(
+      page.getByText(/waiting for authorization/i).first(),
+    ).toBeVisible();
+    await expect(sip.cancelConnectButton()).toBeVisible();
+    await expect(sip.openAuthLink()).toBeVisible();
+
+    // Connect button is gone
+    await expect(sip.connectPlexButton()).not.toBeVisible();
+  });
+
+  test("TC-05: Plex already connected — shows server card with controls", async ({
+    page,
+  }) => {
+    const sip = new SettingsIntegrationsPage(page);
+    await mockLoggedIn(page);
+    await mockBackgroundApis(page);
+    await mockTokenApis(page);
+    await page.route("**/api/integrations**", (route) =>
+      route.fulfill({ json: { integrations: [PLEX_INTEGRATION] } }),
+    );
+
+    await sip.gotoIntegrationsTab();
+    await sip.waitForVisible(page.getByText("My Plex Server").first());
+
+    // Server name and URL visible
+    await expect(page.getByText("My Plex Server").first()).toBeVisible();
+    await expect(
+      page.getByText("http://192.168.1.10:32400").first(),
+    ).toBeVisible();
+
+    // Status pill
+    await expect(page.getByText("Enabled").first()).toBeVisible();
+
+    // Action buttons visible
+    await expect(sip.disconnectButton()).toBeVisible();
+    await expect(sip.syncNowButton()).toBeVisible();
+    await expect(sip.disableButton()).toBeVisible();
+
+    // The "Connect Plex" button is always visible in idle step so users can
+    // add additional servers; it is not hidden by existing integrations.
+  });
+
+  test("TC-06: Disconnecting Plex removes the integration card", async ({
+    page,
+  }) => {
+    const sip = new SettingsIntegrationsPage(page);
+    await mockLoggedIn(page);
+    await mockBackgroundApis(page);
+    await mockTokenApis(page);
+
+    let disconnected = false;
+
+    await page.route("**/api/integrations**", (route) => {
+      const url = route.request().url();
+      const method = route.request().method();
+
+      if (method === "DELETE" && url.includes("/integ-1")) {
+        disconnected = true;
+        return route.fulfill({ json: {} });
+      }
+
+      return route.fulfill({
+        json: {
+          integrations: disconnected ? [] : [PLEX_INTEGRATION],
+        },
+      });
+    });
+
+    await sip.gotoIntegrationsTab();
+    await sip.waitForVisible(sip.disconnectButton());
+
+    await sip.disconnectButton().click();
+
+    // Success message
+    await expect(
+      page.getByText("Plex integration disconnected.").first(),
+    ).toBeVisible();
+
+    // Integration card is gone; Connect Plex button reappears
+    await expect(page.getByText("My Plex Server")).not.toBeVisible();
+    await expect(sip.connectPlexButton()).toBeVisible();
+  });
+});

--- a/e2e/test-cases/settings-integrations.md
+++ b/e2e/test-cases/settings-integrations.md
@@ -1,0 +1,238 @@
+# Test cases: settings — integrations tab
+
+## Preconditions (shared)
+
+- The Remindarr dev server is running (Bun on `:3000`, Vite proxy on `:5173`).
+- Unless stated otherwise, the browser has an active session courtesy of
+  `mockLoggedIn(page)` (stubs `GET /api/auth/get-session` with `MOCK_SESSION`).
+- The integrations tab is reached via `/settings?tab=integrations`.
+- `MOCK_SESSION.user.role` is `"user"` (not admin) — the integrations tab is
+  available to all authenticated users.
+
+---
+
+## TC-01: Integrations tab loads and shows Plex section
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: The page renders immediately from two GET responses (`/api/integrations`
+and `/api/feed/token`). Mocking both lets us assert the section headings without a
+seeded database.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` stubs the session.
+- `page.route()` intercepts `GET **/api/integrations` and returns an empty list:
+
+```json
+{ "integrations": [] }
+```
+
+- `page.route()` intercepts `GET **/api/feed/token` and returns `{ "token": null }`.
+- `page.route()` intercepts `GET **/api/kiosk/token` and returns `{ "token": null }`.
+- `page.route()` intercepts `GET **/api/share/watchlist/token` and returns `{ "token": null }`.
+
+**Steps**:
+
+1. Set up all route intercepts above.
+2. Call `mockLoggedIn(page)`.
+3. Navigate to `/settings?tab=integrations`.
+4. Wait for the page to finish loading (skeleton disappears).
+
+**Expected**:
+
+- The breadcrumb shows `/settings › integrations` (or the translated equivalent).
+- The `"Plex"` section heading is visible.
+- The subtitle `"Connect your Plex server to automatically sync your watched history."` is visible.
+- `getByRole("button", { name: /Connect Plex/i })` is visible (no existing integration).
+
+---
+
+## TC-02: Unauthenticated user is redirected to /login
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: The auth redirect is enforced by the `RequireAuth` component which reads
+the session stub. No backend needed.
+
+**Preconditions**:
+
+- `mockLoggedOut(page)` stubs `GET /api/auth/get-session` with `null`.
+
+**Steps**:
+
+1. Call `mockLoggedOut(page)`.
+2. Navigate to `/settings?tab=integrations`.
+3. Wait for the URL to change away from `/settings`.
+
+**Expected**:
+
+- The browser is redirected to `/login`.
+- The integrations tab content is never rendered (`getByText("Plex")` is absent).
+
+---
+
+## TC-03: Connect Plex button is visible when no integration exists
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: The button's visibility is driven solely by the `GET /api/integrations`
+response returning an empty list. Mocking is sufficient.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` stubs the session.
+- `page.route()` intercepts `GET **/api/integrations` and returns `{ "integrations": [] }`.
+
+**Steps**:
+
+1. Set up the route intercept.
+2. Call `mockLoggedIn(page)`.
+3. Navigate to `/settings?tab=integrations`.
+4. Wait for `getByText("Plex")` to be visible.
+
+**Expected**:
+
+- `getByRole("button", { name: /Connect Plex/i })` is visible.
+- No integration card (server name, "Disconnect" button) is shown.
+
+---
+
+## TC-04: Clicking "Connect Plex" opens the PIN-waiting state
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: `POST /api/integrations/plex/pin` is intercepted to return a fake PIN
+and auth URL. No real Plex API is called; `window.open` can be suppressed via
+`page.evaluate` or a route that simply returns the mock response without opening a
+real window.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` stubs the session.
+- `page.route()` intercepts `GET **/api/integrations` → `{ "integrations": [] }`.
+- `page.route()` intercepts `POST **/api/integrations/plex/pin` → returns:
+
+```json
+{
+  "pinId": 42,
+  "authUrl": "https://app.plex.tv/auth#?clientID=mock&code=mock-pin"
+}
+```
+
+- Suppress the popup: `page.on("popup", popup => popup.close())` (or route the popup
+  URL to a blank page).
+
+**Steps**:
+
+1. Set up all route intercepts above.
+2. Call `mockLoggedIn(page)`.
+3. Navigate to `/settings?tab=integrations`.
+4. Wait for `getByRole("button", { name: /Connect Plex/i })` to be visible.
+5. Click `getByRole("button", { name: /Connect Plex/i })`.
+6. Wait for the waiting-state hint to appear.
+
+**Expected**:
+
+- The `"Connect Plex"` button disappears.
+- Text `"Waiting for authorization"` (or `/Waiting for authorization/i`) is visible.
+- A `"Cancel"` button is visible.
+- A link `"Open authorization page"` is visible and points to the mock `authUrl`.
+
+---
+
+## TC-05: Plex already connected — shows server card with name and Disconnect button
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: The connected state is purely a render of the `/api/integrations` list.
+A single mock entry exercises all card fields without a live Plex account.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` stubs the session.
+- `page.route()` intercepts `GET **/api/integrations` and returns one Plex integration:
+
+```json
+{
+  "integrations": [
+    {
+      "id": "integ-1",
+      "user_id": "user-1",
+      "provider": "plex",
+      "name": "My Plex Server",
+      "config": {
+        "serverUrl": "http://192.168.1.10:32400",
+        "serverId": "abc123",
+        "serverName": "My Plex Server",
+        "plexUsername": "plexuser",
+        "syncMovies": true,
+        "syncEpisodes": true
+      },
+      "enabled": true,
+      "last_sync_at": "2024-03-01T12:00:00Z",
+      "last_sync_error": null,
+      "created_at": "2024-01-01T00:00:00Z",
+      "updated_at": "2024-03-01T12:00:00Z"
+    }
+  ]
+}
+```
+
+**Steps**:
+
+1. Set up the route intercept.
+2. Call `mockLoggedIn(page)`.
+3. Navigate to `/settings?tab=integrations`.
+4. Wait for `getByText("My Plex Server")` to be visible.
+
+**Expected**:
+
+- `getByText("My Plex Server")` is visible.
+- `getByText("http://192.168.1.10:32400")` is visible (server URL).
+- An `"Enabled"` status pill is visible.
+- `getByRole("button", { name: /Disconnect/i })` is visible.
+- `getByRole("button", { name: /Sync now/i })` is visible and enabled.
+- `getByRole("button", { name: /Disable/i })` is visible (toggle button in enabled state).
+- The `"Connect Plex"` button **is** visible (the app always shows it in idle state to allow adding additional servers).
+
+---
+
+## TC-06: Disconnecting Plex removes the integration card
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: Disconnect is a `DELETE /api/integrations/:id` call followed by a
+`GET /api/integrations` refetch. Both can be mocked to assert the UI reverts to the
+empty state.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` stubs the session.
+- `page.route()` intercepts `GET **/api/integrations` initially returns the connected
+  integration from TC-05 (one Plex entry).
+- `page.route()` intercepts `DELETE **/api/integrations/integ-1` → returns `200 {}`.
+- After the DELETE resolves, the `GET **/api/integrations` mock is updated (via
+  `page.unroute` + re-route) to return `{ "integrations": [] }`.
+
+**Steps**:
+
+1. Set up the connected-integration GET mock.
+2. Call `mockLoggedIn(page)`.
+3. Navigate to `/settings?tab=integrations`.
+4. Wait for `getByRole("button", { name: /Disconnect/i })` to be visible.
+5. Set up the DELETE route intercept and the empty-list GET re-route.
+6. Click `getByRole("button", { name: /Disconnect/i })`.
+7. Wait for the success message to appear.
+
+**Expected**:
+
+- The success message `"Plex integration disconnected."` is visible.
+- The `"My Plex Server"` integration card disappears.
+- `getByRole("button", { name: /Connect Plex/i })` reappears (empty state restored).


### PR DESCRIPTION
Part of #853

## Test plan
- Integrations tab loads
- Plex connect flow mocked
- Calendar feed token visible
- Kiosk token visible

## Notes
- Fixed mock URL: watchlist share token endpoint is `/api/share/token`, not `/api/share/watchlist/token`
- TC-05 expectation corrected: product always shows "Connect Plex" in idle state (allows multiple servers); the test-case doc was updated to match actual behavior
- Background routes needed: `/api/achievements/me`, `/api/recommendations/count`, `/api/user/settings/subscriptions` to prevent real-server 401s from clearing the mocked session