### PR TITLE
feat(observability): record cron bootstrap + DO alarm freshness timestamps

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -727,6 +727,7 @@ export interface CronJobInfo {
   last_run: string | null;
   next_run: string;
   enabled: number;
+  alarmLastCompletedAt: string | null;
 }
 
 export interface RecentJob {
@@ -746,6 +747,7 @@ export interface JobsResponse {
   >;
   crons: CronJobInfo[];
   recentJobs: RecentJob[];
+  bootstrap: { lastSeenAt: string | null };
 }
 
 export async function getJobs(signal?: AbortSignal): Promise<JobsResponse> {

--- a/frontend/src/components/CategoryBrowse.test.tsx
+++ b/frontend/src/components/CategoryBrowse.test.tsx
@@ -1,11 +1,9 @@
-import { describe, it, expect, afterEach, beforeEach, spyOn } from "bun:test";
+import { describe, it, expect, mock, afterEach, beforeEach } from "bun:test";
 import { render, screen, cleanup, waitFor, act } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
-import * as api from "../api";
 import { AuthContext } from "../context/AuthContext";
-import CategoryBrowse from "./CategoryBrowse";
 
 let intersectionCallback: IntersectionObserverCallback | null = null;
 
@@ -87,6 +85,14 @@ const mockAuthValue = {
   refresh: async () => {},
 };
 
+const mockBrowseTitles = mock(async () => makeBrowseResponse(1, [], 1));
+
+mock.module("../api", () => ({
+  browseTitles: mockBrowseTitles,
+}));
+
+const { default: CategoryBrowse } = await import("./CategoryBrowse");
+
 function newTestClient() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } });
 }
@@ -101,34 +107,29 @@ function Wrapper({ children }: { children: ReactNode }) {
   );
 }
 
-let spies: ReturnType<typeof spyOn>[] = [];
-
 beforeEach(() => {
-  spies = [];
   intersectionCallback = null;
+  mockBrowseTitles.mockReset();
 });
 
 afterEach(() => {
   cleanup();
-  for (const spy of spies) spy.mockRestore();
   intersectionCallback = null;
 });
 
 describe("CategoryBrowse pagination", () => {
   it("keeps already-loaded titles visible while a subsequent page is fetching", async () => {
     let resolvePage2: (() => void) | null = null;
-    const browseSpy = spyOn(api, "browseTitles");
-    browseSpy.mockImplementationOnce(() =>
-      Promise.resolve(makeBrowseResponse(1, [makeSearchTitle(1)], 2)),
+    mockBrowseTitles.mockResolvedValueOnce(
+      makeBrowseResponse(1, [makeSearchTitle(1)], 2),
     );
-    browseSpy.mockImplementationOnce(
+    mockBrowseTitles.mockImplementationOnce(
       () =>
         new Promise((resolve) => {
           resolvePage2 = () =>
             resolve(makeBrowseResponse(2, [makeSearchTitle(2)], 2));
         }),
     );
-    spies.push(browseSpy);
 
     render(
       <CategoryBrowse
@@ -161,7 +162,7 @@ describe("CategoryBrowse pagination", () => {
     // While page 2 is in flight the existing title must stay rendered —
     // i.e. the entire list must not be replaced with the centered loader.
     await waitFor(() => {
-      expect(browseSpy).toHaveBeenCalledTimes(2);
+      expect(mockBrowseTitles).toHaveBeenCalledTimes(2);
     });
     expect(screen.queryByText("Title 1")).not.toBeNull();
 
@@ -172,11 +173,9 @@ describe("CategoryBrowse pagination", () => {
   });
 
   it("fires exactly one request on initial mount", async () => {
-    const browseSpy = spyOn(api, "browseTitles");
-    browseSpy.mockImplementation(() =>
-      Promise.resolve(makeBrowseResponse(1, [makeSearchTitle(1)], 1)),
+    mockBrowseTitles.mockResolvedValue(
+      makeBrowseResponse(1, [makeSearchTitle(1)], 1),
     );
-    spies.push(browseSpy);
 
     render(
       <CategoryBrowse
@@ -198,18 +197,16 @@ describe("CategoryBrowse pagination", () => {
       expect(screen.getByText("Title 1")).toBeDefined();
     });
 
-    expect(browseSpy).toHaveBeenCalledTimes(1);
+    expect(mockBrowseTitles).toHaveBeenCalledTimes(1);
   });
 
   it("does not auto-chain to page 3 after page 2 resolves without a new intersection", async () => {
-    const browseSpy = spyOn(api, "browseTitles");
-    browseSpy.mockResolvedValueOnce(
+    mockBrowseTitles.mockResolvedValueOnce(
       makeBrowseResponse(1, [makeSearchTitle(1)], 3),
     );
-    browseSpy.mockResolvedValueOnce(
+    mockBrowseTitles.mockResolvedValueOnce(
       makeBrowseResponse(2, [makeSearchTitle(2)], 3),
     );
-    spies.push(browseSpy);
 
     render(
       <CategoryBrowse
@@ -237,20 +234,18 @@ describe("CategoryBrowse pagination", () => {
       );
     });
 
-    await waitFor(() => expect(browseSpy).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mockBrowseTitles).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(screen.getByText("Title 2")).toBeDefined());
 
     // After page 2 resolves, page 3 must NOT auto-load — requires another scroll
     await new Promise<void>((r) => setTimeout(r, 50));
-    expect(browseSpy).toHaveBeenCalledTimes(2);
+    expect(mockBrowseTitles).toHaveBeenCalledTimes(2);
   });
 
   it("does not fire a duplicate request when parent re-renders with identical props", async () => {
-    const browseSpy = spyOn(api, "browseTitles");
-    browseSpy.mockImplementation(() =>
-      Promise.resolve(makeBrowseResponse(1, [makeSearchTitle(1)], 1)),
+    mockBrowseTitles.mockResolvedValue(
+      makeBrowseResponse(1, [makeSearchTitle(1)], 1),
     );
-    spies.push(browseSpy);
 
     function Parent() {
       return (
@@ -275,12 +270,12 @@ describe("CategoryBrowse pagination", () => {
       expect(screen.getByText("Title 1")).toBeDefined();
     });
 
-    const callCountAfterMount = browseSpy.mock.calls.length;
+    const callCountAfterMount = mockBrowseTitles.mock.calls.length;
     rerender(<Parent />);
 
     // Allow any async effects to settle
     await waitFor(() => {
-      expect(browseSpy.mock.calls.length).toBe(callCountAfterMount);
+      expect(mockBrowseTitles.mock.calls.length).toBe(callCountAfterMount);
     });
   });
 });

--- a/frontend/src/components/NewReleases.test.ts
+++ b/frontend/src/components/NewReleases.test.ts
@@ -1,31 +1,43 @@
-import { describe, it, expect, afterEach, spyOn } from "bun:test";
-import * as api from "../api";
+import { describe, it, expect, mock, afterEach } from "bun:test";
 import { loadFilters } from "./loadFilters";
 
 const mockProviders = [
   { id: 1, name: "Netflix", technical_name: "netflix", icon_url: "" },
 ];
 
-let spies: ReturnType<typeof spyOn>[] = [];
+const mockGetGenres = mock(async () => ({ genres: [] as string[] }));
+const mockGetProviders = mock(async () => ({
+  providers: [] as typeof mockProviders,
+  regionProviderIds: [] as number[],
+}));
+const mockGetLanguages = mock(async () => ({
+  languages: [] as string[],
+  priorityLanguageCodes: [] as string[],
+}));
+
+mock.module("../api", () => ({
+  getGenres: mockGetGenres,
+  getProviders: mockGetProviders,
+  getLanguages: mockGetLanguages,
+}));
 
 afterEach(() => {
-  for (const spy of spies) spy.mockRestore();
-  spies = [];
+  mockGetGenres.mockReset();
+  mockGetProviders.mockReset();
+  mockGetLanguages.mockReset();
 });
 
 describe("loadFilters", () => {
   it("returns all filter data when all API calls succeed", async () => {
-    spies = [
-      spyOn(api, "getGenres").mockResolvedValue({
-        genres: ["Action", "Drama"],
-      } as any),
-      spyOn(api, "getProviders").mockResolvedValue({
-        providers: mockProviders,
-      } as any),
-      spyOn(api, "getLanguages").mockResolvedValue({
-        languages: ["en", "fr"],
-      } as any),
-    ];
+    mockGetGenres.mockResolvedValue({ genres: ["Action", "Drama"] });
+    mockGetProviders.mockResolvedValue({
+      providers: mockProviders,
+      regionProviderIds: [],
+    });
+    mockGetLanguages.mockResolvedValue({
+      languages: ["en", "fr"],
+      priorityLanguageCodes: [],
+    });
 
     const result = await loadFilters();
 
@@ -35,15 +47,15 @@ describe("loadFilters", () => {
   });
 
   it("returns empty genres when getGenres fails", async () => {
-    spies = [
-      spyOn(api, "getGenres").mockRejectedValue(new Error("Network error")),
-      spyOn(api, "getProviders").mockResolvedValue({
-        providers: mockProviders,
-      } as any),
-      spyOn(api, "getLanguages").mockResolvedValue({
-        languages: ["en"],
-      } as any),
-    ];
+    mockGetGenres.mockRejectedValue(new Error("Network error"));
+    mockGetProviders.mockResolvedValue({
+      providers: mockProviders,
+      regionProviderIds: [],
+    });
+    mockGetLanguages.mockResolvedValue({
+      languages: ["en"],
+      priorityLanguageCodes: [],
+    });
 
     const result = await loadFilters();
 
@@ -53,13 +65,12 @@ describe("loadFilters", () => {
   });
 
   it("returns empty providers when getProviders fails", async () => {
-    spies = [
-      spyOn(api, "getGenres").mockResolvedValue({ genres: ["Action"] } as any),
-      spyOn(api, "getProviders").mockRejectedValue(new Error("Server error")),
-      spyOn(api, "getLanguages").mockResolvedValue({
-        languages: ["en"],
-      } as any),
-    ];
+    mockGetGenres.mockResolvedValue({ genres: ["Action"] });
+    mockGetProviders.mockRejectedValue(new Error("Server error"));
+    mockGetLanguages.mockResolvedValue({
+      languages: ["en"],
+      priorityLanguageCodes: [],
+    });
 
     const result = await loadFilters();
 
@@ -69,13 +80,12 @@ describe("loadFilters", () => {
   });
 
   it("returns empty languages when getLanguages fails", async () => {
-    spies = [
-      spyOn(api, "getGenres").mockResolvedValue({ genres: ["Action"] } as any),
-      spyOn(api, "getProviders").mockResolvedValue({
-        providers: mockProviders,
-      } as any),
-      spyOn(api, "getLanguages").mockRejectedValue(new Error("Timeout")),
-    ];
+    mockGetGenres.mockResolvedValue({ genres: ["Action"] });
+    mockGetProviders.mockResolvedValue({
+      providers: mockProviders,
+      regionProviderIds: [],
+    });
+    mockGetLanguages.mockRejectedValue(new Error("Timeout"));
 
     const result = await loadFilters();
 
@@ -85,11 +95,9 @@ describe("loadFilters", () => {
   });
 
   it("returns all empty arrays when all API calls fail", async () => {
-    spies = [
-      spyOn(api, "getGenres").mockRejectedValue(new Error("fail")),
-      spyOn(api, "getProviders").mockRejectedValue(new Error("fail")),
-      spyOn(api, "getLanguages").mockRejectedValue(new Error("fail")),
-    ];
+    mockGetGenres.mockRejectedValue(new Error("fail"));
+    mockGetProviders.mockRejectedValue(new Error("fail"));
+    mockGetLanguages.mockRejectedValue(new Error("fail"));
 
     const result = await loadFilters();
 

--- a/frontend/src/components/loadFilters.dedup.test.tsx
+++ b/frontend/src/components/loadFilters.dedup.test.tsx
@@ -1,12 +1,29 @@
-import { describe, it, expect, afterEach, spyOn } from "bun:test";
+import { describe, it, expect, mock, afterEach } from "bun:test";
 import { render, cleanup, waitFor } from "@testing-library/react";
 import {
   QueryClient,
   QueryClientProvider,
   useQuery,
 } from "@tanstack/react-query";
-import * as api from "../api";
 import { loadFilters } from "./loadFilters";
+
+const mockGetGenres = mock(async () => ({
+  genres: [] as string[],
+}));
+const mockGetProviders = mock(async () => ({
+  providers: [],
+  regionProviderIds: [] as number[],
+}));
+const mockGetLanguages = mock(async () => ({
+  languages: [] as string[],
+  priorityLanguageCodes: [] as string[],
+}));
+
+mock.module("../api", () => ({
+  getGenres: mockGetGenres,
+  getProviders: mockGetProviders,
+  getLanguages: mockGetLanguages,
+}));
 
 // Mirrors the exact useQuery call BrowsePage and NewReleases now share.
 function FiltersConsumer() {
@@ -18,26 +35,24 @@ function FiltersConsumer() {
   return null;
 }
 
-let spies: ReturnType<typeof spyOn>[] = [];
-
 afterEach(() => {
   cleanup();
-  for (const spy of spies) spy.mockRestore();
-  spies = [];
+  mockGetGenres.mockReset();
+  mockGetProviders.mockReset();
+  mockGetLanguages.mockReset();
 });
 
 describe("filters shared-cache dedup", () => {
   it("fetches filters once when two consumers share the ['filters'] key", async () => {
-    const getGenres = spyOn(api, "getGenres").mockResolvedValue({
-      genres: ["Action"],
-    } as any);
-    const getProviders = spyOn(api, "getProviders").mockResolvedValue({
+    mockGetGenres.mockResolvedValue({ genres: ["Action"] });
+    mockGetProviders.mockResolvedValue({
       providers: [],
-    } as any);
-    const getLanguages = spyOn(api, "getLanguages").mockResolvedValue({
+      regionProviderIds: [],
+    });
+    mockGetLanguages.mockResolvedValue({
       languages: ["en"],
-    } as any);
-    spies = [getGenres, getProviders, getLanguages];
+      priorityLanguageCodes: [],
+    });
 
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false } },
@@ -50,10 +65,10 @@ describe("filters shared-cache dedup", () => {
       </QueryClientProvider>,
     );
 
-    await waitFor(() => expect(getGenres).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockGetGenres).toHaveBeenCalledTimes(1));
     // Two simultaneous consumers, one shared key → loadFilters runs once,
     // so each underlying endpoint is hit exactly once (was 2× before the shared cache).
-    expect(getProviders).toHaveBeenCalledTimes(1);
-    expect(getLanguages).toHaveBeenCalledTimes(1);
+    expect(mockGetProviders).toHaveBeenCalledTimes(1);
+    expect(mockGetLanguages).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/pages/BrowsePage.test.tsx
+++ b/frontend/src/pages/BrowsePage.test.tsx
@@ -78,6 +78,15 @@ mock.module("../components/CategoryBrowse", () => ({
   default: () => <div data-testid="category-browse" />,
 }));
 
+// BrowsePage.tsx calls api.getLanguages/searchTitles/resolveImdb directly.
+// This override prevents cross-file mock.module leaks from corrupting those calls.
+mock.module("../api", () => ({
+  getLanguages: () =>
+    Promise.resolve({ languages: [], priorityLanguageCodes: [] }),
+  searchTitles: () => Promise.resolve([]),
+  resolveImdb: () => Promise.resolve(null),
+}));
+
 const { default: BrowsePage } = await import("./BrowsePage");
 
 function makeWrapper(initialPath: string) {

--- a/frontend/src/pages/settings/AdminTab.test.tsx
+++ b/frontend/src/pages/settings/AdminTab.test.tsx
@@ -95,3 +95,115 @@ describe("AdminTab", () => {
     });
   });
 });
+
+describe("BackgroundJobsSection bootstrap freshness badge", () => {
+  it("shows error pill when bootstrap.lastSeenAt is older than 30 minutes", async () => {
+    const oldTimestamp = new Date(Date.now() - 35 * 60 * 1000).toISOString();
+    spies.forEach((s) => s.mockRestore());
+    spies = [
+      spyOn(api, "getJobs").mockResolvedValue({
+        crons: [],
+        stats: {},
+        recentJobs: [],
+        bootstrap: { lastSeenAt: oldTimestamp },
+      } as any),
+      spyOn(api, "getAdminSettings").mockResolvedValue({
+        oidc_configured: false,
+        oidc: {
+          issuer_url: { source: "unset", value: "" },
+          client_id: { source: "unset", value: "" },
+          client_secret: { source: "unset", value: "" },
+          redirect_uri: { source: "unset", value: "" },
+        },
+      } as any),
+      spyOn(api, "getAdminConfig").mockResolvedValue({
+        safe: [],
+        secrets: [],
+      } as any),
+      spyOn(api, "getAdminLogs").mockResolvedValue({
+        entries: [],
+      } as any),
+    ];
+
+    const client = newTestClient();
+    render(<AdminTab />, { wrapper: wrapper(client) });
+
+    await waitFor(() => {
+      // The error pill text includes "Bootstrap:" and "m ago" (35+ minutes)
+      const pills = screen.getAllByText(/Bootstrap:/);
+      expect(pills.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("shows ok pill when bootstrap.lastSeenAt is within 5 minutes", async () => {
+    const recentTimestamp = new Date(Date.now() - 3 * 60 * 1000).toISOString();
+    spies.forEach((s) => s.mockRestore());
+    spies = [
+      spyOn(api, "getJobs").mockResolvedValue({
+        crons: [],
+        stats: {},
+        recentJobs: [],
+        bootstrap: { lastSeenAt: recentTimestamp },
+      } as any),
+      spyOn(api, "getAdminSettings").mockResolvedValue({
+        oidc_configured: false,
+        oidc: {
+          issuer_url: { source: "unset", value: "" },
+          client_id: { source: "unset", value: "" },
+          client_secret: { source: "unset", value: "" },
+          redirect_uri: { source: "unset", value: "" },
+        },
+      } as any),
+      spyOn(api, "getAdminConfig").mockResolvedValue({
+        safe: [],
+        secrets: [],
+      } as any),
+      spyOn(api, "getAdminLogs").mockResolvedValue({
+        entries: [],
+      } as any),
+    ];
+
+    const client = newTestClient();
+    render(<AdminTab />, { wrapper: wrapper(client) });
+
+    await waitFor(() => {
+      const pills = screen.getAllByText(/Bootstrap: 3m ago/);
+      expect(pills.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("shows Bootstrap: Never when lastSeenAt is null", async () => {
+    spies.forEach((s) => s.mockRestore());
+    spies = [
+      spyOn(api, "getJobs").mockResolvedValue({
+        crons: [],
+        stats: {},
+        recentJobs: [],
+        bootstrap: { lastSeenAt: null },
+      } as any),
+      spyOn(api, "getAdminSettings").mockResolvedValue({
+        oidc_configured: false,
+        oidc: {
+          issuer_url: { source: "unset", value: "" },
+          client_id: { source: "unset", value: "" },
+          client_secret: { source: "unset", value: "" },
+          redirect_uri: { source: "unset", value: "" },
+        },
+      } as any),
+      spyOn(api, "getAdminConfig").mockResolvedValue({
+        safe: [],
+        secrets: [],
+      } as any),
+      spyOn(api, "getAdminLogs").mockResolvedValue({
+        entries: [],
+      } as any),
+    ];
+
+    const client = newTestClient();
+    render(<AdminTab />, { wrapper: wrapper(client) });
+
+    await waitFor(() => {
+      expect(screen.getByText("Bootstrap: Never")).toBeDefined();
+    });
+  });
+});

--- a/frontend/src/pages/settings/AdminTab.tsx
+++ b/frontend/src/pages/settings/AdminTab.tsx
@@ -33,6 +33,71 @@ function JobStatusBadge({ status }: { status: string }) {
   );
 }
 
+function minutesSince(iso: string | null): number | null {
+  if (!iso) return null;
+  return Math.floor((Date.now() - new Date(iso).getTime()) / 60_000);
+}
+
+function cronIntervalMinutes(cron: string): number {
+  // Handle common patterns: */5 * * * * → 5, 0 * * * * → 60, 0 0 * * * → 1440
+  const everyN = /^\*\/(\d+)\s/.exec(cron);
+  if (everyN) return parseInt(everyN[1], 10);
+  if (/^0 \* \* \* \*/.test(cron)) return 60;
+  if (/^0 0 \* \* \*/.test(cron)) return 1440;
+  return 60;
+}
+
+function BootstrapFreshnessBadge({
+  lastSeenAt,
+}: {
+  lastSeenAt: string | null;
+}) {
+  const mins = minutesSince(lastSeenAt);
+  let kind: "ok" | "amber" | "error" | "neutral";
+  let label: string;
+  if (mins === null) {
+    kind = "error";
+    label = "Bootstrap: Never";
+  } else if (mins <= 10) {
+    kind = "ok";
+    label = `Bootstrap: ${mins}m ago`;
+  } else if (mins <= 30) {
+    kind = "amber";
+    label = `Bootstrap: ${mins}m ago`;
+  } else {
+    kind = "error";
+    label = `Bootstrap: ${mins}m ago`;
+  }
+  return <SStatusPill kind={kind}>{label}</SStatusPill>;
+}
+
+function AlarmFreshnessBadge({
+  alarmLastCompletedAt,
+  cron,
+}: {
+  alarmLastCompletedAt: string | null;
+  cron: string;
+}) {
+  const mins = minutesSince(alarmLastCompletedAt);
+  const interval = cronIntervalMinutes(cron);
+  let kind: "ok" | "amber" | "error" | "neutral";
+  let label: string;
+  if (mins === null) {
+    kind = "neutral";
+    label = "Alarm: Never";
+  } else if (mins <= interval * 2) {
+    kind = "ok";
+    label = `Alarm: ${mins}m ago`;
+  } else if (mins <= interval * 4) {
+    kind = "amber";
+    label = `Alarm: ${mins}m ago`;
+  } else {
+    kind = "error";
+    label = `Alarm: ${mins}m ago`;
+  }
+  return <SStatusPill kind={kind}>{label}</SStatusPill>;
+}
+
 function BackgroundJobsSection() {
   const qc = useQueryClient();
   const [msg, setMsg] = useState("");
@@ -74,6 +139,14 @@ function BackgroundJobsSection() {
 
         {data?.crons.length === 0 && (
           <p className="text-zinc-500 text-sm">No scheduled jobs configured.</p>
+        )}
+
+        {data && (
+          <div className="flex items-center gap-2">
+            <BootstrapFreshnessBadge
+              lastSeenAt={data.bootstrap?.lastSeenAt ?? null}
+            />
+          </div>
         )}
 
         {data && data.crons.length > 0 && (
@@ -160,8 +233,12 @@ function BackgroundJobsSection() {
                           </div>
                         )}
                     </div>
-                    <div>
+                    <div className="flex flex-col gap-1">
                       <SStatusPill kind={pillKind}>{pillText}</SStatusPill>
+                      <AlarmFreshnessBadge
+                        alarmLastCompletedAt={cron.alarmLastCompletedAt}
+                        cron={cron.cron}
+                      />
                     </div>
                     <div>
                       <SButton

--- a/server/jobs/backend.ts
+++ b/server/jobs/backend.ts
@@ -269,6 +269,7 @@ type CronEntry = {
   last_run: string | null;
   next_run: string;
   enabled: number;
+  alarmLastCompletedAt: string | null;
 };
 type RecentJob = {
   id: number;
@@ -289,6 +290,7 @@ export async function getJobsOverview(env: CFEnv): Promise<{
   stats: Record<string, JobStats>;
   crons: CronEntry[];
   recentJobs: RecentJob[];
+  bootstrap: { lastSeenAt: string | null };
 }> {
   if (CONFIG.JOB_QUEUE_BACKEND === "durable-object") {
     return getJobsOverviewDO(env);
@@ -300,6 +302,7 @@ async function getJobsOverviewD1(): Promise<{
   stats: Record<string, JobStats>;
   crons: CronEntry[];
   recentJobs: RecentJob[];
+  bootstrap: { lastSeenAt: string | null };
 }> {
   const { eq, desc, sql, inArray } = await import("drizzle-orm");
   const db = getDb();
@@ -349,6 +352,7 @@ async function getJobsOverviewD1(): Promise<{
         last_run: lastJob?.completedAt ?? null,
         next_run,
         enabled: 1,
+        alarmLastCompletedAt: null,
       };
     }),
   );
@@ -370,16 +374,27 @@ async function getJobsOverviewD1(): Promise<{
     created_at: r.createdAt,
   }));
 
-  return { stats, crons: cronEntries, recentJobs };
+  return {
+    stats,
+    crons: cronEntries,
+    recentJobs,
+    bootstrap: { lastSeenAt: null },
+  };
 }
 
 async function getJobsOverviewDO(env: CFEnv): Promise<{
   stats: Record<string, JobStats>;
   crons: CronEntry[];
   recentJobs: RecentJob[];
+  bootstrap: { lastSeenAt: string | null };
 }> {
   if (!env.JOB_QUEUE_DO) {
-    return { stats: {}, crons: [], recentJobs: [] };
+    return {
+      stats: {},
+      crons: [],
+      recentJobs: [],
+      bootstrap: { lastSeenAt: null },
+    };
   }
 
   const doNames = [...CRON_JOB_NAMES, "cleanup"] as string[];
@@ -389,7 +404,12 @@ async function getJobsOverviewDO(env: CFEnv): Promise<{
     completed: 0,
     failed: 0,
   };
-  const emptyCronInfo = { cron: null, nextRun: null, lastRun: null };
+  const emptyCronInfo = {
+    cron: null,
+    nextRun: null,
+    lastRun: null,
+    alarmLastCompletedAt: null,
+  };
 
   const [statsResults, cronInfoResults, recentResults] = await Promise.all([
     Promise.all(
@@ -408,6 +428,7 @@ async function getJobsOverviewDO(env: CFEnv): Promise<{
           cron: string | null;
           nextRun: string | null;
           lastRun: string | null;
+          alarmLastCompletedAt: string | null;
         }>(env, name, "/cron-info", "GET")
           .then((info) => ({ name, info }))
           .catch((err) => {
@@ -428,6 +449,10 @@ async function getJobsOverviewDO(env: CFEnv): Promise<{
     ),
   ]);
 
+  const lastSeenAt = env.CACHE_KV
+    ? await env.CACHE_KV.get("cron_bootstrap_last_seen_at", "text")
+    : null;
+
   const stats: Record<string, JobStats> = {};
   for (const { name, stats: s } of statsResults) {
     stats[name] = s;
@@ -441,6 +466,7 @@ async function getJobsOverviewDO(env: CFEnv): Promise<{
       last_run: info.lastRun,
       next_run: info.nextRun ?? "",
       enabled: 1,
+      alarmLastCompletedAt: info.alarmLastCompletedAt,
     };
   });
 
@@ -456,7 +482,7 @@ async function getJobsOverviewDO(env: CFEnv): Promise<{
     created_at: r.created_at,
   }));
 
-  return { stats, crons, recentJobs };
+  return { stats, crons, recentJobs, bootstrap: { lastSeenAt } };
 }
 
 /**

--- a/server/jobs/durable-object.test.ts
+++ b/server/jobs/durable-object.test.ts
@@ -464,6 +464,68 @@ describe("JobQueueDO", () => {
     expect(newAlarm).toBeGreaterThan(Date.now());
   });
 
+  it("alarm() writes alarm_last_completed_at to storage after successful run", async () => {
+    processorModule.handlers["sync-titles"] = async () => {};
+    await do_.armCron("sync-titles", "0 3 * * *");
+    state.rawDb
+      .prepare("UPDATE _actor_alarms SET time = 0 WHERE callback = 'runJob'")
+      .run();
+
+    const before = Date.now();
+    await do_.alarm();
+
+    const stored = await state.storage.get<string>("alarm_last_completed_at");
+    expect(typeof stored).toBe("string");
+    const storedTime = new Date(stored!).getTime();
+    expect(storedTime).toBeGreaterThanOrEqual(before);
+  });
+
+  it("alarm() still writes alarm_last_completed_at even when the job handler fails", async () => {
+    // The @cloudflare/actors Alarms framework catches and swallows handler errors
+    // internally (scheduling a retry), so alarm() itself does NOT throw. The finally
+    // block in our alarm() method still fires in both success and failure paths.
+    processorModule.handlers["sync-titles"] = async () => {
+      throw new Error("alarm handler failure");
+    };
+    await do_.armCron("sync-titles", "0 3 * * *");
+    state.rawDb
+      .prepare("UPDATE _actor_alarms SET time = 0 WHERE callback = 'runJob'")
+      .run();
+
+    const before = Date.now();
+    // Does NOT throw — framework swallows the job error
+    await do_.alarm();
+
+    // The finally block fires regardless — timestamp is recorded
+    const stored = await state.storage.get<string>("alarm_last_completed_at");
+    expect(typeof stored).toBe("string");
+    expect(new Date(stored!).getTime()).toBeGreaterThanOrEqual(before);
+  });
+
+  it("getCronInfo() returns alarmLastCompletedAt as null on a fresh DO", async () => {
+    await do_.armCron("sync-titles", "0 3 * * *");
+    const info = await do_.getCronInfo();
+    expect(
+      Object.prototype.hasOwnProperty.call(info, "alarmLastCompletedAt"),
+    ).toBe(true);
+    expect(info.alarmLastCompletedAt).toBeNull();
+  });
+
+  it("getCronInfo() returns alarmLastCompletedAt after alarm fires", async () => {
+    processorModule.handlers["sync-titles"] = async () => {};
+    await do_.armCron("sync-titles", "0 3 * * *");
+    state.rawDb
+      .prepare("UPDATE _actor_alarms SET time = 0 WHERE callback = 'runJob'")
+      .run();
+
+    await do_.alarm();
+
+    const info = await do_.getCronInfo();
+    expect(typeof info.alarmLastCompletedAt).toBe("string");
+    const t = new Date(info.alarmLastCompletedAt!).getTime();
+    expect(t).toBeGreaterThan(0);
+  });
+
   it("ad-hoc DO (no cron) does NOT auto-create when no pending rows exist", async () => {
     const { do_: adHocDo, state: adHocState } = makeDO("sync-show-episodes:99");
     // Enqueue then manually mark it completed, so the DO has a "name" but no pending rows

--- a/server/jobs/durable-object.ts
+++ b/server/jobs/durable-object.ts
@@ -204,7 +204,14 @@ export class JobQueueDO {
 
   async alarm(): Promise<void> {
     this.initSchema();
-    await this.alarms.alarm();
+    try {
+      await this.alarms.alarm();
+    } finally {
+      await this.ctx.storage.put(
+        "alarm_last_completed_at",
+        new Date().toISOString(),
+      );
+    }
   }
 
   // ─── Job execution: invoked by Alarms when a cron or delayed schedule fires
@@ -556,6 +563,7 @@ export class JobQueueDO {
     cron: string | null;
     nextRun: string | null;
     lastRun: string | null;
+    alarmLastCompletedAt: string | null;
   }> {
     this.initSchema();
     const cron = (await this.ctx.storage.get<string>("cron")) ?? null;
@@ -571,7 +579,14 @@ export class JobQueueDO {
         "SELECT completed_at FROM jobs WHERE status IN ('completed', 'failed') ORDER BY id DESC LIMIT 1",
       )
       .toArray() as Array<{ completed_at: string | null }>;
-    return { cron, nextRun, lastRun: lastRows[0]?.completed_at ?? null };
+    const alarmLastCompletedAt =
+      (await this.ctx.storage.get<string>("alarm_last_completed_at")) ?? null;
+    return {
+      cron,
+      nextRun,
+      lastRun: lastRows[0]?.completed_at ?? null,
+      alarmLastCompletedAt,
+    };
   }
 
   // ─── Private helpers ─────────────────────────────────────────────────────

--- a/server/worker.test.ts
+++ b/server/worker.test.ts
@@ -12,6 +12,7 @@ import {
 import { logger } from "./logger";
 import * as backendModule from "./jobs/backend";
 import * as schema from "./db/schema";
+import { CONFIG } from "./config";
 
 // ─── Scheduled handler cron-branching tests ───────────────────────────────────
 
@@ -272,8 +273,11 @@ describe("maybeDeferRegistrySync (#799 deferral contract)", () => {
 describe("scheduled() bootstrap KV timestamp", () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let spies: ReturnType<typeof spyOn<any, any>>[] = [];
+  let configSnapshot: typeof CONFIG;
 
   beforeEach(() => {
+    // Snapshot CONFIG so patchConfigFromEnv mutations don't leak across files.
+    configSnapshot = { ...CONFIG } as typeof CONFIG;
     // Stub out all heavy backend functions so scheduled() completes without a
     // real D1 DB or job infrastructure.
     spies = [
@@ -295,6 +299,7 @@ describe("scheduled() bootstrap KV timestamp", () => {
   afterEach(() => {
     for (const spy of spies) spy.mockRestore();
     spies = [];
+    Object.assign(CONFIG, configSnapshot);
   });
 
   it("puts cron_bootstrap_last_seen_at into CACHE_KV when the scheduled handler runs", async () => {
@@ -310,6 +315,8 @@ describe("scheduled() bootstrap KV timestamp", () => {
       DB: {} as D1Database,
       CACHE_KV: fakeKv,
       TMDB_COUNTRY: "HR",
+      TMDB_LANGUAGE: "hr-HR",
+      LOG_LEVEL: "info",
     } as unknown as Parameters<typeof handler.scheduled>[1];
 
     const fakeCtx = {
@@ -338,6 +345,8 @@ describe("scheduled() bootstrap KV timestamp", () => {
       DB: {} as D1Database,
       CACHE_KV: undefined,
       TMDB_COUNTRY: "HR",
+      TMDB_LANGUAGE: "hr-HR",
+      LOG_LEVEL: "info",
     } as unknown as Parameters<typeof handler.scheduled>[1];
 
     const fakeCtx = {

--- a/server/worker.test.ts
+++ b/server/worker.test.ts
@@ -4,8 +4,14 @@ import { HTTPException } from "hono/http-exception";
 import Sentry from "./sentry";
 import { classifyError } from "./lib/error-classifier";
 import { errorsByCategory } from "./metrics";
-import { maybeDeferRegistrySync, resetAchievementRegistrySync } from "./worker";
+import {
+  maybeDeferRegistrySync,
+  resetAchievementRegistrySync,
+  handler,
+} from "./worker";
 import { logger } from "./logger";
+import * as backendModule from "./jobs/backend";
+import * as schema from "./db/schema";
 
 // ─── Scheduled handler cron-branching tests ───────────────────────────────────
 
@@ -258,5 +264,91 @@ describe("maybeDeferRegistrySync (#799 deferral contract)", () => {
     const { ctx: ctx2, captured: captured2 } = makeCtx();
     maybeDeferRegistrySync(ctx2, () => Promise.resolve());
     expect(captured2).toHaveLength(1);
+  });
+});
+
+// ─── scheduled() writes cron_bootstrap_last_seen_at to CACHE_KV ──────────────
+
+describe("scheduled() bootstrap KV timestamp", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let spies: ReturnType<typeof spyOn<any, any>>[] = [];
+
+  beforeEach(() => {
+    // Stub out all heavy backend functions so scheduled() completes without a
+    // real D1 DB or job infrastructure.
+    spies = [
+      spyOn(backendModule, "armCron").mockResolvedValue(undefined as any),
+      spyOn(backendModule, "recoverStale").mockResolvedValue(0),
+      spyOn(backendModule, "processPending").mockResolvedValue(0),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      spyOn(backendModule, "runWithEnv").mockImplementation(
+        (_env: any, fn: any) => fn(),
+      ),
+      // runWithDb and runWithCache are from other modules — stub via schema/cache
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      spyOn(schema, "runWithDb").mockImplementation((_db: any, fn: any) =>
+        fn(),
+      ),
+    ];
+  });
+
+  afterEach(() => {
+    for (const spy of spies) spy.mockRestore();
+    spies = [];
+  });
+
+  it("puts cron_bootstrap_last_seen_at into CACHE_KV when the scheduled handler runs", async () => {
+    const puts: Array<[string, string]> = [];
+    const fakeKv = {
+      put: async (key: string, value: string) => {
+        puts.push([key, value]);
+      },
+      get: async () => null,
+    } as unknown as KVNamespace;
+
+    const fakeEnv = {
+      DB: {} as D1Database,
+      CACHE_KV: fakeKv,
+    } as unknown as Parameters<typeof handler.scheduled>[1];
+
+    const fakeCtx = {
+      waitUntil: () => {},
+      passThroughOnException: () => {},
+    } as unknown as ExecutionContext;
+
+    await handler.scheduled(
+      { cron: "*/5 * * * *", type: "scheduled", scheduledTime: Date.now() },
+      fakeEnv,
+      fakeCtx,
+    );
+
+    const bootstrapPut = puts.find(
+      ([k]) => k === "cron_bootstrap_last_seen_at",
+    );
+    expect(bootstrapPut).toBeDefined();
+    // Value should be a valid ISO timestamp
+    expect(new Date(bootstrapPut![1]).getTime()).toBeGreaterThan(0);
+  });
+
+  it("does NOT put to CACHE_KV when CACHE_KV is absent", async () => {
+    const puts: Array<[string, string]> = [];
+
+    const fakeEnv = {
+      DB: {} as D1Database,
+      CACHE_KV: undefined,
+    } as unknown as Parameters<typeof handler.scheduled>[1];
+
+    const fakeCtx = {
+      waitUntil: () => {},
+      passThroughOnException: () => {},
+    } as unknown as ExecutionContext;
+
+    await handler.scheduled(
+      { cron: "*/5 * * * *", type: "scheduled", scheduledTime: Date.now() },
+      fakeEnv,
+      fakeCtx,
+    );
+
+    expect(puts).toHaveLength(0);
   });
 });

--- a/server/worker.test.ts
+++ b/server/worker.test.ts
@@ -309,6 +309,7 @@ describe("scheduled() bootstrap KV timestamp", () => {
     const fakeEnv = {
       DB: {} as D1Database,
       CACHE_KV: fakeKv,
+      TMDB_COUNTRY: "HR",
     } as unknown as Parameters<typeof handler.scheduled>[1];
 
     const fakeCtx = {
@@ -336,6 +337,7 @@ describe("scheduled() bootstrap KV timestamp", () => {
     const fakeEnv = {
       DB: {} as D1Database,
       CACHE_KV: undefined,
+      TMDB_COUNTRY: "HR",
     } as unknown as Parameters<typeof handler.scheduled>[1];
 
     const fakeCtx = {

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -737,7 +737,7 @@ function getApp(env: Env): Hono<AppEnv> {
   return app;
 }
 
-const handler = {
+export const handler = {
   async fetch(
     request: Request,
     env: Env,
@@ -824,6 +824,13 @@ const handler = {
         runWithCache(cache, () =>
           runWithDb(db, async () => {
             logger.info("Scheduled bootstrap tick", { cron: event.cron });
+
+            if (env.CACHE_KV) {
+              await env.CACHE_KV.put(
+                "cron_bootstrap_last_seen_at",
+                new Date().toISOString(),
+              );
+            }
 
             // Arm every cron-singleton DO. Idempotent — the DO only schedules its
             // alarm if no `runJob` cron schedule exists. DOs drive their own


### PR DESCRIPTION
## Summary

- Records `cron_bootstrap_last_seen_at` in `CACHE_KV` every time the CF `scheduled()` handler fires, enabling detection of a dead cron trigger
- Records `alarm_last_completed_at` in DO storage via `try/finally` in `JobQueueDO.alarm()`, so the timestamp is written even when a job handler throws internally (the `@cloudflare/actors` framework swallows handler errors)
- Surfaces both signals in `GET /api/jobs`: top-level `bootstrap.lastSeenAt` and per-cron `alarmLastCompletedAt`
- Renders freshness badges in `BackgroundJobsSection` on the admin tab: a bootstrap pill (ok/amber/error based on ≤10/10-30/>30 min age) and a per-cron alarm pill (ok/amber/error based on 2×/4× the cron interval)

## Test plan

- [x] `server/jobs/durable-object.test.ts`: 3 new tests — alarm writes timestamp on success, alarm still writes timestamp when job handler throws, `getCronInfo()` returns `alarmLastCompletedAt: null` on a fresh DO
- [x] `server/worker.test.ts`: 2 new tests — `scheduled()` puts `cron_bootstrap_last_seen_at` into CACHE_KV, does NOT put when CACHE_KV is absent
- [x] `frontend/src/pages/settings/AdminTab.test.tsx`: 3 new tests — error pill for stale bootstrap, ok pill for fresh bootstrap, "Bootstrap: Never" when `lastSeenAt` is null
- [x] `bun run check:fast` passes (types + lint)
- [x] Pre-push hook passes (changed-tests + types-and-lint)

Closes #983

🤖 Generated with [Claude Code](https://claude.com/claude-code)