### PR TITLE
perf(worker): fast 404 for scanner probes + calendar.ics response cache (#999)

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -99,6 +99,7 @@ export const CONFIG = {
   CACHE_TTL_SEARCH: Number(process.env.CACHE_TTL_SEARCH) || 300,
   CACHE_TTL_DETAILS: Number(process.env.CACHE_TTL_DETAILS) || 86400,
   CACHE_TTL_BROWSE: Number(process.env.CACHE_TTL_BROWSE) || 900,
+  CACHE_TTL_FEED_ICS: Number(process.env.CACHE_TTL_FEED_ICS) || 300,
   CACHE_TTL_STREAMING: Number(process.env.CACHE_TTL_STREAMING) || 86400,
   CACHE_MAX_MEMORY_ENTRIES:
     Number(process.env.CACHE_MAX_MEMORY_ENTRIES) || 1000,

--- a/server/index.ts
+++ b/server/index.ts
@@ -54,6 +54,7 @@ import type { AppEnv } from "./types";
 import Sentry from "./sentry";
 import { logger, requestLogger } from "./logger";
 import { classifyError } from "./lib/error-classifier";
+import { isFileLikePath } from "./lib/spa-fallback";
 import { errorsByCategory } from "./metrics";
 import { registerSyncJobs } from "./jobs/sync";
 import { registerNotificationJobs } from "./jobs/notifications";
@@ -510,6 +511,12 @@ app.get("/share/watchlist/:token", async (c) => {
 
 // Serve frontend static files in production
 app.use("/*", serveStatic({ root: "./frontend/dist" }));
+// After the real-file serveStatic above, a file-like path (scanner probe) can
+// only be a 404 — fail fast instead of falling through to index.html below.
+app.use("/*", async (c, next) => {
+  if (isFileLikePath(c.req.path)) return c.text("Not Found", 404);
+  await next();
+});
 app.use("/*", serveStatic({ root: "./frontend/dist", path: "/index.html" }));
 
 // Start background job queue

--- a/server/lib/spa-fallback.test.ts
+++ b/server/lib/spa-fallback.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "bun:test";
+import { isFileLikePath } from "./spa-fallback";
+
+describe("isFileLikePath", () => {
+  it("returns true for scanner-probe file paths", () => {
+    expect(isFileLikePath("/.env")).toBe(true);
+    expect(isFileLikePath("/wp-login.php")).toBe(true);
+    expect(isFileLikePath("/serviceAccount.json")).toBe(true);
+    expect(isFileLikePath("/foo/bar.php")).toBe(true);
+  });
+
+  it("returns false for SPA routes without dots", () => {
+    expect(isFileLikePath("/")).toBe(false);
+    expect(isFileLikePath("/settings")).toBe(false);
+  });
+
+  it("returns false for routes where the last segment has no dot", () => {
+    expect(isFileLikePath("/title/movie-123")).toBe(false);
+  });
+
+  it("returns false for username routes even when usernames contain dots", () => {
+    expect(isFileLikePath("/u/john.doe")).toBe(false);
+    expect(isFileLikePath("/user/john.doe")).toBe(false);
+    expect(isFileLikePath("/u/alice/achievements")).toBe(false);
+  });
+});

--- a/server/lib/spa-fallback.ts
+++ b/server/lib/spa-fallback.ts
@@ -1,0 +1,21 @@
+/**
+ * Heuristic for the SPA fallback: does this path look like a request for a
+ * static file rather than a client-side route?
+ *
+ * On Cloudflare, real static assets never reach the worker — Workers Assets
+ * serves them platform-side and wrangler.toml sets
+ * `not_found_handling = "none"` — so a file-like path that reaches the SPA
+ * fallback (e.g. a scanner probing /.env or /wp-login.php) is a guaranteed
+ * 404. Returning 404 immediately skips the index.html asset fetch, saving a
+ * KV round-trip per scanner probe. Under Bun the equivalent middleware sits
+ * after the real-file serveStatic, so the same guarantee holds.
+ *
+ * Paths under /u/ and /user/ are exempt: better-auth usernames may contain
+ * dots, and /user/:username plus /u/:username/... are real SPA routes (see
+ * frontend/src/App.tsx).
+ */
+export function isFileLikePath(path: string): boolean {
+  if (path.startsWith("/u/") || path.startsWith("/user/")) return false;
+  const lastSegment = path.slice(path.lastIndexOf("/") + 1);
+  return lastSegment.includes(".");
+}

--- a/server/routes/feed.test.ts
+++ b/server/routes/feed.test.ts
@@ -10,6 +10,8 @@ import {
   trackTitle,
 } from "../db/repository";
 import { requireAuth } from "../middleware/auth";
+import { initCache } from "../cache";
+import { MemoryCache } from "../cache/memory";
 import feedApp from "./feed";
 import type { AppEnv } from "../types";
 
@@ -43,6 +45,7 @@ let userId: string;
 
 beforeEach(async () => {
   setupTestDb();
+  initCache(new MemoryCache(1000));
 
   userId = await createUser("feeduser", "hash");
   userToken = await createSession(userId);
@@ -124,6 +127,99 @@ describe("GET /feed/calendar.ics", () => {
     const body = await feedRes.text();
     expect(body).toContain("Future Movie");
     expect(body).toContain(`remindarr-movie-movie-future@remindarr`);
+  });
+
+  it("serves the cached body on repeat requests within the TTL", async () => {
+    const tokenRes = await app.request("/feed/token/regenerate", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    const { token } = (await tokenRes.json()) as { token: string };
+
+    const futureDate = new Date();
+    futureDate.setDate(futureDate.getDate() + 10);
+    const releaseDate = futureDate.toISOString().slice(0, 10);
+
+    await upsertTitles([
+      makeParsedTitle({
+        id: "movie-cache-1",
+        objectType: "MOVIE",
+        title: "Cached Movie One",
+        releaseDate,
+      }),
+    ]);
+    await trackTitle("movie-cache-1", userId);
+
+    const firstRes = await app.request(`/feed/calendar.ics?token=${token}`);
+    expect(firstRes.status).toBe(200);
+    const firstBody = await firstRes.text();
+    expect(firstBody).toContain("Cached Movie One");
+
+    // Track another title — a fresh build would include it, the cache won't
+    await upsertTitles([
+      makeParsedTitle({
+        id: "movie-cache-2",
+        objectType: "MOVIE",
+        title: "Cached Movie Two",
+        releaseDate,
+      }),
+    ]);
+    await trackTitle("movie-cache-2", userId);
+
+    const secondRes = await app.request(`/feed/calendar.ics?token=${token}`);
+    expect(secondRes.status).toBe(200);
+    expect(secondRes.headers.get("Content-Type")).toContain("text/calendar");
+    const secondBody = await secondRes.text();
+    expect(secondBody).toBe(firstBody);
+    expect(secondBody).not.toContain("Cached Movie Two");
+  });
+
+  it("isolates cached feeds between different users", async () => {
+    const tokenRes = await app.request("/feed/token/regenerate", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    const { token: tokenA } = (await tokenRes.json()) as { token: string };
+
+    const otherUserId = await createUser("otherfeeduser", "hash");
+    const otherSession = await createSession(otherUserId);
+    const tokenResB = await app.request("/feed/token/regenerate", {
+      method: "POST",
+      headers: { Cookie: `better-auth.session_token=${otherSession}` },
+    });
+    const { token: tokenB } = (await tokenResB.json()) as { token: string };
+
+    const futureDate = new Date();
+    futureDate.setDate(futureDate.getDate() + 10);
+    const releaseDate = futureDate.toISOString().slice(0, 10);
+
+    await upsertTitles([
+      makeParsedTitle({
+        id: "movie-user-a",
+        objectType: "MOVIE",
+        title: "User A Movie",
+        releaseDate,
+      }),
+      makeParsedTitle({
+        id: "movie-user-b",
+        objectType: "MOVIE",
+        title: "User B Movie",
+        releaseDate,
+      }),
+    ]);
+    await trackTitle("movie-user-a", userId);
+    await trackTitle("movie-user-b", otherUserId);
+
+    const resA = await app.request(`/feed/calendar.ics?token=${tokenA}`);
+    const bodyA = await resA.text();
+    const resB = await app.request(`/feed/calendar.ics?token=${tokenB}`);
+    const bodyB = await resB.text();
+
+    expect(bodyA).toContain("User A Movie");
+    expect(bodyA).not.toContain("User B Movie");
+    expect(bodyB).toContain("User B Movie");
+    expect(bodyB).not.toContain("User A Movie");
+    expect(bodyA).not.toBe(bodyB);
   });
 });
 

--- a/server/routes/feed.ts
+++ b/server/routes/feed.ts
@@ -8,6 +8,8 @@ import {
 } from "../db/repository";
 import { requireAuth } from "../middleware/auth";
 import type { AppEnv } from "../types";
+import { getCache } from "../cache";
+import { CONFIG } from "../config";
 
 const app = new Hono<AppEnv>();
 
@@ -97,19 +99,21 @@ function buildMovieVEvents(
   return lines;
 }
 
+// Shared by fresh and cached responses — Cache-Control stays "no-cache,
+// no-store" because the feed cache is a server-side compute cache; client
+// caching semantics are unchanged.
+const ICS_HEADERS: Record<string, string> = {
+  "Content-Type": "text/calendar; charset=utf-8",
+  "Content-Disposition": 'attachment; filename="remindarr.ics"',
+  "Cache-Control": "no-cache, no-store",
+};
+
 function buildIcsResponse(lines: string[]): {
   body: string;
   headers: Record<string, string>;
 } {
   const body = lines.join("\r\n") + "\r\n";
-  return {
-    body,
-    headers: {
-      "Content-Type": "text/calendar; charset=utf-8",
-      "Content-Disposition": 'attachment; filename="remindarr.ics"',
-      "Cache-Control": "no-cache, no-store",
-    },
-  };
+  return { body, headers: ICS_HEADERS };
 }
 
 // GET /api/feed/calendar.ics?token=<token>  (public, token-authenticated)
@@ -119,6 +123,13 @@ app.get("/calendar.ics", async (c) => {
 
   const user = await getUserByFeedToken(token);
   if (!user) return c.json({ error: "Invalid token" }, 401);
+
+  // Keyed by user id (not the raw token) so token regeneration keeps the entry
+  const cacheKey = `feed:ics:calendar:${user.id}`;
+  const cached = await getCache().get<string>(cacheKey);
+  if (cached !== null) {
+    return c.body(cached, 200, ICS_HEADERS);
+  }
 
   const today = new Date().toISOString().slice(0, 10);
   const endDate = addDays(today, 90);
@@ -136,6 +147,7 @@ app.get("/calendar.ics", async (c) => {
   ];
 
   const { body, headers } = buildIcsResponse(lines);
+  await getCache().set(cacheKey, body, CONFIG.CACHE_TTL_FEED_ICS);
   return c.body(body, 200, headers);
 });
 

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -100,6 +100,7 @@ import type { AppEnv } from "./types";
 import { logger, requestLogger, resetLogLevel } from "./logger";
 import { patchConfig, CONFIG } from "./config";
 import { classifyError } from "./lib/error-classifier";
+import { isFileLikePath } from "./lib/spa-fallback";
 import { errorsByCategory } from "./metrics";
 import Sentry from "./sentry";
 import {
@@ -699,6 +700,11 @@ function createApp(env: Env) {
     // Skip API paths that weren't matched by any route
     if (c.req.path.startsWith("/api/")) {
       return c.json({ error: "Not found" }, 404);
+    }
+    // File-like paths (scanner probes) are guaranteed 404s here — real assets
+    // never reach the worker. Skip the index.html fetch (saves a KV round-trip).
+    if (isFileLikePath(c.req.path)) {
+      return c.text("Not Found", 404);
     }
     try {
       const assets = (c.env as unknown as Env).ASSETS;


### PR DESCRIPTION
## Summary

Follow-up to the p95 latency regression monitor issue. Two of the four suspected causes were already fixed before this PR:

- **TMDB timeout**: `server/tmdb/client.ts` already uses an AbortController with a 5s timeout (`CONFIG.TMDB_API_TIMEOUT_MS = 5000`).
- **Session lookups**: better-auth session `cookieCache` (60s) was enabled in commit 8e5a970.

This PR addresses the remaining two:

### A — Fast 404 for scanner-probe paths in the SPA fallback
- New `server/lib/spa-fallback.ts` exporting `isFileLikePath()`: a path whose last segment contains a dot (`/.env`, `/wp-login.php`, `/serviceAccount.json`, `/foo/bar.php`) is file-like; paths under `/u/` and `/user/` are exempt because better-auth usernames may contain dots and those are real SPA routes.
- `server/worker.ts`: the SPA fallback returns 404 immediately for file-like paths before the `assets.fetch` call. On Cloudflare, real static assets never reach the worker (Workers Assets serves them platform-side; `wrangler.toml` sets `not_found_handling = "none"`), so a file-like path reaching the fallback is a guaranteed 404 — skipping the index.html fetch saves a KV round-trip per scanner probe.
- `server/index.ts` (Bun parity): a middleware between the real-file `serveStatic` and the index.html-fallback `serveStatic` fast-404s the same paths.

### B — Server-side response cache for `calendar.ics`
- New `CONFIG.CACHE_TTL_FEED_ICS` (default **300s**, override via `CACHE_TTL_FEED_ICS` env var).
- `GET /api/feed/calendar.ics` caches the built ICS body keyed by `feed:ics:calendar:<user.id>` (user id, not the raw token). Invalid/missing tokens still 401 without touching the cache.
- ICS response headers hoisted to a shared constant so cached and fresh paths return identical headers; client-facing `Cache-Control: no-cache, no-store` is unchanged — this is purely a server-side compute cache.
- Follow-up candidate (not in this PR): apply the same caching to `episodes.ics` and `releases.ics`.

Future health sweeps will re-detect this if p95 remains elevated.

## Test plan

- New `server/lib/spa-fallback.test.ts`: file-like (`/.env`, `/wp-login.php`, `/serviceAccount.json`, `/foo/bar.php`) vs SPA routes (`/`, `/settings`, `/title/movie-123`) vs dotted-username routes (`/u/john.doe`, `/user/john.doe`, `/u/alice/achievements`). Deliberately a pure-function test file, not in `worker.test.ts`.
- `server/routes/feed.test.ts`: added `initCache(new MemoryCache(...))` (the route now requires a cache); new cases for (1) repeat request returning the byte-identical cached body even after tracking another title, (2) per-user cache isolation, (3) existing 401 tests unchanged (auth happens before the cache).
- `bun test server/lib/spa-fallback.test.ts server/routes/feed.test.ts server/worker.test.ts` — 40 pass / 0 fail.
- `bun run check` (full pipeline: format, tsc x3, ESLint, all tests, frontend build, wrangler dry-run, bundle budget) — green.

Closes #999

🤖 Generated with [Claude Code](https://claude.com/claude-code)