### PR TITLE
perf(streaming-alerts): batch per-user queries in dispatch loop (#990)

### DIFF
--- a/server/db/repository/index.ts
+++ b/server/db/repository/index.ts
@@ -185,6 +185,7 @@ export {
   getDistinctNotifierTimezones,
   getEnabledNotifierSchedules,
   getStreamingAlertNotifiersForUser,
+  getStreamingAlertNotifiersForUsers,
 } from "./notifiers";
 
 export {
@@ -281,6 +282,7 @@ export type { IntegrationConfig, PlexConfig } from "./integrations";
 
 export {
   getUnalertedProviders,
+  getUnalertedProvidersBulk,
   markAlerted,
   getArrivalAlertedProviders,
 } from "./streaming-alerts";

--- a/server/db/repository/notifiers.ts
+++ b/server/db/repository/notifiers.ts
@@ -1,4 +1,4 @@
-import { eq, and, sql, asc } from "drizzle-orm";
+import { eq, and, sql, asc, inArray } from "drizzle-orm";
 import { getDb } from "../schema";
 import { notifiers } from "../schema";
 import { logger } from "../../logger";
@@ -406,5 +406,76 @@ export async function getStreamingAlertNotifiersForUser(userId: string) {
       }
       return { ...row, config };
     });
+  });
+}
+
+// D1 caps bound parameters per statement at 100.
+// Chunk at 50 IDs to stay safely under the cap.
+const STREAMING_NOTIFIERS_CHUNK_SIZE = 50;
+
+/**
+ * Bulk variant of getStreamingAlertNotifiersForUser for many users at once.
+ * Returns a Map from userId to that user's enabled streaming-alert notifiers;
+ * EVERY input userId is present as a key (empty array when none).
+ */
+export async function getStreamingAlertNotifiersForUsers(
+  userIds: string[],
+): Promise<
+  Map<
+    string,
+    Array<{
+      id: string;
+      user_id: string;
+      provider: string;
+      config: Record<string, string>;
+    }>
+  >
+> {
+  return traceDbQuery("getStreamingAlertNotifiersForUsers", async () => {
+    const result = new Map<
+      string,
+      Array<{
+        id: string;
+        user_id: string;
+        provider: string;
+        config: Record<string, string>;
+      }>
+    >();
+    for (const userId of userIds) {
+      result.set(userId, []);
+    }
+    if (userIds.length === 0) return result;
+
+    const db = getDb();
+    for (let i = 0; i < userIds.length; i += STREAMING_NOTIFIERS_CHUNK_SIZE) {
+      const chunk = userIds.slice(i, i + STREAMING_NOTIFIERS_CHUNK_SIZE);
+      const rows = await db
+        .select({
+          id: notifiers.id,
+          user_id: notifiers.userId,
+          provider: notifiers.provider,
+          config: notifiers.config,
+        })
+        .from(notifiers)
+        .where(
+          and(
+            inArray(notifiers.userId, chunk),
+            eq(notifiers.enabled, 1),
+            eq(notifiers.streamingAlertsEnabled, 1),
+          ),
+        )
+        .all();
+      for (const row of rows) {
+        let config: Record<string, string>;
+        try {
+          config = JSON.parse(row.config);
+        } catch {
+          log.warn("Failed to parse notifier config", { id: row.id });
+          config = {};
+        }
+        result.get(row.user_id)?.push({ ...row, config });
+      }
+    }
+    return result;
   });
 }

--- a/server/db/repository/streaming-alerts.test.ts
+++ b/server/db/repository/streaming-alerts.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeEach, afterAll } from "bun:test";
 import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
 import { createUser, upsertTitles } from "../repository";
 import { makeParsedTitle } from "../../test-utils/fixtures";
-import { getUnalertedProviders, markAlerted } from "./streaming-alerts";
+import {
+  getUnalertedProviders,
+  getUnalertedProvidersBulk,
+  markAlerted,
+} from "./streaming-alerts";
 
 let userId: string;
 const TITLE_ID = "movie-streaming-1";
@@ -62,6 +66,87 @@ describe("getUnalertedProviders", () => {
     // TITLE_ID has NOT been alerted for provider 8
     const result = await getUnalertedProviders(userId, TITLE_ID, [8]);
     expect(result).toContain(8);
+  });
+});
+
+describe("getUnalertedProvidersBulk", () => {
+  it("returns per-user unalerted providers when one user is partially alerted", async () => {
+    const otherUserId = await createUser("bulkuser2", "hash");
+    await markAlerted(userId, TITLE_ID, 8, "Netflix");
+
+    const result = await getUnalertedProvidersBulk(
+      [userId, otherUserId],
+      TITLE_ID,
+      [8, 119, 337],
+    );
+
+    expect(result.size).toBe(2);
+    expect(result.get(userId)).toEqual([119, 337]);
+    expect(result.get(otherUserId)).toEqual([8, 119, 337]);
+  });
+
+  it("returns an empty map when userIds is empty", async () => {
+    const result = await getUnalertedProvidersBulk([], TITLE_ID, [8, 119]);
+    expect(result.size).toBe(0);
+  });
+
+  it("maps every user to an empty array when providerIds is empty", async () => {
+    const otherUserId = await createUser("bulkuser3", "hash");
+    const result = await getUnalertedProvidersBulk(
+      [userId, otherUserId],
+      TITLE_ID,
+      [],
+    );
+    expect(result.size).toBe(2);
+    expect(result.get(userId)).toEqual([]);
+    expect(result.get(otherUserId)).toEqual([]);
+  });
+
+  it("is scoped per kind — departure alerts don't affect arrivals", async () => {
+    await markAlerted(userId, TITLE_ID, 8, "Netflix", "departure");
+    const arrivals = await getUnalertedProvidersBulk(
+      [userId],
+      TITLE_ID,
+      [8],
+      "arrival",
+    );
+    expect(arrivals.get(userId)).toEqual([8]);
+    const departures = await getUnalertedProvidersBulk(
+      [userId],
+      TITLE_ID,
+      [8],
+      "departure",
+    );
+    expect(departures.get(userId)).toEqual([]);
+  });
+
+  it("returns correct results for >60 users (userId chunking)", async () => {
+    // 50 providerIds → chunk size 47 (97 - 50), so 61 users span 2 chunks
+    const providerIds = Array.from({ length: 50 }, (_, i) => i + 1);
+    const userIds: string[] = [];
+    for (let i = 0; i < 61; i++) {
+      userIds.push(await createUser(`bulk-chunk-${i}`, "hash"));
+    }
+    // One alerted user in the first chunk, one in the second
+    await markAlerted(userIds[0], TITLE_ID, 1, "Provider 1");
+    await markAlerted(userIds[60], TITLE_ID, 2, "Provider 2");
+
+    const result = await getUnalertedProvidersBulk(
+      userIds,
+      TITLE_ID,
+      providerIds,
+    );
+
+    expect(result.size).toBe(61);
+    expect(result.get(userIds[0])).toEqual(
+      providerIds.filter((id) => id !== 1),
+    );
+    expect(result.get(userIds[60])).toEqual(
+      providerIds.filter((id) => id !== 2),
+    );
+    for (let i = 1; i < 60; i++) {
+      expect(result.get(userIds[i])).toEqual(providerIds);
+    }
   });
 });
 

--- a/server/db/repository/streaming-alerts.ts
+++ b/server/db/repository/streaming-alerts.ts
@@ -34,6 +34,65 @@ export async function getUnalertedProviders(
 }
 
 /**
+ * Bulk variant of getUnalertedProviders for many users at once. Returns, for
+ * EVERY input userId (each is present as a key even when fully alerted), the
+ * providerIds NOT yet alerted for the given (titleId, kind).
+ */
+export async function getUnalertedProvidersBulk(
+  userIds: string[],
+  titleId: string,
+  providerIds: number[],
+  kind: "arrival" | "departure" = "arrival",
+): Promise<Map<string, number[]>> {
+  return traceDbQuery("getUnalertedProvidersBulk", async () => {
+    // Seed every user with the full provider list; alerted pairs are
+    // subtracted below, so users with no alert rows keep all providers.
+    const pending = new Map<string, Set<number>>();
+    for (const userId of userIds) {
+      pending.set(userId, new Set(providerIds));
+    }
+
+    if (userIds.length > 0 && providerIds.length > 0) {
+      const db = getDb();
+      // D1 caps bound parameters at 100 per statement; titleId + kind take 2
+      // slots and providerIds take providerIds.length, so chunk the userIds
+      // to stay under the cap.
+      const chunkSize = Math.max(1, 97 - providerIds.length);
+      for (let i = 0; i < userIds.length; i += chunkSize) {
+        const chunk = userIds.slice(i, i + chunkSize);
+        const alreadyAlerted = await db
+          .select({
+            userId: streamingAlerts.userId,
+            providerId: streamingAlerts.providerId,
+          })
+          .from(streamingAlerts)
+          .where(
+            and(
+              eq(streamingAlerts.titleId, titleId),
+              eq(streamingAlerts.kind, kind),
+              inArray(streamingAlerts.userId, chunk),
+              inArray(streamingAlerts.providerId, providerIds),
+            ),
+          )
+          .all();
+        for (const row of alreadyAlerted) {
+          pending.get(row.userId)?.delete(row.providerId);
+        }
+      }
+    }
+
+    const result = new Map<string, number[]>();
+    for (const [userId, unalerted] of pending) {
+      result.set(
+        userId,
+        providerIds.filter((id) => unalerted.has(id)),
+      );
+    }
+    return result;
+  });
+}
+
+/**
  * Marks a (userId, titleId, providerId, kind) quadruple as alerted so we don't
  * send duplicate notifications.
  */

--- a/server/jobs/check-streaming-alerts.ts
+++ b/server/jobs/check-streaming-alerts.ts
@@ -2,9 +2,9 @@ import { logger } from "../logger";
 import {
   getOffersForTitles,
   getUsersTrackingTitles,
-  getUnalertedProviders,
+  getUnalertedProvidersBulk,
   markAlerted,
-  getStreamingAlertNotifiersForUser,
+  getStreamingAlertNotifiersForUsers,
   getTitleById,
   recordDelivery,
 } from "../db/repository";
@@ -40,6 +40,11 @@ export async function checkStreamingAlerts(titleIds: string[]): Promise<void> {
   );
   if (trackersByTitle.size === 0) return;
 
+  // Fetch notifiers once for the union of all tracking users instead of
+  // once per (title, user) pair
+  const allUserIds = [...new Set([...trackersByTitle.values()].flat())];
+  const notifiersByUser = await getStreamingAlertNotifiersForUsers(allUserIds);
+
   for (const [titleId, userIds] of trackersByTitle) {
     const titleOffers = offersByTitle.get(titleId) ?? [];
     const streamingProviders = titleOffers
@@ -60,18 +65,20 @@ export async function checkStreamingAlerts(titleIds: string[]): Promise<void> {
 
     const today = new Date().toISOString().slice(0, 10);
 
+    // 4. Find providers not yet alerted per user, in one query per title
+    const unalertedByUser = await getUnalertedProvidersBulk(
+      userIds,
+      titleId,
+      providerIds,
+      "arrival",
+    );
+
     for (const userId of userIds) {
-      // 4. Find providers not yet alerted for this (user, title)
-      const newProviderIds = await getUnalertedProviders(
-        userId,
-        titleId,
-        providerIds,
-        "arrival",
-      );
+      const newProviderIds = unalertedByUser.get(userId) ?? [];
       if (newProviderIds.length === 0) continue;
 
-      // 5. Get enabled streaming-alert notifiers for this user
-      const userNotifiers = await getStreamingAlertNotifiersForUser(userId);
+      // 5. Enabled streaming-alert notifiers for this user (prefetched above)
+      const userNotifiers = notifiersByUser.get(userId) ?? [];
 
       for (const pid of newProviderIds) {
         const provider = streamingProviders.find((sp) => sp.id === pid);

--- a/server/jobs/check-streaming-departures.ts
+++ b/server/jobs/check-streaming-departures.ts
@@ -2,9 +2,9 @@ import { logger } from "../logger";
 import {
   getOffersForTitles,
   getArrivalAlertedProviders,
-  getUnalertedProviders,
+  getUnalertedProvidersBulk,
   markAlerted,
-  getStreamingAlertNotifiersForUser,
+  getStreamingAlertNotifiersForUsers,
   getTitleById,
   getUserDepartureSettings,
   recordDelivery,
@@ -72,28 +72,43 @@ export async function checkStreamingDepartures(
     const trackersByTitle = await getUsersTrackingTitles([titleId]);
     const trackingUserIds = new Set(trackersByTitle.get(titleId) ?? []);
 
-    for (const [userId, departedProviders] of byUser) {
-      // Skip if user is no longer tracking this title
-      if (!trackingUserIds.has(userId)) continue;
+    const candidateUserIds = [...byUser.keys()].filter((id) =>
+      trackingUserIds.has(id),
+    );
+    if (candidateUserIds.length === 0) continue;
 
-      // 5. Check user's departure settings
+    // 5. Bulk-fetch unalerted departures and notifiers once per title instead
+    // of once per user. The bulk query uses the union of departed providers;
+    // each user's own departed set is intersected back in below.
+    const departedProviderIds = [
+      ...new Set(departedAlerts.map((a) => a.providerId)),
+    ];
+    const unalertedByUser = await getUnalertedProvidersBulk(
+      candidateUserIds,
+      titleId,
+      departedProviderIds,
+      "departure",
+    );
+    const notifiersByUser =
+      await getStreamingAlertNotifiersForUsers(candidateUserIds);
+
+    for (const userId of candidateUserIds) {
+      const departedProviders = byUser.get(userId) ?? [];
+
+      // 6. Check user's departure settings
       const userSettings = await getUserDepartureSettings(userId);
       if (!userSettings || userSettings.streamingDeparturesEnabled === 0)
         continue;
 
-      const providerIds = departedProviders.map((p) => p.providerId);
-
-      // 6. Find providers not yet alerted for departure for this (user, title)
-      const newProviderIds = await getUnalertedProviders(
-        userId,
-        titleId,
-        providerIds,
-        "departure",
+      // Find providers not yet alerted for departure for this (user, title)
+      const userDeparted = new Set(departedProviders.map((p) => p.providerId));
+      const newProviderIds = (unalertedByUser.get(userId) ?? []).filter((pid) =>
+        userDeparted.has(pid),
       );
       if (newProviderIds.length === 0) continue;
 
-      // 7. Get enabled streaming-alert notifiers for this user
-      const userNotifiers = await getStreamingAlertNotifiersForUser(userId);
+      // 7. Enabled streaming-alert notifiers for this user (prefetched above)
+      const userNotifiers = notifiersByUser.get(userId) ?? [];
 
       // 8. Fetch title info for the notification message
       const titleRow = await getTitleById(titleId);

--- a/server/jobs/streaming-alerts.test.ts
+++ b/server/jobs/streaming-alerts.test.ts
@@ -15,6 +15,7 @@ import {
   trackTitle,
   createNotifier,
   getUnalertedProviders,
+  markAlerted,
 } from "../db/repository";
 import { makeParsedTitle, makeParsedOffer } from "../test-utils/fixtures";
 
@@ -96,6 +97,85 @@ describe("getStreamingAlertNotifiersForUser", () => {
   });
 });
 
+describe("getStreamingAlertNotifiersForUsers", () => {
+  it("groups notifiers by user and maps missing users to an empty array", async () => {
+    const { getStreamingAlertNotifiersForUsers } =
+      await import("../db/repository/notifiers");
+    const userId2 = await createUser("bulknotifuser2", "hash");
+    const userId3 = await createUser("bulknotifuser3", "hash");
+    await createNotifier(
+      userId,
+      "discord",
+      "Discord",
+      { webhookUrl: "https://discord.com/api/webhooks/1/a" },
+      "09:00",
+      "UTC",
+    );
+    await createNotifier(
+      userId,
+      "telegram",
+      "Telegram",
+      { botToken: "t", chatId: "1" },
+      "09:00",
+      "UTC",
+    );
+    await createNotifier(
+      userId2,
+      "discord",
+      "Discord 2",
+      { webhookUrl: "https://discord.com/api/webhooks/2/b" },
+      "09:00",
+      "UTC",
+    );
+
+    const result = await getStreamingAlertNotifiersForUsers([
+      userId,
+      userId2,
+      userId3,
+    ]);
+    expect(result.size).toBe(3);
+    expect(result.get(userId)).toHaveLength(2);
+    expect(result.get(userId2)).toHaveLength(1);
+    expect(result.get(userId2)![0].provider).toBe("discord");
+    expect(result.get(userId2)![0].user_id).toBe(userId2);
+    // userId3 has no notifiers but must still be present as a key
+    expect(result.get(userId3)).toEqual([]);
+  });
+
+  it("excludes disabled notifiers and notifiers with streaming alerts off", async () => {
+    const { getStreamingAlertNotifiersForUsers, updateNotifier } =
+      await import("../db/repository/notifiers");
+    const disabledId = await createNotifier(
+      userId,
+      "discord",
+      "Disabled",
+      { webhookUrl: "https://discord.com/api/webhooks/1/a" },
+      "09:00",
+      "UTC",
+    );
+    await updateNotifier(disabledId, userId, { enabled: false });
+    const noAlertsId = await createNotifier(
+      userId,
+      "discord",
+      "No alerts",
+      { webhookUrl: "https://discord.com/api/webhooks/1/b" },
+      "09:00",
+      "UTC",
+    );
+    await updateNotifier(noAlertsId, userId, { streamingAlertsEnabled: false });
+
+    const result = await getStreamingAlertNotifiersForUsers([userId]);
+    expect(result.get(userId)).toEqual([]);
+  });
+
+  it("returns an empty map for empty input", async () => {
+    const { getStreamingAlertNotifiersForUsers } =
+      await import("../db/repository/notifiers");
+    const result = await getStreamingAlertNotifiersForUsers([]);
+    expect(result.size).toBe(0);
+  });
+});
+
 describe("streaming alert flow via sync", () => {
   it("marks providers as alerted after sync and does not re-alert on next sync", async () => {
     // Set up a title with a flatrate offer
@@ -157,6 +237,106 @@ describe("streaming alert flow via sync", () => {
     sendFn.mockClear();
     await checkStreamingAlerts([TITLE_ID]);
     expect(sendFn).toHaveBeenCalledTimes(0);
+  });
+
+  it("sends one alert per user when multiple users track the same title", async () => {
+    await upsertTitles([
+      makeParsedTitle({
+        id: TITLE_ID,
+        title: "New on Netflix",
+        offers: [
+          makeParsedOffer({
+            titleId: TITLE_ID,
+            providerId: PROVIDER_ID,
+            providerName: PROVIDER_NAME,
+            monetizationType: "FLATRATE",
+          }),
+        ],
+      }),
+    ]);
+
+    const userId2 = await createUser("streamalertuser2", "hash");
+    const userId3 = await createUser("streamalertuser3", "hash");
+
+    const sendFn = mock(async () => {});
+    spies.push(
+      spyOn(registry, "getProvider").mockReturnValue({
+        name: "discord",
+        send: sendFn,
+        validateConfig: () => ({ valid: true }),
+      } as any),
+    );
+
+    for (const uid of [userId, userId2, userId3]) {
+      await trackTitle(TITLE_ID, uid);
+      await createNotifier(
+        uid,
+        "discord",
+        "Discord",
+        { webhookUrl: "https://discord.com/api/webhooks/1/a" },
+        "09:00",
+        "UTC",
+      );
+    }
+
+    const { checkStreamingAlerts } = await import("./check-streaming-alerts");
+    await checkStreamingAlerts([TITLE_ID]);
+
+    expect(sendFn).toHaveBeenCalledTimes(3);
+
+    // Second run sends nothing — all users are now marked as alerted
+    sendFn.mockClear();
+    await checkStreamingAlerts([TITLE_ID]);
+    expect(sendFn).toHaveBeenCalledTimes(0);
+  });
+
+  it("skips users already alerted while still alerting the others", async () => {
+    await upsertTitles([
+      makeParsedTitle({
+        id: TITLE_ID,
+        title: "New on Netflix",
+        offers: [
+          makeParsedOffer({
+            titleId: TITLE_ID,
+            providerId: PROVIDER_ID,
+            providerName: PROVIDER_NAME,
+            monetizationType: "FLATRATE",
+          }),
+        ],
+      }),
+    ]);
+
+    const userId2 = await createUser("streamalertuser2", "hash");
+    const userId3 = await createUser("streamalertuser3", "hash");
+
+    const sendFn = mock(async () => {});
+    spies.push(
+      spyOn(registry, "getProvider").mockReturnValue({
+        name: "discord",
+        send: sendFn,
+        validateConfig: () => ({ valid: true }),
+      } as any),
+    );
+
+    for (const uid of [userId, userId2, userId3]) {
+      await trackTitle(TITLE_ID, uid);
+      await createNotifier(
+        uid,
+        "discord",
+        "Discord",
+        { webhookUrl: "https://discord.com/api/webhooks/1/a" },
+        "09:00",
+        "UTC",
+      );
+    }
+
+    // userId2 was already alerted for this provider
+    await markAlerted(userId2, TITLE_ID, PROVIDER_ID, PROVIDER_NAME);
+
+    const { checkStreamingAlerts } = await import("./check-streaming-alerts");
+    await checkStreamingAlerts([TITLE_ID]);
+
+    expect(sendFn).toHaveBeenCalledTimes(2);
   });
 
   it("does not alert when title has no flatrate/free offers", async () => {


### PR DESCRIPTION
## Summary

The streaming-alert dispatch loop issued one `getUnalertedProviders` and one `getStreamingAlertNotifiersForUser` query per (title, user) pair — an N+1 over users on every sync batch. This PR batches both lookups:

- **`getUnalertedProvidersBulk(userIds, titleId, providerIds, kind)`** (`server/db/repository/streaming-alerts.ts`): returns `Map<userId, number[]>` of providers not yet alerted for `(titleId, kind)`. Every input userId is present as a key. The result map is seeded with the full provider list per user, then alerted `(userId, providerId)` pairs are subtracted via chunked SELECTs; userIds are chunked with `Math.max(1, 97 - providerIds.length)` so each statement stays under the D1 100-bound-param cap (chunk + providerIds + titleId + kind ≤ 99). The existing per-user `getUnalertedProviders` is kept.
- **`getStreamingAlertNotifiersForUsers(userIds)`** (`server/db/repository/notifiers.ts`): returns `Map<userId, notifier[]>` with the same element shape, filters (`enabled=1`, `streamingAlertsEnabled=1`), and JSON-config parse-with-warning behavior as the per-user variant. One SELECT per chunk of 50 ids (same precedent as `XP_BATCH_CHUNK_SIZE`). Every input userId maps to a key (empty array when no notifiers).
- **`server/jobs/check-streaming-alerts.ts`**: notifiers are fetched once for the union of all tracking users before the per-title loop; unalerted providers are fetched once per title before the per-user loop. Reads use `?? []` defensively.
- **`server/jobs/check-streaming-departures.ts`**: **migrated** to both bulk functions as well — called once per title for the users still tracking it, using the union of departed provider ids and intersecting back with each user's own departed set inside the loop.

## Follow-ups (out of scope here)

- `markAlerted` writes remain per-row; write-batching is a possible follow-up.
- In the departures job, `getUserDepartureSettings` (per user) and `getTitleById` (per user) are still fetched inside the loop and could be batched/hoisted in a follow-up.

## Test plan

- `server/db/repository/streaming-alerts.test.ts`: `getUnalertedProvidersBulk` — two users with one partially alerted; empty `userIds` → empty map; empty `providerIds` → every user maps to `[]`; kind scoping; 61-user / 50-provider case exercising the chunk math across two chunks.
- `server/jobs/streaming-alerts.test.ts` (extended): 3 users tracking the same title each with an enabled notifier → provider `send` called 3 times; a second run sends 0; one user pre-alerted → only 2 sends. Plus `getStreamingAlertNotifiersForUsers`: groups rows by user, excludes disabled / streaming-alerts-off notifiers, missing user maps to empty array, empty input → empty map.
- `server/jobs/check-streaming-departures.test.ts`: existing suite passes unchanged against the migrated job.
- `bun run check` (full CI pipeline: type checks, lint, all tests, frontend build, wrangler dry-run) passes.

Closes #990

🤖 Generated with [Claude Code](https://claude.com/claude-code)