### PR TITLE
fix(profile): distinguish 404 from network/server errors on UserProfilePage (#998)

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -39,6 +39,7 @@ import type {
   StreakData,
   CollectionDetails,
 } from "./types";
+import { ApiError } from "./lib/api-error";
 
 const BASE = "/api";
 
@@ -51,11 +52,14 @@ async function doFetch(url: string, options: RequestInit): Promise<Response> {
   const res = await fetch(`${BASE}${url}`, options);
   if (res.status === 401) {
     window.dispatchEvent(new CustomEvent("auth:unauthorized"));
-    throw new Error("Authentication required");
+    throw new ApiError("Authentication required", 401);
   }
   if (!res.ok) {
     const err = await res.json().catch(() => ({ error: res.statusText }));
-    throw new Error(err.error || `Request failed: ${res.status}`);
+    throw new ApiError(
+      err.error || `Request failed: ${res.status}`,
+      res.status,
+    );
   }
   return res;
 }

--- a/frontend/src/lib/api-error.ts
+++ b/frontend/src/lib/api-error.ts
@@ -1,0 +1,18 @@
+/**
+ * Typed error thrown by the API client for non-OK responses, carrying the HTTP
+ * status so callers can distinguish e.g. 404 from server/network failures.
+ *
+ * This class lives OUTSIDE `api.ts` because `frontend/src/test-utils/apiMock.ts`
+ * replaces the ENTIRE `../api` module under test, which would shadow a class
+ * exported from `api.ts` and break `instanceof ApiError` checks. Do not export
+ * or re-export ApiError from `api.ts`.
+ */
+export class ApiError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -359,6 +359,7 @@
     "tvShows": "TV Shows",
     "noTitles": "No titles tracked yet.",
     "userNotFound": "User not found",
+    "loadFailed": "Failed to load profile",
     "watchlist": "Watchlist",
     "watchlistHidden": "This user's watchlist is private.",
     "watchlistFriendsOnly": "This watchlist is only visible to mutual followers.",
@@ -618,7 +619,8 @@
     "save": "Save",
     "saving": "Saving...",
     "cancel": "Cancel",
-    "optional": "optional"
+    "optional": "optional",
+    "retry": "Retry"
   },
   "feed": {
     "title": "Calendar Feed",

--- a/frontend/src/pages/UserProfilePage.test.tsx
+++ b/frontend/src/pages/UserProfilePage.test.tsx
@@ -1,0 +1,200 @@
+import {
+  describe,
+  it,
+  expect,
+  mock,
+  beforeEach,
+  afterEach,
+  spyOn,
+} from "bun:test";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  cleanup,
+} from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Routes, Route } from "react-router";
+// apiMock must be imported BEFORE the page component so the complete `../api`
+// mock is registered before the component binds its api namespace.
+import { apiMock, resetApiMock } from "../test-utils/apiMock";
+import "../i18n";
+import * as AuthContextModule from "../context/AuthContext";
+import { ApiError } from "../lib/api-error";
+import type { UserProfileResponse } from "../types";
+
+const { default: UserProfilePage } = await import("./UserProfilePage");
+
+function newTestClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, retryDelay: 0 },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function renderPage() {
+  return render(
+    <QueryClientProvider client={newTestClient()}>
+      <MemoryRouter initialEntries={["/user/alice"]}>
+        <Routes>
+          <Route path="/user/:username" element={<UserProfilePage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+const profileFixture: UserProfileResponse = {
+  user: {
+    id: "u2",
+    username: "alice",
+    display_name: "Alice",
+    image: null,
+    member_since: null,
+    bio: null,
+    country_code: null,
+  },
+  stats: {
+    tracked_count: 0,
+    watched_movies: 0,
+    watched_episodes: 0,
+    shows_completed: 0,
+    shows_total: 0,
+    total_watched_episodes: 0,
+    total_released_episodes: 0,
+  },
+  overview: {
+    tracked_count: 0,
+    watched_movies: 0,
+    watched_episodes: 0,
+    shows_completed: 0,
+    shows_total: 0,
+    total_watched_episodes: 0,
+    total_released_episodes: 0,
+    tracked_movies: 0,
+    tracked_shows: 0,
+    watch_time_minutes: 0,
+    watch_time_minutes_movies: 0,
+    watch_time_minutes_shows: 0,
+  },
+  genres: [],
+  monthly: [],
+  shows_by_status: {
+    watching: 0,
+    caught_up: 0,
+    completed: 0,
+    not_started: 0,
+    unreleased: 0,
+    on_hold: 0,
+    dropped: 0,
+    plan_to_watch: 0,
+  },
+  friends: [],
+  movies: [],
+  shows: [],
+  show_watchlist: false,
+  profile_visibility: "public",
+  activity_stream_enabled: false,
+  is_own_profile: false,
+  backdrops: [],
+  follower_count: 0,
+  following_count: 0,
+  is_following: false,
+  pinned: [],
+};
+
+let spies: ReturnType<typeof spyOn>[] = [];
+
+beforeEach(() => {
+  spies = [
+    spyOn(AuthContextModule, "useAuth").mockReturnValue({
+      user: {
+        id: "u1",
+        username: "testuser",
+        display_name: null,
+        auth_provider: "local",
+        is_admin: false,
+      },
+      providers: { local: true, oidc: null },
+      loading: false,
+      sessionStatus: "authenticated",
+      subscriptions: null,
+      refreshSubscriptions: mock(() => Promise.resolve()),
+      login: mock(() => Promise.resolve()),
+      signup: mock(() => Promise.resolve()),
+      logout: mock(() => Promise.resolve()),
+      refresh: mock(() => Promise.resolve()),
+    }),
+  ];
+});
+
+afterEach(() => {
+  cleanup();
+  resetApiMock();
+  for (const spy of spies) spy.mockRestore();
+  spies = [];
+});
+
+describe("UserProfilePage error handling", () => {
+  it("renders 'User not found' without a Retry button on 404", async () => {
+    apiMock.getUserProfile.mockImplementation(() =>
+      Promise.reject(new ApiError("User not found", 404)),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("User not found")).toBeDefined();
+    });
+    expect(screen.queryByText("Retry")).toBeNull();
+    expect(screen.queryByText("Failed to load profile")).toBeNull();
+  });
+
+  it("renders 'Failed to load profile' with a Retry button on 500", async () => {
+    apiMock.getUserProfile.mockImplementation(() =>
+      Promise.reject(new ApiError("Internal server error", 500)),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to load profile")).toBeDefined();
+    });
+    expect(screen.getByText("Retry")).toBeDefined();
+    expect(screen.queryByText("User not found")).toBeNull();
+  });
+
+  it("refetches the profile when Retry is clicked and renders it on success", async () => {
+    // The page's query retries non-404 errors once, so the first TWO calls
+    // must fail for the error UI to appear; later calls succeed.
+    let calls = 0;
+    apiMock.getUserProfile.mockImplementation(() => {
+      calls += 1;
+      if (calls <= 2) {
+        return Promise.reject(new ApiError("Internal server error", 500));
+      }
+      return Promise.resolve(profileFixture);
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Retry")).toBeDefined();
+    });
+    const callsBeforeRetry = apiMock.getUserProfile.mock.calls.length;
+
+    fireEvent.click(screen.getByText("Retry"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("profile-hero")).toBeDefined();
+    });
+    expect(apiMock.getUserProfile.mock.calls.length).toBeGreaterThan(
+      callsBeforeRetry,
+    );
+    expect(screen.getByText("@alice")).toBeDefined();
+    expect(screen.queryByText("Failed to load profile")).toBeNull();
+  });
+});

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -3,6 +3,7 @@ import { Card } from "../components/ui/card";
 import { Link, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import * as api from "../api";
+import { ApiError } from "../lib/api-error";
 import type { PinnedTitle } from "../types";
 import { useAuth } from "../context/AuthContext";
 import ProfileHero from "../components/profile/ProfileHero";
@@ -32,11 +33,16 @@ export default function UserProfilePage() {
   const {
     data,
     isLoading: loading,
-    isError: error,
+    isError,
+    error,
+    refetch,
   } = useQuery({
     queryKey: ["user-profile", username],
     queryFn: ({ signal }) => api.getUserProfile(username!, signal),
     enabled: !!username,
+    // A 404 is definitive — retrying won't make the user exist.
+    retry: (failureCount, err) =>
+      !(err instanceof ApiError && err.status === 404) && failureCount < 1,
   });
 
   const isOwnProfileQuery = currentUser?.username === username;
@@ -86,10 +92,24 @@ export default function UserProfilePage() {
     );
   }
 
-  if (error || !data) {
+  if (isError || !data) {
+    const notFound = error instanceof ApiError && error.status === 404;
     return (
       <div className="max-w-7xl mx-auto py-12 text-center">
-        <p className="text-zinc-400 text-lg">{t("userProfile.userNotFound")}</p>
+        <p className="text-zinc-400 text-lg">
+          {notFound
+            ? t("userProfile.userNotFound")
+            : t("userProfile.loadFailed")}
+        </p>
+        {!notFound && (
+          <button
+            type="button"
+            onClick={() => void refetch()}
+            className="inline-block mt-4 px-4 py-2 rounded-xl bg-amber-500 hover:bg-amber-400 text-black font-semibold text-sm transition-colors cursor-pointer"
+          >
+            {t("common.retry")}
+          </button>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## Summary

`UserProfilePage` rendered "User not found" for **every** profile query failure — a 500, a network blip, and a genuinely missing user all looked identical. The root cause was that `doFetch` in `frontend/src/api.ts` threw plain `Error` with no status attached (the issue text claimed a `status` property already existed — it did not).

- **New `frontend/src/lib/api-error.ts`**: `ApiError extends Error` carrying a readonly `status`. It deliberately lives outside `api.ts` because `frontend/src/test-utils/apiMock.ts` replaces the entire `../api` module under test, which would shadow a class exported from `api.ts` and break `instanceof` checks. It is not exported or re-exported from `api.ts`.
- **`api.ts` / `doFetch`**: both throw sites now throw `ApiError` with the same messages as before plus the status (401 for the auth case, `res.status` for the generic case). The 401 `auth:unauthorized` window event dispatch is unchanged.
- **`UserProfilePage.tsx`**: shows `userProfile.userNotFound` only when the error is an `ApiError` with status 404; any other failure renders a new `userProfile.loadFailed` message plus a Retry button wired to `refetch()`. The query also skips retries on 404 (retrying won't make the user exist).
- **Locales**: added `userProfile.loadFailed` ("Failed to load profile") and `common.retry` ("Retry") to `en.json`.
- Audited all `frontend/src` catch sites: none match on error message text or `Error` constructor identity — they all use `instanceof Error`, which the subclass satisfies; `err.name` checks (`AbortError`/`NotAllowedError`) target browser API errors and are unaffected.

## Test plan

- [x] New `frontend/src/pages/UserProfilePage.test.tsx` (none existed):
  - 404 `ApiError` → renders "User not found" and **no** Retry button
  - 500 `ApiError` → renders "Failed to load profile" **and** a Retry button, and does **not** render the not-found text
  - Clicking Retry refetches `getUserProfile`; the subsequent call resolves a minimal profile fixture and the profile renders
- [x] Full frontend suite (`bun test src/` — 1110 pass) since `api.ts` changed
- [x] `bun run check` (full CI pipeline: format, tsc x3, ESLint, all tests, build, wrangler dry-run, bundle budget) — green

Closes #998

🤖 Generated with [Claude Code](https://claude.com/claude-code)