### PR TITLE
perf(tracked): add MAX_TRACKED_LOAD soft cap to getTrackedTitles (#994)

### DIFF
--- a/server/db/repository/tracked.test.ts
+++ b/server/db/repository/tracked.test.ts
@@ -15,6 +15,7 @@ import {
   getTrackedTitles,
   getReleasedUnwatchedTrackedMovies,
   getUpcomingTrackedMoviesOpen,
+  MAX_TRACKED_LOAD,
 } from "./tracked";
 import { getWatchedTitleIds } from "./watched-titles";
 import { getRawDb } from "../bun-db";
@@ -228,6 +229,49 @@ describe("getTrackedTitles show_status", () => {
     expect(show!.show_status).toBe("unreleased");
     expect(show!.released_episodes_count).toBe(0);
     expect(show!.total_episodes).toBe(0);
+  });
+});
+
+describe("getTrackedTitles soft cap", () => {
+  // Seed 5 tracked titles with distinct tracked_at values (cap-1 oldest .. cap-5 newest)
+  async function seedFiveTracked() {
+    const ids = ["cap-1", "cap-2", "cap-3", "cap-4", "cap-5"];
+    await upsertTitles(
+      ids.map((id) =>
+        makeParsedTitle({ id, objectType: "MOVIE", title: `Cap ${id}` }),
+      ),
+    );
+    const db = getRawDb();
+    for (const [i, id] of ids.entries()) {
+      await trackTitle(id, userId);
+      db.prepare(
+        `UPDATE tracked SET tracked_at = ? WHERE title_id = ? AND user_id = ?`,
+      ).run(`2024-01-0${i + 1} 00:00:00`, id, userId);
+    }
+    return ids;
+  }
+
+  it("returns at most opts.limit rows, keeping the most recently tracked", async () => {
+    await seedFiveTracked();
+
+    const results = await getTrackedTitles(userId, { limit: 3 });
+    expect(results).toHaveLength(3);
+    expect(results.map((r) => r.id)).toEqual(["cap-5", "cap-4", "cap-3"]);
+  });
+
+  it("returns all rows by default when under MAX_TRACKED_LOAD", async () => {
+    await seedFiveTracked();
+
+    const results = await getTrackedTitles(userId);
+    expect(MAX_TRACKED_LOAD).toBeGreaterThan(5);
+    expect(results).toHaveLength(5);
+    expect(results.map((r) => r.id)).toEqual([
+      "cap-5",
+      "cap-4",
+      "cap-3",
+      "cap-2",
+      "cap-1",
+    ]);
   });
 });
 

--- a/server/db/repository/tracked.ts
+++ b/server/db/repository/tracked.ts
@@ -2,9 +2,16 @@ import { eq, and, sql, desc, gte, lt, lte, asc, inArray } from "drizzle-orm";
 import { getDb } from "../schema";
 import { titles, scores, tracked, watchedTitles, ratings } from "../schema";
 import { traceDbQuery } from "../../tracing";
+import { logger } from "../../logger";
 import { getOffersWithPlex } from "./offers";
 import { getGenresForTitles } from "./titles";
 import { getTagsForUser } from "./tags";
+
+const log = logger.child({ module: "tracked-repo" });
+
+// Soft cap on rows loaded by getTrackedTitles — a safety net against unbounded
+// result sets, not pagination. Keeps the most recently tracked titles.
+export const MAX_TRACKED_LOAD = 1000;
 
 type ShowStatus =
   | "watching"
@@ -79,8 +86,12 @@ export async function getTrackedTitleIds(userId: string): Promise<Set<string>> {
   });
 }
 
-export async function getTrackedTitles(userId: string) {
+export async function getTrackedTitles(
+  userId: string,
+  opts: { limit?: number } = {},
+) {
   return traceDbQuery("getTrackedTitles", async () => {
+    const limit = opts.limit ?? MAX_TRACKED_LOAD;
     const db = getDb();
     const rows = await db
       .select({
@@ -138,7 +149,15 @@ export async function getTrackedTitles(userId: string) {
       .leftJoin(scores, eq(scores.titleId, titles.id))
       .where(eq(tracked.userId, userId))
       .orderBy(desc(tracked.trackedAt))
+      .limit(limit)
       .all();
+
+    if (rows.length >= limit) {
+      log.warn("getTrackedTitles hit soft cap; result truncated", {
+        userId,
+        limit,
+      });
+    }
 
     const titleIds = rows.map((r) => r.id);
     const [offersByTitle, genresByTitle, tagsByTitle] = await Promise.all([


### PR DESCRIPTION
## Summary

`getTrackedTitles()` loaded every tracked row for a user with no bound, so a pathological library size could blow up memory/latency (and the downstream offers/genres/tags fan-out). This PR adds a soft cap, per the decided scope of #994: **no pagination, no API contract change, no frontend change**.

- New exported constant `MAX_TRACKED_LOAD = 1000` in `server/db/repository/tracked.ts`.
- `getTrackedTitles(userId, opts: { limit?: number } = {})` — the `opts.limit` override exists so tests don't need to seed 1001 rows; `limit` defaults to `MAX_TRACKED_LOAD`.
- `.limit(limit)` appended to the main query. The query was **already ordered by `tracked.trackedAt` descending** (no ordering change was needed), so **the cap keeps the MOST RECENTLY tracked titles** and drops the oldest.
- When `rows.length >= limit`, a structured warning is emitted via `logger.child({ module: "tracked-repo" })`: `getTrackedTitles hit soft cap; result truncated` with `{ userId, limit }`, so truncation is observable in logs.

`MAX_TRACKED_LOAD = 1000` is a conservative safety net chosen over full pagination (per the issue discussion) — real libraries sit far below it, and the warning log tells us if anyone ever approaches it.

All existing callers (`server/routes/track.ts`, `server/routes/share.ts`, `server/routes/stats.ts`, `server/db/repository/profile.ts`, `server/index.ts`, `server/worker.ts` share-OG route) pass no opts and are unaffected.

## Test plan

- [x] New tests in `server/db/repository/tracked.test.ts`: seed 5 tracked titles with distinct `tracked_at` values; `getTrackedTitles(userId, { limit: 3 })` returns exactly 3, newest-first; default call returns all 5 newest-first (and asserts `MAX_TRACKED_LOAD > 5`).
- [x] `bun test server/db/repository/tracked.test.ts server/routes/track.test.ts` — 100 pass, 0 fail (soft-cap warning observed firing in the limit test).
- [x] `bun run check` — full CI pipeline (format, server/e2e/frontend tsc, ESLint, all tests, frontend build, wrangler dry-run, bundle budgets) green.

Closes #994

🤖 Generated with [Claude Code](https://claude.com/claude-code)