### PR TITLE
fix(auth): trust Vite dev proxy origin (:5173) when BASE_URL is unset

### DIFF
--- a/server/auth/better-auth-signup.test.ts
+++ b/server/auth/better-auth-signup.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
 import { createAuth } from "./better-auth";
 import { getDb } from "../db/schema";
+import { CONFIG } from "../config";
 import type { Platform } from "../platform/types";
 
 const platform: Platform = {
@@ -51,5 +52,34 @@ describe("better-auth signup", () => {
     expect(response.status).toBe(200);
     expect(data.user).toBeDefined();
     expect(data.user.username).toBe("testuser");
+  });
+
+  test("sign-up succeeds from Vite dev proxy origin (:5173) when BASE_URL is unset", async () => {
+    const original = CONFIG.BASE_URL;
+    CONFIG.BASE_URL = "";
+    try {
+      const auth = createAuth(getDb(), platform);
+      const request = new Request(
+        "http://localhost:3000/api/auth/sign-up/email",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Origin: "http://localhost:5173",
+            "Sec-Fetch-Site": "same-origin",
+          },
+          body: JSON.stringify({
+            username: "viteuser",
+            email: "vite@example.com",
+            password: "password123",
+            name: "Vite User",
+          }),
+        },
+      );
+      const response = await auth.handler(request);
+      expect(response.status).toBe(200);
+    } finally {
+      CONFIG.BASE_URL = original;
+    }
   });
 });

--- a/server/auth/better-auth.ts
+++ b/server/auth/better-auth.ts
@@ -248,6 +248,10 @@ export function createAuth(
             .flatMap(buildPasskeyOrigins)
         : []),
       ...(CONFIG.BASE_URL ? buildPasskeyOrigins(CONFIG.BASE_URL) : []),
+      // Local dev: `bun run dev` serves the SPA from the Vite proxy on :5173, so the
+      // browser's Origin is http://localhost:5173 — not derivable from BASE_URL (unset
+      // locally). Trust it only when BASE_URL is unset; production always sets BASE_URL.
+      ...(CONFIG.BASE_URL ? [] : ["http://localhost:5173"]),
     ].filter((v, i, a) => a.indexOf(v) === i),
     advanced: {
       ipAddress: {


### PR DESCRIPTION
## Summary

- **Root cause**: `bun run dev` serves the SPA from the Vite proxy on `:5173`. The browser sends `Origin: http://localhost:5173`, but `trustedOrigins` was built only from `BASE_URL` (empty in local dev), so `better-auth`'s CSRF middleware rejected signup requests with `{ "message": "Invalid origin" }`.
- **Fix**: append `http://localhost:5173` to `trustedOrigins` when `CONFIG.BASE_URL` is unset. This is the same `!BASE_URL` condition already used for the passkey localhost fallback (line 100) and the `baseURL` fallback (line 241). `NODE_ENV` is `undefined` under `bun run`, so it cannot be used as the dev signal.
- **Note on #857**: `.gitattributes` (`* text=auto eol=lf`) was already committed on master (`5c8866d`). Running `git add --renormalize .` confirmed the index is fully normalized (0 files changed). Closing both issues via this PR.

## Test plan

- [x] New regression test: sends `Origin: http://localhost:5173` + `Sec-Fetch-Site: same-origin` headers, expects HTTP 200 (pre-fix this returned 403 "Invalid origin")
- [x] Existing signup test still passes
- [x] `bun run check` full CI gauntlet passes (format, tsc, lint, 2147 server tests, 1081 frontend tests, build, wrangler dry-run, bundle size)
- [x] Pre-push hooks pass

Closes #858
Closes #857

🤖 Generated with [Claude Code](https://claude.com/claude-code)