### PR TITLE
feat(legal): add privacy policy and terms of service pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -62,6 +62,12 @@ const AchievementsPage = lazyWithRetry(
 const AchievementDetailPage = lazyWithRetry(
   () => import("./pages/AchievementDetailPage"),
 );
+const PrivacyPolicyPage = lazyWithRetry(
+  () => import("./pages/PrivacyPolicyPage"),
+);
+const TermsOfServicePage = lazyWithRetry(
+  () => import("./pages/TermsOfServicePage"),
+);
 
 // Wraps a route element in an inline ErrorBoundary so a single page crash
 // shows a contained fallback instead of taking down the whole shell.
@@ -487,6 +493,22 @@ export default function App() {
               }
             />
             <Route
+              path="/privacy"
+              element={
+                <Page>
+                  <PrivacyPolicyPage />
+                </Page>
+              }
+            />
+            <Route
+              path="/terms"
+              element={
+                <Page>
+                  <TermsOfServicePage />
+                </Page>
+              }
+            />
+            <Route
               path="*"
               element={
                 <Page>
@@ -502,15 +524,29 @@ export default function App() {
       >
         <div className="max-w-[1440px] mx-auto px-4 flex items-center justify-between text-sm text-zinc-400">
           <span>&copy; {new Date().getFullYear()} Remindarr</span>
-          <a
-            href="https://github.com/MatijaMaric/remindarr"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1.5 text-zinc-400 hover:text-white transition-colors"
-          >
-            <ExternalLink className="size-4" />
-            GitHub
-          </a>
+          <div className="flex items-center gap-4">
+            <Link
+              to="/privacy"
+              className="text-zinc-400 hover:text-white transition-colors"
+            >
+              {t("legal.privacy")}
+            </Link>
+            <Link
+              to="/terms"
+              className="text-zinc-400 hover:text-white transition-colors"
+            >
+              {t("legal.terms")}
+            </Link>
+            <a
+              href="https://github.com/MatijaMaric/remindarr"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1.5 text-zinc-400 hover:text-white transition-colors"
+            >
+              <ExternalLink className="size-4" />
+              GitHub
+            </a>
+          </div>
         </div>
       </footer>
       {!isKioskPage && <BottomTabBar />}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -47,6 +47,17 @@
       }
     }
   },
+  "legal": {
+    "kicker": "Legal",
+    "privacy": "Privacy",
+    "terms": "Terms"
+  },
+  "privacy": {
+    "title": "Privacy Policy"
+  },
+  "terms": {
+    "title": "Terms of Service"
+  },
   "nav": {
     "skipToMain": "Skip to main content",
     "home": "Home",

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -238,6 +238,16 @@ export default function LoginPage() {
             {t("login.signUp")}
           </Link>
         </p>
+
+        <p className="mt-6 text-center text-xs text-zinc-500">
+          <Link to="/privacy" className="hover:text-zinc-300 transition-colors">
+            {t("privacy.title")}
+          </Link>
+          <span className="mx-2">·</span>
+          <Link to="/terms" className="hover:text-zinc-300 transition-colors">
+            {t("terms.title")}
+          </Link>
+        </p>
       </div>
     </div>
   );

--- a/frontend/src/pages/MorePage.tsx
+++ b/frontend/src/pages/MorePage.tsx
@@ -7,6 +7,8 @@ import {
   User,
   Settings,
   LogOut,
+  Shield,
+  FileText,
 } from "lucide-react";
 import { useAuth } from "../context/AuthContext";
 import { useIsMobile } from "../hooks/useIsMobile";
@@ -155,6 +157,21 @@ export default function MorePage() {
           icon={<Settings size={16} />}
           label="Settings"
           to="/settings"
+          isLast
+        />
+      </MoreGroup>
+
+      {/* Legal */}
+      <MoreGroup label="Legal">
+        <MoreRow
+          icon={<Shield size={16} />}
+          label="Privacy Policy"
+          to="/privacy"
+        />
+        <MoreRow
+          icon={<FileText size={16} />}
+          label="Terms of Service"
+          to="/terms"
           isLast
         />
       </MoreGroup>

--- a/frontend/src/pages/PrivacyPolicyPage.test.tsx
+++ b/frontend/src/pages/PrivacyPolicyPage.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { render, screen, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import "../i18n";
+import PrivacyPolicyPage from "./PrivacyPolicyPage";
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <PrivacyPolicyPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("PrivacyPolicyPage", () => {
+  it("renders the page title", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: /Privacy Policy/i, level: 1 }),
+    ).toBeDefined();
+  });
+
+  it("renders representative sections", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: /Information we collect/i }),
+    ).toBeDefined();
+    expect(
+      screen.getByRole("heading", { name: /Third-party data and services/i }),
+    ).toBeDefined();
+  });
+
+  it("links to the terms of service", () => {
+    renderPage();
+    const link = screen.getByRole("link", { name: /Terms of Service/i });
+    expect(link.getAttribute("href")).toBe("/terms");
+  });
+});

--- a/frontend/src/pages/PrivacyPolicyPage.tsx
+++ b/frontend/src/pages/PrivacyPolicyPage.tsx
@@ -1,0 +1,195 @@
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router";
+import { PageHeader } from "../components/design";
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-3">
+      <h2 className="text-lg font-semibold text-zinc-100">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+export default function PrivacyPolicyPage() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="max-w-3xl mx-auto pb-16">
+      <PageHeader kicker={t("legal.kicker")} title={t("privacy.title")} />
+
+      <div className="space-y-8 text-sm text-zinc-300 leading-relaxed">
+        <p className="text-zinc-400">Last updated: May 25, 2026</p>
+
+        <p className="rounded-lg border border-white/[0.08] bg-zinc-900/50 p-4 text-zinc-400 italic">
+          Remindarr is open-source software that anyone can self-host. This
+          document is a template provided for the operator of this instance. It
+          should be reviewed and customized — including the bracketed
+          placeholders below and a review with a legal professional — before
+          being relied upon for a public deployment.
+        </p>
+
+        <p>
+          This Privacy Policy describes how <strong>[Operator Name]</strong>{" "}
+          (&quot;we&quot;, &quot;us&quot;, the &quot;operator&quot;) handles
+          information when you use this instance of Remindarr (the
+          &quot;Service&quot;). If you do not agree with this policy, please do
+          not use the Service.
+        </p>
+
+        <Section title="Information we collect">
+          <p>We collect the information needed to operate the Service:</p>
+          <ul className="list-disc space-y-1 pl-5 marker:text-zinc-600">
+            <li>
+              <strong>Account information:</strong> your username, optional
+              display name, and email address if you provide one. Depending on
+              how you sign in, we store either a hashed password, an identifier
+              from your single sign-on (OIDC) provider, or a passkey (WebAuthn)
+              credential. We never store plaintext passwords.
+            </li>
+            <li>
+              <strong>Activity you create:</strong> the titles you track, your
+              watch history, ratings, tags, watchlist status, and similar
+              activity you record in the app.
+            </li>
+            <li>
+              <strong>Preferences and settings:</strong> appearance, homepage
+              layout, notification preferences, and other configuration you
+              choose.
+            </li>
+            <li>
+              <strong>Notifications:</strong> if you enable browser push
+              notifications, we store the push subscription required to deliver
+              them.
+            </li>
+            <li>
+              <strong>Invitations:</strong> invitations you create or accept to
+              join the Service.
+            </li>
+            <li>
+              <strong>Technical data:</strong> basic logs and request metadata
+              (such as IP address and browser user-agent) that are generated as
+              part of normal operation and used for security and debugging.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="Third-party data and services">
+          <p>
+            Title, season, episode, and person metadata shown in the Service is
+            sourced from{" "}
+            <a
+              href="https://www.themoviedb.org/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-amber-400 underline underline-offset-2 hover:text-amber-300"
+            >
+              The Movie Database (TMDB)
+            </a>
+            . Your use of that content is also subject to TMDB&apos;s terms and
+            privacy policy. This product uses the TMDB API but is not endorsed
+            or certified by TMDB.
+          </p>
+          <p>
+            If you configure outbound notification channels (for example
+            Discord, Telegram, or Gotify), the information you choose to send is
+            transmitted to those third-party services only when you enable them,
+            and is then governed by their respective policies.
+          </p>
+        </Section>
+
+        <Section title="How we use information">
+          <p>We use the information we collect to:</p>
+          <ul className="list-disc space-y-1 pl-5 marker:text-zinc-600">
+            <li>provide, maintain, and secure the Service;</li>
+            <li>
+              remember the titles you track and deliver the release reminders
+              and notifications you request;
+            </li>
+            <li>personalize discovery, recommendations, and statistics;</li>
+            <li>diagnose problems and prevent abuse.</li>
+          </ul>
+        </Section>
+
+        <Section title="How information is shared">
+          <p>
+            We do not sell your personal information. Information is only
+            exposed to others in the ways you choose:
+          </p>
+          <ul className="list-disc space-y-1 pl-5 marker:text-zinc-600">
+            <li>
+              Your public profile and achievements are visible to others
+              according to the visibility settings you control.
+            </li>
+            <li>
+              Share links and kiosk links expose only the data you explicitly
+              opt into sharing, to anyone who has the link.
+            </li>
+            <li>
+              We may disclose information if required to do so by law, or to
+              protect the rights, safety, and integrity of the Service.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="Data retention and deletion">
+          <p>
+            We retain your information for as long as your account exists. You
+            can delete your account, which removes your associated data, subject
+            to backups and legal obligations. For deletion requests or
+            questions, contact the operator using the details below.
+          </p>
+        </Section>
+
+        <Section title="Security">
+          <p>
+            Authentication is handled with industry-standard libraries, and
+            credentials are stored in hashed or tokenized form. No method of
+            transmission or storage is completely secure, but we take reasonable
+            measures to protect your information.
+          </p>
+        </Section>
+
+        <Section title="Children">
+          <p>
+            The Service is not directed to children under the age required by
+            applicable law in your jurisdiction, and we do not knowingly collect
+            information from them.
+          </p>
+        </Section>
+
+        <Section title="Changes to this policy">
+          <p>
+            We may update this Privacy Policy from time to time. Material
+            changes will be reflected by updating the &quot;last updated&quot;
+            date above.
+          </p>
+        </Section>
+
+        <Section title="Contact">
+          <p>
+            Questions about this policy can be directed to the operator at{" "}
+            <strong>[contact@example.com]</strong>.
+          </p>
+        </Section>
+
+        <p className="text-zinc-400">
+          See also our{" "}
+          <Link
+            to="/terms"
+            className="text-amber-400 underline underline-offset-2 hover:text-amber-300"
+          >
+            {t("terms.title")}
+          </Link>
+          .
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/PrivacyPolicyPage.tsx
+++ b/frontend/src/pages/PrivacyPolicyPage.tsx
@@ -27,20 +27,26 @@ export default function PrivacyPolicyPage() {
       <div className="space-y-8 text-sm text-zinc-300 leading-relaxed">
         <p className="text-zinc-400">Last updated: May 25, 2026</p>
 
-        <p className="rounded-lg border border-white/[0.08] bg-zinc-900/50 p-4 text-zinc-400 italic">
-          Remindarr is open-source software that anyone can self-host. This
-          document is a template provided for the operator of this instance. It
-          should be reviewed and customized — including the bracketed
-          placeholders below and a review with a legal professional — before
-          being relied upon for a public deployment.
+        <p className="rounded-lg border border-white/[0.08] bg-zinc-900/50 p-4 text-zinc-400">
+          Remindarr is open-source software. This policy applies to the official
+          instance hosted at{" "}
+          <a
+            href="https://remindarr.app"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-amber-400 underline underline-offset-2 hover:text-amber-300"
+          >
+            remindarr.app
+          </a>
+          . If you use a self-hosted instance operated by someone else, that
+          operator is the data controller and their own privacy policy applies.
         </p>
 
         <p>
-          This Privacy Policy describes how <strong>[Operator Name]</strong>{" "}
-          (&quot;we&quot;, &quot;us&quot;, the &quot;operator&quot;) handles
-          information when you use this instance of Remindarr (the
-          &quot;Service&quot;). If you do not agree with this policy, please do
-          not use the Service.
+          This Privacy Policy describes how Remindarr (&quot;we&quot;,
+          &quot;us&quot;, the &quot;operator&quot;) handles information when you
+          use the Remindarr service (the &quot;Service&quot;). If you do not
+          agree with this policy, please do not use the Service.
         </p>
 
         <Section title="Information we collect">
@@ -174,8 +180,14 @@ export default function PrivacyPolicyPage() {
 
         <Section title="Contact">
           <p>
-            Questions about this policy can be directed to the operator at{" "}
-            <strong>[contact@example.com]</strong>.
+            Questions about this policy can be directed to us at{" "}
+            <a
+              href="mailto:privacy@remindarr.app"
+              className="text-amber-400 underline underline-offset-2 hover:text-amber-300"
+            >
+              privacy@remindarr.app
+            </a>
+            .
           </p>
         </Section>
 

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -158,6 +158,16 @@ export default function SignupPage() {
             {t("signup.signIn")}
           </Link>
         </p>
+
+        <p className="mt-6 text-center text-xs text-zinc-500">
+          <Link to="/privacy" className="hover:text-zinc-300 transition-colors">
+            {t("privacy.title")}
+          </Link>
+          <span className="mx-2">·</span>
+          <Link to="/terms" className="hover:text-zinc-300 transition-colors">
+            {t("terms.title")}
+          </Link>
+        </p>
       </div>
     </div>
   );

--- a/frontend/src/pages/TermsOfServicePage.test.tsx
+++ b/frontend/src/pages/TermsOfServicePage.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { render, screen, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import "../i18n";
+import TermsOfServicePage from "./TermsOfServicePage";
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <TermsOfServicePage />
+    </MemoryRouter>,
+  );
+}
+
+describe("TermsOfServicePage", () => {
+  it("renders the page title", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: /Terms of Service/i, level: 1 }),
+    ).toBeDefined();
+  });
+
+  it("renders representative sections", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: /Acceptance of terms/i }),
+    ).toBeDefined();
+    expect(
+      screen.getByRole("heading", { name: /Acceptable use/i }),
+    ).toBeDefined();
+  });
+
+  it("links to the privacy policy", () => {
+    renderPage();
+    const link = screen.getByRole("link", { name: /Privacy Policy/i });
+    expect(link.getAttribute("href")).toBe("/privacy");
+  });
+});

--- a/frontend/src/pages/TermsOfServicePage.tsx
+++ b/frontend/src/pages/TermsOfServicePage.tsx
@@ -27,20 +27,27 @@ export default function TermsOfServicePage() {
       <div className="space-y-8 text-sm text-zinc-300 leading-relaxed">
         <p className="text-zinc-400">Last updated: May 25, 2026</p>
 
-        <p className="rounded-lg border border-white/[0.08] bg-zinc-900/50 p-4 text-zinc-400 italic">
-          Remindarr is open-source software that anyone can self-host. These
-          Terms are a template provided for the operator of this instance. They
-          should be reviewed and customized — including the bracketed
-          placeholders below and a review with a legal professional — before
-          being relied upon for a public deployment.
+        <p className="rounded-lg border border-white/[0.08] bg-zinc-900/50 p-4 text-zinc-400">
+          Remindarr is open-source software. These Terms apply to the official
+          instance hosted at{" "}
+          <a
+            href="https://remindarr.app"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-amber-400 underline underline-offset-2 hover:text-amber-300"
+          >
+            remindarr.app
+          </a>
+          . Self-hosted instances are operated by, and governed by the terms of,
+          whoever runs them.
         </p>
 
         <Section title="1. Acceptance of terms">
           <p>
-            By accessing or using this instance of Remindarr (the
-            &quot;Service&quot;), operated by <strong>[Operator Name]</strong>,
-            you agree to be bound by these Terms of Service. If you do not
-            agree, do not use the Service.
+            By accessing or using the Remindarr service (the
+            &quot;Service&quot;), operated by Remindarr, you agree to be bound
+            by these Terms of Service. If you do not agree, do not use the
+            Service.
           </p>
         </Section>
 
@@ -146,16 +153,21 @@ export default function TermsOfServicePage() {
 
         <Section title="11. Governing law">
           <p>
-            These Terms are governed by the laws of{" "}
-            <strong>[Jurisdiction]</strong>, without regard to its conflict of
-            law provisions.
+            These Terms are governed by the laws of the Republic of Croatia,
+            without regard to its conflict of law provisions.
           </p>
         </Section>
 
         <Section title="12. Contact">
           <p>
-            Questions about these Terms can be directed to the operator at{" "}
-            <strong>[contact@example.com]</strong>.
+            Questions about these Terms can be directed to us at{" "}
+            <a
+              href="mailto:legal@remindarr.app"
+              className="text-amber-400 underline underline-offset-2 hover:text-amber-300"
+            >
+              legal@remindarr.app
+            </a>
+            .
           </p>
         </Section>
 

--- a/frontend/src/pages/TermsOfServicePage.tsx
+++ b/frontend/src/pages/TermsOfServicePage.tsx
@@ -1,0 +1,175 @@
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router";
+import { PageHeader } from "../components/design";
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-3">
+      <h2 className="text-lg font-semibold text-zinc-100">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+export default function TermsOfServicePage() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="max-w-3xl mx-auto pb-16">
+      <PageHeader kicker={t("legal.kicker")} title={t("terms.title")} />
+
+      <div className="space-y-8 text-sm text-zinc-300 leading-relaxed">
+        <p className="text-zinc-400">Last updated: May 25, 2026</p>
+
+        <p className="rounded-lg border border-white/[0.08] bg-zinc-900/50 p-4 text-zinc-400 italic">
+          Remindarr is open-source software that anyone can self-host. These
+          Terms are a template provided for the operator of this instance. They
+          should be reviewed and customized — including the bracketed
+          placeholders below and a review with a legal professional — before
+          being relied upon for a public deployment.
+        </p>
+
+        <Section title="1. Acceptance of terms">
+          <p>
+            By accessing or using this instance of Remindarr (the
+            &quot;Service&quot;), operated by <strong>[Operator Name]</strong>,
+            you agree to be bound by these Terms of Service. If you do not
+            agree, do not use the Service.
+          </p>
+        </Section>
+
+        <Section title="2. The service">
+          <p>
+            Remindarr is an application for tracking streaming media releases.
+            It lets you track titles, record watch history and ratings, and
+            receive reminders about upcoming releases. Features may change over
+            time.
+          </p>
+        </Section>
+
+        <Section title="3. Accounts">
+          <p>
+            You are responsible for maintaining the confidentiality of your
+            account credentials and for all activity that occurs under your
+            account. Notify the operator promptly of any unauthorized use. You
+            must provide accurate information and meet any minimum age required
+            by applicable law.
+          </p>
+        </Section>
+
+        <Section title="4. Acceptable use">
+          <p>You agree not to:</p>
+          <ul className="list-disc space-y-1 pl-5 marker:text-zinc-600">
+            <li>use the Service for any unlawful purpose;</li>
+            <li>
+              attempt to disrupt, overload, scrape, reverse engineer, or gain
+              unauthorized access to the Service or its data;
+            </li>
+            <li>
+              upload or share content that is illegal, infringing, or abusive;
+            </li>
+            <li>interfere with other users&apos; use of the Service.</li>
+          </ul>
+        </Section>
+
+        <Section title="5. Your content">
+          <p>
+            You retain ownership of the content you create, such as ratings,
+            tags, and profile details. You grant the operator a limited license
+            to store, process, and display that content as needed to provide the
+            Service, including to other users in accordance with your visibility
+            and sharing settings.
+          </p>
+        </Section>
+
+        <Section title="6. Third-party services">
+          <p>
+            Title metadata is provided by{" "}
+            <a
+              href="https://www.themoviedb.org/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-amber-400 underline underline-offset-2 hover:text-amber-300"
+            >
+              The Movie Database (TMDB)
+            </a>
+            . This product uses the TMDB API but is not endorsed or certified by
+            TMDB. Any optional notification providers you connect (such as
+            Discord, Telegram, or Gotify) are operated by third parties and
+            governed by their own terms.
+          </p>
+        </Section>
+
+        <Section title="7. Disclaimers">
+          <p>
+            The Service is provided on an &quot;as is&quot; and &quot;as
+            available&quot; basis, without warranties of any kind, whether
+            express or implied. Because Remindarr is open-source software that
+            may be self-hosted, the operator does not guarantee that the Service
+            will be uninterrupted, error-free, or that any data will be
+            preserved.
+          </p>
+        </Section>
+
+        <Section title="8. Limitation of liability">
+          <p>
+            To the maximum extent permitted by law, the operator shall not be
+            liable for any indirect, incidental, special, consequential, or
+            punitive damages, or any loss of data, arising out of or related to
+            your use of the Service.
+          </p>
+        </Section>
+
+        <Section title="9. Termination">
+          <p>
+            You may stop using the Service and delete your account at any time.
+            The operator may suspend or terminate access to the Service for
+            conduct that violates these Terms or that may harm the Service or
+            other users.
+          </p>
+        </Section>
+
+        <Section title="10. Changes to these terms">
+          <p>
+            We may update these Terms from time to time. Material changes will
+            be reflected by updating the &quot;last updated&quot; date above.
+            Continued use of the Service after changes take effect constitutes
+            acceptance of the revised Terms.
+          </p>
+        </Section>
+
+        <Section title="11. Governing law">
+          <p>
+            These Terms are governed by the laws of{" "}
+            <strong>[Jurisdiction]</strong>, without regard to its conflict of
+            law provisions.
+          </p>
+        </Section>
+
+        <Section title="12. Contact">
+          <p>
+            Questions about these Terms can be directed to the operator at{" "}
+            <strong>[contact@example.com]</strong>.
+          </p>
+        </Section>
+
+        <p className="text-zinc-400">
+          See also our{" "}
+          <Link
+            to="/privacy"
+            className="text-amber-400 underline underline-offset-2 hover:text-amber-300"
+          >
+            {t("privacy.title")}
+          </Link>
+          .
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Remindarr had no Privacy Policy or Terms of Service pages. This adds two public pages and links them where users expect to find them.

- **New routes** `/privacy` and `/terms` — public (no auth gate), lazy-loaded, wrapped in the standard `Page` error boundary.
- **Finalized legal content** for the official `remindarr.app` instance reflecting what remindarr actually does: accounts (username/display name/email, hashed password or OIDC/passkey identifiers), watch history / ratings / tags, push subscriptions, preferences, invitations, TMDB-sourced metadata, and optional outbound notification providers. Concrete operator details are filled in (operator: Remindarr; contacts: privacy@remindarr.app / legal@remindarr.app; governing law: Croatia), with a scope note clarifying that self-hosted instances are governed by their own operators. Includes the required TMDB attribution line.
- **Links added** to the desktop footer (`App.tsx`), the Login and Signup pages, and the mobile More menu.
- **i18n (hybrid)**: page titles, kicker, and footer link labels go through new `en.json` keys (`legal`, `privacy.title`, `terms.title`); the long legal body stays as readable JSX. Body styled with explicit Tailwind classes since no `prose`/typography plugin is installed.
- **Tests**: colocated `PrivacyPolicyPage.test.tsx` and `TermsOfServicePage.test.tsx` assert the title renders, representative sections render, and the cross-links point to the right routes.

## Test plan

- [x] `bun run check` passes (server tsc + e2e tsc + frontend tsc + ESLint zero-warnings + all tests + build + wrangler dry-run + bundle-size)
- [x] Manually verified in a browser (Vite dev): `/privacy` and `/terms` render **while logged out** with no redirect to `/login`; headings show the i18n strings; footer shows Privacy / Terms / GitHub

https://claude.ai/code/session_01EPGedVUuiyZN2f7iY5RRsM