### PR TITLE
fix(a11y): apply global dark-mode color-contrast fixes (WCAG AA)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -206,12 +206,30 @@
   transition-duration: 0.01ms !important;
 }
 
-/* High contrast text */
+/* Global dark-mode color-contrast fixes (WCAG AA)
+ *
+ * text-zinc-500 (#71717a) on zinc-900 (#18181b) = 3.67:1 — fails AA (needs 4.5:1).
+ * Boost to #a1a1aa (zinc-400 value) → 6.91:1 on zinc-900, passes on all dark
+ * theme variants (midnight, moss, plum, oled).
+ *
+ * Explicit ::placeholder color overrides the browser's default ~50%-opacity
+ * rendering which can drop below 3:1 on semi-transparent input backgrounds.
+ */
+.dark .text-zinc-500 {
+  color: #a1a1aa; /* was #71717a (3.67:1 on zinc-900) → now 6.91:1 */
+}
+.dark input::placeholder,
+.dark textarea::placeholder {
+  color: #a1a1aa; /* 6.91:1 on zinc-900, 7.66:1 on background */
+  opacity: 1; /* prevent browser from dimming placeholder further */
+}
+
+/* High contrast text (additional boost beyond the WCAG AA baseline above) */
 :root.high-contrast .text-zinc-400 {
   color: #d4d4d8;
 }
 :root.high-contrast .text-zinc-500 {
-  color: #a1a1aa;
+  color: #d4d4d8; /* extra boost for users who prefer maximum contrast */
 }
 
 /* Light theme overrides for key zinc utility classes */
@@ -328,7 +346,7 @@
   color: #a1a1aa;
 }
 .theme-light .dark-section .text-zinc-500 {
-  color: #71717a;
+  color: #a1a1aa; /* was #71717a (3.67:1 on zinc-900) → now 6.91:1 */
 }
 .theme-light .dark-section .bg-zinc-700 {
   background-color: #3f3f46;


### PR DESCRIPTION
## Summary

- **`text-zinc-500` globally in dark mode**: boosted from `#71717a` (3.64–4.12:1, FAIL) to `#a1a1aa` (6.86–8.19:1, PASS) across all dark theme variants (default, midnight, moss, plum, oled) via a single `.dark .text-zinc-500` rule
- **`::placeholder` in dark inputs/textareas**: added explicit `color: #a1a1aa; opacity: 1` to prevent browsers from applying ~50% opacity dimming which can reduce contrast below 3:1 on semi-transparent input backgrounds
- **`.theme-light .dark-section .text-zinc-500`**: fixed from `#71717a` (3.67:1 on zinc-900, FAIL) to `#a1a1aa` (6.91:1, PASS) — dark-section hero areas use dark backgrounds even in light mode
- **High-contrast preset**: upgraded from `#a1a1aa` → `#d4d4d8` for an additional boost beyond the AA baseline

## Contrast ratios achieved

| Element | Before | After | Worst-case background |
|---|---|---|---|
| `text-zinc-500` on zinc-900 | 3.67:1 ❌ | 6.91:1 ✅ | `#18181b` |
| `text-zinc-500` on midnight-900 | 3.64:1 ❌ | 6.86:1 ✅ | `#151829` |
| `text-zinc-500` on moss-900 | 3.67:1 ❌ | 6.91:1 ✅ | `#141a11` |
| `text-zinc-500` on plum-900 | 3.80:1 ❌ | 7.17:1 ✅ | `#1a1023` |
| `text-zinc-400` (unchanged) | 6.91:1 ✅ | 6.91:1 ✅ | `#18181b` |
| `--muted-foreground` (unchanged) | 7.72:1 ✅ | 7.72:1 ✅ | `#18181b` |

Root cause: `text-zinc-500` (#71717a) is Tailwind's zinc-500 which was designed for light-mode secondary text. In dark mode it needed to be bumped to zinc-400 (#a1a1aa) to clear the WCAG AA 4.5:1 threshold for normal-weight text.

Only `frontend/src/index.css` was modified — no `.tsx` or `.ts` files touched.

Closes #893 (partial)
Closes #917 (partial)

> This PR addresses the color-contrast dimension of all 28 UX review issues found across dark-mode routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)