### PR TITLE
refactor(hooks): extract shared useClickOutside hook

### DIFF
--- a/frontend/src/components/BrowseFilterCard.tsx
+++ b/frontend/src/components/BrowseFilterCard.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState, useMemo } from "react";
+import { useRef, useState, useMemo } from "react";
+import { useClickOutside } from "@/hooks/useClickOutside";
 import { Card } from "@/components/ui/card";
 import { useTranslation } from "react-i18next";
 
@@ -311,22 +312,7 @@ function FilterField({
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    function handleClick(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node))
-        setOpen(false);
-    }
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") setOpen(false);
-    }
-    document.addEventListener("mousedown", handleClick);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", handleClick);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [open]);
+  useClickOutside(ref, open, () => setOpen(false));
 
   return (
     <div ref={ref} className="relative min-w-0">
@@ -377,22 +363,7 @@ function ChipDropdown({
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    function handleClick(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node))
-        setOpen(false);
-    }
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") setOpen(false);
-    }
-    document.addEventListener("mousedown", handleClick);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", handleClick);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [open]);
+  useClickOutside(ref, open, () => setOpen(false));
 
   return (
     <div ref={ref} className="relative">

--- a/frontend/src/components/MultiSelectDropdown.tsx
+++ b/frontend/src/components/MultiSelectDropdown.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from "react";
+import { useClickOutside } from "../hooks/useClickOutside";
 import { useTranslation } from "react-i18next";
 
 export interface Option {
@@ -32,28 +33,10 @@ export default function MultiSelectDropdown({
   const searchRef = useRef<HTMLInputElement>(null);
   const { t } = useTranslation();
 
-  useEffect(() => {
-    function handleClick(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-        setQuery("");
-      }
-    }
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") {
-        setOpen(false);
-        setQuery("");
-      }
-    }
-    if (open) {
-      document.addEventListener("mousedown", handleClick);
-      document.addEventListener("keydown", handleKeyDown);
-      return () => {
-        document.removeEventListener("mousedown", handleClick);
-        document.removeEventListener("keydown", handleKeyDown);
-      };
-    }
-  }, [open]);
+  useClickOutside(ref, open, () => {
+    setOpen(false);
+    setQuery("");
+  });
 
   useEffect(() => {
     if (open && searchRef.current) {

--- a/frontend/src/components/UserSearchDropdown.tsx
+++ b/frontend/src/components/UserSearchDropdown.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { useClickOutside } from "../hooks/useClickOutside";
 import { X, Search } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import * as api from "../api";
@@ -51,19 +52,7 @@ export default function UserSearchDropdown({
     query.length >= 1 && debouncedQuery.length >= 1 && results.length > 0;
   const loading = isFetching;
 
-  // Close dropdown when clicking outside
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(e.target as Node)
-      ) {
-        setQuery("");
-      }
-    }
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
+  useClickOutside(containerRef, open, () => setQuery(""));
 
   if (selected) {
     return (

--- a/frontend/src/hooks/useClickOutside.test.ts
+++ b/frontend/src/hooks/useClickOutside.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, afterEach, mock } from "bun:test";
+import { renderHook, act } from "@testing-library/react";
+import { useRef } from "react";
+import { useClickOutside } from "./useClickOutside";
+
+function buildContainer(): {
+  container: HTMLDivElement;
+  inner: HTMLSpanElement;
+} {
+  const container = document.createElement("div");
+  const inner = document.createElement("span");
+  container.appendChild(inner);
+  document.body.appendChild(container);
+  return { container, inner };
+}
+
+describe("useClickOutside", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("calls onClose on mousedown outside the ref element", () => {
+    const { container } = buildContainer();
+    const outside = document.createElement("button");
+    document.body.appendChild(outside);
+    const onClose = mock(() => {});
+
+    renderHook(() => {
+      const ref = useRef<HTMLDivElement>(container);
+      useClickOutside(ref, true, onClose);
+    });
+
+    act(() => {
+      document.dispatchEvent(
+        new MouseEvent("mousedown", {
+          bubbles: true,
+          target: outside,
+        } as MouseEventInit),
+      );
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onClose on mousedown inside the ref element", () => {
+    const { container, inner } = buildContainer();
+    const onClose = mock(() => {});
+
+    renderHook(() => {
+      const ref = useRef<HTMLDivElement>(container);
+      useClickOutside(ref, true, onClose);
+    });
+
+    act(() => {
+      inner.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(0);
+  });
+
+  it("calls onClose on Escape keydown", () => {
+    const { container } = buildContainer();
+    const onClose = mock(() => {});
+
+    renderHook(() => {
+      const ref = useRef<HTMLDivElement>(container);
+      useClickOutside(ref, true, onClose);
+    });
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onClose for other keys", () => {
+    const { container } = buildContainer();
+    const onClose = mock(() => {});
+
+    renderHook(() => {
+      const ref = useRef<HTMLDivElement>(container);
+      useClickOutside(ref, true, onClose);
+    });
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(0);
+  });
+
+  it("does nothing when enabled is false", () => {
+    const { container } = buildContainer();
+    const outside = document.createElement("button");
+    document.body.appendChild(outside);
+    const onClose = mock(() => {});
+
+    renderHook(() => {
+      const ref = useRef<HTMLDivElement>(container);
+      useClickOutside(ref, false, onClose);
+    });
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(0);
+  });
+
+  it("detaches listeners on unmount", () => {
+    const { container } = buildContainer();
+    const onClose = mock(() => {});
+
+    const { unmount } = renderHook(() => {
+      const ref = useRef<HTMLDivElement>(container);
+      useClickOutside(ref, true, onClose);
+    });
+
+    unmount();
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(0);
+  });
+});

--- a/frontend/src/hooks/useClickOutside.ts
+++ b/frontend/src/hooks/useClickOutside.ts
@@ -1,0 +1,23 @@
+import { useEffect, type RefObject } from "react";
+
+export function useClickOutside(
+  ref: RefObject<HTMLElement | null>,
+  enabled: boolean,
+  onClose: () => void,
+) {
+  useEffect(() => {
+    if (!enabled) return;
+    function onMouseDown(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("mousedown", onMouseDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onMouseDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [ref, enabled, onClose]);
+}

--- a/frontend/src/pages/SeasonDetailPage.tsx
+++ b/frontend/src/pages/SeasonDetailPage.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
+import { useClickOutside } from "../hooks/useClickOutside";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Card } from "../components/ui/card";
 import { useParams, Link, useNavigate } from "react-router";
@@ -682,22 +683,7 @@ function MarkAllWatchedMenu({
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    function onClick(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node))
-        setOpen(false);
-    }
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") setOpen(false);
-    }
-    document.addEventListener("mousedown", onClick);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("mousedown", onClick);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [open]);
+  useClickOutside(ref, open, () => setOpen(false));
 
   return (
     <div ref={ref} className="relative inline-flex items-stretch">
@@ -792,22 +778,7 @@ function EpisodeOverflowMenu({
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    function onClick(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node))
-        setOpen(false);
-    }
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") setOpen(false);
-    }
-    document.addEventListener("mousedown", onClick);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("mousedown", onClick);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [open]);
+  useClickOutside(ref, open, () => setOpen(false));
 
   const handleShare = async () => {
     setOpen(false);

--- a/frontend/src/pages/TrackedPage.tsx
+++ b/frontend/src/pages/TrackedPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useClickOutside } from "../hooks/useClickOutside";
 import { Card } from "../components/ui/card";
 import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
@@ -373,14 +374,7 @@ function RowActionsMenu({
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (!ref.current?.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [open]);
+  useClickOutside(ref, open, () => setOpen(false));
 
   const handleUntrack = async () => {
     setOpen(false);


### PR DESCRIPTION
## Summary
- Created `frontend/src/hooks/useClickOutside.ts` — a single `useClickOutside(ref, enabled, onClose)` hook with mousedown + Escape handling
- Replaced 7 identical inline `useEffect` copies across 5 files with the hook
- `UserSearchDropdown` and `TrackedPage` RowActionsMenu gain Escape-to-close as a side-effect (a11y improvement)
- Added 6-case unit test at `frontend/src/hooks/useClickOutside.test.ts` covering outside click, inside click, Escape, other keys, disabled state, and unmount cleanup

## Test plan
- [x] `bun run check` passes (tsc + lint + all tests + build + wrangler dry-run)
- [x] All 6 unit tests pass for the new hook
- [x] No `addEventListener("mousedown"` remains outside the hook (`grep` confirmed)

Closes #977

🤖 Generated with [Claude Code](https://claude.com/claude-code)