### PR TITLE
feat(validation): add zValidator query schemas to suggestions list + user search (#996)

### DIFF
--- a/server/routes/profile.test.ts
+++ b/server/routes/profile.test.ts
@@ -644,7 +644,30 @@ describe("GET /user/search", () => {
     const res = await app.request("/user/search", { headers: authHeaders() });
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toBe("Query parameter 'q' is required");
+    expect(body.error).toBe("Validation failed");
+    expect(body.issues).toBeInstanceOf(Array);
+  });
+
+  describe("validation", () => {
+    it("rejects missing q — returns 400 with issues array", async () => {
+      const res = await app.request("/user/search", {
+        headers: authHeaders(),
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("Validation failed");
+      expect(body.issues).toBeInstanceOf(Array);
+    });
+
+    it("rejects empty q — returns 400", async () => {
+      const res = await app.request("/user/search?q=", {
+        headers: authHeaders(),
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("Validation failed");
+      expect(body.issues).toBeInstanceOf(Array);
+    });
   });
 
   it("excludes banned users from results", async () => {

--- a/server/routes/profile.ts
+++ b/server/routes/profile.ts
@@ -182,18 +182,16 @@ app.delete("/me/activity/hide/:event_kind/:event_key", async (c) => {
   return ok(c, { hidden: false });
 });
 
-app.get("/search", async (c) => {
+const searchQuerySchema = z.object({ q: z.string().min(1) });
+
+app.get("/search", zValidator("query", searchQuerySchema), async (c) => {
   const user = c.get("user");
   if (!user) {
     return err(c, "Authentication required", 401);
   }
 
-  const query = c.req.query("q");
-  if (!query || query.length < 1) {
-    return err(c, "Query parameter 'q' is required");
-  }
-
-  const users = await searchUsers(query, 10);
+  const { q } = c.req.valid("query");
+  const users = await searchUsers(q, 10);
   return ok(c, { users });
 });
 

--- a/server/routes/suggestions.test.ts
+++ b/server/routes/suggestions.test.ts
@@ -545,28 +545,64 @@ describe("POST /suggestions/dismiss/:titleId", () => {
 });
 
 describe("validation", () => {
-  it("rejects invalid limit — returns 400 with issues array when limit is not a number", async () => {
-    // The handler falls back gracefully for non-numeric limit (NaN → 40),
-    // so an alphabetic limit still returns 200. The limit param is not
-    // validated via zValidator — it coerces. This test documents the
-    // current behaviour (200 with default limit).
+  it("rejects non-numeric limit — returns 400 with issues array", async () => {
+    const res = await app.request("/suggestions?limit=abc");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(body.issues).toBeInstanceOf(Array);
+  });
+
+  it("rejects limit=0 — returns 400 with issues array", async () => {
+    const res = await app.request("/suggestions?limit=0");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(body.issues).toBeInstanceOf(Array);
+  });
+
+  it("happy path — no limit param defaults to 40 and returns 200", async () => {
+    await upsertTitles([
+      makeParsedTitle({ id: "movie-100", tmdbId: "100", objectType: "MOVIE" }),
+    ]);
+    await trackTitle("movie-100", mockUserId);
+
+    // 20 suggestions, capped to 12 per group — well under the default of 40,
+    // so nothing is truncated by the limit.
+    (tmdbClient.fetchMovieSuggestions as any).mockResolvedValueOnce({
+      results: Array.from({ length: 20 }, (_, i) =>
+        makeTmdbDiscoverMovie({ id: 4000 + i, title: `Default Limit ${i}` }),
+      ),
+      page: 1,
+      total_pages: 1,
+      total_results: 20,
+    });
+
+    const res = await app.request("/suggestions");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.flat).toHaveLength(12);
+  });
+
+  it("happy path — ?limit=10 returns 200 and truncates flat to 10", async () => {
     await upsertTitles([
       makeParsedTitle({ id: "movie-100", tmdbId: "100", objectType: "MOVIE" }),
     ]);
     await trackTitle("movie-100", mockUserId);
 
     (tmdbClient.fetchMovieSuggestions as any).mockResolvedValueOnce({
-      results: [],
+      results: Array.from({ length: 20 }, (_, i) =>
+        makeTmdbDiscoverMovie({ id: 5000 + i, title: `Limit Ten ${i}` }),
+      ),
       page: 1,
-      total_pages: 0,
-      total_results: 0,
+      total_pages: 1,
+      total_results: 20,
     });
 
-    const res = await app.request("/suggestions?limit=abc");
-    // NaN → coerces to default 40; handler still returns 200
+    const res = await app.request("/suggestions?limit=10");
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body).toHaveProperty("flat");
+    expect(body.flat).toHaveLength(10);
   });
 });
 

--- a/server/routes/suggestions.ts
+++ b/server/routes/suggestions.ts
@@ -75,13 +75,16 @@ app.delete(
   },
 );
 
-app.get("/", async (c) => {
+const listQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(40),
+});
+
+app.get("/", zValidator("query", listQuerySchema), async (c) => {
   const user = c.get("user");
   if (!user) return err(c, "Authentication required", 401);
   if (!CONFIG.TMDB_API_KEY) return err(c, "TMDB not configured", 503);
 
-  const rawLimit = Number(c.req.query("limit") ?? "40");
-  const limit = isNaN(rawLimit) || rawLimit < 1 ? 40 : Math.min(rawLimit, 100);
+  const { limit } = c.req.valid("query");
 
   try {
     const [sourceTitles, trackedIds, watchedIds, dismissedIds] =


### PR DESCRIPTION
## Summary

Replaces raw `c.req.query()` parsing with `zValidator("query", ...)` schemas on the two remaining endpoints that did manual query handling:

- **`GET /api/suggestions`** — `limit` is now validated as `z.coerce.number().int().min(1).max(100).default(40)` and read via `c.req.valid("query")`, replacing the manual `Number()`/`isNaN` clamp. Auth and TMDB-config checks are unchanged.
- **`GET /api/user/search`** — `q` is now validated as `z.string().min(1)`; the manual guard returning the custom `"Query parameter 'q' is required"` error is removed. The in-handler 401 auth check remains the first statement of the handler.

## Behavior changes

- `GET /api/suggestions` with `limit=abc`, `limit=0`, `limit=150`, or `limit=2.5` now returns **400** with `{ error: "Validation failed", issues: [...] }` — previously these were silently coerced to the default (40) or clamped to 100.
- `GET /api/user/search`: query validation (zValidator middleware) now runs **before** the in-handler auth check, so a bad/missing `q` without auth returns **400** instead of **401**.
- The frontend only ever sends `limit=60` or omits the param entirely (`getSuggestionsAggregate` in `frontend/src/api.ts`), and always sends a non-empty `q` for user search — so there is **no client impact**.

## Test plan

- [x] `server/routes/suggestions.test.ts`: flipped the test documenting graceful coercion of `limit=abc` — it now asserts 400 with `error === "Validation failed"` and an `issues` array; added rejection for `limit=0`; added happy paths for no `limit` param (200, default 40 — flat capped only by GROUP_CAP) and `?limit=10` (200, flat truncated to 10).
- [x] `server/routes/profile.test.ts`: updated the missing-`q` 400 test to the zValidator error shape; added a `describe("validation")` block covering missing `q` and empty `q=` (both 400 + issues). The existing 401-without-auth test (sends `?q=test`) passes unchanged.
- [x] `bun test server/routes/suggestions.test.ts server/routes/profile.test.ts` — 97 pass, 0 fail.
- [x] `bun run check` — full pipeline green (all type checks, lint, all tests, frontend build, wrangler dry-run, bundle-size budgets).

Closes #996

🤖 Generated with [Claude Code](https://claude.com/claude-code)