### PR TITLE
docs(ux-review): 2026-05-24 full-site UX review

### DIFF
--- a/docs/ux-reviews/2026-05-24-ux-review.md
+++ b/docs/ux-reviews/2026-05-24-ux-review.md
@@ -1,359 +1,514 @@
 # UX Review — 2026-05-24
 
-**Scope:** all routes  
-**Viewports:** 320×568 · 375×812 · 640×1024 · 768×1024 · 1280×800 · 1920×1080  
-**Routes reviewed:** 28  
-**Tool:** axe-core + Playwright screenshots, 4 dimensions (Layout · Accessibility · Usability · Copy)
+**Scope**: all routes  
+**Viewports**: 320×568 · 375×812 · 640×1024 · 768×1024 · 1280×800 · 1920×1080  
+**Routes reviewed**: 28  
+**Screenshots**: `.ux-review/artifacts/` (local only — not committed)
 
 ---
 
 ## /
 
-### Findings
-
-| Viewport      | Dimension     | Severity | Finding                                                                                                                                                |
-| ------------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 640×1024      | Layout        | major    | At 640px the layout appears to be in a transitional state — bottom tab bar is present but top nav is not fully rendered; layout doesn't cleanly switch |
-| all mobile    | Accessibility | critical | Multiple `link-name` violations: icon-only links lack accessible names (axe: link-name, multiple nodes)                                                |
-| all viewports | Accessibility | critical | Color-contrast failures on multiple text elements (axe: color-contrast)                                                                                |
-| all           | Usability     | minor    | Primary action not immediately obvious from landing view                                                                                               |
-
----
-
-## /login
-
-### Findings
-
-| Viewport      | Dimension     | Severity | Finding                                                                                                                               |
-| ------------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| all viewports | Accessibility | critical | Color-contrast failures on form labels and input placeholder text (axe: color-contrast)                                               |
-| all viewports | Accessibility | major    | Page is missing an `<h1>` heading (axe: page-has-heading-one)                                                                         |
-| 375×812       | Usability     | major    | Passkey button appears as the primary CTA above username/password; users unfamiliar with passkeys may be confused about how to log in |
-| all viewports | Copy          | minor    | "Sign in with passkey" and "Sign in with username" labels lack hierarchy — unclear which is the recommended path                      |
-
----
-
-## /signup
-
-### Findings
-
-| Viewport         | Dimension     | Severity | Finding                                                                                        |
-| ---------------- | ------------- | -------- | ---------------------------------------------------------------------------------------------- |
-| 320×568          | Layout        | critical | Submit button is hidden below the viewport fold; user cannot see or reach it without scrolling |
-| 320×568, 375×812 | Layout        | major    | Bottom tab bar renders on the sign-up page (unauthenticated route); should not appear          |
-| all viewports    | Accessibility | critical | Color-contrast failures on form labels and helper text (axe: color-contrast)                   |
-
----
-
-## /browse
-
-### Findings
-
-| Viewport         | Dimension     | Severity | Finding                                                                                  |
-| ---------------- | ------------- | -------- | ---------------------------------------------------------------------------------------- |
-| 320×568          | Layout        | critical | Title grid is empty / not visible at 320px — content appears to be hidden or overflowing |
-| 320×568, 375×812 | Layout        | major    | Filter/sort controls are not visible on mobile; users cannot filter browse results       |
-| all viewports    | Accessibility | critical | Color-contrast violations on category labels and search input (axe: color-contrast)      |
-
----
-
-## /title/movie-603
-
-### Findings
-
-| Viewport      | Dimension     | Severity | Finding                                                                                                                                 |
-| ------------- | ------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| 320×568       | Layout        | critical | Content overflows horizontally at 320px; metadata row extends beyond viewport                                                           |
-| 320×568       | Layout        | major    | Action buttons (track, rate) stack awkwardly and the rightmost button is partially clipped                                              |
-| all viewports | Accessibility | critical | Multiple color-contrast violations on title, metadata text, and genre chips (axe: color-contrast)                                       |
-| all viewports | Accessibility | major    | `scrollable-region-focusable` violation — horizontally scrollable cast row is not keyboard-focusable (axe: scrollable-region-focusable) |
-
----
-
-## /title/tv-1399
-
-### Findings
-
-| Viewport      | Dimension     | Severity | Finding                                                                                     |
-| ------------- | ------------- | -------- | ------------------------------------------------------------------------------------------- |
-| 320×568       | Layout        | critical | Layout breaks at 320px — metadata row wraps and overlaps the poster image                   |
-| all viewports | Layout        | major    | Duplicate metadata row visible — runtime and rating appear twice                            |
-| all viewports | Accessibility | critical | Color-contrast failures on title text and metadata (axe: color-contrast)                    |
-| all viewports | Accessibility | major    | `scrollable-region-focusable` violation on cast carousel (axe: scrollable-region-focusable) |
-
----
-
-## /title/tv-1399/season/1
-
-### Findings
-
-| Viewport      | Dimension     | Severity | Finding                                                                                                                         |
-| ------------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| all viewports | Usability     | critical | Episode list is absent — no episodes are displayed despite seed data containing S01 episodes; page shows only the season header |
-| all viewports | Usability     | major    | No empty-state message if episode list truly is empty; user receives no feedback                                                |
-| all viewports | Accessibility | critical | Color-contrast violations on season header text (axe: color-contrast)                                                           |
-
----
-
-## /title/tv-1399/season/1/episode/1
-
-### Findings
-
-| Viewport      | Dimension     | Severity | Finding                                                                                          |
-| ------------- | ------------- | -------- | ------------------------------------------------------------------------------------------------ |
-| all viewports | Layout        | critical | Page is nearly empty — episode title and overview are not rendered; only shell chrome is visible |
-| all viewports | Usability     | critical | No episode content displayed; unclear whether this is a data or rendering failure                |
-| all viewports | Accessibility | critical | Color-contrast violations (axe: color-contrast)                                                  |
-
----
-
-## /person/1
-
-### Findings
-
-| Viewport      | Dimension | Severity | Finding                                                                                                                                  |
-| ------------- | --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| all viewports | Usability | critical | Page shows a loading/spinner state across all 6 viewports — person data never loads (likely TMDB mock not active or person seed missing) |
-| all viewports | Layout    | major    | No fallback or error state shown when data fails to load; user sees infinite spinner                                                     |
-
----
-
-## /user/ux_seed
-
-### Findings
-
-| Viewport      | Dimension     | Severity | Finding                                                                                                               |
-| ------------- | ------------- | -------- | --------------------------------------------------------------------------------------------------------------------- |
-| 375×812       | Layout        | major    | User profile content is invisible at 375px — the page appears blank below the header                                  |
-| all viewports | Accessibility | critical | `landmark-no-duplicate-main` violation — two `<main>` landmarks present on the page (axe: landmark-no-duplicate-main) |
-| all viewports | Accessibility | critical | Color-contrast violations on username and stats text (axe: color-contrast)                                            |
-
----
-
-## /u/ux_seed/achievements
-
-### Findings
-
-| Viewport      | Dimension | Severity | Finding                                                                                   |
-| ------------- | --------- | -------- | ----------------------------------------------------------------------------------------- |
-| all viewports | Usability | critical | Page is permanently in a loading state across all 6 viewports — achievements never render |
-| all viewports | Layout    | major    | No error or empty state; user sees a blank/spinner page with no actionable feedback       |
-
----
-
-## /u/ux_seed/achievements/movies_10
-
-### Findings
-
-| Viewport      | Dimension | Severity | Finding                                                                   |
-| ------------- | --------- | -------- | ------------------------------------------------------------------------- |
-| all viewports | Usability | critical | Page is permanently in a loading state — achievement detail never renders |
-| all viewports | Layout    | major    | No fallback state for failed/slow data fetch                              |
-
----
-
-## /share/watchlist/uxreviewshare0000000000000000000
-
-### Findings
-
-| Viewport         | Dimension     | Severity | Finding                                                                                                     |
-| ---------------- | ------------- | -------- | ----------------------------------------------------------------------------------------------------------- |
-| 320×568, 375×812 | Layout        | major    | Bottom tab bar overlaps the bottom of the shared watchlist content; last item in list is partially obscured |
-| all viewports    | Accessibility | critical | Color-contrast violations on watchlist item text (axe: color-contrast)                                      |
-
----
-
-## /kiosk/uxreviewkiosk00000000000000000000
-
-### Findings
-
-| Viewport         | Dimension     | Severity | Finding                                                                                |
-| ---------------- | ------------- | -------- | -------------------------------------------------------------------------------------- |
-| 320×568          | Layout        | critical | Severe layout breakage at 320px — kiosk tiles overflow horizontally and are unreadable |
-| 320×568, 375×812 | Layout        | major    | Kiosk grid does not reflow to a single column on narrow viewports                      |
-| all viewports    | Accessibility | critical | Color-contrast violations on kiosk item titles (axe: color-contrast)                   |
-
----
-
-## /this-route-does-not-exist-404
-
-### Findings
-
-| Viewport      | Dimension     | Severity | Finding                                                                                                            |
-| ------------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------ |
-| all viewports | Accessibility | major    | 404 heading has contrast ratio of approximately 2.57:1 (below 4.5:1 minimum for normal text) (axe: color-contrast) |
-| all viewports | Usability     | minor    | No navigation suggestions or link back to home from 404 page                                                       |
-
----
-
-## /reels
-
-### Findings
-
-| Viewport         | Dimension     | Severity | Finding                                                                                                        |
-| ---------------- | ------------- | -------- | -------------------------------------------------------------------------------------------------------------- |
-| 320×568, 375×812 | Layout        | major    | Filter/genre chips overflow horizontally without wrapping or scroll affordance; chips are clipped              |
-| all viewports    | Usability     | major    | No poster images displayed for any reel card — appears to be a seed data issue (posterUrl: null in db-seed.ts) |
-| all viewports    | Accessibility | critical | Color-contrast violations on reel card overlaid text (axe: color-contrast)                                     |
-
----
-
-## /more
-
-### Findings
-
-| Viewport                      | Dimension     | Severity | Finding                                                                                                                                                         |
-| ----------------------------- | ------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 768×1024, 1280×800, 1920×1080 | Usability     | major    | `/more` (mobile-only overflow menu) renders at desktop viewports without redirecting; desktop users see a standalone overflow menu page instead of the full nav |
-| all viewports                 | Accessibility | critical | Multiple color-contrast violations on menu item labels (axe: color-contrast)                                                                                    |
-| all viewports                 | Accessibility | major    | `link-name` violations on icon-only nav items that lack accessible text                                                                                         |
-
----
-
-## /tracked
-
-### Findings
-
-| Viewport         | Dimension     | Severity | Finding                                                                                             |
-| ---------------- | ------------- | -------- | --------------------------------------------------------------------------------------------------- |
-| all viewports    | Accessibility | critical | `select-name` violation — sort/filter `<select>` element has no accessible label (axe: select-name) |
-| 320×568, 375×812 | Layout        | major    | Title text in list view is truncated with no tooltip or accessible full-title fallback              |
-| all viewports    | Accessibility | critical | Color-contrast violations on title and metadata text (axe: color-contrast)                          |
-
----
-
-## /tracked?view=stats
-
-### Findings
-
-| Viewport      | Dimension     | Severity | Finding                                                                                                        |
-| ------------- | ------------- | -------- | -------------------------------------------------------------------------------------------------------------- |
-| all viewports | Accessibility | critical | `select-name` violation — same unlabelled `<select>` as `/tracked` (axe: select-name)                          |
-| all viewports | Usability     | major    | Stats view does not show any statistical content — charts/numbers area is empty or not rendered                |
-| 640×1024      | Layout        | major    | Layout issues at the 640px breakpoint — transitional state between mobile/desktop causes misaligned stat cards |
-| all viewports | Accessibility | critical | Color-contrast violations (axe: color-contrast)                                                                |
-
----
-
-## /calendar
-
-### Findings
-
-| Viewport      | Dimension     | Severity | Finding                                                                                                                |
-| ------------- | ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
-| all viewports | Accessibility | critical | Episode day links in the calendar grid have no accessible name — icon-only links with no `aria-label` (axe: link-name) |
-| all viewports | Accessibility | critical | Color-contrast violations on day numbers and episode indicators (axe: color-contrast)                                  |
-| 320×568       | Layout        | major    | Calendar grid cells are too narrow at 320px; day numbers and episode dots are barely legible                           |
-
----
-
-## /discovery
-
-### Findings
-
-| Viewport           | Dimension     | Severity | Finding                                                                                                                           |
-| ------------------ | ------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| 640×1024, 768×1024 | Layout        | major    | Split background visible at 640–768px viewports — gradient or section divider creates an unintended visual seam                   |
-| all viewports      | Usability     | major    | Only an empty state is shown — no recommendation cards rendered (seed user may have insufficient data to trigger recommendations) |
-| all viewports      | Accessibility | critical | Color-contrast violations on empty-state copy (axe: color-contrast)                                                               |
-
----
-
-## /invite
-
-### Findings
-
-| Viewport      | Dimension     | Severity | Finding                                                                                                       |
-| ------------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------- |
-| 640×1024      | Layout        | major    | White/blank column visible at 640px — a layout container does not fill the available width at this breakpoint |
-| all viewports | Usability     | major    | No active tab highlighted in the invite page tab bar — current section is visually indistinguishable          |
-| all viewports | Accessibility | critical | Color-contrast violations on invite link text and form labels (axe: color-contrast)                           |
-
----
-
-## /leaderboard
-
-### Findings
-
-| Viewport      | Dimension     | Severity | Finding                                                                                                       |
-| ------------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------- |
-| all viewports | Usability     | major    | Only an empty state is shown — no leaderboard entries rendered (seed data may not satisfy ranking thresholds) |
-| 640×1024      | Layout        | major    | Same white/blank column issue at 640px as seen in `/invite`                                                   |
-| all viewports | Accessibility | critical | Color-contrast violations on rank/score text (axe: color-contrast)                                            |
+| Viewport                                | Dimension     | Severity | Finding                                                                                                                                                                                                                                                                                                                                  |
+| --------------------------------------- | ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 320x568, 375x812                        | Layout        | major    | Route correctly redirects to `/reels` on mobile, but the screenshots show the `/reels` Reels page, not a HomeRoute layout. The `/reels` destination renders with a fully opaque hero image that covers the entire viewport and the "SWIPE FOR NEXT" affordance is partially clipped on the right edge at 320x568 — the label is cut off. |
+| 320x568                                 | Layout        | minor    | Bottom tab bar "More" label and the last tab chip are tight at 320px; five tabs compress to near the minimum readable size, leaving very little breathing room between labels.                                                                                                                                                           |
+| 1280x800, 1920x1080                     | Layout        | major    | A large dark empty rectangle occupies roughly the top-right third of the desktop layout (visible in both 1280x800 and 1920x1080 screenshots, between the "Up Next" card column and the right edge). This appears to be a hero/featured panel that has rendered with no content — the slot is reserved but blank.                         |
+| 640x1024, 768x1024                      | Layout        | minor    | Content column is left-aligned and relatively narrow; at 768px the right half of the viewport is entirely empty/black. The layout does not expand horizontally to use available space — sections stack in a single narrow column.                                                                                                        |
+| 640x1024, 768x1024, 1280x800, 1920x1080 | Accessibility | major    | `color-contrast` violation (axe, serious, WCAG 2 AA): media card release date text (`text-zinc-500`, `#71717b` on `#18181b`) has contrast ratio 3.67:1 against `bg-zinc-900` card background — fails 4.5:1 requirement. Affects 2 nodes ("Released Mar 16, 2020" and "Released Oct 14, 1994") on all 4 desktop/tablet viewports.         |
+| 640x1024, 768x1024                      | Accessibility | major    | `color-contrast` violation (axe, serious): search bar placeholder text (`#9f9fa9` on `#ffffff`, ratio 2.62:1) and `⌘K` shortcut hint (`#b7b7bf` on `#ffffff`, ratio 1.99:1) both fail WCAG AA — affects 640x1024 only (search bar visible starting at that breakpoint).                                                                  |
+| 640x1024, 768x1024, 1280x800, 1920x1080 | Accessibility | major    | `color-contrast` violation (axe, serious): "Logout" button in the top nav (`text-zinc-400`, `#9f9fa9` on `#ffffff` background, ratio 2.62:1) fails WCAG AA on all desktop/tablet viewports.                                                                                                                                              |
+| 640x1024, 768x1024, 1280x800, 1920x1080 | Accessibility | major    | `color-contrast` violation (axe, serious): footer "© 2026 Remindarr" and the GitHub link (`#71717b` on `#09090b`, ratio 4.12:1) both fall short of 4.5:1 on all desktop/tablet viewports.                                                                                                                                                |
+| 640x1024, 768x1024, 1280x800, 1920x1080 | Accessibility | minor    | `page-has-heading-one` violation (axe, moderate): the desktop HomePage renders no `<h1>` element. Section headings ("Up Next", "Unwatched", "Movies to Watch", "Today") are all sub-headings with no `<h1>` landmark to anchor the page for screen-reader users. Present on all 4 desktop viewports.                                     |
+| 1280x800, 1920x1080                     | Usability     | major    | The blank hero/featured panel to the right of "Up Next" provides no affordance — no loading indicator, no empty-state message, no placeholder art. A user would not know whether this is intentional whitespace, a failed load, or an in-progress feature.                                                                               |
+| 640x1024                                | Usability     | minor    | At exactly the 640px breakpoint the desktop top-nav is present but the content column still feels very narrow (single-column card stack), making the page look sparse and unbalanced compared to the wider viewports.                                                                                                                    |
+| 375x812                                 | Usability     | minor    | On the `/reels` redirect destination the "Mark as Watched" CTA button at the bottom of the screen sits directly above the bottom tab bar with minimal padding; on some episodes it may be obscured or require scrolling to tap.                                                                                                          |
 
 ---
 
 ## /achievements
 
-### Findings
-
-| Viewport      | Dimension     | Severity | Finding                                                                                                                 |
-| ------------- | ------------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
-| all viewports | Accessibility | critical | 48+ color-contrast violations — nearly every text element on the achievements page fails contrast (axe: color-contrast) |
-| all viewports | Accessibility | major    | Page is missing an `<h1>` heading (axe: page-has-heading-one)                                                           |
-| all viewports | Usability     | minor    | Achievement card layout is uniform — locked and unlocked achievements look identical at a glance                        |
+| Viewport                                | Dimension     | Severity | Finding                                                                                                                                                                                                                                                                                  |
+| --------------------------------------- | ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 320×568                                 | Layout        | major    | Filter chip row wraps onto two lines and the last chip ("Long Haul") is partially obscured by the "ACHIEVEMENT UNLOCKED" toast/overlay that renders on top of the filter bar; the overlay is not dismissible from this viewport's visible area                                           |
+| 320×568                                 | Layout        | minor    | Achievement name labels in the 2-column grid truncate with an ellipsis at narrow column width — "Weekend Warr…", "Mini Marathon…", "Marathon Finis…" — losing meaningful differentiation between sibling badges                                                                          |
+| 640×1024                                | Layout        | minor    | Right half of the viewport is blank white (no background colour applied); the content column ends at ~460px and the remaining ~180px of the 640px-wide canvas is unpainted, creating a stark light/dark split at the structural breakpoint                                               |
+| all                                     | Accessibility | major    | `color-contrast` (axe: wcag2aa / wcag143) — `h1` "Achievements" heading uses `text-zinc-500` on `bg-zinc-950` producing a contrast ratio of 4.12:1 against the required 4.5:1; violation present across all 6 viewports, 1 node each                                                     |
+| all                                     | Accessibility | major    | `color-contrast` — progress counter `1/34 earned · 10 XP` (`text-[11px] text-zinc-500`) and section kicker labels "Next up", "Recently earned", and per-category headings (also `text-[11px] text-zinc-500` on `bg-zinc-950`) all fail at 4.12:1; multiple nodes, all 6 viewports        |
+| all                                     | Accessibility | major    | `color-contrast` — "7d ago" timestamp beneath the recently-earned badge uses `text-[10px] text-zinc-500` (10px text) producing 4.12:1; at this font size the threshold is 4.5:1; present across all 6 viewports                                                                          |
+| 640×1024, 768×1024, 1280×800, 1920×1080 | Accessibility | major    | `color-contrast` — "Search titles, people…" placeholder text in the top-nav search button renders at 2.62:1 (foreground `#9f9fa9` on background `#ffffff`); "⌘K" badge renders at 1.99:1; and the "Logout" button text at 2.62:1 — all on desktop viewports where the top nav is present |
+| 320×568                                 | Usability     | major    | The "ACHIEVEMENT UNLOCKED" toast/popup is rendered mid-page overlapping the filter chip bar and partially covering the first row of achievement cards, leaving no visible dismiss control at this viewport; the notification blocks interactive content with no close affordance visible |
+| all                                     | Usability     | minor    | The page `h1` is styled identically to section kicker labels — 11px monospace uppercase zinc-500 — making it visually indistinguishable from sub-section headings and providing no clear landmark for the page title                                                                     |
+| all                                     | Copy          | minor    | The "7d ago" timestamp below the recently-earned badge has no accessible or visible label for the preceding date; a screen reader encounters only "7d ago" with no named context ("Earned 7 days ago")                                                                                   |
 
 ---
 
 ## /achievements/movies_10
 
-### Findings
-
-| Viewport      | Dimension     | Severity | Finding                                                                                             |
-| ------------- | ------------- | -------- | --------------------------------------------------------------------------------------------------- |
-| 1920×1080     | Layout        | minor    | Achievement detail card is left-aligned at 1920px instead of centered; wide whitespace on the right |
-| all viewports | Accessibility | critical | Color-contrast violations on achievement title and progress text (axe: color-contrast)              |
-
----
-
-## /u/ux_seed/overlap/ux_friend
-
-### Findings
-
-| Viewport      | Dimension | Severity | Finding                                                                                                                                                  |
-| ------------- | --------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| all viewports | Usability | critical | Page shows a "private watchlist" or access error — the seed user and friend user do not have a mutual-follow relationship, so overlap cannot be computed |
-| all viewports | Usability | major    | No guidance shown to the user about why the overlap is unavailable or how to resolve it                                                                  |
-
----
-
-## /settings
-
-### Findings
-
-| Viewport      | Dimension     | Severity | Finding                                                                                                                                      |
-| ------------- | ------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| 320×568       | Layout        | major    | Settings tab row (Account · Appearance · Integrations · Notifications) is clipped — the rightmost tabs are not visible or reachable at 320px |
-| all viewports | Accessibility | critical | Breadcrumb separator/text has contrast ratio of approximately 2.15:1 (axe: color-contrast)                                                   |
-| all viewports | Accessibility | critical | Color-contrast violations on tab labels and form field text (axe: color-contrast)                                                            |
+| Viewport                                              | Dimension     | Severity | Finding                                                                                                                                                                                                                                                                                      |
+| ----------------------------------------------------- | ------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 640×1024                                              | Layout        | major    | Page content is constrained to the left ~640px column; the right ~285px of the viewport is a hard white/unpainted area instead of the app's dark background. The layout container ends at the structural breakpoint but the page background does not extend to fill the full viewport width. |
+| 375×812                                               | Layout        | minor    | The "Achievement Unlocked" toast/banner visible at 320×568 is absent at 375×812 despite the same earned state, suggesting inconsistent toast dismissal timing between viewports rather than a deliberate responsive difference.                                                              |
+| all desktop (640×1024, 768×1024, 1280×800, 1920×1080) | Layout        | major    | Page content occupies a very small vertical region (hero + ladder progress only), leaving the bottom 60–75% of the viewport completely empty above the footer. There is no bottom padding or min-height applied that would push the footer to the natural bottom of a content-sparse page.   |
+| 1920×1080                                             | Layout        | minor    | Content block is left-aligned within the `max-w-2xl` container rather than centred. On a 1920px canvas the achievement detail sits in the left quarter of the screen with a large dead zone to the right.                                                                                    |
+| 320×568, 375×812                                      | Accessibility | major    | `color-contrast` violation (axe: color-contrast, serious, WCAG 2 AA): "Ladder progress" section label has contrast ratio 4.12:1 against `#09090b` background; required 4.5:1.                                                                                                                |
+| 320×568, 375×812                                      | Accessibility | major    | `color-contrast` violation: all 5 bottom tab bar labels at 10px / `#71717b` on `#141417` have contrast ratio 3.8:1; required 4.5:1. 5 nodes each viewport.                                                                                                                                   |
+| 640×1024                                              | Accessibility | major    | `color-contrast` violation: search bar placeholder at 2.62:1 and "⌘K" hint at 1.99:1 against white background. Also "Logout" button text at 2.62:1.                                                                                                                                          |
+| 768×1024                                              | Accessibility | major    | "Logout" button contrast failure (2.62:1, `#9f9fa9` on `#ffffff`).                                                                                                                                                                                                                           |
+| 640×1024, 768×1024, 1280×800, 1920×1080               | Accessibility | minor    | Footer "© 2026 Remindarr" and "GitHub" link at 4.12:1 against `#09090b`; just below the 4.5:1 AA threshold.                                                                                                                                                                                  |
+| all                                                   | Usability     | major    | The "Ladder progress" rung dots provide no accessible label, tooltip, or legend explaining what each rung represents or what the filled/unfilled states mean.                                                                                                                                |
+| all                                                   | Usability     | minor    | No page-level `<title>` update, so the browser tab always shows the app default and screen reader users cannot distinguish this page in their session history.                                                                                                                               |
+| all                                                   | Usability     | minor    | Rarity badge ("Rare · 4% earned") is absent in all screenshots with no empty/loading indication — the section disappears silently with no explanation.                                                                                                                                       |
+| all                                                   | Copy          | minor    | "WATCHING" is displayed as an all-caps kicker for a completed/earned achievement — reads as present-tense action rather than a category name.                                                                                                                                                |
 
 ---
 
 ## /admin/users
 
-### Findings
-
-| Viewport      | Dimension     | Severity | Finding                                                                                                                 |
-| ------------- | ------------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
-| all viewports | Accessibility | major    | Email column text has contrast ratio of approximately 2.57:1 against the table background (axe: color-contrast)         |
-| all viewports | Accessibility | major    | Action icon buttons in the user table (edit, delete) have no accessible label — `aria-label` missing (axe: button-name) |
-| all viewports | Accessibility | critical | Color-contrast violations across the admin table (axe: color-contrast)                                                  |
+| Viewport                                              | Dimension     | Severity | Finding                                                                                                                                                                                                             |
+| ----------------------------------------------------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 320x568                                               | Layout        | major    | An "Achievement Unlocked" toast notification overlays the second table row, completely obscuring the `ux_seed` user row; the toast is not dismissible from this view and blocks the action buttons                  |
+| 320x568                                               | Layout        | minor    | The three action icon buttons (Shield, ShieldOff, Trash2) are rendered at `p-1.5` with a 14px icon — effective tap target is approximately 29px, below the 44px minimum for mobile                                  |
+| 640x1024                                              | Layout        | minor    | Content is left-aligned and does not fill the full 640px column; the right half of the viewport is white (unpainted), indicating the page container does not extend to the viewport edge at this exact breakpoint   |
+| all mobile (320x568, 375x812)                         | Accessibility | critical | `color-contrast` violation (axe: serious): "User" role badge uses `text-zinc-400` on `bg-zinc-700` — contrast ratio 3.98:1, expected 4.5:1                                                                          |
+| all mobile (320x568, 375x812)                         | Accessibility | critical | `color-contrast` violation: username secondary line (`text-zinc-500` on `#09090b`) ratio 4.12:1; email line (`text-zinc-600` on `#09090b`) ratio 2.57:1; "you" label ratio 2.57:1; affects 6 nodes across user rows |
+| all mobile (320x568, 375x812)                         | Accessibility | critical | `color-contrast` violation: all 5 bottom tab bar labels render `text-zinc-500` (3.8:1) against the blurred `bg-zinc-900/72` tab bar background                                                                      |
+| 640x1024, 768x1024                                    | Accessibility | critical | `color-contrast` violation: search bar placeholder text and "⌘K" shortcut badge render at 2.62:1 and 1.99:1 against `#ffffff`; "Logout" button at 2.62:1                                                            |
+| all desktop (640x1024, 768x1024, 1280x800, 1920x1080) | Accessibility | critical | `color-contrast` violation: username (4.12:1), email (2.57:1), "you" label (2.57:1), JOINED date cells (4.12:1), footer copyright and GitHub link (4.12:1) — 8–12 nodes per viewport                                |
+| all                                                   | Usability     | minor    | The three action icon buttons (Shield, ShieldOff, Trash2) have no visible label; on touch devices `title` tooltips never appear, leaving the icons ambiguous                                                        |
+| all                                                   | Usability     | minor    | No loading skeleton — the loading state uses a plain text string with no skeleton row structure to preserve layout stability                                                                                        |
+| 320x568                                               | Copy          | minor    | The mobile role badge still carries the same low-contrast styling as the desktop ROLE cell; visual hierarchy for role is unclear on the narrowest viewport                                                          |
 
 ---
 
-## Summary
+## /browse
 
-| Severity | Count |
-| -------- | ----- |
-| critical | 54    |
-| major    | 38    |
-| minor    | 6     |
+| Viewport                                | Dimension     | Severity | Finding                                                                                                                                                                                                                                            |
+| --------------------------------------- | ------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 320x568                                 | Layout        | major    | The filter panel is hidden behind the toggle button with no visual hint that filters exist — no label, no count badge — so a first-time user cannot discover Genre / Provider / Year / Rating filters without tapping a completely unlabelled icon |
+| 320x568                                 | Layout        | minor    | The search field placeholder is clipped at the narrowest viewport ("Search titles or paste IMI" is cut off mid-word)                                                                                                                               |
+| 320x568                                 | Accessibility | major    | "Sign In" tab-bar label fails WCAG AA color contrast: `#71717b` on `#141417` = 3.8:1 (required 4.5:1, 10px text)                                                                                                                                   |
+| 320x568, 375x812                        | Accessibility | major    | "Loading..." text fails WCAG AA color contrast: `#71717b` on `#09090b` = 4.12:1 (required 4.5:1)                                                                                                                                                   |
+| 640x1024, 768x1024, 1280x800, 1920x1080 | Accessibility | major    | Filter card label divs ("Genre", "Provider", "Year", "Min. rating") fail WCAG AA contrast: `#71717b` on `#18181b` = 3.67:1 (required 4.5:1, 10px text)                                                                                             |
+| 640x1024, 768x1024, 1280x800, 1920x1080 | Accessibility | minor    | Footer "© 2026 Remindarr" and "GitHub" link fail contrast: `#71717b` on `#09090b` = 4.12:1                                                                                                                                                         |
+| all                                     | Usability     | major    | All 6 viewports show "Loading..." with no results rendered — the page never displays content cards. Likely a data-loading failure at screenshot time with no error fallback or timeout feedback                                                    |
+| 320x568                                 | Usability     | minor    | The mobile filter toggle (hamburger icon) has no visible text label, making the control's purpose ambiguous to new users                                                                                                                           |
+| 1920x1080                               | Usability     | minor    | At the widest viewport, the "Popular" section heading appears in the upper-left and the lower two-thirds of the canvas is entirely empty black — no max-width centering applied                                                                    |
+| all mobile                              | Usability     | minor    | Active filter chips are hidden on mobile unless the filter panel is open — a user cannot tell filters are active without opening the panel                                                                                                         |
 
-**Top issues by frequency:**
+---
 
-1. **color-contrast** — present on virtually every route; likely a systemic theme token issue rather than per-route bugs
-2. **Loading/empty states showing instead of content** — `/person/1`, `/u/ux_seed/achievements`, `/u/ux_seed/achievements/movies_10`, `/discovery`, `/leaderboard` all show spinners or empty states
-3. **select-name** — unlabelled `<select>` on `/tracked` and `/tracked?view=stats`
-4. **link-name / button-name** — icon-only interactive elements missing accessible labels across multiple routes
-5. **640px breakpoint white column** — `/invite`, `/leaderboard` both show a blank column at exactly 640px
-6. **Bottom tab bar on unauthenticated routes** — `/signup` renders tab bar incorrectly
+## /calendar
+
+| Viewport                                | Dimension     | Severity | Finding                                                                                                                                                                |
+| --------------------------------------- | ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 320×568, 375×812                        | Layout        | major    | Mobile view renders the AgendaCalendar with no visible active styling difference on the toggle row at 320px, making the active state effectively invisible             |
+| 320×568                                 | Layout        | minor    | The filter toolbar row is tightly packed at 320px with individual tap targets smaller than 44px                                                                        |
+| 640×1024                                | Layout        | minor    | At the 640px breakpoint the desktop grid calendar renders but the right-side whitespace beyond the grid edge is dead background, leaving the page asymmetric           |
+| 1920×1080                               | Layout        | minor    | The calendar month grid is left-aligned and does not fill the full 1920px width                                                                                        |
+| 320×568, 375×812                        | Accessibility | major    | `page-has-heading-one` violation: the `MobileCalendar` renders no `<h1>` — the month name is a plain `<div>`, not a semantic heading element                           |
+| 320×568, 375×812                        | Accessibility | major    | `color-contrast` violation: bottom tab bar labels at 10px render at 3.80:1 against `bg-zinc-900/[0.72]`, below 4.5:1. 4 nodes each viewport.                           |
+| 320×568, 375×812                        | Accessibility | major    | `color-contrast` violation: day-item count badge `text-xs text-zinc-500` renders at 3.87:1 and 3.65:1 against card backgrounds                                         |
+| 640×1024, 768×1024, 1280×800, 1920×1080 | Accessibility | major    | `color-contrast` violation: all 7 weekday column headers "Mon"–"Sun" at `text-zinc-500` on `bg-zinc-900` render at 3.67:1, below 4.5:1. 7 nodes per desktop viewport.  |
+| 640×1024, 768×1024, 1280×800, 1920×1080 | Accessibility | major    | `color-contrast` violation: legend labels and footer text at 4.12:1 against `bg-zinc-950`, below 4.5:1. 6 nodes per viewport.                                          |
+| 640×1024                                | Accessibility | major    | `color-contrast` violation: search bar placeholder (2.62:1) and "⌘K" hint (1.99:1) against white background; also "Logout" button                                      |
+| 640×1024, 768×1024                      | Accessibility | major    | `color-contrast` violation: "Logout" button text at 2.62:1 against white-rendered button background                                                                    |
+| 320×568, 375×812                        | Usability     | major    | The "hide watched" eye-icon button and prev/next week buttons lack `aria-label`; `title` attribute is not announced on touch devices                                   |
+| 320×568, 375×812                        | Usability     | minor    | Mobile calendar defaults to Agenda view with no empty-state copy or call-to-action when no episodes are upcoming                                                       |
+| all desktop                             | Usability     | minor    | The "Today" button provides no visual feedback after clicking when the user is already on the current month — appears inert                                            |
+| all                                     | Copy          | minor    | "Followed · new episode" and "Premiere" legend dots use inline `oklch()` style while other colours use Tailwind utilities — mismatch in browsers without oklch support |
+
+---
+
+## /discovery
+
+| Viewport                                | Dimension     | Severity | Finding                                                                                                                                                                                          |
+| --------------------------------------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 640×1024                                | Layout        | major    | Content area occupies only the left ~635px; the right ~285px renders as raw white (unpainted) — the app shell background does not extend to fill the full viewport width at the 640px breakpoint |
+| 768×1024                                | Layout        | minor    | The `⌘K` search dropdown is rendered open and overlapping the top-right corner on initial load                                                                                                   |
+| 1920×1080                               | Layout        | minor    | The footer sits immediately below the empty-state paragraph (~250px from the top) leaving ~750px of dead black space beneath; no `min-height` or vertical centering applied                      |
+| 320×568, 375×812                        | Accessibility | major    | Empty-state paragraph `text-zinc-500` on `#09090b` fails WCAG AA contrast: 4.12:1, required 4.5:1                                                                                                |
+| 320×568, 375×812                        | Accessibility | major    | All 5 bottom tab bar labels at 10px at 3.8:1 against `#141417` fail WCAG AA                                                                                                                      |
+| 640×1024, 768×1024                      | Accessibility | major    | "Logout" button text fails contrast: `#9f9fa9` on `#ffffff`, ratio 2.62:1                                                                                                                        |
+| 640×1024                                | Accessibility | major    | Search bar placeholder fails contrast: 2.62:1; `⌘K` hint at 1.99:1                                                                                                                               |
+| 640×1024, 768×1024, 1280×800, 1920×1080 | Accessibility | minor    | Footer links fail contrast: 4.12:1 against `#09090b`, required 4.5:1. 2 nodes per desktop viewport.                                                                                              |
+| all mobile                              | Usability     | major    | Empty-state copy names no actionable path — no link to Browse or "Find people to follow" CTA; the user is left at a dead end                                                                     |
+| 320×568                                 | Usability     | minor    | Achievement toast renders over the bottom tab bar at 320px, partially obscuring the "More" tab label                                                                                             |
+| all                                     | Usability     | minor    | "Activity" and "For you" tabs share the same empty-state copy which is contextually wrong for the Activity tab                                                                                   |
+| all                                     | Copy          | minor    | `PageHeader` kicker and the tab label "For you" are hard-coded English strings not passed through `t()`, making them i18n blind spots                                                            |
+| all                                     | Copy          | minor    | `becauseLabel()` and `SectionHead` kicker/title strings are all hard-coded English and will not translate when a locale is added                                                                 |
+
+---
+
+## /invite
+
+| Viewport                                | Dimension     | Severity | Finding                                                                                                  |
+| --------------------------------------- | ------------- | -------- | -------------------------------------------------------------------------------------------------------- |
+| 640×1024                                | Layout        | major    | Page content is contained in the left ~62% of the viewport; the right ~38% renders white (unpainted)     |
+| all mobile (320×568, 375×812)           | Accessibility | major    | Bottom tab bar inactive-tab labels at 3.8:1 against `#141417`, below 4.5:1. 5 nodes affected.            |
+| all viewports                           | Accessibility | major    | Empty-state paragraph `text-zinc-500` on `#09090b`, yielding 4.12:1 — below 4.5:1.                       |
+| 640×1024, 768×1024                      | Accessibility | major    | Search bar placeholder at 2.62:1 and "⌘K" shortcut badge at 1.99:1 — well below 4.5:1.                   |
+| 640×1024, 768×1024                      | Accessibility | major    | "Logout" button text at 2.62:1 against `#ffffff`.                                                        |
+| 640×1024, 768×1024, 1280×800, 1920×1080 | Accessibility | minor    | Footer text and "GitHub" link at 4.12:1, below 4.5:1. 2 nodes per viewport.                              |
+| 320×568                                 | Usability     | minor    | Achievement toast overlays the bottom tab bar, making tab labels unreadable                              |
+| 640×1024                                | Usability     | minor    | No active nav highlight in the top nav for `/invite` — the user has no breadcrumb showing where they are |
+| all                                     | Usability     | minor    | No distinction between loading state and genuinely empty list in screenshots                             |
+
+---
+
+## /kiosk/uxreviewkiosk00000000000000000000
+
+| Viewport         | Dimension     | Severity | Finding                                                                                                                                                                                                                                                                    |
+| ---------------- | ------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 320×568          | Layout        | critical | Hero card overflows viewport width — show title and episode info are clipped on the right. Fixed `padding: "20px 56px"` and `margin: "24px 56px 0"` on the hero are too wide for a 320px screen with no responsive override.                                               |
+| 320×568          | Layout        | major    | Footer status bar wraps into three disconnected blocks stacking vertically with "LOCALHOST" text truncated to an unparseable fragment due to `overflow: hidden`                                                                                                            |
+| 320×568          | Layout        | minor    | Both bottom panels are below the fold with no scroll affordance; the page root has `overflow: hidden` blocking scrolling                                                                                                                                                   |
+| 375×812          | Layout        | minor    | "UP NEXT IN YOUR QUEUE" header label wraps onto two lines; the "1 unwatched" counter is pushed down and misaligned                                                                                                                                                         |
+| 768×1024         | Layout        | minor    | Episode code labels are truncated by the narrow left column; the ellipsis cuts off show titles entirely in some rows                                                                                                                                                       |
+| 1920×1080        | Layout        | minor    | No max-width container — two bottom panels are extremely wide (~900px each) with very low content density                                                                                                                                                                  |
+| all              | Accessibility | major    | Page has no `<h1>` element — the show title rendered at `fontSize: 80` is a plain `<div>`, not a heading element                                                                                                                                                           |
+| 320×568, 375×812 | Accessibility | major    | Two `overflow-y: auto` scroll containers inside `.kiosk-body-grid` are not keyboard focusable and contain no focusable children (axe: `scrollable-region-focusable`)                                                                                                       |
+| all              | Accessibility | major    | Multiple low-contrast text elements (axe: `color-contrast`, serious): "KIOSK · RICH" badge (3.83:1 at 10px), footer spans (4.11:1 at 11px), panel counters (3.66:1), episode codes (3.66:1), date in header (4.11:1 at 13px) — all using palette key `veryDim` (`#71717a`) |
+| all              | Usability     | major    | The "Cast to TV" button is `aria-hidden="true"` and `cursor: default` but visually styled as a prominent interactive element at 50% opacity — no tooltip explains it is non-functional                                                                                     |
+| all              | Usability     | minor    | No loading skeleton while `data` is null — the page renders the header and an empty body that may appear broken during the initial fetch                                                                                                                                   |
+| 320×568          | Copy          | major    | Footer metadata labels truncated mid-word: "AUTO- REFRESHES EVERY 5 MIN", "READ- ONLY · TOKEN UXRE", "LOCALHOST" — illegible at this size                                                                                                                                  |
+
+---
+
+## /leaderboard
+
+| Viewport                                | Dimension     | Severity | Finding                                                                                                                                                                                    |
+| --------------------------------------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 640×1024                                | Layout        | major    | Page content (dark app shell) occupies only the left ~62% of the viewport; the right ~38% renders as a solid white strip                                                                   |
+| 768×1024                                | Layout        | major    | Same white-strip artefact persists at 768px — the dark content column ends around 760px and the remainder is bare white                                                                    |
+| 375×812                                 | Layout        | minor    | With only 2 podium entries the bottom half of the screen is entirely empty black with no empty-state prompt                                                                                |
+| 1280×800                                | Layout        | minor    | The two-card podium grid is left-aligned; at wide viewports the cards sit in the left quarter with significant empty space to the right                                                    |
+| 320×568                                 | Accessibility | major    | `color-contrast`: badge count labels ("1 badge", "0 badges", `text-zinc-500`) fail at 3.8:1 against amber-tinted and default card backgrounds; required 4.5:1 — present at all 6 viewports |
+| 320×568, 375×812                        | Accessibility | major    | `color-contrast`: all 5 bottom tab bar labels at 10px render at 3.8:1 against the frosted tab bar background — below 4.5:1; affects both mobile viewports                                  |
+| 640×1024                                | Accessibility | major    | `color-contrast`: search bar placeholder text at 2.62:1 and "⌘K" hint at 1.99:1 against white background                                                                                   |
+| 640×1024, 768×1024, 1280×800, 1920×1080 | Accessibility | major    | `color-contrast`: "Logout" button renders at 2.62:1 against white background in top nav                                                                                                    |
+| 640×1024, 768×1024, 1280×800, 1920×1080 | Accessibility | minor    | `color-contrast`: footer text at 4.12:1 against `#09090b`, below 4.5:1                                                                                                                     |
+| all                                     | Usability     | major    | `LeaderboardPage` still uses a raw `useEffect` + `useState` pattern for data fetching — violates the project's TanStack Query adoption rule                                                |
+| all                                     | Usability     | minor    | No loading skeleton for the page heading during the loading state                                                                                                                          |
+| all                                     | Usability     | minor    | Podium cards are not interactive (not links/buttons) — no affordance to navigate to a ranked user's profile                                                                                |
+| 320×568                                 | Usability     | minor    | Achievement toast overlaps the bottom tab bar at 320×568                                                                                                                                   |
+
+---
+
+## /login
+
+| Viewport                                | Dimension     | Severity | Finding                                                                                                                                                                                          |
+| --------------------------------------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 320×568, 375×812                        | Layout        | minor    | The login form card sits in the upper third of the viewport rather than being vertically centered — `min-h-[70vh]` with `items-center` leaves a large empty region below on short mobile screens |
+| 640×1024, 768×1024, 1280×800, 1920×1080 | Layout        | major    | At all desktop viewports the page renders with the top nav showing a "Sign In" link while the user is already on the login page — the nav CTA is redundant and could confuse users               |
+| 1920×1080                               | Layout        | minor    | Content block occupies a very small central island on a large widescreen canvas with no visual anchoring — the form feels lost in the expanse                                                    |
+| all                                     | Accessibility | critical | `color-contrast`: "Sign in with username instead" button uses `text-zinc-500` on `bg-zinc-950`, contrast ratio 4.12:1 against required 4.5:1                                                     |
+| all                                     | Accessibility | critical | `color-contrast`: "Don't have an account?" paragraph text at 4.12:1 against `bg-zinc-950`                                                                                                        |
+| 640×1024, 768×1024, 1280×800, 1920×1080 | Accessibility | critical | `color-contrast`: footer "© 2026 Remindarr" span and "GitHub" link both at 4.12:1 against `bg-zinc-950`                                                                                          |
+| all                                     | Accessibility | critical | `link-in-text-block`: "Sign up" anchor has only 2.8:1 contrast against surrounding text (minimum 3:1) and no non-color visual distinction — carries no underline                                 |
+| 320×568, 375×812                        | Usability     | major    | The "Sign in with username instead" secondary action is rendered as a plain text button with no obvious affordance — looks like disabled body copy rather than a tappable control                |
+| 320×568, 375×812                        | Usability     | minor    | No back affordance or close gesture for a user who navigated here mid-session; the only escape is the "Sign up" link                                                                             |
+| all                                     | Copy          | minor    | "Sign in with username instead" is understated for its role as a primary fallback; "Use username and password" would be more descriptive                                                         |
+
+---
+
+## /more
+
+| Viewport                                | Dimension     | Severity | Finding                                                                                                                                             |
+| --------------------------------------- | ------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 320×568                                 | Layout        | major    | The "Achievement Unlocked" toast/banner in the ACCOUNT section overlaps the bottom tab bar at 320×568, obscuring the "More" label                   |
+| 320×568                                 | Layout        | minor    | Discovery row subtitle wraps to two lines at 320×568, creating visual imbalance                                                                     |
+| 640×1024, 768×1024, 1280×800, 1920×1080 | Layout        | major    | At all viewports ≥640px, `/more` redirects to `/reels` — desktop users landing on `/more` directly see an unrelated detail page with no explanation |
+| 320×568, 375×812                        | Accessibility | major    | `color-contrast`: section heading labels "Discover", "Account", "Session" at 10px render at 4.12:1 — below 4.5:1. 3 nodes per viewport.             |
+| 320×568, 375×812                        | Accessibility | major    | `color-contrast`: subtitle text at 11px on `#18181b` card background renders at 3.67:1. 2 nodes per viewport.                                       |
+| 320×568, 375×812                        | Accessibility | major    | `color-contrast`: username handle `@ux_seed` at 11px renders at 3.67:1 against `#18181b`. 1 node per viewport.                                      |
+| 320×568, 375×812                        | Accessibility | major    | `color-contrast`: bottom tab bar inactive labels at 10px render at 3.67–3.80:1. 4 nodes per viewport.                                               |
+| 320×568, 375×812                        | Accessibility | minor    | `page-has-heading-one` violation: the page contains no `<h1>` element                                                                               |
+| 320×568                                 | Usability     | major    | Achievement banner covers the Profile and Settings rows in the ACCOUNT section at 320×568 with no dismiss affordance                                |
+| 375×812                                 | Usability     | minor    | Profile and Settings rows are visible at 375×812 but hidden behind the achievement banner at 320×568                                                |
+| all mobile                              | Copy          | minor    | `MoreGroup` section labels are `text-[10px]` uppercase — extremely small rendered size that compounds the contrast failure                          |
+
+---
+
+## /person/1
+
+| Viewport                                         | Dimension     | Severity | Finding                                                                                                                                                                                                                                                                                                             |
+| ------------------------------------------------ | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 375x812, 640x1024, 768x1024, 1280x800, 1920x1080 | Layout        | critical | Page renders nearly empty at all viewports except 320x568: only the avatar placeholder, name, and TMDB badge are visible. Biography, department badge, birth/location metadata, and all filmography sections are absent — the seed person (id=1) has no `known_for_department`, `biography`, or `combined_credits`. |
+| 320x568                                          | Layout        | major    | The bottom tab bar overlaps the biography text; the "Born:" / "From:" metadata row and biography section start text are cut off behind the fixed tab bar with no bottom padding                                                                                                                                     |
+| 320x568                                          | Accessibility | major    | `color-contrast`: "Born: " and "From: " `<span class="text-zinc-500">` labels at 4.12:1 against `#09090b` — below 4.5:1. 2 nodes.                                                                                                                                                                                   |
+| 320x568                                          | Accessibility | major    | `color-contrast`: Year label `<p class="text-xs text-zinc-500">2020</p>` at 4.12:1 against `#09090b` at 12px. 1 node.                                                                                                                                                                                               |
+| 320x568                                          | Accessibility | critical | `color-contrast`: No-poster fallback text inside the credit card (`text-zinc-600` on `bg-zinc-800`) at only 1.92:1 — the only content shown when a poster image is unavailable. 1 node.                                                                                                                             |
+| 320x568, 375x812                                 | Accessibility | major    | `color-contrast`: Bottom tab bar labels at 3.8:1, below 4.5:1. 2 nodes each viewport.                                                                                                                                                                                                                               |
+| 640x1024, 768x1024, 1280x800, 1920x1080          | Accessibility | minor    | `color-contrast`: Footer text at 4.12:1 on `#09090b`. 2 nodes each viewport.                                                                                                                                                                                                                                        |
+| all                                              | Usability     | major    | No loading skeleton or error boundary feedback visible at 375x812–1920x1080; the page silently renders an incomplete profile with no indication that data is missing                                                                                                                                                |
+| all                                              | Usability     | minor    | No back-navigation affordance on any viewport — no back button or breadcrumb                                                                                                                                                                                                                                        |
+| 320x568                                          | Copy          | minor    | The "Biography" section heading is visible but body text is immediately obscured by the overlapping tab bar                                                                                                                                                                                                         |
+
+---
+
+## /reels
+
+| Viewport    | Dimension     | Severity | Finding                                                                                                                                                                    |
+| ----------- | ------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 640×1024    | Layout        | major    | The page renders with the desktop top nav but also shows the bottom tab bar, violating the 640px structural breakpoint rule                                                |
+| 768×1024    | Layout        | major    | Both top nav and full-screen reels card are visible, but the "Mark as Watched" CTA button is cut off at the bottom — the reel card does not account for the top nav height |
+| 1280×800    | Layout        | major    | The reel card occupies the full viewport height without compensating for the top nav bar, pushing "Mark as Watched" off screen                                             |
+| 1920×1080   | Layout        | major    | At 1920px the full-bleed card stretches edge-to-edge with no maximum width or centering constraint                                                                         |
+| 375×812     | Layout        | minor    | The horizontal chip row is cut off on the right with no affordance indicating more items exist                                                                             |
+| 320×568     | Layout        | minor    | The achievement-unlocked toast overlaps the bottom tab bar, partially obscuring both the toast text and the "Home" tab label                                               |
+| 320×568     | Usability     | major    | The "Mark as Watched" primary CTA is completely absent from the 320×568 viewport — replaced by a progress indicator and achievement toast with no visible action button    |
+| 640×1024    | Usability     | minor    | The "SWIPE FOR NEXT" hint label is visible at 640px (desktop breakpoint) — a touch gesture irrelevant to desktop/pointer users                                             |
+| all desktop | Usability     | minor    | No indication of how to navigate between cards at 768px and above; "SWIPE FOR NEXT" is touch-only guidance                                                                 |
+| all         | Accessibility | —        | No axe violations across all 6 viewports                                                                                                                                   |
+
+---
+
+## /settings
+
+| Viewport                                | Dimension     | Severity | Finding                                                                                                                                  |
+| --------------------------------------- | ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| 320x568                                 | Layout        | major    | Settings tab bar clips at the right edge — "Subscriptions" tab label is cut off to "Subscrip" with no overflow scroll affordance visible |
+| 320x568                                 | Layout        | minor    | The horizontal tab strip has no horizontal scroll indicator, so clipped tabs are invisible to the user                                   |
+| 640x1024                                | Layout        | minor    | At 640px the two-column grid activates but both sidebar and content area are very narrow — Profile card fields appear cramped            |
+| all mobile (320x568, 375x812)           | Accessibility | major    | Breadcrumb `/settings` span has contrast ratio 2.15:1 against `#09090b` (`opacity-60` on `text-zinc-500`) — fails WCAG AA 4.5:1          |
+| all                                     | Accessibility | major    | "Manage invite codes on the Invite page" helper text has contrast ratio 3.08:1 (`#71717b` on `#27272a` at 11px) — fails WCAG AA          |
+| 640x1024, 768x1024, 1280x800, 1920x1080 | Accessibility | major    | "TMDB · en-US" build-info text has contrast ratio 3.67:1 (`#71717b` on `#18181b` at 12px) — fails WCAG AA                                |
+| 640x1024                                | Accessibility | major    | Search bar placeholder at 2.62:1 and `⌘K` shortcut badge at 1.99:1 against white-computed nav background                                 |
+| 640x1024, 768x1024, 1280x800, 1920x1080 | Accessibility | major    | "Logout" button text at 2.62:1 in the top nav — fails WCAG AA                                                                            |
+| 640x1024, 768x1024, 1280x800, 1920x1080 | Accessibility | minor    | Footer "© 2026 Remindarr" and GitHub link at 4.12:1, below 4.5:1                                                                         |
+| 320x568                                 | Accessibility | minor    | Bottom tab bar labels at 3.52–3.67:1 against background at 10px — fails WCAG AA for small text                                           |
+| 320x568, 375x812                        | Usability     | minor    | The currently active settings section is not reflected in the bottom tab highlight — no navigation context                               |
+| 1920x1080                               | Usability     | minor    | Settings content column stretches to the full right half of the viewport at 1920px with no max-width cap on form fields                  |
+| all                                     | Copy          | minor    | The breadcrumb renders the raw path literal `/settings` as muted text — redundant with the page heading above it                         |
+
+---
+
+## /share/watchlist/uxreviewshare0000000000000000000
+
+| Viewport           | Dimension     | Severity | Finding                                                                                                                                                                    |
+| ------------------ | ------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 320x568            | Layout        | major    | The bottom tab bar overlaps the third media card, clipping its lower half and making it partially inaccessible without scrolling past the fixed bar                        |
+| 375x812            | Layout        | minor    | The third card is cropped at the bottom edge of the viewport with no visual cue that content continues                                                                     |
+| 1920x1080          | Layout        | minor    | With only 3 items the grid is left-aligned leaving a large empty area to the right; no max-width container centres the content at ultra-wide viewports                     |
+| all                | Accessibility | major    | `color-contrast`: subtitle paragraph "Read-only view — sign in to track these titles" at 4.12:1 against `#09090b`, below 4.5:1. All 6 viewports.                           |
+| all                | Accessibility | major    | `color-contrast`: all three media-card year labels at 3.67:1 against `bg-zinc-900`. 3 nodes on every viewport.                                                             |
+| all                | Accessibility | major    | `color-contrast`: page-level `<footer>` "Powered by" text at 2.57:1 — the worst ratio on the page. All 6 viewports.                                                        |
+| 320x568, 375x812   | Accessibility | major    | `color-contrast`: bottom tab bar "Sign In" and "Browse" labels at 3.80:1. Mobile only.                                                                                     |
+| 640x1024 and above | Accessibility | minor    | `color-contrast`: app-shell footer link "GitHub" and "© 2026 Remindarr" at 4.12:1. 4 desktop viewports.                                                                    |
+| all                | Usability     | minor    | The "sign in to track these titles" subtitle has no linked affordance — no direct CTA button or link to sign in beyond the small tab bar or nav link                       |
+| all                | Copy          | minor    | The inline footer "Powered by Remindarr" duplicates the page-level branding visible in the app-shell footer at desktop viewports — two attributions simultaneously visible |
+
+---
+
+## /signup
+
+| Viewport                                | Dimension     | Severity | Finding                                                                                                                                                                                                       |
+| --------------------------------------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 320x568                                 | Layout        | major    | Form card has no bottom padding — the "Already have an account? Sign in" paragraph is flush against the bottom edge of the viewport; content risks being clipped                                              |
+| 320x568, 375x812                        | Layout        | minor    | No back affordance or breadcrumb to return to the previous screen — users arrived via a deep link have no escape route other than the browser back button                                                     |
+| all                                     | Accessibility | major    | "Create an account" heading is `<h2>` but the page contains no `<h1>` (axe: `page-has-heading-one`, moderate).                                                                                                |
+| all                                     | Accessibility | major    | "Already have an account?" paragraph at 4.12:1 against `#09090b` — below WCAG AA 4.5:1. 1 node, all viewports.                                                                                                |
+| 640x1024, 768x1024, 1280x800, 1920x1080 | Accessibility | major    | Footer "© 2026 Remindarr" and GitHub link both at 4.12:1. 2 nodes, all desktop viewports.                                                                                                                     |
+| all                                     | Accessibility | major    | "Sign in" link inside "Already have an account?" is distinguishable only by amber color; contrast ratio 2.8:1 between link and surrounding text, below minimum 3:1. No underline. (axe: `link-in-text-block`) |
+| all                                     | Usability     | major    | No password visibility toggle on the password field                                                                                                                                                           |
+| all                                     | Usability     | minor    | No password strength hint or minimum-length guidance shown before failed submission                                                                                                                           |
+| all                                     | Usability     | minor    | "Display Name" field is optional but not marked as such                                                                                                                                                       |
+| 1920x1080                               | Layout        | minor    | The form card is vertically centered in a large black void with no decorative treatment or marketing copy flanking the form                                                                                   |
+
+---
+
+## /this-route-does-not-exist-404
+
+| Viewport                                | Dimension     | Severity | Finding                                                                                                                                                                                                                            |
+| --------------------------------------- | ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 320x568, 375x812                        | Layout        | minor    | Mobile shows a top logo bar above the 404 content in addition to the bottom tab bar — two competing chrome pieces that do not appear at desktop viewports                                                                          |
+| all                                     | Accessibility | critical | `h1` "404" has color contrast ratio of 2.57 against `#09090b` (`text-zinc-600` / `#52525c`); required minimum for large bold text is 3:1. 1 node, all 6 viewports.                                                                 |
+| all                                     | Accessibility | major    | Description paragraph at 4.12:1 against `#09090b`, below 4.5:1. 1 node, all 6 viewports.                                                                                                                                           |
+| 640x1024, 768x1024, 1280x800, 1920x1080 | Accessibility | major    | Footer span and "GitHub" link both at 4.12:1 against `#09090b`. 2 nodes, all desktop viewports.                                                                                                                                    |
+| 320x568, 375x812                        | Accessibility | major    | Bottom tab bar labels at 3.8:1 against `#141417`. 2 nodes, mobile viewports.                                                                                                                                                       |
+| all                                     | Usability     | minor    | The `h1` element contains the raw status code "404" rather than a human-readable title. The visible heading "Page not found" is a `<p>` not a semantic heading. Screen readers announce the page heading as "404" with no context. |
+| all                                     | Usability     | minor    | No navigation suggestions beyond "Go back home" — no link to Browse or Search                                                                                                                                                      |
+
+---
+
+## /title/movie-603
+
+| Viewport                           | Dimension     | Severity | Finding                                                                                                                                                                                   |
+| ---------------------------------- | ------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 320×568                            | Layout        | major    | The bottom tab bar overlaps and obscures the page header area: "Browse" and "Sign In" tab labels are rendered mid-page on top of the IMDB/TMDB score row                                  |
+| 375×812                            | Layout        | major    | The bottom tab bar renders in the middle of the page (overlapping the metadata row between the scores and "Overview") — same issue as 320×568 but more visible due to the taller viewport |
+| 320×568                            | Layout        | minor    | Genre chip row ("ACTION", "SCIENCE FICTION", star rating badge) is absent at 320×568 — visible at 375×812 and wider                                                                       |
+| all desktop (640×1024 – 1920×1080) | Layout        | minor    | Content column does not exceed ~640px in usable width even at 1920×1080; the right ~60% of the canvas is empty dark background                                                            |
+| 1920×1080                          | Layout        | minor    | "You might also like" recommendation cards are rendered as a fixed-width grid that stops at ~500px wide, leaving the right two-thirds of the canvas empty                                 |
+| all viewports                      | Accessibility | major    | `color-contrast`: IMDB/TMDB score suffix "/10" at 4.12:1 against `#09090b`, below 4.5:1. 2 nodes, every viewport.                                                                         |
+| all viewports                      | Accessibility | major    | `color-contrast`: "YOUR RATING" label at 4.12:1 at 11px/normal weight. Every viewport.                                                                                                    |
+| 320×568, 375×812                   | Accessibility | major    | `color-contrast`: bottom tab bar labels "Browse" and "Sign In" at 3.8:1 against `#141417`. 2 nodes each.                                                                                  |
+| 640×1024 – 1920×1080               | Accessibility | minor    | `color-contrast`: footer text at 4.12:1 against `#09090b`. All 4 desktop viewports.                                                                                                       |
+| 320×568                            | Usability     | major    | The "YOUR RATING" interactive buttons are rendered below the mid-page floating tab bar; users must scroll past the tab bar obstruction to reach them                                      |
+| 375×812                            | Usability     | minor    | "Share" button floats to the far right of the "YOUR RATING" row and is not vertically aligned with the rating icon buttons                                                                |
+| all viewports                      | Usability     | minor    | "You might also like" cards are loading skeletons across all 6 screenshots — no empty-state message or timeout fallback                                                                   |
+| all viewports                      | Copy          | minor    | Metadata section uses "IMOB" instead of the expected "IMDB" — appears to be a typo in the column header                                                                                   |
+
+---
+
+## /title/tv-1399
+
+| Viewport                                | Dimension     | Severity | Finding                                                                                                                                              |
+| --------------------------------------- | ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 320×568                                 | Layout        | major    | The bottom tab bar renders in the middle of the page content, overlapping the "No stream" button area                                                |
+| 320×568                                 | Layout        | major    | The hero/backdrop image area is entirely black — no image loads — leaving a large blank region ~280px tall at the top of the page                    |
+| 320×568                                 | Layout        | minor    | "You might also like" recommendation cards are clipped at the viewport edge with no scroll affordance                                                |
+| 375×812                                 | Layout        | minor    | The "Your rating" row and Share button create an awkward split alignment with no visual grouping between the two groups                              |
+| 320×568, 375×812                        | Accessibility | major    | `color-contrast`: "No stream" disabled button at 3.67:1 against `#18181a`. 1 node.                                                                   |
+| 320×568, 375×812                        | Accessibility | major    | `color-contrast`: "Your rating" label at 4.12:1 against `#09090b`. 1 node.                                                                           |
+| 320×568, 375×812                        | Accessibility | major    | `color-contrast`: Bottom tab bar labels at 3.8:1 against `#141417`. 2 nodes per viewport.                                                            |
+| 640×1024, 768×1024, 1280×800, 1920×1080 | Accessibility | major    | `color-contrast`: IMDB and TMDB score suffix "/10" spans at 4.12:1 against `#09090b`. 2 nodes per viewport.                                          |
+| 640×1024, 768×1024, 1280×800, 1920×1080 | Accessibility | major    | `color-contrast`: "Your rating" label at 4.12:1 against `#09090b`. 1 node per viewport.                                                              |
+| 640×1024, 768×1024, 1280×800, 1920×1080 | Accessibility | minor    | `color-contrast`: Footer text and GitHub link at 4.12:1 against `#09090b`. 2 nodes per viewport.                                                     |
+| all                                     | Usability     | major    | No primary CTA for a logged-out user — "Track" / watchlist button is absent from all viewports; only four unlabelled reaction icon buttons are shown |
+| all                                     | Usability     | minor    | "You might also like" section shows skeleton placeholder cards with no titles/images and no error fallback                                           |
+| 1920×1080                               | Layout        | minor    | Content column not max-width constrained — poster and text block occupy only the left ~500px at 1920px                                               |
+| all                                     | Usability     | minor    | The four "Your rating" icon buttons have no visible labels; their meaning relies entirely on icon recognition                                        |
+
+---
+
+## /title/tv-1399/season/1
+
+| Viewport                                | Dimension     | Severity | Finding                                                                                                                                                                               |
+| --------------------------------------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 320×568                                 | Layout        | major    | Bottom tab bar overlaps the episode list mid-scroll, visually obscuring "Browse" and "Sign In" labels and partially hiding the first episode card                                     |
+| 375×812                                 | Layout        | major    | Same bottom tab bar overlap clips across the bottom of episode row 02, partially hiding episode 03's title text                                                                       |
+| 640×1024                                | Layout        | major    | Episode row layout breaks at exactly 640px — episode title breaks across three lines and overview text is visually clipped                                                            |
+| all                                     | Accessibility | major    | Episode thumbnail placeholder labels ("E01", "E02", "E03") have a contrast ratio of 1.92:1 against their `bg-zinc-800` container — far below 4.5:1. 3 nodes, all 6 viewports.         |
+| 640×1024, 768×1024, 1280×800, 1920×1080 | Accessibility | major    | Episode overview text (`text-xs text-zinc-500`) at 3.67:1 against `bg-zinc-900`, below 4.5:1. 3 nodes per viewport.                                                                   |
+| 640×1024, 768×1024, 1280×800, 1920×1080 | Accessibility | minor    | Footer "© 2026 Remindarr" and GitHub link at 4.12:1 against `#09090b`. 2 nodes per desktop viewport.                                                                                  |
+| 320×568, 375×812                        | Accessibility | minor    | Bottom tab bar labels at 3.67–3.80:1 against page background. 2 nodes per mobile viewport.                                                                                            |
+| 320×568                                 | Usability     | major    | The page header shows only the Remindarr logo bar; the tab bar overlaps page content but is not positioned at the true bottom — "Browse" and "Sign In" icons appear floating mid-page |
+| all mobile                              | Usability     | minor    | No "back to show" back button or chevron — only the breadcrumb for navigation                                                                                                         |
+| 640×1024                                | Usability     | minor    | The "Share" button is absent from the header at 640×1024 while it appears correctly at 375×812 and 768×1024                                                                           |
+| all                                     | Copy          | minor    | Episode title copy uses raw seed data ("Season 1 Episode 1") — verify that TMDB `name` field is not being replaced by a fallback when a real episode name exists                      |
+
+---
+
+## /title/tv-1399/season/1/episode/1
+
+| Viewport                                              | Dimension     | Severity | Finding                                                                                                                                                                                        |
+| ----------------------------------------------------- | ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| all mobile (320×568, 375×812)                         | Accessibility | major    | Bottom tab bar label text at 3.8:1 against `#141417`, failing WCAG AA 4.5:1 for 10px text. 2 nodes each viewport.                                                                              |
+| all desktop (640×1024, 768×1024, 1280×800, 1920×1080) | Accessibility | major    | Footer text at 4.12:1 against `#09090b`, failing WCAG AA 4.5:1. 2 nodes each viewport.                                                                                                         |
+| all viewports                                         | Usability     | major    | Episode still image is entirely absent — the seed episode has no still, leaving a visually sparse page with no fallback placeholder or skeleton                                                |
+| all viewports                                         | Usability     | major    | The "Rate this episode" section and WatchedIcon toggle are absent (gated on authenticated state) — no sign-in prompt or teaser for these features is shown to logged-out visitors              |
+| 1920×1080                                             | Layout        | major    | Page content is left-aligned with no maximum width constraint — the vast majority of the 1920px viewport is empty black                                                                        |
+| 640×1024                                              | Layout        | minor    | Content sits flush to the left edge with minimal horizontal padding at 640px — tighter than wider desktop viewports                                                                            |
+| all viewports                                         | Usability     | minor    | The breadcrumb displays "Seed Show" and terminates at "Episode 1" — the seed data does not exercise the real episode-name rendering path                                                       |
+| all viewports                                         | Copy          | minor    | Episode title heading fuses the S/E code with the name as a single `<h1>` — "S01E01 Season 1 Episode 1" — with no visual hierarchy between the muted code prefix and the fallback episode name |
+
+---
+
+## /tracked
+
+| Viewport                           | Dimension     | Severity | Finding                                                                                                                                             |
+| ---------------------------------- | ------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 320x568                            | Layout        | major    | Achievement toast overlaps the bottom tab bar, covering the tab labels and cutting off the stats band                                               |
+| 320x568                            | Layout        | minor    | "Backdate to air dates", "Select", "Grid", and "List"/"Stats" pills wrap onto two lines consuming significant vertical space                        |
+| 375x812                            | Layout        | major    | The status tab bar clips "On Hold" label mid-word and the sort dropdown is pushed off the visible row                                               |
+| 640x1024                           | Layout        | major    | In the list/table view, all title names are truncated to "See…" — the SHOW column is too narrow at 640px                                            |
+| 640x1024                           | Layout        | minor    | Only the leftmost portion is used; the right ~30% of the 640px canvas is empty black                                                                |
+| 768x1024                           | Layout        | minor    | The "Dropped" status tab is clipped to "Droppe" — no scroll affordance                                                                              |
+| all mobile (320, 375)              | Accessibility | major    | Stat card labels and sub-labels at 3.67:1 against `bg-zinc-900` — fails WCAG AA 4.5:1. 8–10 nodes per viewport.                                     |
+| all mobile (320, 375)              | Accessibility | major    | Bottom tab bar inactive labels at 3.67–3.80:1 against translucent tab bar background. 4 nodes each viewport.                                        |
+| all desktop (640, 768, 1280, 1920) | Accessibility | major    | List view table column headers at 4.12:1 against `bg-zinc-950` — below 4.5:1. 5–6 nodes per desktop viewport.                                       |
+| all desktop (640, 768, 1280, 1920) | Accessibility | major    | Row sub-labels ("2020 · Movie", etc.) at 3.67:1 against `bg-zinc-900` — fails WCAG AA. 3 nodes per desktop viewport.                                |
+| 640x1024                           | Accessibility | major    | Search bar placeholder at 2.62:1 and "⌘K" hint at 1.99:1 against white background                                                                   |
+| 640x1024, 768x1024                 | Accessibility | major    | "Logout" button text at 2.62:1 against white nav background                                                                                         |
+| all desktop                        | Accessibility | minor    | Footer text at 4.12:1 against `bg-zinc-950`. 2 nodes per desktop viewport.                                                                          |
+| all                                | Accessibility | minor    | The `···` ellipsis button in `RowActionsMenu` has no accessible name — `···` is not meaningfully announced by screen readers                        |
+| 1920x1080                          | Layout        | minor    | Content sits left-anchored with a large empty black area on the right — no `max-w` centering container                                              |
+| all                                | Usability     | minor    | Sort dropdown option text includes the "sort:" prefix ("sort: last aired"), redundant given the control's existing `aria-label`                     |
+| all                                | Copy          | minor    | The `aria-label` on the sort `<select>` is the raw i18n key `tracked.sortBy` — screen readers will read this verbatim if the translation is missing |
+
+---
+
+## /tracked?view=stats
+
+| Viewport                                | Dimension     | Severity | Finding                                                                                                                                                   |
+| --------------------------------------- | ------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 320×568                                 | Layout        | major    | Stats view is not shown — the page renders the List view instead; `?view=stats` param is not being respected on first paint at this viewport              |
+| 320×568                                 | Layout        | major    | "Avg Score" and "Total Tracked" stat cards are absent at 320px — only two of the four stat cards are visible                                              |
+| 375×812                                 | Layout        | minor    | The filter tab bar clips the "On Hold" tab with no scroll indicator                                                                                       |
+| 640×1024                                | Layout        | major    | Title names in the list table are truncated to "See…" at this viewport — the SHOW column is too narrow                                                    |
+| 640×1024                                | Layout        | minor    | Page content does not fill the right half of the canvas — large black void to the right                                                                   |
+| 320×568, 375×812                        | Accessibility | critical | Stat card label text at 3.67:1 against `bg-zinc-900` — fails WCAG AA 4.5:1. 8 nodes, all viewports.                                                       |
+| 320×568, 375×812                        | Accessibility | critical | Bottom tab bar labels at 3.67–3.8:1 against blurred nav background — fails WCAG AA. 4 nodes per mobile viewport.                                          |
+| 640×1024, 768×1024, 1280×800, 1920×1080 | Accessibility | critical | List table column headers at 4.12:1 against `bg-zinc-950` — below 4.5:1. All 4 desktop viewports.                                                         |
+| 640×1024                                | Accessibility | critical | Search bar placeholder at 2.62:1; "Logout" button at 2.62:1; "⌘K" hint at 1.99:1 against white-computed background. 3 nodes.                              |
+| 640×1024, 768×1024, 1280×800, 1920×1080 | Accessibility | critical | Year/type sub-labels at 3.67:1 against `bg-zinc-900` — fails WCAG AA. 3 nodes per desktop viewport.                                                       |
+| 640×1024, 768×1024, 1280×800, 1920×1080 | Accessibility | minor    | Footer text at 4.12:1, below 4.5:1. 2 nodes per desktop viewport.                                                                                         |
+| 768×1024                                | Layout        | minor    | "Dropped" filter tab is clipped to "Droppe"                                                                                                               |
+| 320×568                                 | Usability     | major    | Achievement toast renders mid-page overlapping the stat cards                                                                                             |
+| all                                     | Usability     | minor    | The `?view=stats` route shows the same list view with 4 summary cards; a user navigating here expecting a stats dashboard gets the full list view instead |
+
+---
+
+## /u/ux_seed/achievements
+
+| Viewport            | Dimension     | Severity | Finding                                                                                                                                                                                          |
+| ------------------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| all                 | Accessibility | major    | `h1` "ACHIEVEMENTS" heading at 4.12:1 against `#09090b` — fails WCAG AA 4.5:1. 1 node, all 6 viewports.                                                                                          |
+| all                 | Accessibility | major    | Empty-state "No achievements yet." text at 4.12:1 against `#09090b` — fails WCAG AA. 1 node, all 6 viewports.                                                                                    |
+| 320x568, 375x812    | Accessibility | major    | Bottom tab bar labels at 3.8:1 against zinc-900 composited background — fails WCAG AA. 2 nodes, both mobile viewports.                                                                           |
+| 640x1024 and wider  | Accessibility | minor    | Footer text and "GitHub" link at 4.12:1 against `#09090b`. 2 nodes, all desktop viewports.                                                                                                       |
+| all                 | Usability     | major    | Page shows empty state because the query is gated by `enabled: !!user` — the viewer is unauthenticated, so the query never fires; all achievements data is silently withheld from guest visitors |
+| all                 | Usability     | major    | No user context is shown — no avatar, display name, or link back to `ux_seed`'s profile; the heading just reads "ACHIEVEMENTS" with no indication of whose achievements are being viewed         |
+| 1280x800, 1920x1080 | Layout        | minor    | Content (`max-w-4xl`) is left-aligned leaving a large empty right-hand column at wide viewports                                                                                                  |
+| all                 | Usability     | minor    | Empty state copy "No achievements yet." is ambiguous — does not distinguish between "this user has no achievements" and "achievements could not be loaded"                                       |
+
+---
+
+## /u/ux_seed/achievements/movies_10
+
+| Viewport                                | Dimension     | Severity | Finding                                                                                                                                                                                                                                                                                                      |
+| --------------------------------------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| all                                     | Usability     | critical | Page renders only the "Achievement not found." error state — the query is gated by `enabled: !!key && !!user` (source line 30), but this is a public route being viewed without a session; the `user` guard prevents the fetch from firing for unauthenticated visitors, causing a permanent not-found state |
+| all                                     | Accessibility | major    | "Back" link fails `link-in-text-block` (axe, serious): amber-400 link has only 1.52:1 contrast against surrounding zinc-400 text (minimum 3:1) and no persistent underline                                                                                                                                   |
+| 320×568, 375×812                        | Accessibility | major    | Bottom tab bar labels at 3.8:1 against `#141417`, below 4.5:1 for 10px text. 2 nodes.                                                                                                                                                                                                                        |
+| 640×1024, 768×1024, 1280×800, 1920×1080 | Accessibility | major    | Footer text and "GitHub" link at 4.12:1 against `#09090b`, below 4.5:1. 2 nodes.                                                                                                                                                                                                                             |
+| all                                     | Accessibility | minor    | Page has no `<h1>` element — the error state renders plain text without a heading element.                                                                                                                                                                                                                   |
+| all                                     | Usability     | major    | No loading state shown — the query never fires, so the page jumps directly to "Achievement not found." with no indication of whether data is loading or the achievement genuinely does not exist                                                                                                             |
+| all                                     | Copy          | minor    | The "Back" link label is bare and context-free in the error state — no surrounding context to indicate where it leads                                                                                                                                                                                        |
+
+---
+
+## /u/ux_seed/overlap/ux_friend
+
+| Viewport                                | Dimension     | Severity | Finding                                                                                                                                                               |
+| --------------------------------------- | ------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 320×568                                 | Layout        | major    | Achievement toast renders on top of the bottom tab bar and overlaps the stat chips ("2 in common", "1 yours only"), blocking both elements with no dismiss affordance |
+| 320×568                                 | Layout        | minor    | The "2 in common" stat chip is partially clipped on the left edge                                                                                                     |
+| all mobile (320×568, 375×812)           | Accessibility | serious  | Media card year/runtime labels at 3.67:1 against `bg-zinc-900` — below WCAG AA 4.5:1 for 12px text. 2 nodes per viewport.                                             |
+| all mobile (320×568, 375×812)           | Accessibility | serious  | Bottom tab bar inactive labels at 3.8:1 against the frosted-glass background — below WCAG AA. Up to 5 nodes at 320×568.                                               |
+| 640×1024                                | Accessibility | serious  | Top-nav search button placeholder at 2.62:1 and "⌘K" hint at 1.99:1 against white background; "Logout" button at 2.62:1. 3 nodes.                                     |
+| 640×1024, 768×1024, 1280×800, 1920×1080 | Accessibility | serious  | Footer text and GitHub link at 4.12:1 against `#09090b`. 2 nodes per desktop viewport.                                                                                |
+| all                                     | Accessibility | moderate | Card titles use `<h3>` without a preceding `<h2>` above them in the content area — producing an invalid heading sequence (axe: `heading-order`).                      |
+| 320×568                                 | Usability     | major    | The achievement toast makes the filter chips completely unreachable at the narrowest breakpoint — no visible close affordance                                         |
+| 1920×1080                               | Usability     | minor    | With only 2 results the grid occupies the top-left quadrant; the rest of the page is empty with no guiding CTA                                                        |
+| all desktop                             | Usability     | minor    | The page heading is in a fourth flex item, immediately adjacent to the top-nav with very little top padding, making it easy to miss on first scan                     |
+| all                                     | Copy          | minor    | Stats chip reads "0 ux_friend's only" — if the username ends in "s" the string will read "ux_friends's only"                                                          |
+
+---
+
+## /user/ux_seed
+
+| Viewport                                              | Dimension     | Severity | Finding                                                                                                                                                                        |
+| ----------------------------------------------------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| all mobile (320x568, 375x812)                         | Layout        | critical | The entire page renders as a skeleton loading state — only animate-pulse placeholder blocks are visible. No profile content, username, avatar, bio, or watchlist is ever shown |
+| 320x568                                               | Layout        | major    | The bottom tab bar renders in the unauthenticated state, overlapping the bottom of the page content                                                                            |
+| 1280x800                                              | Layout        | major    | At the two-column sidebar+main layout breakpoint, the sidebar and stat card skeleton blocks are noticeably misaligned with a visible gap                                       |
+| 1920x1080                                             | Layout        | minor    | The hero banner stretches full-width while body content is constrained to `max-w-7xl`, creating asymmetric appearance at ultra-wide                                            |
+| all mobile (320x568, 375x812)                         | Accessibility | serious  | Bottom tab bar labels at 3.74 and 3.70 ratios against a required 4.5:1. 2 nodes each viewport.                                                                                 |
+| all desktop (640x1024, 768x1024, 1280x800, 1920x1080) | Accessibility | serious  | Footer text at 4.12:1 against `#09090b`. 2 nodes each viewport.                                                                                                                |
+| all                                                   | Accessibility | moderate | No `<h1>` exists on the page at any viewport (axe: `page-has-heading-one`) — persists even when content is loaded                                                              |
+| all mobile                                            | Usability     | critical | Page is entirely skeleton at both mobile viewports — no profile information is accessible; users see no content, no error message, and no retry affordance                     |
+| 320x568                                               | Usability     | major    | With only "Browse" and "Sign In" tabs and no visible page identity (skeleton state), a logged-out visitor has no way to navigate back                                          |
+| all desktop                                           | Usability     | minor    | The "Watch together" CTA appears in the sidebar only for logged-in users — cannot confirm visibility for the loaded state due to skeleton rendering                            |


### PR DESCRIPTION
## Summary

- Full UX review of all 28 routes across 6 viewports (320×568 · 375×812 · 640×1024 · 768×1024 · 1280×800 · 1920×1080)
- Screenshots and axe accessibility results captured via `bun run ux:capture`
- Per-route findings reviewed by dedicated agents; results compiled into `docs/ux-reviews/2026-05-24-ux-review.md`
- 28 GitHub issues auto-filed (#926–#953), one per route

## Top cross-cutting themes

1. **`text-zinc-500` contrast failures** — `#71717b` falls below WCAG AA 4.5:1 on dark surfaces across the entire app; a single token bump would fix the majority of violations
2. **Bottom tab bar overlapping content on mobile** — fixed tab bar clips content on nearly every mobile-captured page; pages need `pb-[tab-bar-height]` applied in the shell template
3. **Achievement toast blocking interactive content** — the persistent achievement overlay at 320×568 obstructs tab labels and action buttons across multiple pages; needs a dismiss affordance and proper z-index relative to the tab bar
4. **White-strip layout bug at 640×1024** — app shell background fails to fill the full viewport width at exactly the 640px breakpoint on ~10 routes
5. **Logout/search nav contrast at desktop** — "Logout" button and search bar render against a white-computed background at desktop breakpoints; likely a missing `bg-zinc-950` on the nav element

## Test plan

- [ ] Review `docs/ux-reviews/2026-05-24-ux-review.md` for completeness
- [ ] No runtime changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)