### PR TITLE
chore(e2e): run e2e workflow weekly instead of daily

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,7 +2,7 @@ name: e2e
 
 on:
   schedule:
-    - cron: "0 4 * * *"
+    - cron: "0 4 * * 1"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Changes `0 4 * * *` → `0 4 * * 1` (every Monday at 04:00 UTC).

The suite is now large enough (195 tests, 32 specs) that daily runs aren't necessary given the cost. Weekly on Monday keeps a regular regression signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)