### PR TITLE
fix(jobs): drive DO jobs from watchdog /tick — CF alarms dead since migration

### DIFF
--- a/server/jobs/backend.test.ts
+++ b/server/jobs/backend.test.ts
@@ -25,6 +25,8 @@ import { runWithDb } from "../db/schema";
 import * as processorModule from "./processor";
 import {
   armCron,
+  tickCron,
+  triggerCron,
   cleanupOld,
   enqueueAdhoc,
   enqueueOnce,
@@ -240,6 +242,87 @@ describe("armCron (DO mode)", () => {
   });
 });
 
+describe("tickCron", () => {
+  it("sends POST /tick to the named DO in DO mode", async () => {
+    CONFIG.JOB_QUEUE_BACKEND = "durable-object";
+    const ns = makeFakeDoNamespace();
+    const env = {
+      ...d1Env,
+      JOB_QUEUE_DO: ns as unknown as DurableObjectNamespace,
+    };
+
+    await tickCron(env, "sync-episodes");
+
+    expect(ns.calls).toHaveLength(1);
+    expect(ns.calls[0].path).toBe("/tick");
+    expect(ns.calls[0].method).toBe("POST");
+  });
+
+  it("is a no-op in D1 mode", async () => {
+    CONFIG.JOB_QUEUE_BACKEND = "d1";
+    const ns = makeFakeDoNamespace();
+    const env = {
+      ...d1Env,
+      JOB_QUEUE_DO: ns as unknown as DurableObjectNamespace,
+    };
+
+    await tickCron(env, "sync-episodes");
+
+    expect(ns.calls).toHaveLength(0);
+  });
+
+  it("swallows a failing DO so the watchdog loop continues", async () => {
+    CONFIG.JOB_QUEUE_BACKEND = "durable-object";
+    const throwingNs = {
+      idFromName: (name: string) => ({ toString: () => name }),
+      get: () => ({
+        fetch: async () => {
+          throw new Error("DO unavailable");
+        },
+      }),
+    };
+    const env = {
+      ...d1Env,
+      JOB_QUEUE_DO: throwingNs as unknown as DurableObjectNamespace,
+    };
+
+    // Must not throw
+    await tickCron(env, "sync-episodes");
+  });
+});
+
+describe("triggerCron (DO mode)", () => {
+  it("arms AND ticks the named DO so 'Run now' actually executes", async () => {
+    CONFIG.JOB_QUEUE_BACKEND = "durable-object";
+    const ns = makeFakeDoNamespace();
+    const env = {
+      ...d1Env,
+      JOB_QUEUE_DO: ns as unknown as DurableObjectNamespace,
+    };
+
+    const result = await triggerCron(env, "sync-episodes");
+
+    expect(result.jobId).toBeNull();
+    const paths = ns.calls.map((c) => c.path);
+    expect(paths).toContain("/arm");
+    expect(paths).toContain("/tick");
+  });
+
+  it("returns jobId null for an unknown job without dispatching", async () => {
+    CONFIG.JOB_QUEUE_BACKEND = "durable-object";
+    const ns = makeFakeDoNamespace();
+    const env = {
+      ...d1Env,
+      JOB_QUEUE_DO: ns as unknown as DurableObjectNamespace,
+    };
+
+    const result = await triggerCron(env, "not-a-real-job");
+
+    expect(result.jobId).toBeNull();
+    expect(ns.calls).toHaveLength(0);
+  });
+});
+
 describe("processPending (DO mode)", () => {
   it("returns 0 without calling processPendingJobs", async () => {
     CONFIG.JOB_QUEUE_BACKEND = "durable-object";
@@ -266,8 +349,10 @@ describe("enqueueAdhoc (DO mode)", () => {
       });
     });
 
-    expect(ns.calls).toHaveLength(1);
+    // enqueue then immediately drive the partition via /tick (#795)
+    expect(ns.calls).toHaveLength(2);
     expect(ns.calls[0].path).toBe("/enqueue");
+    expect(ns.calls[1].path).toBe("/tick");
     // idFromName should have been called with "sync-show-episodes:42"
     // (we can't directly check idFromName, but the stub body contains the name)
     const body = ns.calls[0].body as { name: string };
@@ -289,7 +374,9 @@ describe("enqueueAdhoc (DO mode)", () => {
       });
     });
 
-    expect(ns.calls).toHaveLength(1);
+    expect(ns.calls).toHaveLength(2);
+    expect(ns.calls[0].path).toBe("/enqueue");
+    expect(ns.calls[1].path).toBe("/tick");
     const body = ns.calls[0].body as { name: string };
     expect(body.name).toBe("backfill-title-offers");
   });
@@ -306,8 +393,9 @@ describe("enqueueAdhoc (DO mode)", () => {
       await enqueueAdhoc("sync-plex-library");
     });
 
-    expect(ns.calls).toHaveLength(1);
+    expect(ns.calls).toHaveLength(2);
     expect(ns.calls[0].path).toBe("/enqueue");
+    expect(ns.calls[1].path).toBe("/tick");
   });
 });
 
@@ -379,7 +467,8 @@ describe("runWithEnv", () => {
     await runWithEnv(env, async () => {
       await enqueueAdhoc("sync-plex-library");
     });
-    expect(ns.calls).toHaveLength(1);
+    // /enqueue + /tick
+    expect(ns.calls).toHaveLength(2);
   });
 });
 

--- a/server/jobs/backend.ts
+++ b/server/jobs/backend.ts
@@ -129,6 +129,25 @@ export async function armCron(
 }
 
 /**
+ * Drive due work in a cron-singleton DO via the /tick RPC. This is the primary
+ * execution path in DO mode: the every-5-min Worker watchdog (worker.ts scheduled())
+ * calls this for each cron job because the DO alarm() callback is unreliable under
+ * the Sentry-wrapped entrypoint (#795). No-op in D1 mode (D1 drains via processPending).
+ */
+export async function tickCron(env: CFEnv, name: string): Promise<void> {
+  if (CONFIG.JOB_QUEUE_BACKEND !== "durable-object") return;
+  if (!env.JOB_QUEUE_DO) return;
+  try {
+    await doFetch(env, name, "/tick", "POST", {});
+  } catch (err) {
+    log.warn("DO tick failed", {
+      name,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
  * Enqueue an ad-hoc job. Partition key is inferred from data for known names.
  * Used by routes (track, integrations) that need to queue per-item work.
  */
@@ -152,6 +171,10 @@ export async function enqueueAdhoc(
       },
       partitionKey,
     );
+    // Drive execution immediately via the working fetch path — ad-hoc DOs cannot
+    // rely on alarm() delivery (#795), so without this the job would never run.
+    // A single ad-hoc job (e.g. one show's episode sync) fits the 30s DO limit.
+    await doFetch(env, name, "/tick", "POST", {}, partitionKey);
   } else {
     const db = getDb();
     await db.insert(jobs).values({
@@ -498,6 +521,9 @@ export async function triggerCron(
     const jobDef = CRON_JOBS.find((j) => j.name === name);
     if (!jobDef || !env.JOB_QUEUE_DO) return { jobId: null };
     await doFetch(env, name, "/arm", "POST", { name, cron: jobDef.cron });
+    // Arming only (re)schedules an alarm, which is unreliable (#795). Drive the
+    // job immediately via the working fetch path so "Run now" actually executes.
+    await doFetch(env, name, "/tick", "POST", {});
     return { jobId: null };
   }
   const jobId = await enqueueJobReturningId(name);

--- a/server/jobs/durable-object.test.ts
+++ b/server/jobs/durable-object.test.ts
@@ -936,6 +936,128 @@ describe("JobQueueDO", () => {
     deleteExpiredSessionsSpy.mockRestore();
     cleanupState.close();
   });
+
+  // ── tick(): watchdog-driven execution without alarm() (#795) ──────────────
+
+  it("tick() runs a due cron job and completes it without calling alarm()", async () => {
+    let called = false;
+    processorModule.handlers["sync-titles"] = async () => {
+      called = true;
+    };
+    await do_.armCron("sync-titles", "0 3 * * *"); // never run before → due
+
+    const result = await do_.tick();
+
+    expect(called).toBe(true);
+    expect(result.ran).toBe(true);
+    const rows = do_.getRecentJobs();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("completed");
+  });
+
+  it("tick() does NOT run a daily cron that already ran today (cron timing honored)", async () => {
+    let called = false;
+    const { do_: epDo, state: epState } = makeDO("sync-episodes");
+    processorModule.handlers["sync-episodes"] = async () => {
+      called = true;
+    };
+    await epDo.armCron("sync-episodes", "30 3 * * *");
+    // A completed run timestamped now → the daily cron is not due again
+    epState.rawDb
+      .prepare(
+        "INSERT INTO jobs (name, status, run_at, completed_at) VALUES ('sync-episodes','completed',?,?)",
+      )
+      .run(new Date().toISOString(), new Date().toISOString());
+
+    const result = await epDo.tick();
+
+    expect(called).toBe(false);
+    expect(result.ran).toBe(false);
+    // No tick job fabricated — only the pre-existing completed row remains
+    expect(
+      epDo.getRecentJobs().filter((r) => r.status === "pending"),
+    ).toHaveLength(0);
+    epState.close();
+  });
+
+  it("tick() drains a pending ad-hoc job without calling alarm()", async () => {
+    const calledWith: (string | null)[] = [];
+    processorModule.handlers["sync-show-episodes"] = async (data) => {
+      calledWith.push(data);
+    };
+    const { do_: adHocDo, state: adHocState } = makeDO("sync-show-episodes:42");
+    const payload = JSON.stringify({ titleId: 42, tmdbId: 999, title: "X" });
+    await adHocDo.enqueue("sync-show-episodes", payload);
+
+    const result = await adHocDo.tick();
+
+    expect(calledWith[0]).toBe(payload);
+    expect(result.ran).toBe(true);
+    expect(adHocDo.getRecentJobs()[0].status).toBe("completed");
+    adHocState.close();
+  });
+
+  it("tick() runs at most one job per call (30s DO limit)", async () => {
+    processorModule.handlers["sync-show-episodes"] = async () => {};
+    const { do_: adHocDo, state: adHocState } = makeDO("sync-show-episodes:7");
+    await adHocDo.enqueue("sync-show-episodes", null);
+    await adHocDo.enqueue("sync-show-episodes", null);
+
+    await adHocDo.tick();
+
+    const rows = adHocDo.getRecentJobs();
+    expect(rows.filter((r) => r.status === "completed")).toHaveLength(1);
+    expect(rows.filter((r) => r.status === "pending")).toHaveLength(1);
+    // Remaining pending row re-arms a delayed alarm so the next tick drains it
+    expect(
+      adHocDo.alarms
+        .getSchedules({ type: "delayed" })
+        .some((s) => s.callback === "runJob"),
+    ).toBe(true);
+    adHocState.close();
+  });
+
+  it("POST /tick drains due work and returns { ran }", async () => {
+    processorModule.handlers["sync-titles"] = async () => {};
+    await do_.armCron("sync-titles", "0 3 * * *");
+
+    const resp = await do_.fetch(
+      new Request("https://do/tick", { method: "POST" }),
+    );
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { ran: boolean };
+    expect(body.ran).toBe(true);
+    expect(do_.getRecentJobs()[0].status).toBe("completed");
+  });
+
+  // ── armCron: recover a dropped alarm handle (#795 defense-in-depth) ────────
+
+  it("armCron force-sets the alarm when the cron schedule row exists but getAlarm() is null", async () => {
+    await do_.armCron("sync-titles", "0 3 * * *");
+    expect(await state.storage.getAlarm()).not.toBeNull();
+
+    // Simulate a dropped CF alarm handle: the _actor_alarms cron row persists
+    // (so getSchedules still reports it) but the underlying alarm is gone.
+    state.storage.scheduledAlarm = null;
+    expect(
+      do_.alarms
+        .getSchedules({ type: "cron" })
+        .some((s) => s.callback === "runJob"),
+    ).toBe(true);
+
+    addBreadcrumbSpy.mockClear();
+    await do_.armCron("sync-titles", "0 3 * * *");
+
+    const recovered = await state.storage.getAlarm();
+    expect(recovered).not.toBeNull();
+    expect(recovered!).toBeGreaterThan(Date.now());
+    const recoveryBreadcrumb = addBreadcrumbSpy.mock.calls.find(
+      (args) =>
+        (args[0] as { message?: string }).message ===
+        "Recovered dropped cron alarm",
+    );
+    expect(recoveryBreadcrumb).toBeDefined();
+  });
 });
 
 // Restore module-level spies after all tests so they don't leak into later test files on Linux CI.

--- a/server/jobs/durable-object.ts
+++ b/server/jobs/durable-object.ts
@@ -7,6 +7,7 @@
  * The Bun runtime never imports this file.
  */
 import { Alarms } from "@cloudflare/actors/alarms";
+import { CronExpressionParser } from "cron-parser";
 import { drizzle } from "drizzle-orm/d1";
 import { eq, sql } from "drizzle-orm";
 import { runWithDb, schemaExports, titles, settings } from "../db/schema";
@@ -180,6 +181,9 @@ export class JobQueueDO {
         );
         return Response.json({ id });
       }
+      if (request.method === "POST" && path === "/tick") {
+        return Response.json(await this.tick());
+      }
       if (request.method === "POST" && path === "/recover") {
         const body = (await request.json()) as { staleMinutes?: number };
         const count = this.recover(body.staleMinutes ?? 15);
@@ -216,7 +220,10 @@ export class JobQueueDO {
 
   // ─── Job execution: invoked by Alarms when a cron or delayed schedule fires
 
-  async runJob(_payload: unknown = null): Promise<void> {
+  async runJob(
+    _payload: unknown = null,
+    opts: { skipCronAutoCreate?: boolean } = {},
+  ): Promise<void> {
     const name = await this.ctx.storage.get<string>("name");
     if (!name) return;
     const cron = (await this.ctx.storage.get<string>("cron")) ?? null;
@@ -233,7 +240,7 @@ export class JobQueueDO {
     >[];
 
     if (rows.length === 0) {
-      if (cron) {
+      if (cron && !opts.skipCronAutoCreate) {
         // Cron singleton: alarm fires at each scheduled tick. Auto-create the job for
         // this tick if no pending rows exist (including future-scheduled ones).
         const anyPending =
@@ -429,6 +436,68 @@ export class JobQueueDO {
     await this.rearmIfPending(cron);
   }
 
+  /**
+   * Drive due work WITHOUT depending on CF alarm delivery. Invoked via the /tick
+   * RPC by the every-5-min Worker watchdog (server/worker.ts scheduled()), which is
+   * proven to fire reliably in production. The DO alarm() callback has been observed
+   * to never fire under the Sentry-wrapped entrypoint (#795), so this fetch-driven
+   * path is the load-bearing execution mechanism.
+   *
+   * Runs at most one job per call (runJob does LIMIT 1) to respect the 30-second DO
+   * alarm/CPU limit (#726); remaining pending rows re-arm and drain on the next tick.
+   * Cron timing is honored: a cron DO only fabricates a tick job when actually due,
+   * but pending retry/extra rows always drain.
+   */
+  async tick(): Promise<{ ran: boolean }> {
+    this.initSchema();
+    const name = await this.ctx.storage.get<string>("name");
+    if (!name) return { ran: false };
+    const cron = (await this.ctx.storage.get<string>("cron")) ?? null;
+
+    let skipCronAutoCreate = false;
+    if (cron) {
+      const lastRows = this.ctx.storage.sql
+        .exec(
+          "SELECT completed_at FROM jobs WHERE status IN ('completed', 'failed') ORDER BY id DESC LIMIT 1",
+        )
+        .toArray() as Array<{ completed_at: string | null }>;
+      const lastRun = lastRows[0]?.completed_at ?? null;
+      skipCronAutoCreate = !this.isCronDue(cron, lastRun, new Date());
+    }
+
+    const terminalBefore = this.terminalCount();
+    await this.runJob(null, { skipCronAutoCreate });
+    return { ran: this.terminalCount() > terminalBefore };
+  }
+
+  /** Count of rows that have reached a terminal state (used to detect tick execution). */
+  private terminalCount(): number {
+    const rows = this.ctx.storage.sql
+      .exec(
+        "SELECT COUNT(*) as count FROM jobs WHERE status IN ('completed', 'failed')",
+      )
+      .toArray() as Array<{ count: number }>;
+    return rows[0]?.count ?? 0;
+  }
+
+  /** Whether a cron's most recent scheduled fire time is newer than the last run. */
+  private isCronDue(
+    cron: string,
+    lastRunIso: string | null,
+    now: Date,
+  ): boolean {
+    let lastScheduled: Date;
+    try {
+      lastScheduled = CronExpressionParser.parse(cron, { currentDate: now })
+        .prev()
+        .toDate();
+    } catch {
+      return false;
+    }
+    if (!lastRunIso) return true;
+    return new Date(lastRunIso).getTime() < lastScheduled.getTime();
+  }
+
   // ─── Internal methods (also used by tests via subclass) ──────────────────
 
   /** Arm this DO as a cron singleton. Idempotent — only schedules if no cron alarm exists. */
@@ -445,6 +514,34 @@ export class JobQueueDO {
         level: "info",
         data: { name, cron, priorScheduleCount: String(existing.length) },
       });
+      return;
+    }
+
+    // Defense-in-depth: a cron schedule row persists in DO SQL storage across
+    // evictions, but the underlying CF storage alarm handle can be dropped (DO
+    // eviction, or a wrapped entrypoint interfering with @cloudflare/actors/alarms,
+    // #795). When that happens getSchedules() still reports the schedule, so the
+    // guard above skips re-scheduling and the native alarm never fires again.
+    // Detect a missing alarm handle and force-set it to the next cron fire time so
+    // the alarm path self-recovers (the watchdog /tick is the primary driver).
+    const pendingAlarm = await this.ctx.storage.getAlarm();
+    if (pendingAlarm === null) {
+      try {
+        const next = CronExpressionParser.parse(cron, {
+          currentDate: new Date(),
+        })
+          .next()
+          .toDate();
+        await this.ctx.storage.setAlarm(next);
+        Sentry.addBreadcrumb({
+          category: "jobs",
+          message: "Recovered dropped cron alarm",
+          level: "warning",
+          data: { name, cron, nextRun: next.toISOString() },
+        });
+      } catch {
+        // Invalid cron expression — nothing to recover.
+      }
     }
   }
 

--- a/server/routes/jobs-cf.test.ts
+++ b/server/routes/jobs-cf.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterAll } from "bun:test";
 import { Hono } from "hono";
+import { CONFIG } from "../config";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
 import {
   createUser,
@@ -205,5 +206,36 @@ describe("POST /jobs/:name (CF)", () => {
   it("returns 401 without auth", async () => {
     const res = await app.request("/jobs/sync-titles", { method: "POST" });
     expect(res.status).toBe(401);
+  });
+
+  it("arms AND ticks the DO in durable-object mode so 'Run now' executes (#795)", async () => {
+    const original = CONFIG.JOB_QUEUE_BACKEND;
+    CONFIG.JOB_QUEUE_BACKEND = "durable-object";
+    const calls: { path: string; method: string }[] = [];
+    const fakeNs = {
+      idFromName: (name: string) => ({ toString: () => name }),
+      get: () => ({
+        fetch: async (req: Request) => {
+          calls.push({ path: new URL(req.url).pathname, method: req.method });
+          return new Response(JSON.stringify({ ok: true }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      }),
+    };
+    try {
+      const res = await app.request(
+        "/jobs/sync-episodes",
+        { method: "POST", headers: { Cookie: adminCookie } },
+        { JOB_QUEUE_DO: fakeNs, DB: {} } as unknown as Record<string, unknown>,
+      );
+      expect(res.status).toBe(200);
+      const paths = calls.map((c) => c.path);
+      expect(paths).toContain("/arm");
+      expect(paths).toContain("/tick");
+    } finally {
+      CONFIG.JOB_QUEUE_BACKEND = original;
+    }
   });
 });

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -110,6 +110,7 @@ import {
 import { CloudflarePlatform } from "./platform/cloudflare";
 import {
   armCron,
+  tickCron,
   cleanupOld,
   enqueueOnce,
   processPending,
@@ -838,12 +839,16 @@ export const handler = {
               );
             }
 
-            // Arm every cron-singleton DO. Idempotent — the DO only schedules its
-            // alarm if no `runJob` cron schedule exists. DOs drive their own
-            // sub-daily execution via @cloudflare/actors/alarms. Running on every
-            // 5-min watchdog tick ensures a dropped alarm self-heals within 5 min (#795).
+            // Arm every cron-singleton DO, then drive it via /tick. armCron keeps
+            // the native alarm schedule (and recovers a dropped alarm handle, #795),
+            // but CF alarm() delivery has proven unreliable under the Sentry-wrapped
+            // entrypoint, so tickCron is the load-bearing execution path: this
+            // watchdog fires reliably every 5 min and drains due work over the
+            // proven-working DO fetch RPC. Cron timing is honored inside the DO —
+            // daily jobs only run once/day while send-notifications runs each tick.
             for (const { name, cron } of CRON_JOBS) {
               await armCron(cfEnv, name, cron);
+              await tickCron(cfEnv, name);
             }
 
             // Recover stuck jobs and drain D1 pending jobs (no-ops in DO mode)


### PR DESCRIPTION
@-