### PR TITLE
feat(e2e): add batch-1 specs (home, browse, stats, calendar, achievements, leaderboard)

### DIFF
--- a/e2e/achievements.spec.ts
+++ b/e2e/achievements.spec.ts
@@ -1,0 +1,197 @@
+import { test, expect } from "@playwright/test";
+import { mockLoggedIn, mockLoggedOut } from "./helpers";
+import {
+  AchievementsPage,
+  MOCK_ACHIEVEMENT_EARNED,
+  MOCK_ACHIEVEMENT_LOCKED,
+  MOCK_ACHIEVEMENT_DETAIL_LOCKED,
+} from "./pages/achievements-page";
+
+const TWO_ACHIEVEMENTS = {
+  achievements: [MOCK_ACHIEVEMENT_EARNED, MOCK_ACHIEVEMENT_LOCKED],
+};
+
+test.describe("Achievements", () => {
+  test.skip(
+    ({ browserName }) => browserName !== "chromium",
+    "chromium only — desktop layout requires a stable viewport",
+  );
+
+  // ── TC-01: Achievements page loads and shows achievement cards ─────────────
+  test("TC-01: achievements page loads with earned and locked cards", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const ach = new AchievementsPage(page);
+    await mockLoggedIn(page);
+    await ach.mockAchievementsShellEndpoints();
+    await page.route("**/api/achievements/me**", (route) =>
+      route.fulfill({ json: TWO_ACHIEVEMENTS }),
+    );
+
+    await ach.gotoAchievements();
+
+    // "Achievements" Kicker is visible
+    await expect(ach.pageKicker()).toBeVisible();
+
+    // XP summary: "1/2 earned · 10 XP"
+    await expect(page.getByText(/1\/2 earned/)).toBeVisible();
+
+    // Both achievement cards are visible
+    await expect(page.getByText("First Watch").first()).toBeVisible();
+    await expect(page.getByText("Binge Starter").first()).toBeVisible();
+
+    // Not the empty state
+    await expect(page.getByText("No achievements yet.")).not.toBeVisible();
+  });
+
+  // ── TC-02: Locked vs earned achievements are visually differentiated ────────
+  test("TC-02: locked achievement has a progress bar; earned does not", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const ach = new AchievementsPage(page);
+    await mockLoggedIn(page);
+    await ach.mockAchievementsShellEndpoints();
+    await page.route("**/api/achievements/me**", (route) =>
+      route.fulfill({ json: TWO_ACHIEVEMENTS }),
+    );
+
+    await ach.gotoAchievements();
+    await expect(page.getByText("First Watch").first()).toBeVisible();
+
+    // Earned card links to /achievements/first_movie
+    const earnedLink = page.getByRole("link", { name: /First Watch/i }).first();
+    await expect(earnedLink).toHaveAttribute(
+      "href",
+      /\/achievements\/first_movie/,
+    );
+
+    // Locked card links to /achievements/watch_10
+    const lockedLink = page
+      .getByRole("link", { name: /Binge Starter/i })
+      .first();
+    await expect(lockedLink).toHaveAttribute(
+      "href",
+      /\/achievements\/watch_10/,
+    );
+
+    // Locked card (in category grid) has a ThinProgress bar (a plain div with
+    // inline height style). Earned card does not render ThinProgress.
+    // Use opacity-60 class as a proxy: BadgeTile applies it to locked tiles.
+    const lockedGridCard = page
+      .getByRole("link", { name: /Binge Starter/i })
+      .last();
+    await expect(lockedGridCard).toHaveClass(/opacity-60/);
+  });
+
+  // ── TC-03: Clicking an achievement navigates to the detail page ─────────────
+  test("TC-03: clicking an achievement card navigates to its detail page", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const ach = new AchievementsPage(page);
+    await mockLoggedIn(page);
+    await ach.mockAchievementsShellEndpoints();
+    await page.route("**/api/achievements/me**", (route) =>
+      route.fulfill({ json: TWO_ACHIEVEMENTS }),
+    );
+    await page.route("**/api/achievements/first_movie/me**", (route) =>
+      route.fulfill({
+        json: {
+          ...MOCK_ACHIEVEMENT_EARNED,
+          ladder: null,
+          history: [],
+          rarity: null,
+        },
+      }),
+    );
+
+    await ach.gotoAchievements();
+    await expect(page.getByText("First Watch").first()).toBeVisible();
+
+    await page
+      .getByRole("link", { name: /First Watch/i })
+      .first()
+      .click();
+
+    await page.waitForURL(/\/achievements\/first_movie/);
+    await expect(page).toHaveURL(/\/achievements\/first_movie/);
+  });
+
+  // ── TC-04: Achievement detail page shows name, description, and progress ────
+  test("TC-04: achievement detail page renders all fields", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const ach = new AchievementsPage(page);
+    await mockLoggedIn(page);
+    await ach.mockAchievementsShellEndpoints();
+    // Detail page also triggers AchievementToast poll
+    await page.route("**/api/achievements/me**", (route) =>
+      route.fulfill({ json: { achievements: [] } }),
+    );
+    await page.route("**/api/achievements/watch_10/me**", (route) =>
+      route.fulfill({ json: MOCK_ACHIEVEMENT_DETAIL_LOCKED }),
+    );
+
+    await ach.gotoAchievementDetail("watch_10");
+
+    // h1 heading shows title
+    await expect(page.getByRole("heading", { level: 1 })).toHaveText(
+      "Binge Starter",
+    );
+
+    // Description
+    await expect(page.getByText("Watch 10 movies")).toBeVisible();
+
+    // Progress section (shown for own locked achievement)
+    await expect(page.getByText("Progress")).toBeVisible();
+    await expect(page.getByText("3 / 10")).toBeVisible();
+
+    // Rarity badge
+    await expect(page.getByText(/Rare/)).toBeVisible();
+
+    // Back link to /achievements
+    await expect(
+      page.getByRole("link", { name: /All achievements/i }),
+    ).toHaveAttribute("href", "/achievements");
+  });
+
+  // ── TC-05: Empty state shows no achievements message ────────────────────────
+  test("TC-05: empty state shows no achievements message", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const ach = new AchievementsPage(page);
+    await mockLoggedIn(page);
+    await ach.mockAchievementsShellEndpoints();
+    await page.route("**/api/achievements/me**", (route) =>
+      route.fulfill({ json: { achievements: [] } }),
+    );
+
+    await ach.gotoAchievements();
+
+    // Kicker still visible
+    await expect(ach.pageKicker()).toBeVisible();
+
+    // Empty state message
+    await expect(page.getByText("No achievements yet.")).toBeVisible();
+
+    // XP summary not shown (no data)
+    await expect(page.getByText(/earned · \d+ XP/)).not.toBeVisible();
+  });
+
+  // ── TC-06: Unauthenticated user is redirected to /login ─────────────────────
+  test("TC-06: unauthenticated user is redirected to /login", async ({
+    page,
+  }) => {
+    await mockLoggedOut(page);
+    await page.goto("/achievements");
+
+    await page.waitForURL(/\/login/);
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.getByRole("heading", { name: /sign in/i })).toBeVisible();
+
+    // Achievements content not visible
+    await expect(page.getByText("No achievements yet.")).not.toBeVisible();
+  });
+});

--- a/e2e/browse.spec.ts
+++ b/e2e/browse.spec.ts
@@ -1,0 +1,237 @@
+import { test, expect } from "@playwright/test";
+import { mockLoggedOut } from "./helpers";
+import {
+  BrowsePage,
+  MOCK_BROWSE_TITLE,
+  MOCK_ACTION_TITLE,
+  MOCK_NETFLIX_TITLE,
+} from "./pages/browse-page";
+
+test.describe("Browse", () => {
+  test.skip(
+    ({ browserName }) => browserName !== "chromium",
+    "chromium only — desktop filter layout requires a stable viewport",
+  );
+
+  // ── TC-01: Browse page loads with header, category tabs, filter bar, title cards ──
+  test("TC-01: browse page loads with header, category tabs, filter bar, and title cards", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const browse = new BrowsePage(page);
+    await mockLoggedOut(page);
+    await browse.mockBrowseDataEndpoints();
+    await page.goto("/browse");
+
+    await expect(browse.browseHeading()).toBeVisible();
+
+    // Kicker text above heading
+    await expect(page.getByText(/Catalog/i)).toBeVisible();
+
+    // Search bar
+    await expect(
+      page.getByPlaceholder(/Search titles or paste IMDB link/i),
+    ).toBeVisible();
+
+    // Category tab buttons
+    await expect(browse.categoryButton("Popular")).toBeVisible();
+    await expect(browse.categoryButton("Upcoming")).toBeVisible();
+    await expect(browse.categoryButton("Top Rated")).toBeVisible();
+    await expect(browse.categoryButton("Now Playing")).toBeVisible();
+
+    // Filter dropdowns
+    await expect(browse.genreDropdownButton()).toBeVisible();
+    await expect(browse.providerDropdownButton()).toBeVisible();
+    await expect(page.getByRole("button", { name: /Any year/i })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Any rating/i }),
+    ).toBeVisible();
+
+    // Content type group: All (pressed by default)
+    const typeGroup = browse.contentTypeGroup();
+    await expect(typeGroup).toBeVisible();
+    await expect(
+      typeGroup.getByRole("button", { name: /^All$/i }),
+    ).toHaveAttribute("aria-pressed", "true");
+    await expect(
+      typeGroup.getByRole("button", { name: /Movies/i }),
+    ).toBeVisible();
+    await expect(
+      typeGroup.getByRole("button", { name: /Shows/i }),
+    ).toBeVisible();
+
+    // Title card for the mocked title
+    await expect(browse.titleCard("Test Movie")).toBeVisible();
+
+    // "Popular" heading above the title grid
+    await expect(
+      page.getByRole("heading", { name: "Popular", level: 2 }),
+    ).toBeVisible();
+  });
+
+  // ── TC-02: Genre filter selects Action and updates results ──────────────────
+  test("TC-02: genre filter re-queries API and updates results", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const browse = new BrowsePage(page);
+    await mockLoggedOut(page);
+    await browse.mockBrowseDataEndpoints();
+    // Override browse for genre=Action — registered AFTER so it wins (LIFO)
+    await page.route("**/api/browse**", (route) => {
+      const url = new URL(route.request().url());
+      if (url.searchParams.get("genre") === "Action") {
+        return route.fulfill({
+          json: {
+            titles: [MOCK_ACTION_TITLE],
+            page: 1,
+            totalPages: 1,
+            totalResults: 1,
+          },
+        });
+      }
+      return route.continue();
+    });
+    await page.goto("/browse");
+    await expect(browse.browseHeading()).toBeVisible();
+
+    // Open Genre dropdown
+    await browse.genreDropdownButton().click();
+    // Checklist should appear — click the Action checkbox
+    await page.getByRole("checkbox", { name: "Action" }).click();
+    // Close the dropdown
+    await page.keyboard.press("Escape");
+
+    // Active filter chip appears in the active-filters row (× is Unicode U+00D7)
+    await expect(browse.activeFilterChip("Action ×")).toBeVisible();
+
+    // New title appears; old title gone
+    await expect(browse.titleCard("Action Movie")).toBeVisible();
+    await expect(browse.titleCard("Test Movie")).not.toBeVisible();
+  });
+
+  // ── TC-03: Provider filter selects Netflix and updates results ──────────────
+  test("TC-03: provider filter re-queries API and updates results", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const browse = new BrowsePage(page);
+    await mockLoggedOut(page);
+    await browse.mockBrowseDataEndpoints();
+    // Override browse for provider=8 — registered AFTER so it wins (LIFO)
+    await page.route("**/api/browse**", (route) => {
+      const url = new URL(route.request().url());
+      if (url.searchParams.get("provider") === "8") {
+        return route.fulfill({
+          json: {
+            titles: [MOCK_NETFLIX_TITLE],
+            page: 1,
+            totalPages: 1,
+            totalResults: 1,
+          },
+        });
+      }
+      return route.continue();
+    });
+    await page.goto("/browse");
+    await expect(browse.browseHeading()).toBeVisible();
+
+    // Open Provider dropdown
+    await browse.providerDropdownButton().click();
+    // Click the Netflix checkbox
+    await page.getByRole("checkbox", { name: "Netflix" }).click();
+    // Close the dropdown
+    await page.keyboard.press("Escape");
+
+    // Active filter chip appears in the active-filters row (× is Unicode U+00D7)
+    await expect(browse.activeFilterChip("Netflix ×")).toBeVisible();
+
+    // Netflix Movie appears; Test Movie gone
+    await expect(browse.titleCard("Netflix Movie")).toBeVisible();
+    await expect(browse.titleCard("Test Movie")).not.toBeVisible();
+  });
+
+  // ── TC-04: Empty results show no-titles message ─────────────────────────────
+  test("TC-04: empty results show no titles message", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const browse = new BrowsePage(page);
+    await mockLoggedOut(page);
+    await browse.mockBrowseDataEndpoints();
+    // Override browse with empty results — registered AFTER so it wins (LIFO)
+    await page.route("**/api/browse**", (route) =>
+      route.fulfill({
+        json: { titles: [], page: 1, totalPages: 0, totalResults: 0 },
+      }),
+    );
+    await page.goto("/browse");
+
+    await expect(browse.browseHeading()).toBeVisible();
+
+    // No article elements in the grid
+    await expect(page.getByRole("article")).toHaveCount(0);
+
+    // Empty state message from TitleList
+    await expect(page.getByText("No titles found.")).toBeVisible();
+
+    // Filter bar still rendered
+    await expect(browse.categoryButton("Popular")).toBeVisible();
+    await expect(browse.genreDropdownButton()).toBeVisible();
+
+    // No error banner
+    await expect(page.locator(".bg-red-900\\/50")).not.toBeVisible();
+  });
+
+  // ── TC-05: Unauthenticated user can access /browse (public page) ────────────
+  test("TC-05: unauthenticated user can access /browse without redirect", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const browse = new BrowsePage(page);
+    await mockLoggedOut(page);
+    await browse.mockBrowseDataEndpoints();
+    await page.goto("/browse");
+
+    // URL stays at /browse — no redirect to /login
+    await expect(page).toHaveURL("/browse");
+    await expect(browse.browseHeading()).toBeVisible();
+
+    // Top nav shows "Sign In" link (not a user avatar)
+    await expect(
+      page
+        .getByRole("navigation", { name: /main navigation/i })
+        .getByRole("link", { name: /sign in/i }),
+    ).toBeVisible();
+
+    // Title grid renders the mocked title
+    await expect(browse.titleCard("Test Movie")).toBeVisible();
+  });
+
+  // ── TC-06: Clicking a title navigates to the title detail page ──────────────
+  test("TC-06: clicking a title card navigates to the title detail page", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const browse = new BrowsePage(page);
+    await mockLoggedOut(page);
+    await browse.mockBrowseDataEndpoints();
+    // Stub details endpoint so the page doesn't get a 404/error (optional)
+    await page.route("**/api/details/**", (route) =>
+      route.fulfill({ json: null }),
+    );
+    await page.goto("/browse");
+    await expect(browse.titleCard("Test Movie")).toBeVisible();
+
+    // Click the title link inside the article
+    await browse
+      .titleCard("Test Movie")
+      .getByRole("link", { name: "Test Movie" })
+      .first()
+      .click();
+
+    await page.waitForURL(/\/title\/movie-12345/);
+    await expect(page).toHaveURL(/\/title\/movie-12345/);
+
+    // Browse heading and category tabs are no longer visible
+    await expect(browse.browseHeading()).not.toBeVisible();
+  });
+});

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect } from "@playwright/test";
+import { mockLoggedIn, mockLoggedOut } from "./helpers";
+import {
+  CalendarPage,
+  mockCalendarSingle,
+  mockCalendarMultiShow,
+} from "./pages/calendar-page";
+
+test.describe("Calendar", () => {
+  test.skip(
+    ({ browserName }) => browserName !== "chromium",
+    "chromium only — desktop grid layout requires a stable viewport",
+  );
+
+  // ── TC-01: Calendar page loads and shows upcoming episodes ─────────────────
+  test("TC-01: calendar page loads and shows upcoming episodes", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const cal = new CalendarPage(page);
+    await mockLoggedIn(page);
+    await cal.mockCalendarShellEndpoints();
+    await page.route("**/api/calendar**", (route) =>
+      route.fulfill({ json: mockCalendarSingle() }),
+    );
+
+    await cal.gotoCalendar();
+
+    // URL stays at /calendar
+    await expect(page).toHaveURL("/calendar");
+
+    // Page heading shows current month name (e.g. "May 2026")
+    await expect(cal.monthHeading()).toBeVisible();
+
+    // Show title and/or episode name appears somewhere in the grid
+    await expect(page.getByText("Test Show")).toBeVisible();
+
+    // No error banner
+    await expect(page.locator(".bg-red-900\\/50")).not.toBeVisible();
+  });
+
+  // ── TC-02: Episodes grouped by date/show correctly ─────────────────────────
+  test("TC-02: episodes appear in correct date cells", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const cal = new CalendarPage(page);
+    await mockLoggedIn(page);
+    await cal.mockCalendarShellEndpoints();
+    await page.route("**/api/calendar**", (route) =>
+      route.fulfill({ json: mockCalendarMultiShow() }),
+    );
+
+    await cal.gotoCalendar();
+    await expect(cal.monthHeading()).toBeVisible();
+
+    // Both Alpha Show episodes appear as pills. Each pill text is
+    // "S{n}E{n} {show_title}". Two pills match the Alpha Show pattern;
+    // use .first() to avoid strict mode violation.
+    await expect(
+      page.getByText(/S2E3.*Alpha Show|Alpha Show/).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/S2E4.*Alpha Show|Alpha Show/).first(),
+    ).toBeVisible();
+
+    // Beta Show appears in a different date cell
+    await expect(
+      page.getByText(/S1E1.*Beta Show|Beta Show/).first(),
+    ).toBeVisible();
+
+    // The two show names appear at least once each
+    await expect(page.getByText("Alpha Show").first()).toBeVisible();
+    await expect(page.getByText("Beta Show").first()).toBeVisible();
+  });
+
+  // ── TC-03: Empty state — no upcoming episodes ──────────────────────────────
+  test("TC-03: empty calendar renders grid without error", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const cal = new CalendarPage(page);
+    await mockLoggedIn(page);
+    await cal.mockCalendarShellEndpoints();
+    await page.route("**/api/calendar**", (route) =>
+      route.fulfill({ json: { titles: [], episodes: [], count: 0 } }),
+    );
+
+    await cal.gotoCalendar();
+
+    // Month heading visible
+    await expect(cal.monthHeading()).toBeVisible();
+
+    // No episode pills anywhere
+    await expect(page.getByText(/S\d+E\d+/)).not.toBeVisible();
+
+    // No error banner
+    await expect(page.locator(".bg-red-900\\/50")).not.toBeVisible();
+  });
+
+  // ── TC-04: Clicking a show title navigates to the title detail page ─────────
+  test("TC-04: clicking show title navigates to title detail page", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const cal = new CalendarPage(page);
+    await mockLoggedIn(page);
+    await cal.mockCalendarShellEndpoints();
+    await page.route("**/api/calendar**", (route) =>
+      route.fulfill({ json: mockCalendarSingle("tv-98765", "Test Show") }),
+    );
+    // Stub detail page so navigation can succeed
+    await page.route("**/api/details/**", (route) =>
+      route.fulfill({ json: null }),
+    );
+
+    await cal.gotoCalendar();
+
+    // Click the date cell containing the episode to open the slide-over
+    // The grid cell contains a pill with "Test Show" text — click it
+    await page.getByText("Test Show").first().click();
+
+    // After clicking the cell, a slide-over panel opens with a link to the title
+    // Wait for either direct navigation or the slide-over link to appear
+    const titleLink = page.getByRole("link", { name: /Test Show/i }).first();
+    await expect(titleLink).toBeVisible({ timeout: 5000 });
+    await titleLink.click();
+
+    await page.waitForURL(/\/title\/tv-98765/);
+    await expect(page).toHaveURL(/\/title\/tv-98765/);
+  });
+
+  // ── TC-05: Unauthenticated user visiting /upcoming is redirected to /login ──
+  test("TC-05: unauthenticated user visiting /upcoming redirects to /login", async ({
+    page,
+  }) => {
+    await mockLoggedOut(page);
+    await page.goto("/upcoming");
+
+    await page.waitForURL(/\/login/);
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.getByRole("heading", { name: /sign in/i })).toBeVisible();
+
+    // Calendar/upcoming content not visible
+    await expect(page.getByText(/S\d+E\d+/)).not.toBeVisible();
+  });
+});

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,0 +1,197 @@
+import { test, expect } from "@playwright/test";
+import {
+  mockLoggedIn,
+  mockLoggedOut,
+  MOCK_EPISODE,
+  MOCK_UPCOMING_EPISODE,
+  MOCK_SEARCH_TITLE,
+} from "./helpers";
+import { HomePage } from "./pages/home-page";
+
+test.describe("Home", () => {
+  test.skip(
+    ({ browserName }) => browserName !== "chromium",
+    "chromium only — desktop layout requires a stable viewport",
+  );
+
+  // ── TC-01: Authenticated user sees the home page ──────────────────────────
+  test("TC-01: authenticated user sees the home page", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const home = new HomePage(page);
+    await mockLoggedIn(page);
+    await home.mockHomeDataEndpoints();
+    await home.gotoHome();
+
+    await expect(page).toHaveTitle(/remindarr/i);
+    // Unauthenticated hero should NOT be visible
+    await expect(
+      page.getByRole("heading", { name: /track movies.*tv shows/i }),
+    ).not.toBeVisible();
+    // Main content area should be present
+    await expect(page.locator("main")).toBeVisible();
+    // Top nav has a Home link
+    await expect(
+      page
+        .getByRole("navigation", { name: /main navigation/i })
+        .getByRole("link", { name: /home/i }),
+    ).toBeVisible();
+    // No error banner
+    await expect(page.locator(".bg-red-900\\/50")).not.toBeVisible();
+  });
+
+  // ── TC-02: Home page shows tracked titles list (upcoming episodes) ────────
+  test("TC-02: shows today's airing episode", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const home = new HomePage(page);
+    await mockLoggedIn(page);
+    // Register base mocks first (includes empty episodes fallback)
+    await home.mockHomeDataEndpoints();
+    // Override episodes with today's episode — registered AFTER so it wins (LIFO)
+    await page.route("**/api/episodes/upcoming", (route) =>
+      route.fulfill({
+        json: { today: [MOCK_EPISODE], upcoming: [], unwatched: [] },
+      }),
+    );
+    await home.gotoHome();
+
+    await expect(page.locator("main")).toBeVisible();
+    // "Today" section heading from t("home.today")
+    await expect(page.getByRole("heading", { name: /today/i })).toBeVisible();
+    // Show title appears
+    await expect(page.getByText(MOCK_EPISODE.show_title)).toBeVisible();
+    // Episode code chip e.g. "S01·E01"
+    await expect(page.getByText(/S01[·\s]?E01/)).toBeVisible();
+  });
+
+  // ── TC-03: Home page shows upcoming episodes section ──────────────────────
+  test("TC-03: shows upcoming episodes section", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const home = new HomePage(page);
+    await mockLoggedIn(page);
+    await home.mockHomeDataEndpoints();
+    // Override episodes with upcoming episode — registered AFTER so it wins (LIFO)
+    await page.route("**/api/episodes/upcoming", (route) =>
+      route.fulfill({
+        json: { today: [], upcoming: [MOCK_UPCOMING_EPISODE], unwatched: [] },
+      }),
+    );
+    await home.gotoHome();
+
+    await expect(page.locator("main")).toBeVisible();
+    // "Coming Up" section heading from t("home.comingUp")
+    await expect(
+      page.getByRole("heading", { name: /coming up/i }),
+    ).toBeVisible();
+    // Show title appears
+    await expect(
+      page.getByText(MOCK_UPCOMING_EPISODE.show_title),
+    ).toBeVisible();
+    // Episode code chip e.g. "S01·E02"
+    await expect(page.getByText(/S01[·\s]?E02/)).toBeVisible();
+  });
+
+  // ── TC-04: Empty state — no tracked titles ────────────────────────────────
+  test("TC-04: empty state shows no episodes message", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const home = new HomePage(page);
+    await mockLoggedIn(page);
+    // mockHomeDataEndpoints stubs episodes/upcoming with empty arrays
+    await home.mockHomeDataEndpoints();
+    await home.gotoHome();
+
+    await expect(page.locator("main")).toBeVisible();
+    // "Today" section kicker "Airing tonight" is rendered as a div (Kicker component)
+    await expect(page.getByText(/airing tonight/i)).toBeVisible();
+    // Empty state message — t("home.noEpisodes") when all lists empty
+    await expect(page.getByText(/no upcoming episodes/i)).toBeVisible();
+    // No JS error banner
+    await expect(page.locator(".bg-red-900\\/50")).not.toBeVisible();
+  });
+
+  // ── TC-05: Unauthenticated user sees the landing page ────────────────────
+  test("TC-05: unauthenticated user sees landing page", async ({ page }) => {
+    const home = new HomePage(page);
+    await mockLoggedOut(page);
+    // Browse endpoint for Popular Right Now section
+    await page.route("**/api/browse**", (route) =>
+      route.fulfill({
+        json: {
+          titles: [MOCK_SEARCH_TITLE],
+          page: 1,
+          totalPages: 1,
+          totalResults: 1,
+          availableGenres: [],
+          availableProviders: [],
+          availableLanguages: [],
+        },
+      }),
+    );
+    await home.gotoHome();
+
+    // Hero heading visible
+    await expect(
+      page.getByRole("heading", { name: /track movies.*tv shows/i }),
+    ).toBeVisible();
+    // Sign In link in main content area (scoped to avoid strict mode with nav link)
+    await expect(
+      page.locator("#main-content").getByRole("link", { name: /sign in/i }),
+    ).toBeVisible();
+    // Create Account link to /signup
+    await expect(
+      page.getByRole("link", { name: /create account/i }),
+    ).toBeVisible();
+    // Popular Right Now section
+    await expect(
+      page.getByRole("heading", { name: /popular right now/i }),
+    ).toBeVisible();
+    // URL remains /
+    await expect(page).toHaveURL("/");
+  });
+
+  // ── TC-06: Navigation — home is accessible from the nav bar ──────────────
+  test("TC-06: Home nav link navigates to home", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const home = new HomePage(page);
+    await mockLoggedIn(page);
+    await home.mockHomeDataEndpoints();
+    // Stub browse so /browse can render without hitting real backend
+    await page.route("**/api/browse**", (route) =>
+      route.fulfill({
+        json: {
+          titles: [],
+          page: 1,
+          totalPages: 0,
+          totalResults: 0,
+          availableGenres: [],
+          availableProviders: [],
+          availableLanguages: [],
+        },
+      }),
+    );
+    await page.route("**/api/titles/genres", (route) =>
+      route.fulfill({ json: { genres: [] } }),
+    );
+    await page.route("**/api/titles/providers", (route) =>
+      route.fulfill({ json: { providers: [], regionProviderIds: [] } }),
+    );
+    await page.route("**/api/titles/languages", (route) =>
+      route.fulfill({ json: { languages: [], priorityLanguageCodes: [] } }),
+    );
+
+    // Navigate away from home first
+    await page.goto("/browse");
+    await expect(page.getByRole("heading", { name: "Browse" })).toBeVisible();
+
+    // Click Home nav link
+    const nav = page.getByRole("navigation", { name: /main navigation/i });
+    await nav.getByRole("link", { name: /home/i }).click();
+    await page.waitForURL("/");
+
+    await expect(page).toHaveURL("/");
+    // Main content visible (authenticated home, not landing)
+    await expect(page.locator("main")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /track movies.*tv shows/i }),
+    ).not.toBeVisible();
+  });
+});

--- a/e2e/leaderboard.spec.ts
+++ b/e2e/leaderboard.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from "@playwright/test";
+import { mockLoggedIn, mockLoggedOut } from "./helpers";
+import {
+  LeaderboardPage,
+  MOCK_LEADERBOARD_FOUR_ENTRIES,
+  MOCK_LEADERBOARD_WITH_ME,
+} from "./pages/leaderboard-page";
+
+test.describe("Leaderboard", () => {
+  test.skip(
+    ({ browserName }) => browserName !== "chromium",
+    "chromium only — desktop layout requires a stable viewport",
+  );
+
+  // ── TC-01: Leaderboard loads and shows ranked users ──────────────────────────
+  test("TC-01: leaderboard loads with podium and ranked list", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const lb = new LeaderboardPage(page);
+    await mockLoggedIn(page);
+    await lb.mockLeaderboardShellEndpoints();
+    await page.route("**/api/leaderboard**", (route) =>
+      route.fulfill({ json: MOCK_LEADERBOARD_FOUR_ENTRIES }),
+    );
+
+    await lb.gotoLeaderboard();
+    await expect(lb.pageHeading()).toBeVisible();
+
+    // Subtitle
+    await expect(page.getByText("Among people you follow")).toBeVisible();
+
+    // Podium: ranks 1–3 visible
+    await expect(page.getByText("#1")).toBeVisible();
+    await expect(page.getByText("#2")).toBeVisible();
+    await expect(page.getByText("#3")).toBeVisible();
+
+    // Podium entries: Alice (rank 1, shown center), Bob (rank 2, left), Charlie (rank 3, right)
+    await expect(page.getByText("Alice", { exact: true })).toBeVisible();
+    await expect(page.getByText("Bob", { exact: true })).toBeVisible();
+    await expect(page.getByText("Charlie", { exact: true })).toBeVisible();
+
+    // XP visible for podium entries
+    await expect(page.getByText("500 XP")).toBeVisible();
+
+    // Ranked list shows Diana at #4
+    await expect(page.getByText("#4")).toBeVisible();
+    await expect(page.getByText("Diana", { exact: true })).toBeVisible();
+
+    // No error banner
+    await expect(page.locator(".bg-red-900\\/40")).not.toBeVisible();
+  });
+
+  // ── TC-02: Current user's entry is highlighted ───────────────────────────────
+  test("TC-02: current user podium card has amber highlight", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const lb = new LeaderboardPage(page);
+    await mockLoggedIn(page);
+    await lb.mockLeaderboardShellEndpoints();
+    await page.route("**/api/leaderboard**", (route) =>
+      route.fulfill({ json: MOCK_LEADERBOARD_WITH_ME }),
+    );
+
+    await lb.gotoLeaderboard();
+    await expect(lb.pageHeading()).toBeVisible();
+
+    // Current user is rank 2 (in podium). Locate the @testuser text, then
+    // walk up to the podium card container and verify amber highlight class.
+    const usernameEl = page.getByText("@testuser");
+    await expect(usernameEl).toBeVisible();
+
+    // The PodiumSpot div is the first ancestor div with border-amber-400/40
+    const podiumCard = usernameEl
+      .locator("xpath=ancestor::div[contains(@class,'border-amber')]")
+      .first();
+    await expect(podiumCard).toBeVisible();
+    await expect(podiumCard).toHaveClass(/border-amber/);
+
+    // Other podium cards (Alice, Bob) do not have amber border
+    const aliceCard = page
+      .getByText("@alice")
+      .locator("xpath=ancestor::div[contains(@class,'rounded-xl')]")
+      .first();
+    await expect(aliceCard).not.toHaveClass(/border-amber/);
+  });
+
+  // ── TC-03: Empty leaderboard shows empty state message ───────────────────────
+  test("TC-03: empty leaderboard shows follow prompt", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const lb = new LeaderboardPage(page);
+    await mockLoggedIn(page);
+    await lb.mockLeaderboardShellEndpoints();
+    await page.route("**/api/leaderboard**", (route) =>
+      route.fulfill({ json: { entries: [] } }),
+    );
+
+    await lb.gotoLeaderboard();
+
+    // Heading and subtitle visible in empty state
+    await expect(lb.pageHeading()).toBeVisible();
+    await expect(page.getByText("Among people you follow")).toBeVisible();
+
+    // Empty state message
+    await expect(
+      page.getByText(/follow people to see them on the leaderboard/i),
+    ).toBeVisible();
+
+    // No podium rank labels
+    await expect(page.getByText("#1")).not.toBeVisible();
+    await expect(page.getByText("#2")).not.toBeVisible();
+    await expect(page.getByText("#3")).not.toBeVisible();
+  });
+
+  // ── TC-05: Unauthenticated user is redirected to /login ──────────────────────
+  test("TC-05: unauthenticated user is redirected to /login", async ({
+    page,
+  }) => {
+    await mockLoggedOut(page);
+    await page.goto("/leaderboard");
+
+    await page.waitForURL(/\/login/);
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.getByRole("heading", { name: /sign in/i })).toBeVisible();
+
+    // Leaderboard content not visible
+    await expect(
+      page.getByRole("heading", { name: /leaderboard/i }),
+    ).not.toBeVisible();
+  });
+});

--- a/e2e/pages/achievements-page.ts
+++ b/e2e/pages/achievements-page.ts
@@ -1,0 +1,97 @@
+import type { Page } from "@playwright/test";
+import { BasePage } from "./base-page";
+
+/**
+ * Achievements page POM.
+ *
+ * Non-DOM notes:
+ * - AchievementsPage at /achievements calls GET /api/achievements/me.
+ * - AchievementDetailPage at /achievements/:key calls GET /api/achievements/:key/me.
+ * - AchievementToast in the app shell also polls GET /api/achievements/me —
+ *   mocking it here satisfies both the page query and the background poll.
+ * - App shell endpoints (subscriptions, recommendations/count) must be mocked
+ *   to prevent auth:unauthorized logout events.
+ * - The "Achievements" text is rendered as a Kicker component (not a heading role).
+ */
+export class AchievementsPage extends BasePage {
+  async gotoAchievements(): Promise<void> {
+    await this.goto("/achievements");
+  }
+
+  async gotoAchievementDetail(key: string): Promise<void> {
+    await this.goto(`/achievements/${key}`);
+  }
+
+  /**
+   * Stub all shell endpoints needed for authenticated visits to achievements pages.
+   * Does NOT mock /api/achievements/me or detail endpoints — tests register those.
+   */
+  async mockAchievementsShellEndpoints(): Promise<void> {
+    await this.page.route("**/api/user/settings/subscriptions**", (route) =>
+      route.fulfill({ json: { providerIds: [] } }),
+    );
+    await this.page.route("**/api/recommendations/count**", (route) =>
+      route.fulfill({ json: { count: 0 } }),
+    );
+    await this.page.route("**/api/suggestions**", (route) =>
+      route.fulfill({ json: { flat: [], bySource: {} } }),
+    );
+  }
+
+  pageKicker() {
+    return this.page.getByText("Achievements").first();
+  }
+}
+
+// ── Achievement fixtures ──────────────────────────────────────────────────────
+
+export const MOCK_ACHIEVEMENT_EARNED = {
+  key: "first_movie",
+  kind: "count_movies",
+  title: "First Watch",
+  description: "Watch your first movie",
+  icon: "Film",
+  threshold: 1,
+  points: 10,
+  progress: 1,
+  earned: true,
+  earnedAt: "2024-03-01T12:00:00Z",
+  category: "watching",
+  tier: "one-shot",
+  repeatable: false,
+  family: null,
+  rungIndex: null,
+  earnedCount: 1,
+  lastEarnedAt: "2024-03-01T12:00:00Z",
+  nextRung: null,
+  rarity: null,
+};
+
+export const MOCK_ACHIEVEMENT_LOCKED = {
+  key: "watch_10",
+  kind: "count_movies",
+  title: "Binge Starter",
+  description: "Watch 10 movies",
+  icon: "Film",
+  threshold: 10,
+  points: 25,
+  progress: 3,
+  earned: false,
+  earnedAt: null,
+  category: "watching",
+  tier: "one-shot",
+  repeatable: false,
+  family: null,
+  rungIndex: null,
+  earnedCount: 0,
+  lastEarnedAt: null,
+  nextRung: null,
+  rarity: null,
+};
+
+export const MOCK_ACHIEVEMENT_DETAIL_LOCKED = {
+  ...MOCK_ACHIEVEMENT_LOCKED,
+  rarity: { bucket: "Rare", pct: 12 },
+  ladder: null,
+  history: [],
+};

--- a/e2e/pages/browse-page.ts
+++ b/e2e/pages/browse-page.ts
@@ -1,0 +1,148 @@
+import type { Page } from "@playwright/test";
+import { BasePage } from "./base-page";
+
+/**
+ * Browse page POM.
+ *
+ * Non-DOM notes:
+ * - The browse page at `/browse` is publicly accessible — no RequireAuth wrapper.
+ * - CategoryBrowse calls GET /api/browse?category=popular&page=1 on load.
+ *   The glob pattern catches all variants (with query params).
+ * - loadFilters calls genres/providers/languages in parallel on mount.
+ * - Filter dropdowns (Genre, Provider) are FilterField components: clicking the
+ *   summary button toggles an absolutely-positioned checklist panel.
+ *   Each option is a label wrapping an input[type=checkbox].
+ * - Active filter chips are button elements with text like "Action x".
+ * - Category tabs use the Pill component which renders as a button.
+ * - Title cards render as article[aria-label={title.title}].
+ * - The BrowseFilterCard type group uses role="group" aria-label="Content type".
+ */
+export class BrowsePage extends BasePage {
+  async gotoBrowse(): Promise<void> {
+    await this.goto("/browse");
+  }
+
+  /**
+   * Mock all filter-data endpoints (genres, providers, languages) and the
+   * browse results endpoint with a single title: "Test Movie" (id "movie-12345").
+   * Call this before navigating. Register more specific browse route mocks AFTER
+   * this call so they win (Playwright applies routes LIFO).
+   */
+  async mockBrowseDataEndpoints(): Promise<void> {
+    await this.page.route("**/api/titles/genres", (route) =>
+      route.fulfill({
+        json: { genres: ["Action", "Drama", "Comedy"] },
+      }),
+    );
+    await this.page.route("**/api/titles/providers", (route) =>
+      route.fulfill({
+        json: {
+          providers: [
+            {
+              id: 8,
+              name: "Netflix",
+              technical_name: "netflix",
+              icon_url: "",
+            },
+          ],
+          regionProviderIds: [8],
+        },
+      }),
+    );
+    await this.page.route("**/api/titles/languages", (route) =>
+      route.fulfill({
+        json: { languages: ["en", "es"], priorityLanguageCodes: ["en"] },
+      }),
+    );
+    await this.page.route("**/api/browse**", (route) =>
+      route.fulfill({
+        json: {
+          titles: [MOCK_BROWSE_TITLE],
+          page: 1,
+          totalPages: 1,
+          totalResults: 1,
+        },
+      }),
+    );
+  }
+
+  browseHeading() {
+    return this.page.getByRole("heading", { name: "Browse" });
+  }
+
+  categoryButton(name: string) {
+    return this.page.getByRole("button", { name, exact: true });
+  }
+
+  genreDropdownButton() {
+    return this.page.getByRole("button", { name: /All genres/i });
+  }
+
+  providerDropdownButton() {
+    return this.page.getByRole("button", { name: /All providers/i });
+  }
+
+  contentTypeGroup() {
+    return this.page.getByRole("group", { name: /Content type/i });
+  }
+
+  titleCard(name: string) {
+    return this.page.getByRole("article", { name });
+  }
+
+  /**
+   * Active filter chips have aria-label="Remove X filter" but display text "X x".
+   * Use getByText for the visible label (the "x" is the Unicode multiplication sign).
+   */
+  activeFilterChip(displayText: string) {
+    return this.page.getByText(displayText, { exact: true });
+  }
+}
+
+/** Standard browse fixture — matches the camelCase SearchTitle shape returned by /api/browse. */
+export const MOCK_BROWSE_TITLE = {
+  id: "movie-12345",
+  objectType: "MOVIE",
+  title: "Test Movie",
+  originalTitle: "Test Movie",
+  releaseYear: 2024,
+  releaseDate: "2024-06-15",
+  runtimeMinutes: 120,
+  shortDescription: "A test movie",
+  genres: ["Action"],
+  imdbId: "tt1234567",
+  tmdbId: 12345,
+  posterUrl: null,
+  ageCertification: "PG-13",
+  originalLanguage: "en",
+  tmdbUrl: "https://www.themoviedb.org/movie/12345",
+  offers: [],
+  scores: { imdbScore: 7.5, imdbVotes: 10000, tmdbScore: 7.8 },
+  isTracked: false,
+};
+
+/** Browse fixture for an Action-genre filter result. */
+export const MOCK_ACTION_TITLE = {
+  ...MOCK_BROWSE_TITLE,
+  id: "movie-99999",
+  title: "Action Movie",
+  originalTitle: "Action Movie",
+};
+
+/** Browse fixture for a Netflix provider filter result. */
+export const MOCK_NETFLIX_TITLE = {
+  ...MOCK_BROWSE_TITLE,
+  id: "movie-88888",
+  title: "Netflix Movie",
+  originalTitle: "Netflix Movie",
+  offers: [
+    {
+      provider_id: 8,
+      provider_name: "Netflix",
+      provider_technical_name: "netflix",
+      provider_icon_url: "",
+      monetization_type: "FLATRATE",
+      url: "https://netflix.com",
+    },
+  ],
+};

--- a/e2e/pages/calendar-page.ts
+++ b/e2e/pages/calendar-page.ts
@@ -1,0 +1,148 @@
+import type { Page } from "@playwright/test";
+import { BasePage } from "./base-page";
+
+/**
+ * Calendar page POM.
+ *
+ * Non-DOM notes:
+ * - CalendarPage at /calendar renders a GridCalendar (default), Agenda, or
+ *   Week view. Tests use desktop viewport (1280x720) to ensure grid view renders
+ *   (mobile renders MobileCalendar).
+ * - GridCalendar calls GET /api/calendar?month=YYYY-MM on mount.
+ * - GridCalendar also calls GET /api/user/settings/crowded-weeks on mount.
+ * - App shell background components need mocks for subscriptions, achievements/me,
+ *   recommendations/count, and suggestions to avoid auth:unauthorized events.
+ * - Episode pills in the grid show "S{n}E{n} {show_title}" text.
+ * - The page heading is the current month name, e.g. "May 2026".
+ */
+export class CalendarPage extends BasePage {
+  async gotoCalendar(): Promise<void> {
+    await this.goto("/calendar");
+  }
+
+  /**
+   * Stub all shell endpoints needed for an authenticated visit to /calendar.
+   * Does NOT mock /api/calendar or /api/user/settings/crowded-weeks — tests
+   * register those themselves. Call before navigating.
+   */
+  async mockCalendarShellEndpoints(): Promise<void> {
+    // AuthContext post-auth call
+    await this.page.route("**/api/user/settings/subscriptions**", (route) =>
+      route.fulfill({ json: { providerIds: [] } }),
+    );
+    // AchievementToast background polling
+    await this.page.route("**/api/achievements/me**", (route) =>
+      route.fulfill({ json: [] }),
+    );
+    // Nav recommendations count badge
+    await this.page.route("**/api/recommendations/count**", (route) =>
+      route.fulfill({ json: { count: 0 } }),
+    );
+    // SuggestedForYouRow (not rendered on calendar page but stub for safety)
+    await this.page.route("**/api/suggestions**", (route) =>
+      route.fulfill({ json: { flat: [], bySource: {} } }),
+    );
+    // Crowded week settings — return safe defaults
+    await this.page.route("**/api/user/settings/crowded-weeks**", (route) =>
+      route.fulfill({
+        json: { crowdedWeekThreshold: 5, crowdedWeekBadgeEnabled: 0 },
+      }),
+    );
+  }
+
+  /** The month heading rendered by PageHeader, e.g. "May 2026". */
+  monthHeading() {
+    return this.page.getByRole("heading", { level: 1 });
+  }
+}
+
+// ── Calendar API fixtures ─────────────────────────────────────────────────────
+
+/** Build a date string N days from today in YYYY-MM-DD format. */
+export function dateFromToday(offsetDays: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + offsetDays);
+  return d.toISOString().split("T")[0];
+}
+
+/** Standard single-episode calendar response. */
+export function mockCalendarSingle(
+  titleId = "tv-98765",
+  showTitle = "Test Show",
+) {
+  const tomorrow = dateFromToday(1);
+  return {
+    titles: [],
+    episodes: [
+      {
+        id: 102,
+        title_id: titleId,
+        season_number: 1,
+        episode_number: 2,
+        name: "Second Episode",
+        overview: "The second episode",
+        air_date: tomorrow,
+        still_path: null,
+        show_title: showTitle,
+        poster_url: null,
+        is_watched: false,
+        offers: [],
+      },
+    ],
+    count: 1,
+  };
+}
+
+/** Two-show calendar response for grouping tests. */
+export function mockCalendarMultiShow() {
+  const dateA = dateFromToday(1);
+  const dateB = dateFromToday(8);
+  return {
+    titles: [],
+    episodes: [
+      {
+        id: 201,
+        title_id: "tv-111",
+        season_number: 2,
+        episode_number: 3,
+        name: "Part One",
+        air_date: dateA,
+        show_title: "Alpha Show",
+        poster_url: null,
+        is_watched: false,
+        offers: [],
+        still_path: null,
+        overview: "",
+      },
+      {
+        id: 202,
+        title_id: "tv-111",
+        season_number: 2,
+        episode_number: 4,
+        name: "Part Two",
+        air_date: dateA,
+        show_title: "Alpha Show",
+        poster_url: null,
+        is_watched: false,
+        offers: [],
+        still_path: null,
+        overview: "",
+      },
+      {
+        id: 203,
+        title_id: "tv-222",
+        season_number: 1,
+        episode_number: 1,
+        name: "Premiere",
+        air_date: dateB,
+        show_title: "Beta Show",
+        poster_url: null,
+        is_watched: false,
+        offers: [],
+        still_path: null,
+        overview: "",
+      },
+    ],
+    count: 3,
+  };
+}

--- a/e2e/pages/home-page.ts
+++ b/e2e/pages/home-page.ts
@@ -1,0 +1,120 @@
+import type { Page } from "@playwright/test";
+import { BasePage } from "./base-page";
+
+/**
+ * Home page POM.
+ *
+ * Non-DOM notes:
+ * - The home route renders `HomePage` which shows an unauthenticated landing
+ *   hero when no session is present, or the authenticated sections layout when
+ *   logged in.
+ * - On desktop (≥ 640 px) the desktop layout renders; on mobile an entirely
+ *   different `MobileFeedHome` component is shown and may redirect to `/reels`.
+ *   Tests that use this POM should set viewport to 1280x720.
+ * - The authenticated home fetches several endpoints in parallel (episodes,
+ *   recommendations, homepage-layout, up-next, friends-loved, streak, movies).
+ *   All must be mocked to avoid network calls.
+ */
+export class HomePage extends BasePage {
+  async gotoHome(): Promise<void> {
+    await this.goto("/");
+  }
+
+  /**
+   * Stub all authenticated home data endpoints with empty/valid responses.
+   * Stubs GET /api/episodes/upcoming with empty arrays by default.
+   * To override, register your own episodes/upcoming route AFTER calling this
+   * method — Playwright processes routes LIFO so the last registration wins.
+   */
+  async mockHomeDataEndpoints(): Promise<void> {
+    await this.page.route("**/api/episodes/upcoming", (route) =>
+      route.fulfill({
+        json: { today: [], upcoming: [], unwatched: [] },
+      }),
+    );
+    await this.page.route("**/api/recommendations**", (route) =>
+      route.fulfill({ json: { recommendations: [], count: 0 } }),
+    );
+    // Real URL: /api/user/settings/homepage-layout
+    await this.page.route("**/api/user/settings/homepage-layout**", (route) =>
+      route.fulfill({
+        json: {
+          homepage_layout: [
+            { id: "today", enabled: true },
+            { id: "upcoming", enabled: true },
+            { id: "up_next", enabled: true },
+            { id: "friends_loved", enabled: true },
+            { id: "movies_to_watch", enabled: true },
+            { id: "upcoming_movies", enabled: true },
+            { id: "streak", enabled: true },
+          ],
+        },
+      }),
+    );
+    // Real URL: /api/up-next?limit=12
+    await this.page.route("**/api/up-next**", (route) =>
+      route.fulfill({ json: { items: [] } }),
+    );
+    // Real URL: /api/social/friends-loved?limit=20
+    await this.page.route("**/api/social/friends-loved**", (route) =>
+      route.fulfill({ json: { items: [] } }),
+    );
+    // Real URL: /api/streak/me
+    await this.page.route("**/api/streak/me**", (route) =>
+      route.fulfill({ json: null }),
+    );
+    // Real URL: /api/movies/tracking
+    await this.page.route("**/api/movies/tracking**", (route) =>
+      route.fulfill({ json: { to_watch: [], upcoming: [] } }),
+    );
+    // AuthContext calls getSubscriptions() after auth succeeds.
+    // If unmocked it hits the real server with a fake userId and gets 401,
+    // which triggers the auth:unauthorized event and logs the user out.
+    await this.page.route("**/api/user/settings/subscriptions**", (route) =>
+      route.fulfill({ json: { providerIds: [] } }),
+    );
+    // AchievementToast polls achievements in the background. Without this mock
+    // it returns 401 and triggers auth:unauthorized (even though the component
+    // catches the error, fetchJson dispatches the event first).
+    await this.page.route("**/api/achievements/me**", (route) =>
+      route.fulfill({ json: [] }),
+    );
+    // Catch-all for any remaining authenticated API calls that return 401.
+    // This prevents unexpected logouts from unmocked background requests.
+    await this.page.route("**/api/recommendations/count**", (route) =>
+      route.fulfill({ json: { count: 0 } }),
+    );
+    // SuggestedForYouRow is always rendered at the bottom of HomePage and
+    // calls /api/suggestions. Without this mock it returns 401 from the real
+    // backend (fake userId), firing auth:unauthorized and logging the user out.
+    await this.page.route("**/api/suggestions**", (route) =>
+      route.fulfill({ json: { flat: [], bySource: {} } }),
+    );
+  }
+
+  mainContent() {
+    return this.page.locator("main");
+  }
+
+  heroHeading() {
+    return this.page.getByRole("heading", {
+      name: /track movies.*tv shows/i,
+    });
+  }
+
+  signInLink() {
+    return this.page.getByRole("link", { name: /sign in/i });
+  }
+
+  createAccountLink() {
+    return this.page.getByRole("link", { name: /create account/i });
+  }
+
+  popularNowHeading() {
+    return this.page.getByRole("heading", { name: /popular right now/i });
+  }
+
+  homeNavLink() {
+    return this.page.getByRole("link", { name: /^home$/i });
+  }
+}

--- a/e2e/pages/leaderboard-page.ts
+++ b/e2e/pages/leaderboard-page.ts
@@ -1,0 +1,122 @@
+import type { Page } from "@playwright/test";
+import { BasePage } from "./base-page";
+
+/**
+ * Leaderboard page POM.
+ *
+ * Non-DOM notes:
+ * - LeaderboardPage at /leaderboard calls GET /api/leaderboard.
+ * - The podium reorders entries for visual display: 2nd left, 1st center, 3rd right.
+ * - Current user's podium card has amber border/bg; list row also has amber styling.
+ * - Empty state condition: entries.length <= 1 (not just 0).
+ * - App shell endpoints must be mocked to prevent auth:unauthorized logout events.
+ */
+export class LeaderboardPage extends BasePage {
+  async gotoLeaderboard(): Promise<void> {
+    await this.goto("/leaderboard");
+  }
+
+  /**
+   * Stub all shell endpoints needed for authenticated visits to the leaderboard page.
+   * Does NOT mock /api/leaderboard — tests register that themselves.
+   */
+  async mockLeaderboardShellEndpoints(): Promise<void> {
+    await this.page.route("**/api/user/settings/subscriptions**", (route) =>
+      route.fulfill({ json: { providerIds: [] } }),
+    );
+    await this.page.route("**/api/recommendations/count**", (route) =>
+      route.fulfill({ json: { count: 0 } }),
+    );
+    await this.page.route("**/api/achievements/me**", (route) =>
+      route.fulfill({ json: { achievements: [] } }),
+    );
+  }
+
+  pageHeading() {
+    return this.page.getByRole("heading", { name: /leaderboard/i });
+  }
+}
+
+// ── Leaderboard fixtures ──────────────────────────────────────────────────────
+
+export const MOCK_LEADERBOARD_FOUR_ENTRIES = {
+  entries: [
+    {
+      userId: "user-2",
+      username: "alice",
+      name: "Alice",
+      image: null,
+      xp: 500,
+      badgeCount: 3,
+      rank: 1,
+    },
+    {
+      userId: "user-3",
+      username: "bob",
+      name: "Bob",
+      image: null,
+      xp: 420,
+      badgeCount: 2,
+      rank: 2,
+    },
+    {
+      userId: "user-4",
+      username: "charlie",
+      name: "Charlie",
+      image: null,
+      xp: 310,
+      badgeCount: 1,
+      rank: 3,
+    },
+    {
+      userId: "user-5",
+      username: "diana",
+      name: "Diana",
+      image: null,
+      xp: 200,
+      badgeCount: 0,
+      rank: 4,
+    },
+  ],
+};
+
+export const MOCK_LEADERBOARD_WITH_ME = {
+  entries: [
+    {
+      userId: "user-2",
+      username: "alice",
+      name: "Alice",
+      image: null,
+      xp: 600,
+      badgeCount: 4,
+      rank: 1,
+    },
+    {
+      userId: "user-1",
+      username: "testuser",
+      name: "Test User",
+      image: null,
+      xp: 500,
+      badgeCount: 3,
+      rank: 2,
+    },
+    {
+      userId: "user-3",
+      username: "bob",
+      name: "Bob",
+      image: null,
+      xp: 400,
+      badgeCount: 2,
+      rank: 3,
+    },
+    {
+      userId: "user-4",
+      username: "charlie",
+      name: "Charlie",
+      image: null,
+      xp: 200,
+      badgeCount: 0,
+      rank: 4,
+    },
+  ],
+};

--- a/e2e/pages/stats-page.ts
+++ b/e2e/pages/stats-page.ts
@@ -1,0 +1,135 @@
+import type { Page } from "@playwright/test";
+import { BasePage } from "./base-page";
+
+/**
+ * Stats page POM.
+ *
+ * Non-DOM notes:
+ * - Stats are accessed via the Tracked page at /tracked by clicking the
+ *   "Stats" Pill button. The route /stats redirects to /tracked?view=stats
+ *   but TrackedPage does NOT read the ?view=stats query param — the pill
+ *   must be clicked to switch views.
+ * - TrackedPage calls GET /api/track on mount (getTrackedTitles).
+ * - StatsView calls GET /api/stats when mounted (after clicking the pill).
+ * - The app shell background components (AchievementToast, SuggestedForYouRow,
+ *   AuthContext.getSubscriptions) call additional endpoints that must be mocked
+ *   to prevent auth:unauthorized events from logging the test user out.
+ */
+export class StatsPage extends BasePage {
+  async gotoTracked(): Promise<void> {
+    await this.goto("/tracked");
+  }
+
+  /**
+   * Click the "Stats" pill on the Tracked page to switch to the stats view.
+   * Call gotoTracked() and wait for the page to load before calling this.
+   */
+  async clickStatsPill(): Promise<void> {
+    await this.page.getByRole("button", { name: /^Stats$/i }).click();
+  }
+
+  /**
+   * Stub all endpoints needed for an authenticated visit to /tracked,
+   * excluding GET /api/stats and GET /api/track which tests set up themselves.
+   * Call before navigating. Register stats/track mocks AFTER this call so
+   * they win (Playwright applies routes LIFO).
+   */
+  async mockTrackedShellEndpoints(): Promise<void> {
+    // AuthContext calls getSubscriptions() after auth succeeds.
+    await this.page.route("**/api/user/settings/subscriptions**", (route) =>
+      route.fulfill({ json: { providerIds: [] } }),
+    );
+    // AchievementToast polls /api/achievements/me in the background.
+    await this.page.route("**/api/achievements/me**", (route) =>
+      route.fulfill({ json: [] }),
+    );
+    // SuggestedForYouRow is always rendered on HomePage, but not on TrackedPage.
+    // Still safe to stub in case any lazy-loaded component requests it.
+    await this.page.route("**/api/suggestions**", (route) =>
+      route.fulfill({ json: { flat: [], bySource: {} } }),
+    );
+    // RecommendationsCount badge in the nav shell calls /api/recommendations/count.
+    // Without this mock it returns 401 and fires auth:unauthorized.
+    await this.page.route("**/api/recommendations/count**", (route) =>
+      route.fulfill({ json: { count: 0 } }),
+    );
+  }
+
+  statsHeading() {
+    return this.page.getByText("Stats").first();
+  }
+
+  overviewCard(label: string) {
+    return this.page.getByText(label);
+  }
+
+  sectionHeading(name: string) {
+    return this.page.getByText(name);
+  }
+}
+
+// ── Standard stats fixture ────────────────────────────────────────────────────
+
+export const MOCK_STATS_FULL = {
+  overview: {
+    watched_movies: 12,
+    watched_episodes: 84,
+    tracked_shows: 5,
+    tracked_movies: 7,
+    watch_time_minutes: 3720,
+    watch_time_minutes_shows: 1260,
+    watch_time_minutes_movies: 2460,
+  },
+  genres: [
+    { genre: "Drama", count: 30 },
+    { genre: "Action", count: 18 },
+  ],
+  languages: [
+    { language: "en", count: 45 },
+    { language: "ja", count: 10 },
+  ],
+  monthly: [{ month: "2026-05", movies_watched: 3, episodes_watched: 12 }],
+  shows_by_status: {
+    watching: 3,
+    caught_up: 1,
+    not_started: 0,
+    completed: 1,
+    on_hold: 0,
+    dropped: 0,
+    plan_to_watch: 0,
+    unreleased: 0,
+  },
+  pace: {
+    minutesPerDay: 62,
+    watchlistEtaDays: 14,
+  },
+};
+
+export const MOCK_STATS_EMPTY = {
+  overview: {
+    watched_movies: 0,
+    watched_episodes: 0,
+    tracked_shows: 0,
+    tracked_movies: 0,
+    watch_time_minutes: 0,
+    watch_time_minutes_shows: 0,
+    watch_time_minutes_movies: 0,
+  },
+  genres: [],
+  languages: [],
+  monthly: [],
+  shows_by_status: {
+    watching: 0,
+    caught_up: 0,
+    not_started: 0,
+    completed: 0,
+    on_hold: 0,
+    dropped: 0,
+    plan_to_watch: 0,
+    unreleased: 0,
+  },
+  pace: {
+    minutesPerDay: 0,
+    watchlistEtaDays: null,
+  },
+};

--- a/e2e/stats.spec.ts
+++ b/e2e/stats.spec.ts
@@ -1,0 +1,177 @@
+import { test, expect } from "@playwright/test";
+import { mockLoggedIn, mockLoggedOut } from "./helpers";
+import {
+  StatsPage,
+  MOCK_STATS_FULL,
+  MOCK_STATS_EMPTY,
+} from "./pages/stats-page";
+
+const EMPTY_TRACKED = {
+  titles: [],
+  count: 0,
+  profile_public: false,
+  profile_visibility: "private",
+};
+
+test.describe("Stats", () => {
+  test.skip(
+    ({ browserName }) => browserName !== "chromium",
+    "chromium only — desktop layout requires a stable viewport",
+  );
+
+  // ── TC-01: Stats page loads with all sections visible ──────────────────────
+  test("TC-01: stats page loads with all sections visible", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const stats = new StatsPage(page);
+    await mockLoggedIn(page);
+    await stats.mockTrackedShellEndpoints();
+    await page.route("**/api/track**", (route) =>
+      route.fulfill({ json: EMPTY_TRACKED }),
+    );
+    await page.route("**/api/stats**", (route) =>
+      route.fulfill({ json: MOCK_STATS_FULL }),
+    );
+
+    await stats.gotoTracked();
+    await stats.clickStatsPill();
+
+    // Overview section cards
+    await expect(page.getByText("Movies Watched")).toBeVisible();
+    await expect(page.getByText("Episodes Watched")).toBeVisible();
+    await expect(page.getByText("Shows Tracked")).toBeVisible();
+    await expect(page.getByText("Movies Tracked")).toBeVisible();
+    await expect(page.getByText("Watch Time", { exact: true })).toBeVisible();
+    await expect(page.getByText("Watchlist ETA")).toBeVisible();
+
+    // Monthly Activity section (legend items use exact: true to avoid
+    // matching "Episodes Watched" / "Movies Watched" overview card labels)
+    await expect(page.getByText("Monthly Activity")).toBeVisible();
+    await expect(page.getByText("Episodes", { exact: true })).toBeVisible();
+    await expect(page.getByText("Movies", { exact: true })).toBeVisible();
+
+    // Genre, Language, Status sections
+    await expect(page.getByText("Top Genres")).toBeVisible();
+    await expect(page.getByText("Top Languages")).toBeVisible();
+    await expect(page.getByText("Shows by Status")).toBeVisible();
+
+    // Watch time breakdown cards
+    await expect(page.getByText("TV Watch Time")).toBeVisible();
+    await expect(page.getByText("Movie Watch Time")).toBeVisible();
+  });
+
+  // ── TC-02: Stats show correct counts from mock data ─────────────────────────
+  test("TC-02: stats show correct counts", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const stats = new StatsPage(page);
+    await mockLoggedIn(page);
+    await stats.mockTrackedShellEndpoints();
+    await page.route("**/api/track**", (route) =>
+      route.fulfill({ json: EMPTY_TRACKED }),
+    );
+    await page.route("**/api/stats**", (route) =>
+      route.fulfill({ json: MOCK_STATS_FULL }),
+    );
+
+    await stats.gotoTracked();
+    await stats.clickStatsPill();
+
+    // Wait for stats to render (skeleton disappears)
+    await expect(page.getByText("Movies Watched")).toBeVisible();
+
+    // Overview card values
+    await expect(page.getByText("12").first()).toBeVisible(); // watched_movies
+    await expect(page.getByText("84").first()).toBeVisible(); // watched_episodes
+    await expect(page.getByText("5").first()).toBeVisible(); // tracked_shows
+    await expect(page.getByText("7").first()).toBeVisible(); // tracked_movies
+    await expect(page.getByText("62h")).toBeVisible(); // 3720 min = 62h
+    await expect(page.getByText("~2w")).toBeVisible(); // 14 days ≈ 2 weeks
+
+    // Watch-time breakdown
+    await expect(page.getByText("21h")).toBeVisible(); // 1260 min = 21h
+    await expect(page.getByText("84 episodes")).toBeVisible();
+    await expect(page.getByText("41h")).toBeVisible(); // 2460 min = 41h
+    await expect(page.getByText("12 movies")).toBeVisible();
+
+    // Top Genres
+    await expect(page.getByText("Drama")).toBeVisible();
+    await expect(page.getByText("Action")).toBeVisible();
+
+    // Top Languages (language codes mapped to display names)
+    await expect(page.getByText("English")).toBeVisible();
+    await expect(page.getByText("Japanese")).toBeVisible();
+
+    // Shows by Status — only non-zero entries rendered.
+    // "Watching" also appears in TrackedStatsBand as "Currently watching" but exact:true
+    // avoids that. "Completed" appears in both TrackedStatsBand and ShowStatusGrid;
+    // scope to the Shows by Status section heading's sibling grid.
+    await expect(page.getByText("Watching", { exact: true })).toBeVisible();
+    await expect(page.getByText("Caught Up", { exact: true })).toBeVisible();
+    await expect(
+      page.getByText("Shows by Status").locator("..").getByText("Completed"),
+    ).toBeVisible();
+    // Zero-count entries are NOT rendered
+    await expect(
+      page.getByText("Not Started", { exact: true }),
+    ).not.toBeVisible();
+    await expect(page.getByText("On Hold", { exact: true })).not.toBeVisible();
+    await expect(page.getByText("Dropped", { exact: true })).not.toBeVisible();
+  });
+
+  // ── TC-03: Empty stats — new user with no watch history ─────────────────────
+  test("TC-03: empty stats show zeros and hide empty sections", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const stats = new StatsPage(page);
+    await mockLoggedIn(page);
+    await stats.mockTrackedShellEndpoints();
+    await page.route("**/api/track**", (route) =>
+      route.fulfill({ json: EMPTY_TRACKED }),
+    );
+    await page.route("**/api/stats**", (route) =>
+      route.fulfill({ json: MOCK_STATS_EMPTY }),
+    );
+
+    await stats.gotoTracked();
+    await stats.clickStatsPill();
+
+    // Wait for stats to render
+    await expect(page.getByText("Movies Watched")).toBeVisible();
+
+    // Overview cards show zero values
+    await expect(page.getByText("0h").first()).toBeVisible();
+    // Watchlist ETA is null → displayed as "—" (use first() since TrackedStatsBand
+    // also shows "—" for avg score when there are no rated titles)
+    await expect(page.getByText("—").first()).toBeVisible();
+
+    // Monthly Activity section is always rendered
+    await expect(page.getByText("Monthly Activity")).toBeVisible();
+
+    // Empty array sections are hidden
+    await expect(page.getByText("Top Genres")).not.toBeVisible();
+    await expect(page.getByText("Top Languages")).not.toBeVisible();
+    // tracked_shows === 0 → Shows by Status hidden
+    await expect(page.getByText("Shows by Status")).not.toBeVisible();
+
+    // No error banner
+    await expect(page.locator(".bg-red-900\\/50")).not.toBeVisible();
+  });
+
+  // ── TC-04: Unauthenticated user is redirected to /login ─────────────────────
+  test("TC-04: unauthenticated user is redirected to /login", async ({
+    page,
+  }) => {
+    await mockLoggedOut(page);
+    await page.goto("/stats");
+
+    // RequireAuth redirects to /login
+    await page.waitForURL(/\/login/);
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.getByRole("heading", { name: /sign in/i })).toBeVisible();
+
+    // Stats content is not visible
+    await expect(page.getByText("Monthly Activity")).not.toBeVisible();
+  });
+});

--- a/e2e/test-cases/achievements.md
+++ b/e2e/test-cases/achievements.md
@@ -1,0 +1,272 @@
+# Test cases: achievements
+
+## Preconditions (shared)
+
+- The Remindarr dev server is running (Bun on `:3000`, Vite proxy on `:5173`).
+- Unless stated otherwise, the browser has an active session courtesy of
+  `mockLoggedIn(page)` (stubs `GET /api/auth/get-session` with `MOCK_SESSION`).
+- The achievements page is at `/achievements`.
+- The achievement detail page is at `/achievements/:key`.
+
+---
+
+## TC-01: Achievements page loads and shows achievement cards
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: The achievement grid is a pure render of the API response. Mocking
+`GET /api/achievements/me` lets us assert the exact cards without a seeded database.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` stubs the session.
+- `page.route()` intercepts `GET **/api/achievements/me` and returns two achievements:
+  one earned (`earned: true`) and one locked (`earned: false`).
+
+```json
+{
+  "achievements": [
+    {
+      "key": "first_movie",
+      "kind": "count_movies",
+      "title": "First Watch",
+      "description": "Watch your first movie",
+      "icon": "Film",
+      "threshold": 1,
+      "points": 10,
+      "progress": 1,
+      "earned": true,
+      "earnedAt": "2024-03-01T12:00:00Z",
+      "category": "watching",
+      "tier": "one-shot",
+      "repeatable": false,
+      "family": null,
+      "rungIndex": null,
+      "earnedCount": 1,
+      "lastEarnedAt": "2024-03-01T12:00:00Z",
+      "nextRung": null,
+      "rarity": null
+    },
+    {
+      "key": "watch_10",
+      "kind": "count_movies",
+      "title": "Binge Starter",
+      "description": "Watch 10 movies",
+      "icon": "Film",
+      "threshold": 10,
+      "points": 25,
+      "progress": 3,
+      "earned": false,
+      "earnedAt": null,
+      "category": "watching",
+      "tier": "one-shot",
+      "repeatable": false,
+      "family": null,
+      "rungIndex": null,
+      "earnedCount": 0,
+      "lastEarnedAt": null,
+      "nextRung": null,
+      "rarity": null
+    }
+  ]
+}
+```
+
+**Steps**:
+
+1. Set up route intercept on `**/api/achievements/me` with the payload above.
+2. Call `mockLoggedIn(page)`.
+3. Navigate to `/achievements`.
+4. Wait for the page to finish loading (loading text disappears).
+
+**Expected**:
+
+- `getByText("Achievements")` heading (Kicker) is visible.
+- The XP summary line is visible (e.g. contains `"1/2 earned"`).
+- `getByText("First Watch")` is visible — the earned badge card.
+- `getByText("Binge Starter")` is visible — the locked badge card.
+- The page does not show `"No achievements yet."`.
+
+---
+
+## TC-02: Locked vs unlocked achievements visually differentiated
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: Visual differentiation is driven by the `earned` field in the API response.
+Mocking guarantees both states are present without DB seeding.
+
+**Preconditions**:
+
+- Same route intercept and session mock as TC-01 (one earned, one locked).
+
+**Steps**:
+
+1. Set up the route intercept on `**/api/achievements/me` as in TC-01.
+2. Call `mockLoggedIn(page)`.
+3. Navigate to `/achievements`.
+4. Wait for `getByText("First Watch")` to be visible.
+
+**Expected**:
+
+- The earned badge card (`getByText("First Watch")`):
+  - Links to `/achievements/first_movie`.
+  - Does **not** have the `opacity-60` visual treatment (it is fully opaque).
+- The locked badge card (`getByText("Binge Starter")`):
+  - Still links to `/achievements/watch_10` (locked badges are still navigable for self).
+  - Has a progress bar visible beneath the title (rendered by `ThinProgress` for locked
+    self-view).
+  - Appears visually dimmer than the earned badge (Playwright `opacity` check, or presence
+    of the progress bar element suffices as a proxy).
+
+> **Note**: The locked tile renders a `ThinProgress` bar only in `mode="self"`. If the
+> locator strategy is fragile, asserting the presence of a `progressbar` role element within
+> the locked card's link is an acceptable alternative.
+
+---
+
+## TC-03: Clicking an achievement navigates to the detail page
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: Navigation is a frontend routing concern. We only need the list response so
+the card renders; the destination page can be stubbed separately.
+
+**Preconditions**:
+
+- Route intercept on `**/api/achievements/me` returns at least the `first_movie` achievement
+  (earned, from TC-01).
+- Route intercept on `**/api/achievements/first_movie/me` returns a valid detail payload
+  (see TC-04 preconditions).
+- `mockLoggedIn(page)` is active.
+
+**Steps**:
+
+1. Set up both route intercepts.
+2. Call `mockLoggedIn(page)`.
+3. Navigate to `/achievements`.
+4. Wait for `getByText("First Watch")` to be visible.
+5. `getByRole("link", { name: /First Watch/i })` → click.
+6. Wait for URL to change to `/achievements/first_movie`.
+
+**Expected**:
+
+- The browser navigates to `/achievements/first_movie`.
+- The detail page renders (see TC-04 for detail assertions).
+
+---
+
+## TC-04: Achievement detail page shows name, description, and progress
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: All rendered fields come from a single `GET /api/achievements/:key/me`
+response. Mocking is sufficient to verify the page renders each field correctly.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` is active.
+- `page.route()` intercepts `GET **/api/achievements/watch_10/me` and returns a locked
+  achievement with visible progress:
+
+```json
+{
+  "key": "watch_10",
+  "kind": "count_movies",
+  "title": "Binge Starter",
+  "description": "Watch 10 movies",
+  "icon": "Film",
+  "threshold": 10,
+  "points": 25,
+  "progress": 3,
+  "earned": false,
+  "earnedAt": null,
+  "earnedCount": 0,
+  "lastEarnedAt": null,
+  "category": "watching",
+  "tier": "one-shot",
+  "repeatable": false,
+  "family": null,
+  "rungIndex": null,
+  "rarity": { "bucket": "Rare", "pct": 12 },
+  "ladder": null,
+  "history": []
+}
+```
+
+**Steps**:
+
+1. Set up the route intercept on `**/api/achievements/watch_10/me`.
+2. Call `mockLoggedIn(page)`.
+3. Navigate directly to `/achievements/watch_10`.
+4. Wait for `getByRole("heading", { level: 1 })` to be visible.
+
+**Expected**:
+
+- `getByRole("heading", { level: 1 })` text is `"Binge Starter"`.
+- `getByText("Watch 10 movies")` (the description) is visible.
+- `getByText("Progress")` label is visible (progress section shown for locked own-profile).
+- `getByText("3 / 10")` progress counter is visible.
+- `getByText(/Rare/)` rarity badge is visible.
+- `getByRole("link", { name: /All achievements/i })` back link points to `/achievements`.
+
+---
+
+## TC-05: Empty state — no achievements
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: The empty-state branch (`achievements.length === 0`) is a frontend render
+guard. Returning an empty array from the mock exercises it fully.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` is active.
+- `page.route()` intercepts `GET **/api/achievements/me` and returns `{ "achievements": [] }`.
+
+**Steps**:
+
+1. Set up the route intercept on `**/api/achievements/me` with an empty achievements array.
+2. Call `mockLoggedIn(page)`.
+3. Navigate to `/achievements`.
+4. Wait for the page to finish loading.
+
+**Expected**:
+
+- `getByText("Achievements")` heading (Kicker) is visible.
+- `getByText("No achievements yet.")` is visible.
+- No badge cards are rendered (no `getByRole("link")` within the achievements list area).
+- The XP summary line (`earned · XP`) is **not** shown (it only renders when there is data).
+
+---
+
+## TC-06: Unauthenticated user redirected to /login
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: The auth redirect guard is a frontend `RequireAuth` component that reads
+the session from `GET /api/auth/get-session`. Using `mockLoggedOut(page)` (which returns
+`null` for the session) fully exercises the guard without a real auth stack.
+
+**Preconditions**:
+
+- `mockLoggedOut(page)` stubs `GET /api/auth/get-session` with `null` and provides mock
+  providers.
+
+**Steps**:
+
+1. Call `mockLoggedOut(page)`.
+2. Navigate to `/achievements`.
+3. Wait for the URL to change away from `/achievements`.
+
+**Expected**:
+
+- The browser is redirected to `/login` (URL pathname is `/login`).
+- The login form is visible (`getByRole("button", { name: /sign in/i })` is present).
+- The achievements page content is never rendered (`getByText("Achievements")` is absent).

--- a/e2e/test-cases/browse.md
+++ b/e2e/test-cases/browse.md
@@ -1,0 +1,267 @@
+# Test cases: browse
+
+## Preconditions (shared)
+
+- The Remindarr dev server is running (Bun on `:3000`, Vite proxy on `:5173`).
+- Unless stated otherwise, the browser is unauthenticated (no active session cookie).
+- The browse page is at `/browse`.
+- All test cases use `page.route()` mocks unless explicitly marked **Real**.
+- Before navigating, mock the following base endpoints so the page renders without hitting
+  the real backend:
+  - `GET **/api/auth/get-session` → `null` (logged-out)
+  - `GET **/api/auth/custom/providers` → `{ local: true, oidc: null }`
+  - `GET **/api/titles/genres` → `{ genres: ["Action", "Drama", "Comedy"] }`
+  - `GET **/api/titles/providers` → `{ providers: [{ id: 8, name: "Netflix", technical_name: "netflix", icon_url: "" }], regionProviderIds: [8] }`
+  - `GET **/api/titles/languages` → `{ languages: ["en", "es"], priorityLanguageCodes: ["en"] }`
+  - `GET **/api/titles/languages` (also used by the advanced search language dropdown)
+  - `GET **/api/browse**` → a standard `browseTitlesResponse` fixture (see below)
+
+### Standard `browseTitlesResponse` fixture
+
+```json
+{
+  "titles": [
+    {
+      "id": "movie-12345",
+      "objectType": "MOVIE",
+      "title": "Test Movie",
+      "originalTitle": "Test Movie",
+      "releaseYear": 2024,
+      "releaseDate": "2024-06-15",
+      "runtimeMinutes": 120,
+      "shortDescription": "A test movie",
+      "genres": ["Action"],
+      "imdbId": "tt1234567",
+      "tmdbId": 12345,
+      "posterUrl": null,
+      "ageCertification": "PG-13",
+      "originalLanguage": "en",
+      "tmdbUrl": "https://www.themoviedb.org/movie/12345",
+      "offers": [],
+      "scores": { "imdbScore": 7.5, "imdbVotes": 10000, "tmdbScore": 7.8 },
+      "isTracked": false
+    }
+  ],
+  "page": 1,
+  "totalPages": 1,
+  "totalResults": 1
+}
+```
+
+---
+
+## TC-01: Browse page loads with category tabs, filter bar, and title cards visible
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: Verifies the complete initial render — page header, category tabs, filter
+dropdowns, and title grid — without touching the real TMDB-backed browse endpoint. A mock
+response guarantees a stable title list for assertion.
+
+**Preconditions**:
+
+- All shared mocks applied (see shared preconditions above).
+- `GET **/api/browse**` returns the standard `browseTitlesResponse` fixture (1 title:
+  `"Test Movie"`).
+
+**Steps**:
+
+1. Apply all shared route mocks.
+2. Navigate to `/browse`.
+3. Wait for `getByRole("heading", { name: "Browse" })` to be visible.
+
+**Expected**:
+
+- Heading `"Browse"` (level 1) is visible.
+- The kicker text above the heading contains `"Catalog"` and a title count (e.g.
+  `"Catalog · 1 titles"`).
+- A search bar with placeholder `"Search titles or paste IMDB link..."` is present.
+- The category bar shows four buttons: `"Popular"`, `"Upcoming"`, `"Top Rated"`,
+  `"Now Playing"`. The `"Popular"` button is active by default.
+- The filter card shows four dropdown buttons: `"All genres"`, `"All providers"`,
+  `"Any year"`, `"Any rating"`.
+- The content-type group (role `group`, `aria-label="Content type"`) shows three
+  buttons: `"All"` (pressed), `"Movies"`, `"Shows"`.
+- `getByRole("article", { name: "Test Movie" })` is visible in the title grid.
+- `getByRole("heading", { name: "Popular", level: 2 })` is visible above the title grid.
+
+---
+
+## TC-02: Genre filter — selecting a genre re-queries the API and updates results
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: Verifies that picking a genre adds a `genre=Action` query param to the
+`/api/browse` request and that the updated results render correctly. Mocking lets us assert
+the exact URL sent to the backend.
+
+**Preconditions**:
+
+- All shared mocks applied.
+- Initial `GET **/api/browse**` (no genre param) returns the standard `browseTitlesResponse`
+  fixture.
+- A second `page.route()` intercepts `GET **/api/browse?*genre=Action*` and returns a
+  fixture with one title: `"Action Movie"` (genre `["Action"]`).
+
+**Steps**:
+
+1. Apply all shared route mocks including the genre-specific intercept.
+2. Navigate to `/browse` and wait for `getByRole("heading", { name: "Browse" })`.
+3. Click `getByRole("button", { name: /All genres/i })` to open the Genre dropdown.
+4. Wait for the genre checklist to appear.
+5. Click the checkbox labelled `"Action"` inside the genre dropdown.
+6. Wait for the title grid to update.
+
+**Expected**:
+
+- The `GET /api/browse` request includes `genre=Action` in the query string.
+- The Genre dropdown button now shows `"Action"` as its summary (not `"All genres"`).
+- An active filter chip with the text `"Action ×"` appears in the active-filters row.
+- `getByRole("article", { name: "Action Movie" })` is visible in the title grid.
+- `getByRole("article", { name: "Test Movie" })` is no longer visible (replaced by the
+  genre-filtered result).
+
+---
+
+## TC-03: Provider filter — selecting a provider updates results
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: Same reasoning as TC-02 — validates that the provider param is forwarded to
+the API and the results re-render.
+
+**Preconditions**:
+
+- All shared mocks applied.
+- Initial `GET **/api/browse**` (no provider param) returns the standard
+  `browseTitlesResponse`.
+- A second route intercept matches `GET **/api/browse?*provider=8*` and returns a fixture
+  with one title: `"Netflix Movie"` whose `offers` array includes a Netflix offer.
+
+**Steps**:
+
+1. Apply all shared route mocks including the provider-specific intercept.
+2. Navigate to `/browse` and wait for `getByRole("heading", { name: "Browse" })`.
+3. Click `getByRole("button", { name: /All providers/i })` to open the Provider dropdown.
+4. Wait for the provider checklist to appear.
+5. Click the checkbox labelled `"Netflix"` inside the provider dropdown.
+6. Wait for the title grid to update.
+
+**Expected**:
+
+- The `GET /api/browse` request includes `provider=8` (or `provider=netflix`) in the query
+  string.
+- The Provider dropdown button summary changes from `"All providers"` to `"Netflix"`.
+- An active filter chip with the text `"Netflix ×"` appears.
+- `getByRole("article", { name: "Netflix Movie" })` is visible.
+
+---
+
+## TC-04: Empty results — no titles match filters
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: Tests the empty-state UI branch; we force zero results by returning an empty
+`titles` array from the browse endpoint.
+
+**Preconditions**:
+
+- All shared mocks applied.
+- `GET **/api/browse**` returns:
+  ```json
+  { "titles": [], "page": 1, "totalPages": 0, "totalResults": 0 }
+  ```
+
+**Steps**:
+
+1. Apply all shared route mocks with the empty-results response.
+2. Navigate to `/browse`.
+3. Wait for `getByRole("heading", { name: "Browse" })`.
+4. Wait for the title grid area to settle (no loading spinner).
+
+**Expected**:
+
+- No `<article>` elements are present in the title grid.
+- The empty-state message `"No titles found."` is visible (rendered by `TitleList`).
+- The filter bar is still rendered (category tabs and filter dropdowns remain visible).
+- No error banner is shown.
+
+---
+
+## TC-05: Unauthenticated user can access /browse (public page)
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: Confirms that `/browse` is not guarded by `RequireAuth` — an unauthenticated
+visitor must reach the page without being redirected to `/login`. The route in `App.tsx`
+confirms this: `/browse` has no `<RequireAuth>` wrapper.
+
+**Preconditions**:
+
+- `GET **/api/auth/get-session` → `null` (explicitly no session).
+- `GET **/api/auth/custom/providers` → `{ local: true, oidc: null }`.
+- `GET **/api/titles/genres` → `{ genres: [] }`.
+- `GET **/api/titles/providers` → `{ providers: [], regionProviderIds: [] }`.
+- `GET **/api/titles/languages` → `{ languages: [], priorityLanguageCodes: [] }`.
+- `GET **/api/browse**` → standard `browseTitlesResponse` fixture.
+
+**Steps**:
+
+1. Apply unauthenticated session mock (`get-session` → `null`).
+2. Apply remaining mocks listed above.
+3. Navigate to `/browse`.
+4. Wait for `getByRole("heading", { name: "Browse" })`.
+
+**Expected**:
+
+- The browser URL remains `/browse` — no redirect to `/login` occurs.
+- `getByRole("heading", { name: "Browse" })` is visible.
+- The top navigation bar shows a `"Sign In"` link (not a user avatar or logout button),
+  confirming the unauthenticated state is correctly reflected.
+- The title grid renders the mocked title.
+
+> **Note**: The `"On my services"` toggle chip does **not** appear for unauthenticated
+> users (it requires `subscriptions.providerIds.length > 0` from the auth context).
+
+---
+
+## TC-06: Clicking a title navigates to the title detail page
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: Navigation is a frontend concern. We only need to verify that the `<Link>`
+element on each title card routes to `/title/<id>`. No detail-page data needs to load.
+
+**Preconditions**:
+
+- All shared mocks applied.
+- `GET **/api/browse**` returns the standard `browseTitlesResponse` (title id
+  `"movie-12345"`, title `"Test Movie"`).
+- `GET **/api/details/**` → any minimal valid response (or left unrouted — we only
+  assert URL change, not detail-page render).
+
+**Steps**:
+
+1. Apply all shared route mocks.
+2. Navigate to `/browse` and wait for `getByRole("heading", { name: "Browse" })`.
+3. Wait for `getByRole("article", { name: "Test Movie" })` to be visible.
+4. Click the `getByRole("link", { name: "Test Movie" })` inside that article (the poster
+   or title heading link — both point to the same URL).
+5. Wait for the URL to change.
+
+**Expected**:
+
+- The browser URL changes to `/title/movie-12345`.
+- The page no longer shows the browse heading or the category tab bar.
+
+> **Implementation note**: Each `TitleCard` renders two `<Link to="/title/${title.id}">`
+> elements — one wrapping the poster image and one wrapping the heading. Either is a valid
+> click target. Prefer `getByRole("link", { name: "Test Movie" })` which matches both; if
+> Playwright finds multiple, scope to the article: `getByRole("article", { name: "Test Movie"
+}).getByRole("link", { name: "Test Movie" }).first()`.

--- a/e2e/test-cases/calendar.md
+++ b/e2e/test-cases/calendar.md
@@ -1,0 +1,262 @@
+# Test cases: upcoming / calendar
+
+## Background
+
+`/upcoming` is a **legacy route** that immediately redirects authenticated users to `/calendar`
+(a `<Navigate to="/calendar" replace />` in `App.tsx`). The real upcoming-episodes feature
+lives at `/calendar` and is rendered by `CalendarPage.tsx`, which supports grid, agenda, and
+week views. The backend endpoint is `GET /api/episodes/upcoming` (returns
+`{ today, upcoming, unwatched }`) and `GET /api/calendar` (returns `{ titles, episodes, count }`).
+
+The test cases below are written against the **feature URL `/calendar`** (what users actually
+see), with one TC (TC-05) specifically exercising the `/upcoming` → `/login` redirect for
+unauthenticated users.
+
+## Preconditions (shared)
+
+- The Remindarr dev server is running (Bun on `:3000`, Vite proxy on `:5173`).
+- The E2E database has been wiped; bootstrap admin has been created.
+- Unless stated otherwise the browser viewport is desktop-sized (≥ 1024 px wide) so the
+  desktop grid view renders (mobile renders `MobileCalendar` instead).
+- `mockLoggedIn(page)` stubs `GET /api/auth/get-session` and
+  `GET /api/auth/custom/providers` via `e2e/helpers.ts`.
+
+---
+
+## TC-01: Calendar page loads and shows upcoming episodes
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: Verifies the page renders episode data fetched from `/api/calendar` without
+needing real DB rows or TMDB sync. Keeps the test hermetic and fast.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` has been called.
+- `page.route()` intercepts `GET **/api/calendar**` and returns:
+  ```json
+  {
+    "titles": [],
+    "episodes": [
+      {
+        "id": 102,
+        "title_id": "tv-98765",
+        "season_number": 1,
+        "episode_number": 2,
+        "name": "Second Episode",
+        "overview": "The second episode",
+        "air_date": "<tomorrow's date as YYYY-MM-DD>",
+        "still_path": null,
+        "show_title": "Test Show",
+        "poster_url": null,
+        "is_watched": false,
+        "offers": []
+      }
+    ],
+    "count": 1
+  }
+  ```
+- `page.route()` intercepts `GET **/api/user/settings**` and returns `{}`.
+
+**Steps**:
+
+1. Set up route intercepts as described in preconditions.
+2. Call `mockLoggedIn(page)`.
+3. Navigate to `/calendar`.
+4. Wait for the page heading to be visible.
+
+**Expected**:
+
+- The URL is `/calendar` (no further redirect).
+- A page heading (the current month name, e.g. "May 2026") is visible via
+  `getByRole("heading")`.
+- The episode name "Second Episode" or the show title "Test Show" is visible somewhere on
+  the page (exact location depends on view mode — grid cell label, agenda row, etc.).
+- No error banner is shown.
+
+---
+
+## TC-02: Episodes grouped by date/show correctly
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: The grouping logic (`groupByShow`, date-bucketing) is frontend-only. Providing
+controlled mock data lets us assert the exact grouping without relying on real DB contents.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` has been called.
+- `page.route()` intercepts `GET **/api/calendar**` and returns two episodes for the same
+  show on the same day, and one episode for a different show on a different day:
+  ```json
+  {
+    "titles": [],
+    "episodes": [
+      {
+        "id": 201,
+        "title_id": "tv-111",
+        "season_number": 2,
+        "episode_number": 3,
+        "name": "Part One",
+        "air_date": "<date A>",
+        "show_title": "Alpha Show",
+        "poster_url": null,
+        "is_watched": false,
+        "offers": [],
+        "still_path": null,
+        "overview": ""
+      },
+      {
+        "id": 202,
+        "title_id": "tv-111",
+        "season_number": 2,
+        "episode_number": 4,
+        "name": "Part Two",
+        "air_date": "<date A>",
+        "show_title": "Alpha Show",
+        "poster_url": null,
+        "is_watched": false,
+        "offers": [],
+        "still_path": null,
+        "overview": ""
+      },
+      {
+        "id": 203,
+        "title_id": "tv-222",
+        "season_number": 1,
+        "episode_number": 1,
+        "name": "Premiere",
+        "air_date": "<date B, one week later>",
+        "show_title": "Beta Show",
+        "poster_url": null,
+        "is_watched": false,
+        "offers": [],
+        "still_path": null,
+        "overview": ""
+      }
+    ],
+    "count": 3
+  }
+  ```
+- `page.route()` intercepts `GET **/api/user/settings**` and returns `{}`.
+
+**Steps**:
+
+1. Set up route intercepts as described in preconditions.
+2. Call `mockLoggedIn(page)`.
+3. Navigate to `/calendar`.
+4. Wait for the page to finish loading (heading visible, no skeleton).
+
+**Expected**:
+
+- "Alpha Show" appears once in the calendar (the two episodes from the same show on the same
+  day are grouped under a single show card, not rendered as two separate cards).
+- "Beta Show" appears in its own separate cell or date group.
+- The episode codes "S02E03" and "S02E04" are both visible within the Alpha Show group.
+- "S01E01" is visible within the Beta Show group.
+- The two date groups are visually distinct (different calendar cells or date headings).
+
+---
+
+## TC-03: Empty state — no upcoming episodes
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: The empty-state rendering is a frontend concern. A stub returning empty arrays
+is sufficient to exercise the code path.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` has been called.
+- `page.route()` intercepts `GET **/api/calendar**` and returns:
+  ```json
+  { "titles": [], "episodes": [], "count": 0 }
+  ```
+- `page.route()` intercepts `GET **/api/user/settings**` and returns `{}`.
+
+**Steps**:
+
+1. Set up route intercepts as described in preconditions.
+2. Call `mockLoggedIn(page)`.
+3. Navigate to `/calendar`.
+4. Wait for the page heading (month name) to be visible.
+
+**Expected**:
+
+- The calendar grid renders and the current month heading is visible.
+- No episode cards or show-title links appear anywhere on the page.
+- No error banner is shown (empty is not an error — the calendar simply renders with
+  empty cells).
+- The page does not show a loading skeleton indefinitely.
+
+---
+
+## TC-04: Clicking a show title navigates to the title detail page
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: The link target (`/title/:id`) is embedded in the episode data. We only need
+to verify the link is rendered with the correct `href` and that clicking it triggers
+navigation — no real title-detail data is needed for the click assertion.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` has been called.
+- `page.route()` intercepts `GET **/api/calendar**` and returns one episode with
+  `title_id: "tv-98765"` and `show_title: "Test Show"`.
+- `page.route()` intercepts `GET **/api/user/settings**` and returns `{}`.
+- `page.route()` intercepts `GET **/api/details/show/**` and returns a minimal valid
+  show-details payload (or returns an empty `{}` — the test only needs navigation to succeed,
+  not the detail page to fully render).
+
+**Steps**:
+
+1. Set up route intercepts as described in preconditions.
+2. Call `mockLoggedIn(page)`.
+3. Navigate to `/calendar`.
+4. Wait for "Test Show" to be visible on the page.
+5. `getByRole("link", { name: /Test Show/i })` — click the first matching link.
+6. Wait for URL to change.
+
+**Expected**:
+
+- The browser navigates to `/title/tv-98765`.
+- The URL pathname is `/title/tv-98765`.
+
+---
+
+## TC-05: Unauthenticated user visiting /upcoming is redirected to /login
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: The `RequireAuth` guard and the `/upcoming → /calendar` redirect are both
+frontend route guards. Stubbing `GET /api/auth/get-session` with `null` (logged-out state)
+is sufficient; no real session or DB is needed.
+
+**Preconditions**:
+
+- `mockLoggedOut(page)` has been called (from `e2e/helpers.ts`), which stubs
+  `GET **/api/auth/get-session` to return `null`.
+
+**Steps**:
+
+1. Call `mockLoggedOut(page)`.
+2. Navigate to `/upcoming`.
+3. Wait for the URL to change (the client-side guard triggers asynchronously).
+
+**Expected**:
+
+- The browser is redirected to `/login`.
+- The URL pathname is `/login`.
+- The login form is visible (`getByRole("heading", { name: /sign in/i })` or the username
+  and password fields are present).
+- The `/upcoming` or `/calendar` page content is never rendered.
+
+> **Note**: The redirect chain is `/upcoming` → `RequireAuth` detects no session →
+> `/login`. The intermediate `/calendar` redirect (which only runs for authenticated users)
+> is never reached.

--- a/e2e/test-cases/home.md
+++ b/e2e/test-cases/home.md
@@ -1,0 +1,204 @@
+# Test cases: home
+
+## Preconditions (shared)
+
+- The Remindarr dev server is running (Bun on `:3000`, Vite dev server on `:5173`, Vite proxies `/api` to `:3000`).
+- The home page is served at `/` (`HomeRoute` renders `HomePage` for desktop, redirects to `/reels` for authenticated mobile users).
+- Unless stated otherwise, all API calls are mocked via `page.route()`.
+
+---
+
+## TC-01: Authenticated user sees the home page
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: Verifies that an authenticated session causes `HomePage` to render its
+content area rather than the unauthenticated landing hero. A mock is sufficient — no
+real DB state is needed to confirm the session-gated branch renders.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` stubs `/api/auth/get-session` with a valid session.
+- `page.route()` stubs all auth-home data endpoints with empty-but-valid responses:
+  - `GET **/api/episodes/upcoming` → `{ today: [], upcoming: [], unwatched: [] }`
+  - `GET **/api/recommendations**` → `{ recommendations: [], count: 0 }`
+  - `GET **/api/homepage-layout**` → omit or return the default layout
+  - `GET **/api/up-next**` → `{ items: [] }`
+  - `GET **/api/friends-loved**` → `{ items: [] }`
+  - `GET **/api/streak**` → `null`
+  - `GET **/api/movies/tracking**` → `{ to_watch: [], upcoming: [] }`
+- Viewport is set to desktop width (≥ 640 px) to avoid the mobile redirect to `/reels`.
+
+**Steps**:
+
+1. Call `mockLoggedIn(page)` and set up all data stubs listed in preconditions.
+2. Navigate to `/`.
+3. Wait for the page to finish loading (skeleton disappears).
+
+**Expected**:
+
+- The page title is `Remindarr`.
+- The unauthenticated hero heading ("Track movies & TV shows you love") is **not** visible.
+- The main content area (`<main>`) is present and visible.
+- The top navigation shows a "Home" link (`getByRole("link", { name: /home/i })`).
+- No error banner is shown.
+
+---
+
+## TC-02: Home page shows tracked titles list (upcoming episodes)
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: Validates that episode data returned from `/api/episodes/upcoming` is
+rendered on screen. Mocking the endpoint makes the test deterministic and fast.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` called.
+- `GET **/api/episodes/upcoming` returns `MOCK_EPISODE` (from `e2e/helpers.ts`) in the
+  `today` array: `{ today: [MOCK_EPISODE], upcoming: [], unwatched: [] }`.
+- All other home data endpoints return empty/null responses (same stubs as TC-01).
+- Viewport is desktop width (≥ 640 px).
+
+**Steps**:
+
+1. Set up mocks as described in preconditions.
+2. Navigate to `/`.
+3. Wait for the main content area to appear.
+4. Locate the "Airing tonight" section heading.
+
+**Expected**:
+
+- `getByRole("heading", { name: /today/i })` (or the translated equivalent) is visible.
+- The show title `"Test Show"` (from `MOCK_EPISODE.show_title`) is visible on screen.
+- Episode information `"S01·E01"` is rendered within the episode card.
+
+---
+
+## TC-03: Home page shows upcoming episodes section
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: Confirms that `upcoming` episodes (air date in the future) are rendered in
+the "Coming Up" / "This week" section. Stubbing the endpoint keeps the air dates stable.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` called.
+- `GET **/api/episodes/upcoming` returns `MOCK_UPCOMING_EPISODE` (from `e2e/helpers.ts`)
+  in the `upcoming` array:
+  `{ today: [], upcoming: [MOCK_UPCOMING_EPISODE], unwatched: [] }`.
+- All other home data endpoints return empty/null responses.
+- Viewport is desktop width (≥ 640 px).
+
+**Steps**:
+
+1. Set up mocks as described in preconditions.
+2. Navigate to `/`.
+3. Wait for the main content area to appear.
+4. Locate the upcoming-episodes section heading.
+
+**Expected**:
+
+- A heading matching "Coming Up" or "Airing Soon" (translated equivalent) is visible,
+  **or** a "This week" section heading is present.
+- The show title `"Test Show"` (from `MOCK_UPCOMING_EPISODE.show_title`) appears within
+  the upcoming section.
+- The episode label `"S01·E02"` is rendered in the card.
+
+---
+
+## TC-04: Empty state — no tracked titles
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: Confirms the empty-state message is shown when all episode lists are empty.
+A real account with no tracked titles would also work, but mocking is faster and avoids
+DB setup.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` called.
+- `GET **/api/episodes/upcoming` returns `{ today: [], upcoming: [], unwatched: [] }`.
+- All other home data endpoints return empty/null responses.
+- Viewport is desktop width (≥ 640 px).
+
+**Steps**:
+
+1. Set up mocks as described in preconditions.
+2. Navigate to `/`.
+3. Wait for the main content area to appear.
+
+**Expected**:
+
+- The "Today" section (kicker "Airing tonight") is present in the layout.
+- Within that section, the empty-state text is shown — `getByText(/no episodes/i)` or
+  the translated equivalent (e.g. "No episodes today").
+- No episode cards are rendered.
+- No JavaScript error is thrown (error banner absent).
+
+---
+
+## TC-05: Unauthenticated user sees the landing page (not redirected)
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: The unauthenticated branch of `HomePage` is a pure frontend render that
+depends only on the session state. `mockLoggedOut(page)` stubs the session endpoint to
+return `null`; no real auth state is required.
+
+**Preconditions**:
+
+- `mockLoggedOut(page)` called (stubs `GET /api/auth/get-session` → `null`).
+- `GET **/api/browse**` returns a list containing at least one title (e.g. `MOCK_SEARCH_TITLE`
+  from `e2e/helpers.ts`) so the "Popular Right Now" grid has content.
+
+**Steps**:
+
+1. Call `mockLoggedOut(page)` and stub the browse endpoint.
+2. Navigate to `/`.
+3. Wait for the main content area to render.
+
+**Expected**:
+
+- The hero heading `getByRole("heading", { name: /track movies.*tv shows/i })` is visible.
+- A `getByRole("link", { name: /sign in/i })` link pointing to `/login` is present.
+- A `getByRole("link", { name: /create account/i })` link pointing to `/signup` is present.
+- The "Popular Right Now" section heading is visible.
+- The URL remains `/` (no redirect occurs).
+
+---
+
+## TC-06: Navigation — home is accessible from the nav bar
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: This test exercises the shell navigation only. Session state controls which
+nav links are rendered; mocking the session is sufficient.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` called.
+- All home data endpoints return empty responses (same stubs as TC-01).
+- Viewport is desktop width (≥ 640 px).
+
+**Steps**:
+
+1. Set up mocks as described in preconditions.
+2. Navigate to `/browse` (a page other than home).
+3. Locate the "Home" nav link: `getByRole("navigation", { name: /main navigation/i })`
+   → `getByRole("link", { name: /home/i })`.
+4. Click the "Home" link.
+5. Wait for navigation to complete.
+
+**Expected**:
+
+- The URL changes to `/`.
+- The main content area is visible (authenticated home layout, not the landing hero).
+- The "Home" nav link has an active/current style (aria-current or highlighted).

--- a/e2e/test-cases/leaderboard.md
+++ b/e2e/test-cases/leaderboard.md
@@ -1,0 +1,259 @@
+# Test cases: leaderboard
+
+## Preconditions (shared)
+
+- The Remindarr dev server is running (Bun on `:3000`, Vite dev server on `:5173`).
+- The leaderboard page is at `/leaderboard`.
+- The leaderboard API endpoint is `GET /api/leaderboard` (requires auth; returns
+  `{ entries: LeaderboardEntry[] }` where each entry has `userId`, `username`, `name`,
+  `image`, `xp`, `badgeCount`, `rank`).
+- Unless stated otherwise, `mockLoggedIn(page)` is called before each test so the
+  `RequireAuth` guard passes.
+
+---
+
+## TC-01: Leaderboard loads and shows ranked users
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: The leaderboard data is deterministic once stubbed — mocking keeps the test
+hermetic, avoids a real DB with follow relationships, and lets us assert exact text.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` is called with `MOCK_SESSION` (current user id `"user-1"`).
+- `page.route()` intercepts `GET **/api/leaderboard` and returns:
+  ```json
+  {
+    "entries": [
+      {
+        "userId": "user-2",
+        "username": "alice",
+        "name": "Alice",
+        "image": null,
+        "xp": 500,
+        "badgeCount": 3,
+        "rank": 1
+      },
+      {
+        "userId": "user-3",
+        "username": "bob",
+        "name": "Bob",
+        "image": null,
+        "xp": 420,
+        "badgeCount": 2,
+        "rank": 2
+      },
+      {
+        "userId": "user-4",
+        "username": "charlie",
+        "name": "Charlie",
+        "image": null,
+        "xp": 310,
+        "badgeCount": 1,
+        "rank": 3
+      },
+      {
+        "userId": "user-5",
+        "username": "diana",
+        "name": "Diana",
+        "image": null,
+        "xp": 200,
+        "badgeCount": 0,
+        "rank": 4
+      }
+    ]
+  }
+  ```
+
+**Steps**:
+
+1. Call `mockLoggedIn(page)`.
+2. Set up `page.route()` intercept on `**/api/leaderboard` as described above.
+3. Navigate to `/leaderboard`.
+4. Wait for the heading to appear: `getByRole("heading", { name: /leaderboard/i })`.
+
+**Expected**:
+
+- The page heading `"Leaderboard"` is visible.
+- The subtitle `"Among people you follow"` is visible.
+- The podium section shows exactly three entries (ranks 1–3): `"Alice"`, `"Bob"`,
+  `"Charlie"` with their rank labels `#1`, `#2`, `#3`.
+- Rank labels use `#` prefix (e.g. `getByText("#1")` is visible).
+- XP values are visible for podium entries (e.g. `"500 XP"` for Alice).
+- The ranked-list section below the podium shows `"Diana"` at `#4`.
+- No error banner is rendered.
+
+---
+
+## TC-02: Current user's entry is highlighted
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: The highlight is a purely client-side comparison of `entry.userId` against the
+session's user id. A mocked session and mocked leaderboard response are sufficient.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` is called. `MOCK_SESSION.user.id` is `"user-1"`.
+- `page.route()` intercepts `GET **/api/leaderboard` and returns an entry for the current
+  user in both the podium and the list:
+  ```json
+  {
+    "entries": [
+      {
+        "userId": "user-2",
+        "username": "alice",
+        "name": "Alice",
+        "image": null,
+        "xp": 600,
+        "badgeCount": 4,
+        "rank": 1
+      },
+      {
+        "userId": "user-1",
+        "username": "testuser",
+        "name": "Test User",
+        "image": null,
+        "xp": 500,
+        "badgeCount": 3,
+        "rank": 2
+      },
+      {
+        "userId": "user-3",
+        "username": "bob",
+        "name": "Bob",
+        "image": null,
+        "xp": 400,
+        "badgeCount": 2,
+        "rank": 3
+      },
+      {
+        "userId": "user-4",
+        "username": "charlie",
+        "name": "Charlie",
+        "image": null,
+        "xp": 200,
+        "badgeCount": 0,
+        "rank": 4
+      }
+    ]
+  }
+  ```
+  (Current user is rank 2 — in the podium.)
+
+**Steps**:
+
+1. Call `mockLoggedIn(page)`.
+2. Set up `page.route()` intercept as described above.
+3. Navigate to `/leaderboard`.
+4. Wait for `getByRole("heading", { name: /leaderboard/i })` to be visible.
+5. Locate the podium card containing `"Test User"` / `"@testuser"`.
+
+**Expected**:
+
+- The current user's podium card has a visually distinct highlight (amber border/background).
+  Assert by checking that the card container has an amber highlight class or `aria` attribute
+  distinguishable from the other cards — use `getByText("@testuser").locator("..")` to
+  reach the card's parent and assert it has `class` containing `amber` or equivalent.
+- The other podium cards (Alice, Bob) do not carry the same highlight styling.
+- If the current user appears in the ranked list (rank 4+), that row is similarly
+  highlighted compared to adjacent rows.
+
+---
+
+## TC-03: Empty leaderboard — no entries (or only the user themselves)
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: The empty state is a client-side branch (`entries.length <= 1`). A mocked
+empty array response exercises this path without any DB state.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` is called.
+- `page.route()` intercepts `GET **/api/leaderboard` and returns `{ "entries": [] }`.
+
+**Steps**:
+
+1. Call `mockLoggedIn(page)`.
+2. Set up `page.route()` intercept returning `{ "entries": [] }`.
+3. Navigate to `/leaderboard`.
+4. Wait for the page to finish loading (no skeleton/pulse elements visible).
+
+**Expected**:
+
+- The heading `"Leaderboard"` and subtitle `"Among people you follow"` are visible.
+- The empty-state message `"Follow people to see them on the leaderboard."` is visible
+  (`getByText(/follow people to see them on the leaderboard/i)`).
+- No podium cards are rendered.
+- No ranked-list rows are rendered.
+- A trophy icon is present alongside the empty-state message.
+
+---
+
+## TC-04: Clicking a user navigates to their profile
+
+**Priority**: P2
+**Backend**: Mock
+
+**Why P2 / design note**: The current `LeaderboardPage.tsx` renders names and usernames as
+plain text — there are no `<a>` or `<Link>` elements wrapping the user cards. This TC
+documents the **expected navigation behaviour** so that when clickable profiles are added the
+test can be promoted to P1 and automated.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` is called.
+- `page.route()` intercepts `GET **/api/leaderboard` and returns at least three entries
+  (same payload as TC-01).
+
+**Steps** (manual / future automation):
+
+1. Call `mockLoggedIn(page)`.
+2. Set up `page.route()` intercept with a multi-entry payload.
+3. Navigate to `/leaderboard`.
+4. Wait for the leaderboard entries to render.
+5. Click the podium card or list row for username `"alice"`.
+
+**Expected** (target behaviour once implemented):
+
+- The browser navigates to `/user/alice`.
+- The user profile page for Alice is rendered (heading or username `"alice"` visible).
+
+**Current state**: This navigation is not yet implemented. The TC is recorded so it can
+be automated once the feature ships. When automating, add a `page.route()` stub for
+`**/api/user/alice` returning a minimal profile payload to keep the test hermetic.
+
+---
+
+## TC-05: Auth requirement — unauthenticated access redirects to login
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: The `RequireAuth` guard in `App.tsx` is a client-side route check. Stubbing
+`GET /api/auth/get-session` with a null session via `mockLoggedOut(page)` is sufficient;
+no real session or DB state is required.
+
+**Preconditions**:
+
+- `mockLoggedOut(page)` is called to stub the session endpoint with `null`.
+- No `mockLoggedIn(page)` call is made.
+
+**Steps**:
+
+1. Call `mockLoggedOut(page)` to inject a null session.
+2. Navigate directly to `/leaderboard`.
+3. Wait for any client-side redirect to resolve.
+
+**Expected**:
+
+- The browser is redirected away from `/leaderboard` to `/login` (or equivalent auth
+  entry point).
+- The leaderboard content (`getByRole("heading", { name: /leaderboard/i })`) is never
+  rendered.
+- The login form (or login page) is visible.

--- a/e2e/test-cases/stats.md
+++ b/e2e/test-cases/stats.md
@@ -1,0 +1,239 @@
+# Test cases: stats
+
+## Preconditions (shared)
+
+- The Remindarr dev server is running (Bun on `:3000`, Vite proxy on `:5173`).
+- The stats view is reached via the **Tracked** page at `/tracked` — the route `/stats`
+  is a redirect alias to `/tracked?view=stats`, and the Stats view is activated by clicking
+  the **Stats** pill on that page. Note: `TrackedPage` does **not** read `?view=stats`
+  from the URL query param; the pill must be clicked to switch views.
+- `GET /api/stats` is the backing endpoint (requires auth).
+- Unless stated otherwise, the browser is authenticated via `mockLoggedIn(page)`.
+
+---
+
+## TC-01: Stats page loads with stats sections visible
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: The stats layout and section headings are pure frontend concerns. Mocking
+`GET /api/stats` with a realistic payload lets the test assert that all six sections render
+correctly without depending on a seeded database.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` has been called.
+- `page.route()` intercepts `GET **/api/stats` and returns HTTP 200 with a payload
+  containing non-zero overview counts, at least one genre, at least one language, 13
+  monthly entries, and non-zero `shows_by_status` values.
+- `page.route()` intercepts `GET **/api/titles**` and returns `{ titles: [], count: 0 }`.
+
+**Steps**:
+
+1. Set up route intercepts as described in preconditions.
+2. Navigate to `/tracked`.
+3. `getByText("Stats")` (the Stats pill) → click.
+4. Wait for the stats content to appear (skeleton disappears).
+
+**Expected**:
+
+- The heading `getByText("Stats")` is visible on the page.
+- The overview grid is visible, containing cards labelled:
+  - `getByText("Movies Watched")`
+  - `getByText("Episodes Watched")`
+  - `getByText("Shows Tracked")`
+  - `getByText("Movies Tracked")`
+  - `getByText("Watch Time")`
+  - `getByText("Watchlist ETA")`
+- The section heading `getByText("Monthly Activity")` is visible.
+- The legend items `getByText("Episodes")` and `getByText("Movies")` are visible.
+- The section heading `getByText("Top Genres")` is visible.
+- The section heading `getByText("Top Languages")` is visible.
+- The section heading `getByText("Shows by Status")` is visible.
+- The watch-time breakdown cards `getByText("TV Watch Time")` and
+  `getByText("Movie Watch Time")` are visible.
+
+---
+
+## TC-02: Stats show correct counts
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: The displayed values come directly from the API response. Mocking the
+response with specific numbers lets the test assert exact rendered values without
+seeding a database.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` has been called.
+- `page.route()` intercepts `GET **/api/stats` and returns:
+
+  ```json
+  {
+    "overview": {
+      "watched_movies": 12,
+      "watched_episodes": 84,
+      "tracked_shows": 5,
+      "tracked_movies": 7,
+      "watch_time_minutes": 3720,
+      "watch_time_minutes_shows": 1260,
+      "watch_time_minutes_movies": 2460
+    },
+    "genres": [
+      { "genre": "Drama", "count": 30 },
+      { "genre": "Action", "count": 18 }
+    ],
+    "languages": [
+      { "language": "en", "count": 45 },
+      { "language": "ja", "count": 10 }
+    ],
+    "monthly": [
+      { "month": "2026-05", "movies_watched": 3, "episodes_watched": 12 }
+    ],
+    "shows_by_status": {
+      "watching": 3,
+      "caught_up": 1,
+      "not_started": 0,
+      "completed": 1,
+      "on_hold": 0,
+      "dropped": 0,
+      "plan_to_watch": 0,
+      "unreleased": 0
+    },
+    "pace": {
+      "minutesPerDay": 62,
+      "watchlistEtaDays": 14
+    }
+  }
+  ```
+
+- `page.route()` intercepts `GET **/api/titles**` and returns `{ titles: [], count: 0 }`.
+
+**Steps**:
+
+1. Set up route intercepts as described in preconditions.
+2. Navigate to `/tracked`.
+3. `getByText("Stats")` (the Stats pill) → click.
+4. Wait for the stats content to render (no skeleton visible).
+
+**Expected**:
+
+- The Movies Watched card displays the value `12`.
+- The Episodes Watched card displays the value `84`.
+- The Shows Tracked card displays the value `5`.
+- The Movies Tracked card displays the value `7`.
+- The Watch Time card displays `62h` (3720 min = 62h exactly).
+- The Watchlist ETA card displays `~2w` (14 days formatted as approximately 2 weeks).
+- The TV Watch Time breakdown card displays `21h` and sub-label containing `84 episodes`.
+- The Movie Watch Time breakdown card displays `41h` and sub-label containing `12 movies`.
+- `getByText("Drama")` is visible in the Top Genres section with count `30`.
+- `getByText("Action")` is visible in the Top Genres section with count `18`.
+- `getByText("English")` is visible in the Top Languages section with count `45`.
+- `getByText("Japanese")` is visible in the Top Languages section with count `10`.
+- In the Shows by Status grid, a cell shows `3` with label `Watching`.
+- In the Shows by Status grid, a cell shows `1` with label `Caught Up`.
+- In the Shows by Status grid, a cell shows `1` with label `Completed`.
+- Status entries with count `0` (`Not Started`, `On Hold`, `Dropped`, `Plan to Watch`,
+  `Unreleased`) are **not** rendered (the component returns `null` for zero-count entries).
+
+---
+
+## TC-03: Empty stats — new user with no watch history
+
+**Priority**: P1
+**Backend**: Mock
+
+**Why mock**: A zero-state user is trivial to reproduce via a mock response. This test
+verifies that the page does not crash or show broken UI when all counts are zero, genre
+and language arrays are empty, and monthly activity has no data.
+
+**Preconditions**:
+
+- `mockLoggedIn(page)` has been called.
+- `page.route()` intercepts `GET **/api/stats` and returns:
+
+  ```json
+  {
+    "overview": {
+      "watched_movies": 0,
+      "watched_episodes": 0,
+      "tracked_shows": 0,
+      "tracked_movies": 0,
+      "watch_time_minutes": 0,
+      "watch_time_minutes_shows": 0,
+      "watch_time_minutes_movies": 0
+    },
+    "genres": [],
+    "languages": [],
+    "monthly": [],
+    "shows_by_status": {
+      "watching": 0,
+      "caught_up": 0,
+      "not_started": 0,
+      "completed": 0,
+      "on_hold": 0,
+      "dropped": 0,
+      "plan_to_watch": 0,
+      "unreleased": 0
+    },
+    "pace": {
+      "minutesPerDay": 0,
+      "watchlistEtaDays": null
+    }
+  }
+  ```
+
+- `page.route()` intercepts `GET **/api/titles**` and returns `{ titles: [], count: 0 }`.
+
+**Steps**:
+
+1. Set up route intercepts as described in preconditions.
+2. Navigate to `/tracked`.
+3. `getByText("Stats")` (the Stats pill) → click.
+4. Wait for the stats content to render.
+
+**Expected**:
+
+- The six overview cards are visible with value `0` for counts and `0h` for watch time.
+- The Watchlist ETA card displays `—` (the null ETA sentinel).
+- The TV Watch Time card displays `0h` with sub-label `0 episodes`.
+- The Movie Watch Time card displays `0h` with sub-label `0 movies`.
+- The `Top Genres` section heading is **not** rendered (empty array → section hidden).
+- The `Top Languages` section heading is **not** rendered (empty array → section hidden).
+- The `Shows by Status` section heading is **not** rendered
+  (`tracked_shows === 0` guards the entire block).
+- The Monthly Activity section **is** still rendered (the chart container is always shown,
+  but all bar columns are flat/empty).
+- No error banner or crash is visible.
+
+---
+
+## TC-04: Unauthenticated user is redirected to /login
+
+**Priority**: P0
+**Backend**: Mock
+
+**Why mock**: The auth guard is a frontend `RequireAuth` component that reads the session
+from `GET /api/auth/get-session`. Using `mockLoggedOut(page)` (from `e2e/helpers.ts`) to
+return `null` is sufficient to trigger the redirect without a real server.
+
+**Preconditions**:
+
+- `mockLoggedOut(page)` has been called (stubs `GET /api/auth/get-session` → `null` and
+  `GET /api/auth/custom/providers` → `{ local: true, oidc: null }`).
+
+**Steps**:
+
+1. Call `mockLoggedOut(page)` to inject a mock logged-out session.
+2. Navigate to `/stats`.
+3. Wait for navigation to settle.
+
+**Expected**:
+
+- The browser first redirects to `/tracked?view=stats` (the alias redirect from `App.tsx`).
+- Then the `RequireAuth` guard on the Tracked page redirects to `/login`.
+- The final URL is `/login` (or `/login?redirect=...`).
+- The login form is visible: `getByRole("heading", { name: /sign in/i })`.
+- The stats page content (overview cards, Monthly Activity heading) is **not** visible.


### PR DESCRIPTION
Brings the 6 batch-1 e2e specs to master — these were merged into the pipeline branch instead of master during the initial rollout.

Cherry-picked from `claude/853-e2e-pipeline`:
- home spec (TC-01–TC-06)
- browse spec (TC-01–TC-06)
- stats spec (TC-01–TC-04)
- calendar spec (TC-01–TC-05)
- achievements spec (TC-01–TC-06)
- leaderboard spec (TC-01–TC-05)

Part of #853

## Test plan
- All 6 specs passed locally before being committed
- Cherry-picks are conflict-free (only new files)