### PR TITLE
fix(achievements): align backfill sentinel key to stop log spam on every request

### DIFF
--- a/server/achievements/sync.test.ts
+++ b/server/achievements/sync.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { eq } from "drizzle-orm";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
 import { ACHIEVEMENTS } from "./definitions";
-import { syncAchievementRegistry } from "./sync";
+import { syncAchievementRegistry, BACKFILL_DONE_KEY } from "./sync";
 import { listAchievementDefs } from "../db/repository/achievements";
 import { getDb } from "../db/schema";
 import { achievements, settings } from "../db/schema";
@@ -64,11 +64,9 @@ describe("syncAchievementRegistry", () => {
     spy.mockRestore();
   });
 
-  it("does not enqueue backfill when achievements_backfill_done_v2 is set", async () => {
+  it("does not enqueue backfill when BACKFILL_DONE_KEY is set", async () => {
     const db = getDb();
-    await db
-      .insert(settings)
-      .values({ key: "achievements_backfill_done_v2", value: "1" });
+    await db.insert(settings).values({ key: BACKFILL_DONE_KEY, value: "1" });
     const spy = spyOn(backend, "enqueueOnce").mockResolvedValue(undefined);
     await syncAchievementRegistry();
     expect(spy).not.toHaveBeenCalled();

--- a/server/achievements/sync.ts
+++ b/server/achievements/sync.ts
@@ -6,6 +6,8 @@ import { logger } from "../logger";
 
 const log = logger.child({ module: "achievements-sync" });
 
+export const BACKFILL_DONE_KEY = "achievements_backfill_done_v2";
+
 /**
  * Sync the ACHIEVEMENTS registry into the `achievements` table.
  * UPSERTs each entry — does NOT delete missing keys (orphan rows are tolerated).
@@ -23,7 +25,7 @@ export async function syncAchievementRegistry(): Promise<void> {
 
   // Auto-trigger backfill once — idempotent via the backend dispatcher's
   // dedup logic (DO: idempotent flag; D1: enqueueOneTimeMigration sentinel row)
-  const done = await getSetting("achievements_backfill_done_v2");
+  const done = await getSetting(BACKFILL_DONE_KEY);
   if (!done) {
     await enqueueOnce("backfill-achievements");
     log.info("Enqueued achievements backfill job");

--- a/server/jobs/backfill-achievements.test.ts
+++ b/server/jobs/backfill-achievements.test.ts
@@ -4,9 +4,11 @@ import { createUser } from "../db/repository";
 import * as achievementsRepo from "../db/repository/achievements";
 import * as streaksRepo from "../db/repository/streaks";
 import * as settingsRepo from "../db/repository/settings";
+import { getSetting } from "../db/repository/settings";
 import * as queue from "../jobs/queue";
 import * as evaluate from "../achievements/evaluate";
 import { runBackfillAchievements } from "./backfill-achievements";
+import { BACKFILL_DONE_KEY } from "../achievements/sync";
 
 beforeEach(async () => {
   setupTestDb();
@@ -175,10 +177,7 @@ describe("backfill-achievements job", () => {
     await runBackfillAchievements(null);
 
     // Last batch (< 50): sets done flag and does NOT re-enqueue
-    expect(setSettingSpy).toHaveBeenCalledWith(
-      "achievements_backfill_done",
-      "1",
-    );
+    expect(setSettingSpy).toHaveBeenCalledWith(BACKFILL_DONE_KEY, "1");
     const backfillEnqueues = enqueueSpy.mock.calls.filter(
       (c) => c[0] === "backfill-achievements",
     );
@@ -271,5 +270,11 @@ describe("backfill-achievements job", () => {
     evalCompSpy.mockRestore();
     evalFollowSpy.mockRestore();
     evalRecSpy.mockRestore();
+  });
+
+  it("writer/reader key parity: BACKFILL_DONE_KEY is written when zero users exist", async () => {
+    await runBackfillAchievements(null);
+    const value = await getSetting(BACKFILL_DONE_KEY);
+    expect(value).toBe("1");
   });
 });

--- a/server/jobs/backfill-achievements.ts
+++ b/server/jobs/backfill-achievements.ts
@@ -2,6 +2,7 @@ import { sql } from "drizzle-orm";
 import { getDb } from "../db/schema";
 import { users } from "../db/schema";
 import { ACHIEVEMENTS } from "../achievements/definitions";
+import { BACKFILL_DONE_KEY } from "../achievements/sync";
 import {
   evaluateCountMovies,
   evaluateCountEpisodes,
@@ -42,7 +43,7 @@ export async function runBackfillAchievements(
   `);
 
   if (rows.length === 0) {
-    await setSetting("achievements_backfill_done", "1");
+    await setSetting(BACKFILL_DONE_KEY, "1");
     log.info("Backfill complete — no more users");
     return;
   }
@@ -164,7 +165,7 @@ export async function runBackfillAchievements(
     log.info("Backfill: enqueued next batch", { nextCursor: lastUserId });
   } else {
     // 6. Done
-    await setSetting("achievements_backfill_done", "1");
+    await setSetting(BACKFILL_DONE_KEY, "1");
     log.info("Backfill: complete", { totalProcessed: rows.length });
   }
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `server/achievements/sync.ts` read sentinel key `achievements_backfill_done_v2`, but `server/jobs/backfill-achievements.ts` wrote `achievements_backfill_done` (no `_v2` suffix). The sentinel was never found, causing `enqueueOnce("backfill-achievements")` to fire on every cold-isolate request and spamming the log.
- **Fix**: Introduced a shared exported constant `BACKFILL_DONE_KEY = "achievements_backfill_done_v2"` in `sync.ts` and imported it in `backfill-achievements.ts`, replacing both literal strings at lines ~45 and ~167.
- **Regression test**: Added `"writer/reader key parity"` test in `backfill-achievements.test.ts` — verifies that after `runBackfillAchievements()` runs with zero users, `getSetting(BACKFILL_DONE_KEY)` returns `"1"`. If the writer and reader ever diverge again, this test will catch it.

## Test plan

- [x] `bun test server/achievements/sync.test.ts server/jobs/backfill-achievements.test.ts` — 10 pass, 0 fail
- [x] `bun run check` — full CI pipeline passes (3252 tests, 0 fail, tsc clean, ESLint clean, build + wrangler dry-run OK)

Closes #980

🤖 Generated with [Claude Code](https://claude.com/claude-code)