### PR TITLE
perf(achievements): batch INSERT in appendUserAchievementEarns (#991)

### DIFF
--- a/server/db/repository/achievements.test.ts
+++ b/server/db/repository/achievements.test.ts
@@ -314,6 +314,27 @@ describe("appendUserAchievementEarns", () => {
     expect(row?.lastEarnedAt).toBe("2024-02-01T00:00:00.000Z");
   });
 
+  it("inserts all rows when earns exceed the insert chunk size", async () => {
+    const userId = await createUser("append-earns-chunk", "hash");
+    await upsertAchievementDef(makeAchievementDef("repeatable_key_chunk"));
+    await upsertUserAchievement(userId, "repeatable_key_chunk", 0, null);
+
+    // 45 earns spans 3 chunks of 20 (20 + 20 + 5)
+    const earns = Array.from({ length: 45 }, (_, i) => ({
+      earnedAt: `2024-01-01T00:00:${String(i).padStart(2, "0")}.000Z`,
+      context: { index: i },
+    }));
+    await appendUserAchievementEarns(userId, "repeatable_key_chunk", earns);
+
+    const history = await getEarnHistory(userId, "repeatable_key_chunk", 100);
+    expect(history).toHaveLength(45);
+
+    const rows = await getUserAchievements(userId);
+    const row = rows.find((r) => r.achievementKey === "repeatable_key_chunk");
+    expect(row?.earnedCount).toBe(45);
+    expect(row?.lastEarnedAt).toBe("2024-01-01T00:00:44.000Z");
+  });
+
   it("is a no-op when earns array is empty", async () => {
     const userId = await createUser("append-earns-2", "hash");
     await upsertAchievementDef(makeAchievementDef("repeatable_key_2"));

--- a/server/db/repository/achievements.ts
+++ b/server/db/repository/achievements.ts
@@ -233,6 +233,9 @@ export async function sumXpForUser(userId: string): Promise<number> {
   });
 }
 
+// D1 caps bound parameters at 100 per statement; 4 params per row -> 80 per chunk.
+const EARN_INSERT_CHUNK_SIZE = 20;
+
 /**
  * Insert new earn audit rows and bump earned_count + last_earned_at in user_achievements.
  */
@@ -249,15 +252,18 @@ export async function appendUserAchievementEarns(
       earns[0].earnedAt,
     );
 
-    for (const earn of earns) {
+    for (let i = 0; i < earns.length; i += EARN_INSERT_CHUNK_SIZE) {
+      const chunk = earns.slice(i, i + EARN_INSERT_CHUNK_SIZE);
       await db
         .insert(userAchievementEarns)
-        .values({
-          userId,
-          achievementKey: key,
-          earnedAt: earn.earnedAt,
-          context: earn.context ? JSON.stringify(earn.context) : null,
-        })
+        .values(
+          chunk.map((earn) => ({
+            userId,
+            achievementKey: key,
+            earnedAt: earn.earnedAt,
+            context: earn.context ? JSON.stringify(earn.context) : null,
+          })),
+        )
         .run();
     }
 


### PR DESCRIPTION
## Summary

- Replace the per-earn single-row insert loop in `appendUserAchievementEarns` (`server/db/repository/achievements.ts`) with a chunked multi-row insert: one `db.insert(...).values(chunk.map(...)).run()` per chunk instead of one statement per earn.
- Add module constant `EARN_INSERT_CHUNK_SIZE = 20` — 4 bound params per row -> 80 params per statement, safely under D1's 100-bound-parameter cap (comment style follows `server/db/repository/plex-library.ts`).
- Function signature and the trailing `user_achievements` count-bump UPDATE are unchanged.

## Test plan

- [x] New test in `server/db/repository/achievements.test.ts`: appending 45 earns in one call (spans 3 chunks of 20) inserts all 45 rows into `user_achievement_earns`, increments `earned_count` by 45, and sets `last_earned_at` to the maximum `earnedAt` of the batch.
- [x] `bun test server/db/repository/achievements.test.ts server/jobs/evaluate-achievements.test.ts` — 38 pass, 0 fail.
- [x] `bun run check` — full pipeline green (type checks, lint, all tests, frontend build, wrangler dry-run, bundle budget).

Closes #991

🤖 Generated with [Claude Code](https://claude.com/claude-code)