### PR TITLE
[auto-review] perf: hoist getTitleById outside per-user loop in streaming-alerts

### DIFF
--- a/server/jobs/check-streaming-alerts.ts
+++ b/server/jobs/check-streaming-alerts.ts
@@ -53,6 +53,12 @@ export async function checkStreamingAlerts(titleIds: string[]): Promise<void> {
 
     const providerIds = streamingProviders.map((p) => p.id);
 
+    // Fetch title once per titleId, not once per (titleId, userId) pair
+    const titleRow = await getTitleById(titleId);
+    if (!titleRow) continue;
+
+    const today = new Date().toISOString().slice(0, 10);
+
     for (const userId of userIds) {
       // 4. Find providers not yet alerted for this (user, title)
       const newProviderIds = await getUnalertedProviders(
@@ -65,12 +71,6 @@ export async function checkStreamingAlerts(titleIds: string[]): Promise<void> {
 
       // 5. Get enabled streaming-alert notifiers for this user
       const userNotifiers = await getStreamingAlertNotifiersForUser(userId);
-
-      // 6. Fetch title info for the notification message
-      const titleRow = await getTitleById(titleId);
-      if (!titleRow) continue;
-
-      const today = new Date().toISOString().slice(0, 10);
 
       for (const pid of newProviderIds) {
         const provider = streamingProviders.find((sp) => sp.id === pid);


### PR DESCRIPTION
## Summary

`checkStreamingAlerts` in `server/jobs/check-streaming-alerts.ts` called `getTitleById(titleId)` inside the inner `for (const userId of userIds)` loop. Since the title row is identical for all users tracking the same title, this caused **N redundant DB round-trips** per sync batch — one per tracking user instead of one per title.

This PR hoists the `getTitleById` call (and the `today` constant) to the outer loop scope, eliminating the duplication.

### Before

```
for each titleId:
  for each userId tracking that title:
    await getUnalertedProviders(userId, titleId, ...)   ← per user  ✓
    await getStreamingAlertNotifiersForUser(userId)     ← per user  ✓
    await getTitleById(titleId)                         ← PER USER  ✗ (same result every time)
```

### After

```
for each titleId:
  await getTitleById(titleId)                           ← once per title ✓
  for each userId tracking that title:
    await getUnalertedProviders(userId, titleId, ...)
    await getStreamingAlertNotifiersForUser(userId)
```

## Test plan

- [x] `bun test server/jobs/streaming-alerts.test.ts` — all 5 tests pass
- [x] Pre-push hook (tsc + lint) passes

---
_Source: architecture_

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCmgYYKd25dZGTjz6R2XpZ)_