### PR TITLE
perf(pinned): replace O(n) per-row UPDATE loops with bulk statements (#992)

### DIFF
--- a/server/db/repository/pinned.test.ts
+++ b/server/db/repository/pinned.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
+import { makeParsedTitle } from "../../test-utils/fixtures";
+import { upsertTitles, createUser } from "../repository";
+import {
+  getPinnedTitles,
+  pinTitle,
+  unpinTitle,
+  reorderPinnedTitles,
+  isPinnedTitle,
+} from "./pinned";
+
+let userId: string;
+
+beforeEach(async () => {
+  setupTestDb();
+  userId = await createUser("testuser", "hash");
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+// Helper: create FK-parent titles movie-1..movie-N
+async function insertTitles(count: number): Promise<string[]> {
+  const ids = Array.from({ length: count }, (_, i) => `movie-${i + 1}`);
+  await upsertTitles(
+    ids.map((id) => makeParsedTitle({ id, title: `Movie ${id}` })),
+  );
+  return ids;
+}
+
+async function pinAll(ids: string[]): Promise<void> {
+  for (const id of ids) {
+    const result = await pinTitle(userId, id);
+    expect(result.ok).toBe(true);
+  }
+}
+
+async function getPositions(): Promise<{ id: string; position: number }[]> {
+  const rows = await getPinnedTitles(userId);
+  return rows.map((r) => ({ id: r.id, position: r.position }));
+}
+
+describe("pinTitle", () => {
+  it("assigns sequential positions 0, 1, 2, …", async () => {
+    const ids = await insertTitles(3);
+    await pinAll(ids);
+
+    expect(await getPositions()).toEqual([
+      { id: "movie-1", position: 0 },
+      { id: "movie-2", position: 1 },
+      { id: "movie-3", position: 2 },
+    ]);
+  });
+
+  it("rejects the 9th pin (MAX_PINNED=8)", async () => {
+    const ids = await insertTitles(9);
+    await pinAll(ids.slice(0, 8));
+
+    const result = await pinTitle(userId, "movie-9");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("8");
+    }
+    expect(await getPinnedTitles(userId)).toHaveLength(8);
+  });
+
+  it("is a no-op when the title is already pinned", async () => {
+    const ids = await insertTitles(2);
+    await pinAll(ids);
+
+    const result = await pinTitle(userId, "movie-1");
+    expect(result.ok).toBe(true);
+
+    expect(await getPositions()).toEqual([
+      { id: "movie-1", position: 0 },
+      { id: "movie-2", position: 1 },
+    ]);
+  });
+});
+
+describe("unpinTitle", () => {
+  it("renumbers remaining rows dense 0..n-1 when a middle item is removed", async () => {
+    const ids = await insertTitles(4);
+    await pinAll(ids);
+
+    await unpinTitle(userId, "movie-2");
+
+    expect(await getPositions()).toEqual([
+      { id: "movie-1", position: 0 },
+      { id: "movie-3", position: 1 },
+      { id: "movie-4", position: 2 },
+    ]);
+  });
+
+  it("renumbers when the first item is removed", async () => {
+    const ids = await insertTitles(3);
+    await pinAll(ids);
+
+    await unpinTitle(userId, "movie-1");
+
+    expect(await getPositions()).toEqual([
+      { id: "movie-2", position: 0 },
+      { id: "movie-3", position: 1 },
+    ]);
+  });
+
+  it("leaves positions intact when the last item is removed", async () => {
+    const ids = await insertTitles(3);
+    await pinAll(ids);
+
+    await unpinTitle(userId, "movie-3");
+
+    expect(await getPositions()).toEqual([
+      { id: "movie-1", position: 0 },
+      { id: "movie-2", position: 1 },
+    ]);
+  });
+
+  it("is a no-op for a non-pinned title and does not disturb positions", async () => {
+    const ids = await insertTitles(4);
+    await pinAll(ids.slice(0, 3));
+
+    await unpinTitle(userId, "movie-4");
+
+    expect(await getPositions()).toEqual([
+      { id: "movie-1", position: 0 },
+      { id: "movie-2", position: 1 },
+      { id: "movie-3", position: 2 },
+    ]);
+  });
+});
+
+describe("reorderPinnedTitles", () => {
+  it("applies a full permutation", async () => {
+    const ids = await insertTitles(3);
+    await pinAll(ids);
+
+    await reorderPinnedTitles(userId, ["movie-3", "movie-1", "movie-2"]);
+
+    expect(await getPositions()).toEqual([
+      { id: "movie-3", position: 0 },
+      { id: "movie-1", position: 1 },
+      { id: "movie-2", position: 2 },
+    ]);
+  });
+
+  it("deletes rows omitted from the new order", async () => {
+    const ids = await insertTitles(3);
+    await pinAll(ids);
+
+    await reorderPinnedTitles(userId, ["movie-3", "movie-1"]);
+
+    expect(await getPositions()).toEqual([
+      { id: "movie-3", position: 0 },
+      { id: "movie-1", position: 1 },
+    ]);
+    expect(await isPinnedTitle(userId, "movie-2")).toBe(false);
+  });
+
+  it("inserts a brand-new titleId at its position", async () => {
+    const ids = await insertTitles(3);
+    await pinAll(ids.slice(0, 2));
+
+    await reorderPinnedTitles(userId, ["movie-2", "movie-3", "movie-1"]);
+
+    expect(await getPositions()).toEqual([
+      { id: "movie-2", position: 0 },
+      { id: "movie-3", position: 1 },
+      { id: "movie-1", position: 2 },
+    ]);
+  });
+
+  it("clears all pins when given an empty array", async () => {
+    const ids = await insertTitles(3);
+    await pinAll(ids);
+
+    await reorderPinnedTitles(userId, []);
+
+    expect(await getPinnedTitles(userId)).toHaveLength(0);
+  });
+
+  it("clamps to MAX_PINNED when given 10 ids", async () => {
+    const ids = await insertTitles(10);
+    await pinAll(ids.slice(0, 8));
+
+    await reorderPinnedTitles(userId, ids);
+
+    const rows = await getPositions();
+    expect(rows).toHaveLength(8);
+    expect(rows).toEqual(ids.slice(0, 8).map((id, i) => ({ id, position: i })));
+    expect(await isPinnedTitle(userId, "movie-9")).toBe(false);
+    expect(await isPinnedTitle(userId, "movie-10")).toBe(false);
+  });
+});
+
+describe("getPinnedTitles", () => {
+  it("returns rows ordered by position", async () => {
+    const ids = await insertTitles(3);
+    await pinAll(ids);
+    await reorderPinnedTitles(userId, ["movie-2", "movie-3", "movie-1"]);
+
+    const rows = await getPinnedTitles(userId);
+    expect(rows.map((r) => r.id)).toEqual(["movie-2", "movie-3", "movie-1"]);
+    expect(rows.map((r) => r.position)).toEqual([0, 1, 2]);
+  });
+});
+
+describe("isPinnedTitle", () => {
+  it("returns true for a pinned title and false otherwise", async () => {
+    await insertTitles(2);
+    await pinTitle(userId, "movie-1");
+
+    expect(await isPinnedTitle(userId, "movie-1")).toBe(true);
+    expect(await isPinnedTitle(userId, "movie-2")).toBe(false);
+  });
+});

--- a/server/db/repository/pinned.ts
+++ b/server/db/repository/pinned.ts
@@ -1,4 +1,4 @@
-import { eq, and, asc, sql, max } from "drizzle-orm";
+import { eq, and, asc, gt, notInArray, sql, max } from "drizzle-orm";
 import { getDb, pinnedTitles, titles } from "../schema";
 import { traceDbQuery } from "../../tracing";
 
@@ -93,6 +93,16 @@ export async function unpinTitle(
   return traceDbQuery("unpinTitle", async () => {
     const db = getDb();
 
+    const pinned = await db
+      .select({ position: pinnedTitles.position })
+      .from(pinnedTitles)
+      .where(
+        and(eq(pinnedTitles.userId, userId), eq(pinnedTitles.titleId, titleId)),
+      )
+      .get();
+
+    if (!pinned) return;
+
     await db
       .delete(pinnedTitles)
       .where(
@@ -100,26 +110,17 @@ export async function unpinTitle(
       )
       .run();
 
-    // Renumber remaining rows
-    const remaining = await db
-      .select({ titleId: pinnedTitles.titleId })
-      .from(pinnedTitles)
-      .where(eq(pinnedTitles.userId, userId))
-      .orderBy(asc(pinnedTitles.position))
-      .all();
-
-    for (let i = 0; i < remaining.length; i++) {
-      await db
-        .update(pinnedTitles)
-        .set({ position: i })
-        .where(
-          and(
-            eq(pinnedTitles.userId, userId),
-            eq(pinnedTitles.titleId, remaining[i].titleId),
-          ),
-        )
-        .run();
-    }
+    // Close the gap: shift everything after the removed position down by one
+    await db
+      .update(pinnedTitles)
+      .set({ position: sql`${pinnedTitles.position} - 1` })
+      .where(
+        and(
+          eq(pinnedTitles.userId, userId),
+          gt(pinnedTitles.position, pinned.position),
+        ),
+      )
+      .run();
   });
 }
 
@@ -138,39 +139,35 @@ export async function reorderPinnedTitles(
     // Clamp to MAX_PINNED
     const ordered = titleIds.slice(0, MAX_PINNED);
 
-    // Delete any existing pinned rows not in the new ordered list
-    const existing = await db
-      .select({ titleId: pinnedTitles.titleId })
-      .from(pinnedTitles)
-      .where(eq(pinnedTitles.userId, userId))
-      .all();
-
-    const orderedSet = new Set(ordered);
-    for (const row of existing) {
-      if (!orderedSet.has(row.titleId)) {
-        await db
-          .delete(pinnedTitles)
-          .where(
-            and(
-              eq(pinnedTitles.userId, userId),
-              eq(pinnedTitles.titleId, row.titleId),
-            ),
-          )
-          .run();
-      }
-    }
-
-    // Upsert each title with its new position
-    for (let i = 0; i < ordered.length; i++) {
+    if (ordered.length === 0) {
       await db
-        .insert(pinnedTitles)
-        .values({ userId, titleId: ordered[i], position: i })
-        .onConflictDoUpdate({
-          target: [pinnedTitles.userId, pinnedTitles.titleId],
-          set: { position: i },
-        })
+        .delete(pinnedTitles)
+        .where(eq(pinnedTitles.userId, userId))
         .run();
+      return;
     }
+
+    // Delete any existing pinned rows not in the new ordered list
+    await db
+      .delete(pinnedTitles)
+      .where(
+        and(
+          eq(pinnedTitles.userId, userId),
+          notInArray(pinnedTitles.titleId, ordered),
+        ),
+      )
+      .run();
+
+    // Upsert all titles with their new positions in one statement.
+    // MAX_PINNED is 8, so this binds at most ~24 params — far below D1's 100 cap.
+    await db
+      .insert(pinnedTitles)
+      .values(ordered.map((titleId, i) => ({ userId, titleId, position: i })))
+      .onConflictDoUpdate({
+        target: [pinnedTitles.userId, pinnedTitles.titleId],
+        set: { position: sql`excluded.position` },
+      })
+      .run();
   });
 }
 


### PR DESCRIPTION
## Summary

- `unpinTitle` previously deleted the row and then renumbered every remaining pinned row with one `UPDATE` per row. It now SELECTs the position of the row to delete (returning early if not pinned, preserving the no-op semantics), DELETEs it, and closes the gap with a single bulk `UPDATE ... SET position = position - 1 WHERE user_id = ? AND position > ?`.
- `reorderPinnedTitles` previously ran a per-row delete loop plus a per-row upsert loop. It now clamps to `MAX_PINNED`, deletes all pins in one statement when given an empty array, and otherwise issues ONE `notInArray` DELETE for omitted rows plus ONE multi-row insert with `onConflictDoUpdate` using `excluded.position`. `MAX_PINNED` is 8, so the multi-row insert binds at most ~24 parameters — far below D1's 100-parameter cap.
- All exported signatures, return types, and `traceDbQuery` wrappers are unchanged. No transactions added (positions have no unique index on `(user_id, position)`, so there is no transient-conflict risk).

## Test plan

- [x] New `server/db/repository/pinned.test.ts` (14 tests) covering: sequential position assignment; 9th pin rejected (MAX_PINNED=8); re-pin no-op; unpin of middle/first/last item leaves dense 0..n-1 positions with order preserved; unpin of a non-pinned title is a no-op; reorder full permutation; reorder subset deletes omitted row; reorder inserts a brand-new titleId; reorder with empty array clears all pins; reorder with 10 ids clamps to 8; `getPinnedTitles` position ordering; `isPinnedTitle` true/false.
- [x] `bun test server/db/repository/pinned.test.ts server/routes/profile.test.ts` — 77 pass, 0 fail (profile.test.ts covers the pin/unpin/reorder HTTP endpoints)
- [x] `bun run check` — full pipeline green (type checks, lint, all tests, frontend build, wrangler dry-run, bundle-size budget)

Closes #992

🤖 Generated with [Claude Code](https://claude.com/claude-code)