### PR TITLE
test(infra): centralized CONFIG snapshot guard + test-utils READMEs (#997)

### DIFF
--- a/frontend/src/test-utils/README.md
+++ b/frontend/src/test-utils/README.md
@@ -1,0 +1,89 @@
+# frontend/src/test-utils
+
+Shared infrastructure for the frontend `bun:test` suite
+(`@testing-library/react` + happy-dom).
+
+## `apiMock.ts` — the one and only `../api` mock
+
+`apiMock.ts` is a **complete** mock of every export of `frontend/src/api.ts`,
+registered once via `mock.module("../api", …)` with shared singleton mock
+functions. **No test file may declare its own `mock.module("../api", …)`** —
+partial or otherwise.
+
+Why it must be complete and shared: Bun does not reset `mock.module()`
+registrations between test files in a single `bun test` process, and there is
+no way to un-mock. On Linux CI (where test-file discovery order differs from
+local) a _partial_ `../api` mock declared in one file leaks globally into every
+other file, producing two failure modes:
+
+1. **Wrong-instance binding** — a component's live `import * as api` namespace
+   points at another file's mock, so resolved data / call counts are wrong.
+2. **Load-time `SyntaxError: Export named 'X' not found`** — a static
+   `import { X } from "../api"` (e.g. AuthContext's `getSubscriptions`) hits a
+   partial mock that omits `X`.
+
+Because this mock is complete, no static import ever fails; because the mock
+instances are shared singletons, it doesn't matter which file's binding
+"wins" — they all reference the same mocks.
+
+### Usage rules
+
+- **Import order**: import `apiMock` BEFORE importing the component/page under
+  test, so the mock is registered before the component binds its `../api`
+  namespace:
+
+  ```tsx
+  import { apiMock, resetApiMock } from "../test-utils/apiMock";
+  import { MyPage } from "./MyPage"; // AFTER apiMock
+  ```
+
+- **Per-test overrides** go on the shared instances:
+
+  ```ts
+  apiMock.getTrackedTitles.mockResolvedValue({ titles: [someTitle] });
+  ```
+
+- **`resetApiMock()` in `afterEach`** — resets call history AND restores every
+  default implementation, so per-test `mockResolvedValue` overrides don't bleed
+  into the next test:
+
+  ```ts
+  afterEach(() => {
+    cleanup();
+    resetApiMock();
+  });
+  ```
+
+- New exports added to `api.ts` must also be added to the `defaults` table in
+  `apiMock.ts` with a realistic empty-shape default.
+
+See the header comment in `apiMock.ts` for the full background.
+
+## `setup.ts` — happy-dom preload
+
+Preloaded for every frontend test run (see `frontend/bunfig.toml`). It registers
+happy-dom globals so `document`/`window` exist, then restores Bun's native
+`fetch`, `Request`, `Response`, `URL`, streams, etc. that happy-dom would
+otherwise overwrite. It also polyfills Vite define constants
+(`__APP_VERSION__`). Tests never import it directly.
+
+## TanStack Query convention
+
+Components under test that use `useQuery`/`useMutation` must be wrapped in a
+**fresh `QueryClient` per test** with retries disabled, so failures surface
+immediately instead of retrying, and no query cache leaks between tests:
+
+```tsx
+function makeClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+render(
+  <QueryClientProvider client={makeClient()}>
+    <MyComponent />
+  </QueryClientProvider>,
+);
+```
+
+See `frontend/src/components/CategoryBrowse.test.tsx` for a full example of
+all of the above together.

--- a/server/auth/better-auth-passkey.test.ts
+++ b/server/auth/better-auth-passkey.test.ts
@@ -1,12 +1,6 @@
-import {
-  describe,
-  it,
-  expect,
-  beforeEach,
-  afterAll,
-  afterEach,
-} from "bun:test";
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { withConfigGuard } from "../test-utils/config";
 import { getDb, passkey as passkeyTable, users } from "../db/schema";
 import { sql } from "drizzle-orm";
 import { createAuth, getPasskeyRpId, buildPasskeyOrigins } from "./better-auth";
@@ -151,21 +145,7 @@ describe("passkey support", () => {
   });
 
   describe("passkey RP ID derivation from BASE_URL", () => {
-    let originalBaseUrl: string;
-    let originalRpId: string;
-    let originalOrigin: string;
-
-    beforeEach(() => {
-      originalBaseUrl = CONFIG.BASE_URL;
-      originalRpId = CONFIG.PASSKEY_RP_ID;
-      originalOrigin = CONFIG.PASSKEY_ORIGIN;
-    });
-
-    afterEach(() => {
-      CONFIG.BASE_URL = originalBaseUrl;
-      CONFIG.PASSKEY_RP_ID = originalRpId;
-      CONFIG.PASSKEY_ORIGIN = originalOrigin;
-    });
+    withConfigGuard();
 
     it("derives rpID from BASE_URL when PASSKEY_RP_ID is not set", () => {
       CONFIG.BASE_URL = "https://remindarr.app";

--- a/server/auth/better-auth-signup.test.ts
+++ b/server/auth/better-auth-signup.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { withConfigGuard } from "../test-utils/config";
 import { createAuth } from "./better-auth";
 import { getDb } from "../db/schema";
 import { CONFIG } from "../config";
@@ -19,6 +20,7 @@ const platform: Platform = {
 };
 
 describe("better-auth signup", () => {
+  withConfigGuard();
   beforeAll(() => setupTestDb());
   afterAll(() => teardownTestDb());
 
@@ -55,31 +57,27 @@ describe("better-auth signup", () => {
   });
 
   test("sign-up succeeds from Vite dev proxy origin (:5173) when BASE_URL is unset", async () => {
-    const original = CONFIG.BASE_URL;
+    // withConfigGuard() restores CONFIG after this test.
     CONFIG.BASE_URL = "";
-    try {
-      const auth = createAuth(getDb(), platform);
-      const request = new Request(
-        "http://localhost:3000/api/auth/sign-up/email",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Origin: "http://localhost:5173",
-            "Sec-Fetch-Site": "same-origin",
-          },
-          body: JSON.stringify({
-            username: "viteuser",
-            email: "vite@example.com",
-            password: "password123",
-            name: "Vite User",
-          }),
+    const auth = createAuth(getDb(), platform);
+    const request = new Request(
+      "http://localhost:3000/api/auth/sign-up/email",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "http://localhost:5173",
+          "Sec-Fetch-Site": "same-origin",
         },
-      );
-      const response = await auth.handler(request);
-      expect(response.status).toBe(200);
-    } finally {
-      CONFIG.BASE_URL = original;
-    }
+        body: JSON.stringify({
+          username: "viteuser",
+          email: "vite@example.com",
+          password: "password123",
+          name: "Vite User",
+        }),
+      },
+    );
+    const response = await auth.handler(request);
+    expect(response.status).toBe(200);
   });
 });

--- a/server/test-utils/README.md
+++ b/server/test-utils/README.md
@@ -1,0 +1,86 @@
+# server/test-utils
+
+Shared helpers for the server-side `bun:test` suite. All server tests run in a
+single `bun test` process, so anything mutable that escapes a test file
+(module mocks, spies, singletons, `CONFIG`) leaks into every file that runs
+after it — these helpers exist to make that impossible for the common cases.
+
+## `setup.ts` — in-memory test database
+
+```ts
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+
+beforeEach(() => setupTestDb());
+afterAll(() => teardownTestDb());
+```
+
+- Importing `setup.ts` sets `CONFIG.DB_PATH = ":memory:"` as a module
+  side effect, so the test process can never touch a real database file.
+- `setupTestDb()` resets the DB singletons and initializes a fresh in-memory
+  SQLite database. The **first** call runs the full Drizzle migration chain and
+  caches a serialized snapshot of the migrated DB; every later call (across all
+  test files in the process) restores from that snapshot instead of replaying
+  migrations, which keeps the suite fast.
+- `teardownTestDb()` resets the singletons again.
+- Gotcha: never top-level-`await` a DB-dependent function in a test file — it
+  runs at module load, before any `beforeEach(setupTestDb)` hook has fired.
+
+## `fixtures.ts` — typed test data factories
+
+Factories for TMDB-shaped objects, each accepting a `Partial<T>` overrides
+argument: `makeParsedTitle`, `makeParsedOffer`, `makeTmdbMovieDetails`,
+`makeTmdbTvDetails`, `makeTmdbDiscoverMovie`, `makeTmdbDiscoverTv`,
+`makeTmdbSearchMultiMovie`, `makeTmdbSearchMultiTv`. Prefer these over inline
+object literals so shape changes only need fixing in one place.
+
+## `auth.ts` — authenticated requests
+
+`createTestSession(opts?)` creates a user + session in the test DB and returns
+`{ userId, token, cookieHeader }`. Pass `cookieHeader` to Hono's
+`app.request(path, { headers: { Cookie: cookieHeader } })` to exercise
+`requireAuth` / `requireAdmin` routes. Options: `username`, `isAdmin`,
+`authProvider`, `providerSubject`.
+
+## `config.ts` — CONFIG mutation guard
+
+**Rule: never mutate `CONFIG` in a test without `withConfigGuard()`.**
+
+`CONFIG` (from `server/config.ts`) is a process-wide mutable singleton. A test
+that sets `CONFIG.BASE_URL` and forgets to restore it silently changes behavior
+for every test that runs afterwards — including tests in _other files_, in an
+order that differs between local runs and Linux CI.
+
+```ts
+import { withConfigGuard } from "../test-utils/config";
+
+describe("my feature", () => {
+  withConfigGuard(); // snapshot before each test, restore after each test
+
+  it("uses a custom base URL", () => {
+    CONFIG.BASE_URL = "https://example.com"; // restored automatically
+    // ...
+  });
+});
+```
+
+- Calling `withConfigGuard()` inside a `describe` scopes the hooks to that
+  describe; calling it at file top level guards the whole file.
+- `snapshotConfig()` / `restoreConfig(snapshot)` are exported for the rare case
+  where you need manual control (e.g. inside a single hook).
+
+## Cache gotcha
+
+Routes that call `getCache()` (browse, details, search, …) throw
+`"Cache not initialized"` unless the test initializes the singleton first:
+
+```ts
+import { initCache } from "../cache";
+import { MemoryCache } from "../cache/memory";
+
+beforeEach(() => {
+  setupTestDb();
+  initCache(new MemoryCache(1000));
+});
+```
+
+See `server/routes/browse.test.ts` for the full pattern.

--- a/server/test-utils/config.test.ts
+++ b/server/test-utils/config.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from "bun:test";
+import { CONFIG } from "../config";
+import { snapshotConfig, restoreConfig, withConfigGuard } from "./config";
+
+const ORIGINAL_BASE_URL = CONFIG.BASE_URL;
+
+describe("withConfigGuard", () => {
+  withConfigGuard();
+
+  // These two tests are intentionally order-dependent: A mutates CONFIG and
+  // B verifies the guard restored it between tests.
+  test("A: a test can mutate CONFIG.BASE_URL", () => {
+    CONFIG.BASE_URL = "https://mutated.example.com";
+    expect(CONFIG.BASE_URL).toBe("https://mutated.example.com");
+  });
+
+  test("B: the mutation from A was restored by the guard", () => {
+    expect(CONFIG.BASE_URL).toBe(ORIGINAL_BASE_URL);
+  });
+});
+
+describe("snapshotConfig / restoreConfig", () => {
+  test("round-trips a direct mutation", () => {
+    const snapshot = snapshotConfig();
+    const original = CONFIG.BASE_URL;
+
+    CONFIG.BASE_URL = "https://round-trip.example.com";
+    expect(CONFIG.BASE_URL).not.toBe(original);
+
+    restoreConfig(snapshot);
+    expect(CONFIG.BASE_URL).toBe(original);
+  });
+});

--- a/server/test-utils/config.ts
+++ b/server/test-utils/config.ts
@@ -1,0 +1,35 @@
+import { beforeEach, afterEach } from "bun:test";
+import { CONFIG } from "../config";
+
+/** A full shallow snapshot of CONFIG, field for field. */
+export type ConfigSnapshot = {
+  [K in keyof typeof CONFIG]: (typeof CONFIG)[K];
+};
+
+/** Take a shallow copy of the current CONFIG. */
+export function snapshotConfig(): ConfigSnapshot {
+  return { ...CONFIG };
+}
+
+/** Write a previously taken snapshot back onto the live CONFIG object. */
+export function restoreConfig(snapshot: ConfigSnapshot): void {
+  Object.assign(CONFIG, snapshot);
+}
+
+/**
+ * Register beforeEach/afterEach hooks that snapshot CONFIG before every test
+ * and restore it after every test.
+ *
+ * Calling withConfigGuard() inside a `describe` scopes the hooks to that
+ * describe block; calling it at file top level guards the whole file. The
+ * point: direct CONFIG mutations can never leak across tests or files.
+ */
+export function withConfigGuard(): void {
+  let snapshot: ConfigSnapshot;
+  beforeEach(() => {
+    snapshot = snapshotConfig();
+  });
+  afterEach(() => {
+    restoreConfig(snapshot);
+  });
+}

--- a/server/worker.test.ts
+++ b/server/worker.test.ts
@@ -12,7 +12,7 @@ import {
 import { logger } from "./logger";
 import * as backendModule from "./jobs/backend";
 import * as schema from "./db/schema";
-import { CONFIG } from "./config";
+import { withConfigGuard } from "./test-utils/config";
 
 // ─── Scheduled handler cron-branching tests ───────────────────────────────────
 
@@ -271,13 +271,13 @@ describe("maybeDeferRegistrySync (#799 deferral contract)", () => {
 // ─── scheduled() writes cron_bootstrap_last_seen_at to CACHE_KV ──────────────
 
 describe("scheduled() bootstrap KV timestamp", () => {
+  // Guard CONFIG so patchConfigFromEnv mutations don't leak across files.
+  withConfigGuard();
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let spies: ReturnType<typeof spyOn<any, any>>[] = [];
-  let configSnapshot: typeof CONFIG;
 
   beforeEach(() => {
-    // Snapshot CONFIG so patchConfigFromEnv mutations don't leak across files.
-    configSnapshot = { ...CONFIG } as typeof CONFIG;
     // Stub out all heavy backend functions so scheduled() completes without a
     // real D1 DB or job infrastructure.
     spies = [
@@ -299,7 +299,6 @@ describe("scheduled() bootstrap KV timestamp", () => {
   afterEach(() => {
     for (const spy of spies) spy.mockRestore();
     spies = [];
-    Object.assign(CONFIG, configSnapshot);
   });
 
   it("puts cron_bootstrap_last_seen_at into CACHE_KV when the scheduled handler runs", async () => {


### PR DESCRIPTION
## Summary

Server-side half of the shared guard pattern for test mock/config leaks on Linux CI (the frontend half — the complete shared `apiMock.ts` — already landed in 286b0d3).

- **New `server/test-utils/config.ts`**: exports a `ConfigSnapshot` type (mapped from `typeof CONFIG`), `snapshotConfig()` (shallow copy), `restoreConfig(snapshot)` (`Object.assign` back onto the live CONFIG), and `withConfigGuard()` which registers `beforeEach`/`afterEach` hooks that snapshot CONFIG before each test and restore it after. Calling it inside a `describe` scopes the guard to that block; at file top level it guards the whole file — direct CONFIG mutations can never leak across tests or files.
- **Refactored the three hand-rolled snapshot/restore sites** to use the helper:
  - `server/worker.test.ts` — removed the manual `configSnapshot` variable and snapshot/`Object.assign` lines from the `scheduled() bootstrap KV timestamp` describe; the spy setup/restore plumbing is unchanged.
  - `server/auth/better-auth-passkey.test.ts` — replaced the per-field save/restore of `BASE_URL`/`PASSKEY_RP_ID`/`PASSKEY_ORIGIN` with `withConfigGuard()`.
  - `server/auth/better-auth-signup.test.ts` — dropped the inline `try/finally` save/restore of `BASE_URL`; the describe is now guarded.
- **New `server/test-utils/README.md`**: documents `setupTestDb`/`teardownTestDb` semantics (in-memory SQLite, cached migration snapshot), `fixtures.ts` and `auth.ts` helpers, the CONFIG-guard rule (never mutate CONFIG in a test without `withConfigGuard()`), and the `getCache()`/`initCache(new MemoryCache(...))` gotcha.
- **New `frontend/src/test-utils/README.md`**: documents why `apiMock.ts` is a COMPLETE module mock (bun `mock.module` leaks between test files on Linux CI; partial mocks corrupt other files), the import-order rule (apiMock before the component under test), `resetApiMock()` in `afterEach`, what `setup.ts` preloads, and the fresh-QueryClient-with-`retry: false`-per-test convention.

## Test plan

- New `server/test-utils/config.test.ts`: a guarded describe with two intentionally order-dependent tests (A mutates `CONFIG.BASE_URL`, B asserts the guard restored it) plus a direct `snapshotConfig`/`restoreConfig` round-trip test.
- Targeted run: `bun test server/test-utils server/worker.test.ts server/auth` — 90 pass, 0 fail.
- Full pipeline: `bun run check` — green end to end (format, server/e2e/frontend tsc, ESLint, 2160 server tests, frontend tests, build, wrangler dry-run, bundle budget gate).

Closes #997

🤖 Generated with [Claude Code](https://claude.com/claude-code)