### PR TITLE
fix(http): short-circuit retry loop on abort signal

### DIFF
--- a/server/lib/http.test.ts
+++ b/server/lib/http.test.ts
@@ -152,4 +152,53 @@ describe("httpFetch", () => {
       fetchSpy.mockRestore();
     }
   });
+
+  it("abort signal short-circuits retry loop — fetch called exactly once", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const abortError = new DOMException(
+      "The operation was aborted.",
+      "AbortError",
+    );
+    const fetchSpy = spyOn(globalThis, "fetch").mockRejectedValue(abortError);
+    try {
+      const { httpFetch } = await import("./http");
+
+      await expect(
+        httpFetch(
+          "https://example.com",
+          { signal: controller.signal },
+          { maxRetries: 3, baseDelayMs: 0 },
+        ),
+      ).rejects.toThrow("The operation was aborted.");
+
+      // Must not retry — signal is already aborted after the first throw
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("normal network errors still retry without a signal", async () => {
+    let callCount = 0;
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((() => {
+      callCount++;
+      if (callCount < 3) return Promise.reject(new Error("network error"));
+      return Promise.resolve(makeResponse(200));
+    }) as any);
+    try {
+      const { httpFetch } = await import("./http");
+
+      const res = await httpFetch("https://example.com", undefined, {
+        maxRetries: 3,
+        baseDelayMs: 0,
+      });
+      expect(res.status).toBe(200);
+      // fetch was called more than once — retries happened
+      expect(callCount).toBeGreaterThan(1);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
 });

--- a/server/lib/http.ts
+++ b/server/lib/http.ts
@@ -41,6 +41,7 @@ export async function httpFetch(
       await sleep(delay);
     } catch (err) {
       lastError = err;
+      if (init?.signal?.aborted) break;
       if (attempt === maxRetries) break;
       const delay = jitteredDelay(baseDelayMs, attempt, maxDelayMs);
       log.warn("HTTP fetch error, retrying", {


### PR DESCRIPTION
## Summary

- **Bug**: when an `AbortController` fires mid-retry in `httpFetch`, the catch block would capture the `AbortError` and then sleep the backoff delay before issuing another `fetch()` on the already-aborted signal — which throws again immediately. This cycle repeats `maxRetries` times, so a 5-second TMDB timeout actually cost `5s + (maxRetries × backoff)` wall time.
- **Fix**: add `if (init?.signal?.aborted) break;` immediately after `lastError = err` in the catch block. This exits the retry loop the moment the caller's signal is aborted, skipping all backoff sleeps and redundant fetches.
- **Tests**: two new cases in `server/lib/http.test.ts` — abort signal results in exactly one `fetch` call (regression guard), and plain network errors without a signal still retry as before.

Closes #979

## Test plan

- [x] `bun test server/lib/http` — 8 tests pass (6 pre-existing + 2 new)
- [x] `bun run check` — full CI pipeline passes (type checks, lint, all tests, build, wrangler dry-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)