### PR TITLE
fix(layout): global shell — white strip, tab bar clearance, toast dismiss, nav

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,0 +1,94 @@
+import {
+  describe,
+  it,
+  expect,
+  mock,
+  beforeEach,
+  afterEach,
+  spyOn,
+} from "bun:test";
+import { render, screen, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import "./i18n";
+import * as api from "./api";
+import { AuthContext } from "./context/AuthContext";
+import App from "./App";
+
+// Silence push-subscription API calls made by usePushSubscriptionSync
+let getNotifiersSpy: ReturnType<typeof spyOn>;
+
+function newTestClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+const mockUser = {
+  id: "1",
+  username: "testuser",
+  display_name: null,
+  auth_provider: "local",
+  is_admin: false,
+};
+
+const noUserAuth = {
+  user: null,
+  providers: null,
+  loading: false,
+  login: mock(() => Promise.resolve()),
+  logout: mock(() => Promise.resolve()),
+  refresh: mock(() => Promise.resolve()),
+};
+
+const loggedInAuth = {
+  ...noUserAuth,
+  user: mockUser,
+};
+
+function renderApp(path: string, auth: typeof noUserAuth = noUserAuth) {
+  return render(
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter initialEntries={[path]}>
+        <AuthContext value={auth as any}>
+          <App />
+        </AuthContext>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  getNotifiersSpy = spyOn(api, "getNotifiers").mockResolvedValue([] as never);
+});
+
+afterEach(() => {
+  getNotifiersSpy.mockRestore();
+  cleanup();
+});
+
+describe("App nav Sign In link", () => {
+  it("shows Sign In link in the desktop nav when user is not logged in and not on /login", () => {
+    renderApp("/");
+    // The desktop nav should contain a link pointing to /login
+    const nav = screen.getByRole("navigation", { name: "Main navigation" });
+    const signInLink = nav.querySelector("a[href='/login']");
+    expect(signInLink).not.toBeNull();
+  });
+
+  it("hides Sign In link in the desktop nav when already on /login", () => {
+    renderApp("/login");
+    const nav = screen.getByRole("navigation", { name: "Main navigation" });
+    const signInLink = nav.querySelector("a[href='/login']");
+    // The desktop nav Sign In link must not appear when location is /login
+    expect(signInLink).toBeNull();
+  });
+
+  it("hides Sign In link in the desktop nav when user is logged in", () => {
+    renderApp("/", loggedInAuth);
+    const nav = screen.getByRole("navigation", { name: "Main navigation" });
+    const signInLink = nav.querySelector("a[href='/login']");
+    expect(signInLink).toBeNull();
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -104,7 +104,7 @@ export default function App() {
 
   return (
     <div
-      className={`bg-zinc-950 text-zinc-100 ${isReelsPage || isKioskPage ? "h-[100dvh] overflow-hidden" : "min-h-screen"}`}
+      className={`bg-zinc-950 text-zinc-100 w-full ${isReelsPage || isKioskPage ? "h-[100dvh] overflow-hidden" : "min-h-screen"}`}
       style={{ background: "var(--bg-app)", color: "var(--text-app)" }}
     >
       {/* Skip to main content link */}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -216,12 +216,14 @@ export default function App() {
                 </button>
               </>
             ) : (
-              <NavLink
-                to="/login"
-                className="text-sm text-zinc-300 hover:text-white transition-colors"
-              >
-                {t("nav.signIn")}
-              </NavLink>
+              location.pathname !== "/login" && (
+                <NavLink
+                  to="/login"
+                  className="text-sm text-zinc-400 hover:text-white transition-colors"
+                >
+                  {t("nav.signIn")}
+                </NavLink>
+              )
             )}
           </div>
         </div>

--- a/frontend/src/components/profile/AchievementToast.test.tsx
+++ b/frontend/src/components/profile/AchievementToast.test.tsx
@@ -1,10 +1,24 @@
-import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
-import { render, screen, act, cleanup } from "@testing-library/react";
+import {
+  describe,
+  it,
+  expect,
+  mock,
+  beforeEach,
+  afterEach,
+  spyOn,
+} from "bun:test";
+import {
+  render,
+  screen,
+  act,
+  cleanup,
+  fireEvent,
+} from "@testing-library/react";
 import { renderHook } from "@testing-library/react";
 import type { UserAchievement } from "../../types";
 import * as api from "../../api";
 
-import { useNewAchievements } from "./AchievementToast";
+import { useNewAchievements, ToastItem } from "./AchievementToast";
 import AchievementToast from "./AchievementToast";
 
 // ---- localStorage helper -------------------------------------------------------
@@ -228,5 +242,41 @@ describe("AchievementToast", () => {
 
     const alerts = screen.getAllByRole("alert");
     expect(alerts.length).toBeGreaterThan(0);
+  });
+});
+
+// ---- ToastItem dismiss button --------------------------------------------------
+
+describe("ToastItem", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the achievement title and dismiss button", () => {
+    const onDismiss = mock(() => {});
+    render(
+      <ToastItem
+        achievement={makeAchievement({ title: "Movie Buff" })}
+        onDismiss={onDismiss}
+      />,
+    );
+    expect(screen.getByText("Movie Buff")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /dismiss achievement notification/i }),
+    ).toBeTruthy();
+  });
+
+  it("calls onDismiss when dismiss button is clicked", () => {
+    const onDismiss = mock(() => {});
+    render(
+      <ToastItem
+        achievement={makeAchievement({ title: "Movie Buff" })}
+        onDismiss={onDismiss}
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /dismiss achievement notification/i }),
+    );
+    expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/profile/AchievementToast.tsx
+++ b/frontend/src/components/profile/AchievementToast.tsx
@@ -55,7 +55,7 @@ interface ToastItemProps {
   onDismiss: () => void;
 }
 
-function ToastItem({ achievement, onDismiss }: ToastItemProps) {
+export function ToastItem({ achievement, onDismiss }: ToastItemProps) {
   useEffect(() => {
     const timer = setTimeout(onDismiss, TOAST_DURATION_MS);
     return () => clearTimeout(timer);

--- a/frontend/src/components/profile/AchievementToast.tsx
+++ b/frontend/src/components/profile/AchievementToast.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Trophy } from "lucide-react";
+import { Trophy, X } from "lucide-react";
 import * as api from "../../api";
 import type { UserAchievement } from "../../types";
 
@@ -69,7 +69,7 @@ function ToastItem({ achievement, onDismiss }: ToastItemProps) {
       <div className="w-9 h-9 rounded-lg bg-amber-400/20 flex items-center justify-center shrink-0">
         <Trophy size={18} className="text-amber-400" />
       </div>
-      <div className="min-w-0">
+      <div className="min-w-0 flex-1">
         <div className="text-xs font-mono font-semibold uppercase tracking-widest text-amber-400 mb-0.5">
           Achievement unlocked
         </div>
@@ -80,6 +80,14 @@ function ToastItem({ achievement, onDismiss }: ToastItemProps) {
           {achievement.description}
         </div>
       </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss achievement notification"
+        className="shrink-0 text-zinc-500 hover:text-zinc-300 transition-colors p-1 -mr-1"
+      >
+        <X size={14} />
+      </button>
     </div>
   );
 }
@@ -97,7 +105,7 @@ export default function AchievementToast() {
   if (visible.length === 0) return null;
 
   return (
-    <div className="fixed bottom-20 right-4 z-50 flex flex-col gap-2 sm:bottom-6">
+    <div className="fixed bottom-24 right-4 z-50 flex flex-col gap-2 sm:bottom-6">
       {visible.map((a) => (
         <ToastItem
           key={a.key}


### PR DESCRIPTION
## Summary
- Root div: add `w-full` to eliminate 640px white-strip on leaderboard/invite/discovery pages
- Nav: hide redundant "Sign In" link when already on `/login`
- AchievementToast: add `×` dismiss button; raise `bottom-24` on mobile to clear tab bar

## Test plan
- [ ] `bun run check` passes
- [ ] At 640px viewport, leaderboard/invite/discovery pages fill the full viewport width
- [ ] On `/login`, the desktop nav does not show a "Sign In" link
- [ ] Achievement toast shows a dismiss button; tapping it closes the toast immediately

Closes portions of #926 #927 #928 #929 #930 #931 #932 #933 #935 #936 #937 #940 #941 #944 #945 #946 #948 #949 #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)