### PR TITLE
fix(lighthouse-ci): rename LHCI_* env vars to LH_* to avoid yargs collision

### DIFF
--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -5,14 +5,16 @@
 // To flip from warn-only to blocking: change "warn" → "error" in assertions
 // and add the lighthouse job to the all-passed gate in .github/workflows/test.yml.
 
-const cookie = process.env.LHCI_COOKIE;
-const preset = process.env.LHCI_PRESET === "desktop" ? "desktop" : undefined;
+// Use LH_* prefix (not LHCI_*) — lhci's yargs env scanner maps LHCI_* to CLI
+// flags, which conflicts with our custom variables.
+const cookie = process.env.LH_COOKIE;
+const preset = process.env.LH_PRESET === "desktop" ? "desktop" : undefined;
 
 /** @type {import('@lhci/cli').LighthouseConfig} */
 module.exports = {
   ci: {
     collect: {
-      url: (process.env.LHCI_URLS || "").split(",").map((u) => u.trim()),
+      url: (process.env.LH_URLS || "").split(",").map((u) => u.trim()),
       numberOfRuns: 1,
       settings: {
         ...(preset ? { preset } : {}),
@@ -38,7 +40,7 @@ module.exports = {
     },
     upload: {
       target: "filesystem",
-      outputDir: process.env.LHCI_OUTPUT_DIR || ".lighthouseci",
+      outputDir: process.env.LH_OUTPUT_DIR || ".lighthouseci",
     },
   },
 };

--- a/scripts/lighthouse-ci.test.ts
+++ b/scripts/lighthouse-ci.test.ts
@@ -104,16 +104,16 @@ function loadConfig(env: Record<string, string | undefined>): LhciConfig {
 
 describe("lighthouserc.cjs", () => {
   const baseEnv = {
-    LHCI_URLS: `${LIGHTHOUSE_BASE_URL}/`,
-    LHCI_PRESET: "mobile",
-    LHCI_OUTPUT_DIR: "/tmp/lhci-test",
-    LHCI_COOKIE: undefined,
+    LH_URLS: `${LIGHTHOUSE_BASE_URL}/`,
+    LH_PRESET: "mobile",
+    LH_OUTPUT_DIR: "/tmp/lhci-test",
+    LH_COOKIE: undefined,
   };
 
-  it("splits LHCI_URLS on commas to produce the url array", () => {
+  it("splits LH_URLS on commas to produce the url array", () => {
     const cfg = loadConfig({
       ...baseEnv,
-      LHCI_URLS: `${LIGHTHOUSE_BASE_URL}/,${LIGHTHOUSE_BASE_URL}/browse`,
+      LH_URLS: `${LIGHTHOUSE_BASE_URL}/,${LIGHTHOUSE_BASE_URL}/browse`,
     });
     expect(cfg.ci.collect.url).toEqual([
       `${LIGHTHOUSE_BASE_URL}/`,
@@ -122,24 +122,24 @@ describe("lighthouserc.cjs", () => {
   });
 
   it("mobile preset: no preset key in settings", () => {
-    const cfg = loadConfig({ ...baseEnv, LHCI_PRESET: "mobile" });
+    const cfg = loadConfig({ ...baseEnv, LH_PRESET: "mobile" });
     expect(cfg.ci.collect.settings.preset).toBeUndefined();
   });
 
   it("desktop preset: settings.preset is 'desktop'", () => {
-    const cfg = loadConfig({ ...baseEnv, LHCI_PRESET: "desktop" });
+    const cfg = loadConfig({ ...baseEnv, LH_PRESET: "desktop" });
     expect(cfg.ci.collect.settings.preset).toBe("desktop");
   });
 
-  it("no extraHeaders when LHCI_COOKIE is unset", () => {
-    const cfg = loadConfig({ ...baseEnv, LHCI_COOKIE: undefined });
+  it("no extraHeaders when LH_COOKIE is unset", () => {
+    const cfg = loadConfig({ ...baseEnv, LH_COOKIE: undefined });
     expect(cfg.ci.collect.settings.extraHeaders).toBeUndefined();
   });
 
-  it("includes Cookie in extraHeaders when LHCI_COOKIE is set", () => {
+  it("includes Cookie in extraHeaders when LH_COOKIE is set", () => {
     const cfg = loadConfig({
       ...baseEnv,
-      LHCI_COOKIE: "better-auth.session_token=tok",
+      LH_COOKIE: "better-auth.session_token=tok",
     });
     expect(cfg.ci.collect.settings.extraHeaders).toEqual({
       Cookie: "better-auth.session_token=tok",

--- a/scripts/lighthouse-ci.ts
+++ b/scripts/lighthouse-ci.ts
@@ -178,10 +178,10 @@ async function main() {
 
         const runEnv: NodeJS.ProcessEnv = {
           ...process.env,
-          LHCI_PRESET: formFactor,
-          LHCI_URLS: urls.join(","),
-          LHCI_OUTPUT_DIR: outputDir,
-          ...(group === "auth" ? { LHCI_COOKIE: cookie } : {}),
+          LH_PRESET: formFactor,
+          LH_URLS: urls.join(","),
+          LH_OUTPUT_DIR: outputDir,
+          ...(group === "auth" ? { LH_COOKIE: cookie } : {}),
         };
 
         console.log(`[lhci] ${formFactor}/${group}: ${urls.join(", ")}`);


### PR DESCRIPTION
## Summary
- lhci uses `yargs.env('LHCI')` internally, which auto-maps `LHCI_PRESET=mobile` to `--preset=mobile` on the `assert` command
- `assert`'s `--preset` expects assertion preset names (`"lighthouse:all"` etc.), not form factor names — causing every assert phase to fail with exit code 1
- `LHCI_OUTPUT_DIR` was similarly intercepted, which is why the artifact upload step found no files despite reports being written
- Fix: rename all custom orchestration env vars from `LHCI_*` → `LH_*` in `lighthouserc.cjs`, `scripts/lighthouse-ci.ts`, and `scripts/lighthouse-ci.test.ts`

## Test plan
- [x] 17 unit tests pass (`bun test scripts/lighthouse-ci.test.ts`)
- [ ] Trigger the `lighthouse` workflow via `workflow_dispatch` to confirm reports are written and artifact uploads successfully

Closes #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)