### PR TITLE
feat(ux): /ux-review on-demand agentic UX review command

### DIFF
--- a/.claude/agents/ux-route-reviewer.md
+++ b/.claude/agents/ux-route-reviewer.md
@@ -1,0 +1,126 @@
+---
+name: ux-route-reviewer
+description: Reviews one remindarr route at 6 viewport sizes across 4 UX dimensions (responsive layout, accessibility, usability heuristics, copy/i18n). Reads screenshots and axe JSON artifacts produced by the ux:capture run, then returns a structured findings table. Used by /ux-review.
+model: sonnet
+tools: Read, Glob, Grep
+---
+
+You are the UX reviewer for remindarr. You review ONE route at a time.
+
+You will be given (in the prompt that dispatches you):
+
+- The route **path** (e.g. `/calendar`)
+- The route **slug** (filesystem-safe name, e.g. `calendar`)
+- A short **description** of the route
+- The **source file** path (optional)
+- The **artifacts directory**: `.ux-review/artifacts/<slug>/`
+
+The artifacts contain:
+
+- Screenshots: `<viewport>.png` for each of the 6 viewport labels (320x568, 375x812, 640x1024, 768x1024, 1280x800, 1920x1080)
+- Axe results: `<viewport>.axe.json` — array of axe violation objects (may be empty)
+
+**App context you must keep in mind**:
+
+- Remindarr is a media-tracking app with a single structural breakpoint at **640px**
+- Below 640px (mobile): no top nav/footer, bottom tab bar, `/reels` replaces `/` for logged-in users, `/more` is the overflow menu
+- Above 640px (desktop): top nav + footer + `⌘K` search, `HomePage` at `/`
+- Theme is dark by default; light theme is available via AppearanceTab
+
+---
+
+## Step 1 — Read all 6 screenshots
+
+Use the Read tool to view each PNG file:
+
+```
+.ux-review/artifacts/<slug>/320x568.png
+.ux-review/artifacts/<slug>/375x812.png
+.ux-review/artifacts/<slug>/640x1024.png
+.ux-review/artifacts/<slug>/768x1024.png
+.ux-review/artifacts/<slug>/1280x800.png
+.ux-review/artifacts/<slug>/1920x1080.png
+```
+
+Read ALL 6 before moving to the next step. If a file is missing, note it.
+
+## Step 2 — Read all 6 axe JSON files
+
+Read each `.ux-review/artifacts/<slug>/<viewport>.axe.json`. Each file is a JSON array of axe violation objects with fields: `id`, `impact`, `help`, `nodes` (array). An empty array means no violations.
+
+## Step 3 — Read source file (optional)
+
+If a source file path was provided, read it briefly for component context. Skip if not provided.
+
+## Step 4 — Judge across 4 dimensions
+
+For each finding assign a severity: **critical** | **major** | **minor**.
+
+### Dimension 1 — Responsive layout
+
+- Does content overflow or require horizontal scroll at any viewport?
+- Are elements clipped, overlapping, or invisible?
+- Are tap targets legibly sized (min ~44px on mobile viewports)?
+- Does the layout switch correctly at 640px (bottom tab bar ↔ top nav)?
+- At 1920px, does content center properly or stretch awkwardly?
+
+### Dimension 2 — Accessibility (from axe violations)
+
+- Report each violation with: viewport, `impact`, `help` description, node count
+- Group identical violations appearing across multiple viewports (e.g. "all mobile viewports")
+- If zero violations across all viewports: state "No axe violations"
+
+### Dimension 3 — Usability (Nielsen heuristics)
+
+- Is the primary action visible and clearly labeled?
+- Are loading, empty, and error states handled (visible feedback)?
+- Is the page's purpose immediately clear?
+- Is navigation consistent with the app shell (correct tab highlighted, back affordance)?
+- On mobile, are key actions reachable without scrolling far?
+
+### Dimension 4 — Copy & i18n
+
+- Are raw i18n translation keys visible (e.g. `settings.tab.account` as literal text)?
+- Is any label or heading truncated or cut off at smaller viewports?
+- Is copy clear, action-oriented, and consistent with the rest of the app?
+
+---
+
+## Step 5 — Return findings
+
+Return a markdown section in exactly this format:
+
+---
+
+## /calendar
+
+### Findings
+
+| Viewport | Dimension     | Severity | Finding                                                               |
+| -------- | ------------- | -------- | --------------------------------------------------------------------- |
+| 375×812  | Layout        | major    | Month grid overflows horizontally; day cells are clipped on the right |
+| all      | Accessibility | critical | 2 icon buttons missing accessible names (axe: button-name, 3 nodes)   |
+| 640×1024 | Usability     | minor    | No empty state copy when user has zero tracked shows                  |
+| 375×812  | Copy          | minor    | "Add to watchlist" truncates to "Add to watch…"                       |
+
+---
+
+If the route is clean:
+
+---
+
+## /calendar
+
+### Findings
+
+No issues found across all 6 viewports and 4 dimensions.
+
+---
+
+**Rules**:
+
+- Only report what you can actually see in the screenshots or read in the axe JSON — no speculation
+- Be specific: name the element, the viewport, and what is wrong
+- Severity guide: critical = broken/inaccessible/crashes, major = clearly wrong or usability-blocking, minor = polish nit
+- If a screenshot shows a redirect (e.g. `/` redirects to `/reels`), review the destination page
+- If a screenshot is blank or shows an error page, report it as a critical layout issue

--- a/.claude/commands/ux-review.md
+++ b/.claude/commands/ux-review.md
@@ -1,0 +1,125 @@
+Run an on-demand agentic UX review of remindarr across 6 viewport sizes. Captures screenshots + axe accessibility results for every route, then dispatches per-route reviewer agents and publishes findings as a markdown report + GitHub issues.
+
+**Usage**: `/ux-review [route-slug]`
+
+- No arg → review all routes (~28 routes × 6 viewports)
+- With arg → review only routes whose slug contains the string (e.g. `/ux-review calendar`)
+
+---
+
+## Step 1 — Pre-flight
+
+Check that `frontend/dist/index.html` exists:
+
+```bash
+test -f frontend/dist/index.html && echo "dist ok" || echo "MISSING — run bun run build first"
+```
+
+If missing, run `bun run build` before continuing (the capture server needs the pre-built frontend).
+
+---
+
+## Step 2 — Capture
+
+Run the deterministic screenshot + axe sweep:
+
+```bash
+# No arg:
+bun run ux:capture 2>&1
+
+# With route arg (e.g. "calendar"):
+bun run ux:capture -- --grep "capture <arg>" 2>&1
+```
+
+This boots an isolated production server on port 3100 with a clean seeded DB (`.ux-review/`), captures screenshots and axe violations for each route at all 6 viewports into `.ux-review/artifacts/<slug>/`, and writes `.ux-review/manifest.json`.
+
+---
+
+## Step 3 — Enumerate routes to review
+
+Read `.ux-review/manifest.json` to confirm seeding succeeded. Then list the artifact directories to get the captured route slugs:
+
+```bash
+ls .ux-review/artifacts/ 2>/dev/null
+```
+
+Filter by the arg if provided (slug contains the arg string). Build the list of routes to review.
+
+---
+
+## Step 4 — Dispatch per-route reviewer agents (parallel)
+
+For each route slug in the captured list, dispatch one `ux-route-reviewer` subagent. Send all of them in a single message (true parallel dispatch — do NOT wait for one before sending the next).
+
+For each agent, pass a prompt in this exact format:
+
+> Route path: `<resolved-path-from-manifest>`
+> Route slug: `<slug>`
+> Description: `<description-from-routes.ts>`
+> Source file: `<sourceFile-from-routes.ts>` (omit line if none)
+> Artifacts directory: `.ux-review/artifacts/<slug>/`
+>
+> Review this route across all 6 viewports (320x568, 375x812, 640x1024, 768x1024, 1280x800, 1920x1080). Read the screenshots and axe JSON files, then return findings in the standard table format.
+
+To build the prompt, read `ux-review/routes.ts` so you know each route's description and sourceFile.
+
+Collect all findings as agents complete.
+
+---
+
+## Step 5 — Write the report
+
+Create `docs/ux-reviews/<YYYY-MM-DD>-ux-review.md` (use today's date) with this structure:
+
+```markdown
+# UX Review — <YYYY-MM-DD>
+
+**Scope**: <arg or "all routes">  
+**Viewports**: 320×568 · 375×812 · 640×1024 · 768×1024 · 1280×800 · 1920×1080  
+**Routes reviewed**: <count>  
+**Screenshots**: `.ux-review/artifacts/` (local only — not committed)
+
+---
+
+<paste each agent's findings section in route-path alphabetical order>
+```
+
+---
+
+## Step 6 — File / update / close GitHub issues
+
+Ensure the label exists:
+
+```bash
+gh label create ux-review --color 0075CA --description "UX review finding — auto-filed" || true
+```
+
+Fetch all currently open `ux-review` issues:
+
+```bash
+gh issue list --label ux-review --state open --json number,title,body
+```
+
+For each reviewed route:
+
+- **Findings present** and an issue titled `UX review: <route-path>` exists → update its body with the new findings table and add a comment: `Updated by UX review run <YYYY-MM-DD>. Report: docs/ux-reviews/<date>-ux-review.md`
+- **Findings present** and no matching issue → create one:
+  ```bash
+  gh issue create \
+    --title "UX review: <route-path>" \
+    --label "ux-review" \
+    --body "<findings-table>\n\nAuto-filed by /ux-review on <date>. Report: docs/ux-reviews/<date>-ux-review.md"
+  ```
+- **Route is clean** (no findings) and an issue exists → close it:
+  ```bash
+  gh issue close <number> --comment "No issues found in UX review run <YYYY-MM-DD> — closing."
+  ```
+- **Route is clean** and no issue exists → nothing to do.
+
+---
+
+## Step 7 — Summary
+
+Print a one-line summary:
+
+> UX review complete. <N> routes reviewed, <M> with findings. Report: `docs/ux-reviews/<date>-ux-review.md`. Issues filed/updated: <K>.

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ test-results/
 .playwright/
 .playwright-cli/
 .e2e/
+.ux-review/
 
 # Superpowers
 .superpowers/

--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.3",
         "@cloudflare/workers-types": "^4.20260509.1",
         "@happy-dom/global-registrator": "^20.8.4",
         "@playwright/test": "^1.54.0",
@@ -104,6 +105,8 @@
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
     "@apideck/better-ajv-errors": ["@apideck/better-ajv-errors@0.3.6", "", { "dependencies": { "json-schema": "^0.4.0", "jsonpointer": "^5.0.0", "leven": "^3.1.0" }, "peerDependencies": { "ajv": ">=8" } }, "sha512-P+ZygBLZtkp0qqOAJJVX4oX/sFo5JR3eBWwwuqHHhK0GIgQOKWrAfiAaWX0aArHkRWHMuggFEgAZNxVPwPZYaA=="],
+
+    "@axe-core/playwright": ["@axe-core/playwright@4.11.3", "", { "dependencies": { "axe-core": "~4.11.4" }, "peerDependencies": { "playwright-core": ">= 1.0.0" } }, "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -980,6 +983,8 @@
     "at-least-node": ["at-least-node@1.0.0", "", {}, "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="],
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
+
+    "axe-core": ["axe-core@4.11.4", "", {}, "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA=="],
 
     "babel-plugin-polyfill-corejs2": ["babel-plugin-polyfill-corejs2@0.4.17", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-define-polyfill-provider": "^0.6.8", "semver": "^6.3.1" }, "peerDependencies": { "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0" } }, "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w=="],
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:server": "bun test server/",
     "test:frontend": "cd frontend && bun test src/",
     "test:e2e": "playwright test",
+    "ux:capture": "bun run build && playwright test -c playwright.ux.config.ts",
     "eval": "bun test evals/",
     "eval:notifications": "bun test evals/notifications/",
     "eval:tmdb": "bun test evals/tmdb-parser/",
@@ -57,6 +58,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@cloudflare/workers-types": "^4.20260509.1",
     "@happy-dom/global-registrator": "^20.8.4",
     "@playwright/test": "^1.54.0",

--- a/playwright.ux.config.ts
+++ b/playwright.ux.config.ts
@@ -1,0 +1,80 @@
+import { defineConfig, devices } from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  UX_DB_DIR,
+  UX_DB_PATH,
+  UX_PORT,
+  UX_BASE_URL,
+} from "./ux-review/constants";
+
+// Wipe and recreate the isolated UX-review DB dir before the server boots.
+// Same sentinel pattern as playwright.config.ts to handle multi-worker reloads.
+const absDbDir = path.resolve(UX_DB_DIR);
+if (!process.env.__PW_UX_DB_READY) {
+  if (fs.existsSync(absDbDir)) {
+    try {
+      fs.rmSync(absDbDir, { recursive: true, force: true });
+    } catch {
+      // SQLite file held open — leave it; the backend re-opens cleanly.
+    }
+  }
+  fs.mkdirSync(absDbDir, { recursive: true });
+  process.env.__PW_UX_DB_READY = "1";
+} else {
+  fs.mkdirSync(absDbDir, { recursive: true });
+}
+
+const serverEnv: Record<string, string> = {
+  DB_PATH: path.resolve(UX_DB_PATH),
+  PORT: String(UX_PORT),
+  BASE_URL: UX_BASE_URL,
+  BETTER_AUTH_SECRET: "ux-review-better-auth-secret",
+  TMDB_API_KEY: "ux-review-placeholder",
+  AUTH_RATE_LIMIT_PER_MINUTE: "1000",
+  LOG_LEVEL: "warn",
+  // Disable all cron jobs — this instance is for UI review only.
+  SYNC_TITLES_CRON: "",
+  SYNC_EPISODES_CRON: "",
+  BACKUP_CRON: "",
+  SYNC_DEEP_LINKS_CRON: "",
+  SYNC_PLEX_CRON: "",
+  SYNC_PLEX_LIBRARY_CRON: "",
+};
+
+export default defineConfig({
+  testDir: "./ux-review",
+  testIgnore: ["**/fixtures/**"],
+  // Sequential capture — stable viewport rendering, no race between screenshots.
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  reporter: "html",
+  // 6 viewports × up to 30 s each + axe analysis headroom.
+  timeout: 300_000,
+  globalSetup: "./ux-review/global-setup.ts",
+  use: {
+    baseURL: UX_BASE_URL,
+    // storageState is applied per-test via test.use() in capture.spec.ts
+    // so the file doesn't need to exist at config-parse time.
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "ux-chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    // Production server serves both API and pre-built frontend/dist.
+    // Run `bun run build` first (the ux:capture script does this automatically).
+    command: "bun run server/index.ts",
+    url: `${UX_BASE_URL}/api/health`,
+    // Never reuse an existing server — need a clean isolated DB each run.
+    reuseExistingServer: false,
+    timeout: 60_000,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: serverEnv,
+  },
+});

--- a/ux-review/capture.spec.ts
+++ b/ux-review/capture.spec.ts
@@ -1,0 +1,122 @@
+import { test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  VIEWPORTS,
+  UX_ARTIFACTS_DIR,
+  UX_MANIFEST_PATH,
+  UX_AUTH_STATE_PATH,
+} from "./constants";
+import type { UxManifest } from "./constants";
+import { resolveRoutes } from "./routes";
+import type { UxRoute } from "./routes";
+import { PERSON_FIXTURE, PERSON_ID } from "./fixtures/person";
+
+// Static route stubs — defined at module-load time (before globalSetup runs).
+// Manifest-dependent paths are resolved inside each test body after globalSetup writes manifest.json.
+type AuthCtx = "public" | "authed";
+const ROUTE_STUBS: Array<{ slug: string; authContext: AuthCtx }> = [
+  // public
+  { slug: "login", authContext: "public" },
+  { slug: "signup", authContext: "public" },
+  { slug: "browse", authContext: "public" },
+  { slug: "title-movie", authContext: "public" },
+  { slug: "title-show", authContext: "public" },
+  { slug: "season-detail", authContext: "public" },
+  { slug: "episode-detail", authContext: "public" },
+  { slug: "person", authContext: "public" },
+  { slug: "user-profile", authContext: "public" },
+  { slug: "user-achievements-public", authContext: "public" },
+  { slug: "achievement-detail-public", authContext: "public" },
+  { slug: "shared-watchlist", authContext: "public" },
+  { slug: "kiosk", authContext: "public" },
+  { slug: "not-found", authContext: "public" },
+  // authed
+  { slug: "home", authContext: "authed" },
+  { slug: "reels", authContext: "authed" },
+  { slug: "more", authContext: "authed" },
+  { slug: "tracked", authContext: "authed" },
+  { slug: "tracked-stats", authContext: "authed" },
+  { slug: "calendar", authContext: "authed" },
+  { slug: "discovery", authContext: "authed" },
+  { slug: "invite", authContext: "authed" },
+  { slug: "leaderboard", authContext: "authed" },
+  { slug: "achievements", authContext: "authed" },
+  { slug: "achievement-detail", authContext: "authed" },
+  { slug: "user-overlap", authContext: "authed" },
+  { slug: "settings", authContext: "authed" },
+  { slug: "admin-users", authContext: "authed" },
+];
+
+function readManifest(): UxManifest {
+  return JSON.parse(fs.readFileSync(UX_MANIFEST_PATH, "utf-8")) as UxManifest;
+}
+
+function lookupRoute(slug: string, manifest: UxManifest): UxRoute {
+  const route = resolveRoutes(manifest).find((r) => r.slug === slug);
+  if (!route) throw new Error(`Route slug not found: ${slug}`);
+  return route;
+}
+
+async function captureRoute(page: Page, route: UxRoute): Promise<void> {
+  if (route.mockPerson) {
+    await page.route(`**/api/details/person/${PERSON_ID}`, (r) =>
+      r.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ person: PERSON_FIXTURE }),
+      }),
+    );
+  }
+
+  for (const vp of VIEWPORTS) {
+    const dir = path.resolve(UX_ARTIFACTS_DIR, route.slug);
+    fs.mkdirSync(dir, { recursive: true });
+
+    await page.setViewportSize({ width: vp.width, height: vp.height });
+    await page.goto(route.path, { waitUntil: "networkidle", timeout: 30_000 });
+
+    await page.screenshot({
+      path: path.join(dir, `${vp.label}.png`),
+      fullPage: true,
+    });
+
+    const results = await new AxeBuilder({ page }).analyze();
+    fs.writeFileSync(
+      path.join(dir, `${vp.label}.axe.json`),
+      JSON.stringify(results.violations, null, 2),
+    );
+  }
+}
+
+// ── Public routes (no session cookie) ────────────────────────────────────────
+
+const publicStubs = ROUTE_STUBS.filter((r) => r.authContext === "public");
+
+test.describe("public routes", () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  for (const stub of publicStubs) {
+    test(`capture ${stub.slug}`, async ({ page }) => {
+      const manifest = readManifest();
+      await captureRoute(page, lookupRoute(stub.slug, manifest));
+    });
+  }
+});
+
+// ── Authenticated routes ──────────────────────────────────────────────────────
+
+const authedStubs = ROUTE_STUBS.filter((r) => r.authContext === "authed");
+
+test.describe("authed routes", () => {
+  test.use({ storageState: UX_AUTH_STATE_PATH });
+
+  for (const stub of authedStubs) {
+    test(`capture ${stub.slug}`, async ({ page }) => {
+      const manifest = readManifest();
+      await captureRoute(page, lookupRoute(stub.slug, manifest));
+    });
+  }
+});

--- a/ux-review/constants.ts
+++ b/ux-review/constants.ts
@@ -1,0 +1,32 @@
+export const UX_DB_DIR = ".ux-review";
+export const UX_DB_PATH = `${UX_DB_DIR}/remindarr.sqlite`;
+export const UX_MANIFEST_PATH = `${UX_DB_DIR}/manifest.json`;
+export const UX_AUTH_STATE_PATH = `${UX_DB_DIR}/auth.json`;
+export const UX_ARTIFACTS_DIR = `${UX_DB_DIR}/artifacts`;
+export const UX_PORT = 3100;
+export const UX_BASE_URL = `http://localhost:${UX_PORT}`;
+
+export const VIEWPORTS = [
+  { width: 320, height: 568, label: "320x568" },
+  { width: 375, height: 812, label: "375x812" },
+  { width: 640, height: 1024, label: "640x1024" },
+  { width: 768, height: 1024, label: "768x1024" },
+  { width: 1280, height: 800, label: "1280x800" },
+  { width: 1920, height: 1080, label: "1920x1080" },
+] as const;
+
+export type Viewport = (typeof VIEWPORTS)[number];
+
+export interface UxManifest {
+  username: string;
+  password: string;
+  friendUsername: string;
+  movieId: string;
+  showId: string;
+  seasonNumber: number;
+  episodeNumber: number;
+  personId: number;
+  kioskToken: string;
+  shareToken: string;
+  achievementKey: string;
+}

--- a/ux-review/fixtures/person.ts
+++ b/ux-review/fixtures/person.ts
@@ -1,0 +1,34 @@
+// Fixture for /api/details/person/:id — mocked because person data is TMDB-live (no DB table).
+export const PERSON_ID = 1;
+
+export const PERSON_FIXTURE = {
+  id: PERSON_ID,
+  name: "Jane Actor",
+  biography:
+    "A versatile performer known for dramatic roles in both independent and mainstream cinema.",
+  birthday: "1985-03-12",
+  deathday: null,
+  place_of_birth: "New York, USA",
+  known_for_department: "Acting",
+  profile_path: null,
+  also_known_as: ["Jana A."],
+  popularity: 45.2,
+  combined_credits: {
+    cast: [
+      {
+        id: 603,
+        title: "Seed Movie",
+        release_date: "2020-01-01",
+        poster_path: null,
+        vote_average: 7.5,
+        media_type: "movie",
+        character: "Lead",
+        order: 0,
+      },
+    ],
+    crew: [],
+  },
+  external_ids: {
+    imdb_id: "nm0000001",
+  },
+};

--- a/ux-review/global-setup.ts
+++ b/ux-review/global-setup.ts
@@ -1,0 +1,212 @@
+import { request as playwrightRequest } from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  UX_DB_PATH,
+  UX_MANIFEST_PATH,
+  UX_AUTH_STATE_PATH,
+  UX_BASE_URL,
+} from "./constants";
+import type { UxManifest } from "./constants";
+
+const SEED_USERNAME = "ux_seed";
+const SEED_PASSWORD = "UxSeed_pw1!";
+const SEED_EMAIL = "ux_seed@example.com";
+const FRIEND_USERNAME = "ux_friend";
+const FRIEND_PASSWORD = "UxFriend_pw1!";
+const FRIEND_EMAIL = "ux_friend@example.com";
+
+const MOVIE_ID_1 = "movie-603";
+const MOVIE_ID_2 = "movie-680";
+const MOVIE_ID_3 = "movie-278";
+const SHOW_ID = "tv-1399";
+const SEASON_NUMBER = 1;
+const EPISODE_NUMBER = 1;
+const KIOSK_TOKEN = "uxreviewkiosk00000000000000000000";
+const SHARE_TOKEN = "uxreviewshare0000000000000000000";
+const ACHIEVEMENT_KEY = "movies_10";
+
+export default async function globalSetup() {
+  // Set env before any server module import so CONFIG.DB_PATH resolves correctly.
+  process.env.DB_PATH = path.resolve(UX_DB_PATH);
+  process.env.BETTER_AUTH_SECRET = "ux-review-better-auth-secret";
+  process.env.TMDB_API_KEY = "ux-review-placeholder";
+  process.env.BASE_URL = UX_BASE_URL;
+  process.env.AUTH_RATE_LIMIT_PER_MINUTE = "1000";
+
+  // Open a second connection to the already-migrated DB (server holds the first).
+  // SQLite WAL mode allows concurrent readers + one writer — writes here are
+  // committed before any test reads them.
+  const { initBunDb } = await import("../server/db/bun-db");
+  await initBunDb();
+
+  const { upsertTitles } = await import("../server/db/repository/titles");
+  const { upsertEpisodes } = await import("../server/db/repository/episodes");
+  const { trackTitle } = await import("../server/db/repository/tracked");
+  const { updateUserAdmin, setKioskToken, setWatchlistShareToken } =
+    await import("../server/db/repository/users");
+  const { makeParsedTitle } = await import("../server/test-utils/fixtures");
+
+  // ── Seed media ──────────────────────────────────────────────────────────────
+  const today = new Date().toISOString().slice(0, 10);
+  const yesterday = new Date(Date.now() - 86_400_000)
+    .toISOString()
+    .slice(0, 10);
+
+  await upsertTitles([
+    makeParsedTitle({
+      id: MOVIE_ID_1,
+      objectType: "MOVIE",
+      title: "Seed Movie One",
+      tmdbId: "603",
+      releaseYear: 2020,
+      releaseDate: "2020-03-16",
+      runtimeMinutes: 136,
+      shortDescription: "A seeded movie for UX review.",
+      genres: ["Action", "Science Fiction"],
+      posterUrl: null,
+    }),
+    makeParsedTitle({
+      id: MOVIE_ID_2,
+      objectType: "MOVIE",
+      title: "Seed Movie Two",
+      tmdbId: "680",
+      releaseYear: 1994,
+      releaseDate: "1994-10-14",
+      runtimeMinutes: 154,
+      shortDescription: "Another seeded movie.",
+      genres: ["Crime", "Drama"],
+      posterUrl: null,
+    }),
+    makeParsedTitle({
+      id: MOVIE_ID_3,
+      objectType: "MOVIE",
+      title: "Seed Movie Three",
+      tmdbId: "278",
+      releaseYear: 1994,
+      releaseDate: "1994-09-23",
+      runtimeMinutes: 142,
+      shortDescription: "Third seeded movie.",
+      genres: ["Drama", "Crime"],
+      posterUrl: null,
+    }),
+    makeParsedTitle({
+      id: SHOW_ID,
+      objectType: "SHOW",
+      title: "Seed Show",
+      tmdbId: "1399",
+      releaseYear: 2011,
+      releaseDate: "2011-04-17",
+      runtimeMinutes: 60,
+      shortDescription: "A seeded show for UX review.",
+      genres: ["Drama", "Fantasy"],
+      posterUrl: null,
+    }),
+  ]);
+
+  // Two seasons, 3 episodes each. air_date ≤ today so kiosk / up-next surfaces them.
+  const episodes = [];
+  for (let ep = 1; ep <= 3; ep++) {
+    episodes.push({
+      title_id: SHOW_ID,
+      season_number: 1,
+      episode_number: ep,
+      name: `Season 1 Episode ${ep}`,
+      overview: `Overview of S01E0${ep}`,
+      air_date: yesterday,
+      still_path: null,
+    });
+    episodes.push({
+      title_id: SHOW_ID,
+      season_number: 2,
+      episode_number: ep,
+      name: `Season 2 Episode ${ep}`,
+      overview: `Overview of S02E0${ep}`,
+      air_date: today,
+      still_path: null,
+    });
+  }
+  await upsertEpisodes(episodes);
+
+  // ── Create users via HTTP (proper better-auth accounts) ─────────────────────
+  const req = await playwrightRequest.newContext({ baseURL: UX_BASE_URL });
+
+  async function signUp(
+    username: string,
+    email: string,
+    password: string,
+  ): Promise<string> {
+    const res = await req.post("/api/auth/sign-up/email", {
+      data: { username, email, password, name: username },
+      headers: { "Content-Type": "application/json" },
+    });
+    if (!res.ok()) {
+      throw new Error(
+        `sign-up failed for ${username}: ${res.status()} ${await res.text()}`,
+      );
+    }
+    const body = (await res.json().catch(() => ({}))) as Record<
+      string,
+      unknown
+    >;
+    const nested = body?.user as Record<string, unknown> | undefined;
+    const nested2 = (body?.data as Record<string, unknown> | undefined)
+      ?.user as Record<string, unknown> | undefined;
+    const userId = (nested?.id ?? nested2?.id) as string | undefined;
+    if (!userId)
+      throw new Error(`No user id in sign-up response for ${username}`);
+    return userId;
+  }
+
+  const seedUserId = await signUp(SEED_USERNAME, SEED_EMAIL, SEED_PASSWORD);
+  const friendUserId = await signUp(
+    FRIEND_USERNAME,
+    FRIEND_EMAIL,
+    FRIEND_PASSWORD,
+  );
+
+  // Promote seed user to admin so /admin/users and settings admin tab render.
+  await updateUserAdmin(seedUserId, true);
+
+  // ── Seed watchlists ──────────────────────────────────────────────────────────
+  await trackTitle(MOVIE_ID_1, seedUserId);
+  await trackTitle(MOVIE_ID_2, seedUserId);
+  await trackTitle(SHOW_ID, seedUserId);
+  // Friend tracks overlapping title for the /u/:user/overlap/:friend route.
+  await trackTitle(MOVIE_ID_1, friendUserId);
+  await trackTitle(SHOW_ID, friendUserId);
+
+  // ── Set sharing tokens ───────────────────────────────────────────────────────
+  await setKioskToken(seedUserId, KIOSK_TOKEN);
+  await setWatchlistShareToken(seedUserId, SHARE_TOKEN);
+
+  // ── Log in and save storageState for authenticated capture tests ─────────────
+  const loginRes = await req.post("/api/auth/sign-in/username", {
+    data: { username: SEED_USERNAME, password: SEED_PASSWORD },
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!loginRes.ok()) {
+    throw new Error(
+      `Login failed: ${loginRes.status()} ${await loginRes.text()}`,
+    );
+  }
+  fs.mkdirSync(path.dirname(UX_AUTH_STATE_PATH), { recursive: true });
+  await req.storageState({ path: UX_AUTH_STATE_PATH });
+  await req.dispose();
+
+  // ── Write manifest for capture spec ─────────────────────────────────────────
+  const manifest: UxManifest = {
+    username: SEED_USERNAME,
+    password: SEED_PASSWORD,
+    friendUsername: FRIEND_USERNAME,
+    movieId: MOVIE_ID_1,
+    showId: SHOW_ID,
+    seasonNumber: SEASON_NUMBER,
+    episodeNumber: EPISODE_NUMBER,
+    personId: 1,
+    kioskToken: KIOSK_TOKEN,
+    shareToken: SHARE_TOKEN,
+    achievementKey: ACHIEVEMENT_KEY,
+  };
+  fs.writeFileSync(UX_MANIFEST_PATH, JSON.stringify(manifest, null, 2));
+}

--- a/ux-review/routes.ts
+++ b/ux-review/routes.ts
@@ -1,0 +1,223 @@
+import type { UxManifest } from "./constants";
+
+export interface UxRoute {
+  /** Filesystem-safe slug used as the artifacts subdirectory name. */
+  slug: string;
+  /** Resolved URL path to navigate to. */
+  path: string;
+  /** Which browser context to use when capturing this route. */
+  authContext: "authed" | "public";
+  /** One-line description for display and issue titles. */
+  description: string;
+  /** Optional source file path, given to the reviewer agent for context. */
+  sourceFile?: string;
+  /** True if this route requires the person API mock to be active. */
+  mockPerson?: boolean;
+}
+
+export function resolveRoutes(m: UxManifest): UxRoute[] {
+  return [
+    // ─── Public / unauthenticated ────────────────────────────────────────────
+    {
+      slug: "login",
+      path: "/login",
+      authContext: "public",
+      description: "Login page — username/password + OIDC/passkey toggle",
+      sourceFile: "frontend/src/pages/LoginPage.tsx",
+    },
+    {
+      slug: "signup",
+      path: "/signup",
+      authContext: "public",
+      description: "Sign-up page — new account registration",
+      sourceFile: "frontend/src/pages/SignupPage.tsx",
+    },
+    {
+      slug: "browse",
+      path: "/browse",
+      authContext: "public",
+      description: "Browse — category search and filters",
+      sourceFile: "frontend/src/pages/BrowsePage.tsx",
+    },
+    {
+      slug: "title-movie",
+      path: `/title/${m.movieId}`,
+      authContext: "public",
+      description: "Title detail — movie",
+      sourceFile: "frontend/src/pages/TitleDetailPage.tsx",
+    },
+    {
+      slug: "title-show",
+      path: `/title/${m.showId}`,
+      authContext: "public",
+      description: "Title detail — show",
+      sourceFile: "frontend/src/pages/TitleDetailPage.tsx",
+    },
+    {
+      slug: "season-detail",
+      path: `/title/${m.showId}/season/${m.seasonNumber}`,
+      authContext: "public",
+      description: "Season detail — episode list",
+      sourceFile: "frontend/src/pages/SeasonDetailPage.tsx",
+    },
+    {
+      slug: "episode-detail",
+      path: `/title/${m.showId}/season/${m.seasonNumber}/episode/${m.episodeNumber}`,
+      authContext: "public",
+      description: "Episode detail",
+      sourceFile: "frontend/src/pages/EpisodeDetailPage.tsx",
+    },
+    {
+      slug: "person",
+      path: `/person/${m.personId}`,
+      authContext: "public",
+      description: "Person / actor filmography (TMDB-mocked)",
+      sourceFile: "frontend/src/pages/PersonPage.tsx",
+      mockPerson: true,
+    },
+    {
+      slug: "user-profile",
+      path: `/user/${m.username}`,
+      authContext: "public",
+      description: "User profile page",
+      sourceFile: "frontend/src/pages/UserProfilePage.tsx",
+    },
+    {
+      slug: "user-achievements-public",
+      path: `/u/${m.username}/achievements`,
+      authContext: "public",
+      description: "Achievements — public view of another user",
+      sourceFile: "frontend/src/pages/AchievementsPage.tsx",
+    },
+    {
+      slug: "achievement-detail-public",
+      path: `/u/${m.username}/achievements/${m.achievementKey}`,
+      authContext: "public",
+      description: "Achievement detail — public view",
+      sourceFile: "frontend/src/pages/AchievementDetailPage.tsx",
+    },
+    {
+      slug: "shared-watchlist",
+      path: `/share/watchlist/${m.shareToken}`,
+      authContext: "public",
+      description: "Shared watchlist — public token view",
+      sourceFile: "frontend/src/pages/SharedWatchlistPage.tsx",
+    },
+    {
+      slug: "kiosk",
+      path: `/kiosk/${m.kioskToken}`,
+      authContext: "public",
+      description: "Kiosk view — token-gated, no chrome",
+      sourceFile: "frontend/src/pages/KioskPage.tsx",
+    },
+    {
+      slug: "not-found",
+      path: "/this-route-does-not-exist-404",
+      authContext: "public",
+      description: "404 not-found page",
+      sourceFile: "frontend/src/pages/NotFoundPage.tsx",
+    },
+
+    // ─── Authenticated ───────────────────────────────────────────────────────
+    {
+      slug: "home",
+      path: "/",
+      authContext: "authed",
+      description:
+        "Home — desktop landing (desktop redirects here, mobile → /reels)",
+      sourceFile: "frontend/src/routes/HomeRoute.tsx",
+    },
+    {
+      slug: "reels",
+      path: "/reels",
+      authContext: "authed",
+      description: "Reels — swipeable mobile discovery",
+      sourceFile: "frontend/src/pages/ReelsPage.tsx",
+    },
+    {
+      slug: "more",
+      path: "/more",
+      authContext: "authed",
+      description: "More — mobile-only overflow menu",
+      sourceFile: "frontend/src/pages/MorePage.tsx",
+    },
+    {
+      slug: "tracked",
+      path: "/tracked",
+      authContext: "authed",
+      description: "Tracked / watchlist",
+      sourceFile: "frontend/src/pages/TrackedPage.tsx",
+    },
+    {
+      slug: "tracked-stats",
+      path: "/tracked?view=stats",
+      authContext: "authed",
+      description: "Tracked — stats view",
+      sourceFile: "frontend/src/pages/TrackedPage.tsx",
+    },
+    {
+      slug: "calendar",
+      path: "/calendar",
+      authContext: "authed",
+      description: "Calendar — monthly episode grid",
+      sourceFile: "frontend/src/pages/CalendarPage.tsx",
+    },
+    {
+      slug: "discovery",
+      path: "/discovery",
+      authContext: "authed",
+      description: "Discovery — personalised recommendations feed",
+      sourceFile: "frontend/src/pages/DiscoveryPage.tsx",
+    },
+    {
+      slug: "invite",
+      path: "/invite",
+      authContext: "authed",
+      description: "Invite — manage invitations",
+      sourceFile: "frontend/src/pages/InvitePage.tsx",
+    },
+    {
+      slug: "leaderboard",
+      path: "/leaderboard",
+      authContext: "authed",
+      description: "Leaderboard — user ranking",
+      sourceFile: "frontend/src/pages/LeaderboardPage.tsx",
+    },
+    {
+      slug: "achievements",
+      path: "/achievements",
+      authContext: "authed",
+      description: "Achievements — current user",
+      sourceFile: "frontend/src/pages/AchievementsPage.tsx",
+    },
+    {
+      slug: "achievement-detail",
+      path: `/achievements/${m.achievementKey}`,
+      authContext: "authed",
+      description: "Achievement detail — current user",
+      sourceFile: "frontend/src/pages/AchievementDetailPage.tsx",
+    },
+    {
+      slug: "user-overlap",
+      path: `/u/${m.username}/overlap/${m.friendUsername}`,
+      authContext: "authed",
+      description: "User overlap — watch comparison between two users",
+      sourceFile: "frontend/src/pages/UserOverlapPage.tsx",
+    },
+    {
+      slug: "settings",
+      path: "/settings",
+      authContext: "authed",
+      description:
+        "Settings — all tabs (account, appearance, integrations, notifications)",
+      sourceFile: "frontend/src/pages/SettingsPage.tsx",
+    },
+    {
+      slug: "admin-users",
+      path: "/admin/users",
+      authContext: "authed",
+      description: "Admin — user management (admin-only route)",
+      sourceFile: "frontend/src/pages/AdminUsersPage.tsx",
+    },
+  ];
+}

--- a/ux-review/tsconfig.json
+++ b/ux-review/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["@types/bun"]
+  },
+  "include": ["../ux-review/**/*.ts", "../playwright.ux.config.ts"]
+}


### PR DESCRIPTION
## Summary

- Adds `/ux-review [route-slug]` — an on-demand slash command for agentic UX + a11y review
- Boots an isolated fixture-seeded instance (port 3100, `.ux-review/` DB) and captures all 28 routes × 6 viewports (320×568 → 1920×1080) with full-page screenshots + axe accessibility JSON
- Dispatches per-route `ux-route-reviewer` subagents in parallel, each reviewing 4 dimensions: responsive layout · accessibility · usability heuristics · copy/i18n
- Writes findings to `docs/ux-reviews/<date>-ux-review.md` and files/updates/closes GitHub issues (label `ux-review`) per route

## New files

| File | Purpose |
|------|---------|
| `ux-review/constants.ts` | Viewports, DB/artifact paths, `UxManifest` type |
| `ux-review/routes.ts` | 28-route catalog; `resolveRoutes(manifest)` |
| `ux-review/global-setup.ts` | Playwright globalSetup — seeds isolated DB (users, titles, episodes, tokens), writes `manifest.json` + `auth.json` |
| `ux-review/capture.spec.ts` | Screenshot + axe capture across all routes × 6 viewports |
| `ux-review/fixtures/person.ts` | Person route mock (no DB table — TMDB-live route intercepted via `page.route`) |
| `ux-review/tsconfig.json` | TS config for the capture infra |
| `playwright.ux.config.ts` | Isolated Playwright config — port 3100, separate DB, own globalSetup |
| `.claude/agents/ux-route-reviewer.md` | Per-route reviewer subagent |
| `.claude/commands/ux-review.md` | 7-step orchestration command |
| `docs/ux-reviews/.gitkeep` | Report output directory |

## Test plan

- [ ] `bun run ux:capture -- --grep "capture calendar"` — single-route smoke (confirm `.ux-review/artifacts/calendar/` has 6 PNGs + 6 axe JSONs)
- [ ] `/ux-review calendar` — scoped run: report section + one `UX review: /calendar` issue filed/updated
- [ ] `bun run check:fast` passes (tsc + lint) ✅ (pre-push hook confirmed)
- [ ] Note: 21 pre-existing e2e failures on `auth`/`tracking`/`episodes` specs (last master CI green — `77ef9a8`); not introduced by this branch

Closes #891

🤖 Generated with [Claude Code](https://claude.com/claude-code)