### PR TITLE
feat(e2e): promote all 28 new specs to CI (Stage 4)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
 
@@ -30,17 +30,43 @@ jobs:
         run: bunx playwright install --with-deps chromium
 
       - name: Run e2e tests
-        # Scope to the specs introduced for passkey / OIDC / feed / notifications
-        # coverage. The pre-existing mock-backed specs (auth / episodes / search /
-        # tracking) have separate ownership and are already covered by the
-        # frontend unit tests — including them here would introduce cross-spec
-        # flake that isn't this workflow's job to police.
+        # Full Playwright coverage. The four legacy specs (auth / episodes /
+        # search / tracking) remain excluded — they are deemed flaky/redundant
+        # per e2e/CLAUDE.md and have no Page Object equivalents.
         run: |
           bun run test:e2e --project=chromium \
             e2e/passkey.spec.ts \
             e2e/oidc.spec.ts \
             e2e/calendar-feed.spec.ts \
-            e2e/notifications.spec.ts
+            e2e/notifications.spec.ts \
+            e2e/achievements.spec.ts \
+            e2e/admin-users.spec.ts \
+            e2e/browse.spec.ts \
+            e2e/calendar.spec.ts \
+            e2e/discovery.spec.ts \
+            e2e/home.spec.ts \
+            e2e/invite-accept.spec.ts \
+            e2e/kiosk.spec.ts \
+            e2e/leaderboard.spec.ts \
+            e2e/more.spec.ts \
+            e2e/person.spec.ts \
+            e2e/profile.spec.ts \
+            e2e/recommendations.spec.ts \
+            e2e/reels.spec.ts \
+            e2e/season-detail.spec.ts \
+            e2e/settings-account.spec.ts \
+            e2e/settings-admin.spec.ts \
+            e2e/settings-appearance.spec.ts \
+            e2e/settings-integrations.spec.ts \
+            e2e/settings-notifications.spec.ts \
+            e2e/settings-subscriptions.spec.ts \
+            e2e/shared-watchlist.spec.ts \
+            e2e/signup.spec.ts \
+            e2e/stats.spec.ts \
+            e2e/title-detail.spec.ts \
+            e2e/up-next.spec.ts \
+            e2e/user-overlap.spec.ts \
+            e2e/watched-ratings.spec.ts
         env:
           CI: "1"
 


### PR DESCRIPTION
## Summary

- Adds all 28 feature specs generated during the full-coverage drive to the nightly e2e workflow
- Increases `timeout-minutes` from 20 → 45 to handle serial chromium execution of 32 specs (`workers: 1` in CI)
- Keeps the four legacy CI-excluded specs (`auth`, `episodes`, `search`, `tracking`) excluded per `e2e/CLAUDE.md`

## Spec list added (28 new)

`achievements`, `admin-users`, `browse`, `calendar`, `discovery`, `home`, `invite-accept`, `kiosk`, `leaderboard`, `more`, `person`, `profile`, `recommendations`, `reels`, `season-detail`, `settings-account`, `settings-admin`, `settings-appearance`, `settings-integrations`, `settings-notifications`, `settings-subscriptions`, `shared-watchlist`, `signup`, `stats`, `title-detail`, `up-next`, `user-overlap`, `watched-ratings`

## Test plan

- [ ] All 32 spec files exist on master (`git ls-files e2e/*.spec.ts` confirms)
- [ ] `bunx tsc --noEmit -p e2e/tsconfig.json` is clean (verified locally)
- [ ] PR touches only `.github/workflows/e2e.yml` — no spec files, no shared fixtures

Part of #853

🤖 Generated with [Claude Code](https://claude.com/claude-code)