### PR TITLE
[auto-review] fix(observability): track streaming_arrival in notificationsSentTotal counter

### DIFF
--- a/server/jobs/check-streaming-alerts.ts
+++ b/server/jobs/check-streaming-alerts.ts
@@ -9,6 +9,7 @@ import {
   recordDelivery,
 } from "../db/repository";
 import { getProvider } from "../notifications/registry";
+import { notificationsSentTotal } from "../metrics";
 
 const log = logger.child({ module: "streaming-alerts" });
 
@@ -104,6 +105,11 @@ export async function checkStreamingAlerts(titleIds: string[]): Promise<void> {
                 latencyMs: Date.now() - alertStart,
                 eventKind: "streaming_arrival",
               });
+              notificationsSentTotal.inc({
+                provider: notifier.provider,
+                kind: "streaming_arrival",
+                outcome: "success",
+              });
               log.info("Sent streaming alert", {
                 userId,
                 titleId,
@@ -118,6 +124,11 @@ export async function checkStreamingAlerts(titleIds: string[]): Promise<void> {
                 latencyMs: Date.now() - alertStart,
                 errorMessage: message,
                 eventKind: "streaming_arrival",
+              });
+              notificationsSentTotal.inc({
+                provider: notifier.provider,
+                kind: "streaming_arrival",
+                outcome: "failure",
               });
               log.error("Failed to send streaming alert", {
                 notifierId: notifier.id,


### PR DESCRIPTION
## Summary

- `check-streaming-alerts.ts` dispatched notifications and called `recordDelivery()` but never incremented `notificationsSentTotal`, so all `streaming_arrival` sends were invisible to Prometheus/Grafana.
- Added two `.inc({ provider, kind: "streaming_arrival", outcome })` calls — one in the success branch and one in the catch block — matching the pattern already used in `notifications.ts`.
- No behaviour change; existing 5 tests all pass.

## Test plan

- [ ] All existing `streaming-alerts.test.ts` tests pass (`bun test ./server/jobs/streaming-alerts.test.ts`)
- [ ] `bun run check:fast` clean
- [ ] After deploy, verify `notifications_sent_total{kind="streaming_arrival"}` appears in `/metrics`

---
_Source: observability_

https://claude.ai/code/session_013pGnUcH3TfVuYuTtRBaLwU

---
_Generated by [Claude Code](https://claude.ai/code/session_013pGnUcH3TfVuYuTtRBaLwU)_