### PR TITLE
fix(offers): chunk IN-clause queries to respect D1 100-param limit

### DIFF
--- a/server/db/repository/offers.test.ts
+++ b/server/db/repository/offers.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { setupTestDb, teardownTestDb } from "../../test-utils/setup";
+import { makeParsedTitle, makeParsedOffer } from "../../test-utils/fixtures";
+import { upsertTitles } from "./titles";
+import { getOffersForTitles } from "./offers";
+import { getGenresForTitles } from "./titles";
+
+beforeEach(() => {
+  setupTestDb();
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+// Regression for #1009: D1 caps bound parameters at 100 per statement. Both
+// getOffersForTitles and getGenresForTitles passed every title ID into a single
+// `IN (...)` clause, which threw on D1 (→ HTTP 500 on GET /api/movies/tracking)
+// for users tracking >100 titles. The chunked versions must accept arbitrarily
+// large ID lists and still return one entry per title.
+describe("IN-clause chunking for >100 titles", () => {
+  const COUNT = 150;
+  const ids = Array.from({ length: COUNT }, (_, i) => `chunk-${i}`);
+
+  beforeEach(async () => {
+    await upsertTitles(
+      ids.map((id) =>
+        makeParsedTitle({
+          id,
+          title: `Movie ${id}`,
+          genres: ["Action"],
+          offers: [makeParsedOffer({ titleId: id })],
+        }),
+      ),
+    );
+  });
+
+  it("getOffersForTitles returns offers for every title past the 100-param limit", async () => {
+    const map = await getOffersForTitles(ids);
+    expect(map.size).toBe(COUNT);
+    for (const id of ids) {
+      expect(map.get(id)?.length).toBe(1);
+    }
+  });
+
+  it("getGenresForTitles returns genres for every title past the 100-param limit", async () => {
+    const map = await getGenresForTitles(ids);
+    expect(map.size).toBe(COUNT);
+    for (const id of ids) {
+      expect(map.get(id)).toEqual(["Action"]);
+    }
+  });
+
+  it("getOffersForTitles returns an empty map for no titles", async () => {
+    const map = await getOffersForTitles([]);
+    expect(map.size).toBe(0);
+  });
+});

--- a/server/db/repository/offers.ts
+++ b/server/db/repository/offers.ts
@@ -39,17 +39,25 @@ export async function getOffersForTitle(titleId: string) {
   });
 }
 
+// D1 caps bound parameters at 100 per statement; this query binds only titleIds.
+const OFFERS_TITLEIDS_CHUNK_SIZE = 100;
+
 export async function getOffersForTitles(titleIds: string[]) {
   return traceDbQuery("getOffersForTitles", async () => {
     if (titleIds.length === 0)
       return new Map<string, Awaited<ReturnType<typeof getOffersForTitle>>>();
     const db = getDb();
-    const allOffers = await db
-      .select(offerColumns)
-      .from(offers)
-      .innerJoin(providers, eq(offers.providerId, providers.id))
-      .where(inArray(offers.titleId, titleIds))
-      .all();
+    const allOffers: Awaited<ReturnType<typeof getOffersForTitle>> = [];
+    for (let i = 0; i < titleIds.length; i += OFFERS_TITLEIDS_CHUNK_SIZE) {
+      const chunk = titleIds.slice(i, i + OFFERS_TITLEIDS_CHUNK_SIZE);
+      const rows = await db
+        .select(offerColumns)
+        .from(offers)
+        .innerJoin(providers, eq(offers.providerId, providers.id))
+        .where(inArray(offers.titleId, chunk))
+        .all();
+      allOffers.push(...rows);
+    }
     return Map.groupBy(allOffers, (o) => o.title_id);
   });
 }

--- a/server/db/repository/titles.ts
+++ b/server/db/repository/titles.ts
@@ -278,21 +278,27 @@ export async function upsertTitles(parsedTitles: ParsedTitle[]) {
 
 // ─── Genre helpers ───────────────────────────────────────────────────────────
 
+// D1 caps bound parameters at 100 per statement; this query binds only titleIds.
+const GENRES_TITLEIDS_CHUNK_SIZE = 100;
+
 export async function getGenresForTitles(
   titleIds: string[],
 ): Promise<Map<string, string[]>> {
   if (titleIds.length === 0) return new Map();
   const db = getDb();
-  const rows = await db
-    .select({ titleId: titleGenres.titleId, genre: titleGenres.genre })
-    .from(titleGenres)
-    .where(inArray(titleGenres.titleId, titleIds))
-    .all();
   const map = new Map<string, string[]>();
-  for (const row of rows) {
-    const list = map.get(row.titleId) ?? [];
-    list.push(row.genre);
-    map.set(row.titleId, list);
+  for (let i = 0; i < titleIds.length; i += GENRES_TITLEIDS_CHUNK_SIZE) {
+    const chunk = titleIds.slice(i, i + GENRES_TITLEIDS_CHUNK_SIZE);
+    const rows = await db
+      .select({ titleId: titleGenres.titleId, genre: titleGenres.genre })
+      .from(titleGenres)
+      .where(inArray(titleGenres.titleId, chunk))
+      .all();
+    for (const row of rows) {
+      const list = map.get(row.titleId) ?? [];
+      list.push(row.genre);
+      map.set(row.titleId, list);
+    }
   }
   return map;
 }


### PR DESCRIPTION
@
## Summary

`GET /api/movies/tracking` returned a single HTTP 500 (issue #1009). Root cause: Cloudflare D1 caps bound parameters at **100 per statement**, but `getOffersForTitles` passed every tracked title ID into one `WHERE titleId IN (...)`. A user tracking >100 released-unwatched (or >100 upcoming) movies overflowed the limit; D1 rejected the statement and the throw surfaced as an unhandled 500.

`getPlexOffersForUser` (the sibling on the same code path) already chunked at `PLEX_TITLEIDS_CHUNK_SIZE = 99` — `getOffersForTitles` was the one place that didnt.

`getGenresForTitles` had the identical unchunked `IN (...)` clause (reached via `getTrackedTitles` on the home/tracked page and the calendar routes), so its chunked here too — same bug class.

## Changes

- `server/db/repository/offers.ts` — `getOffersForTitles` now loops in slices of 100, accumulates rows, and groups once. Return shape (`Map.groupBy`) unchanged, so callers are untouched.
- `server/db/repository/titles.ts` — `getGenresForTitles` chunked the same way.
- `server/db/repository/offers.test.ts` (new) — seeds 150 titles and asserts both functions return one entry per title past the 100-param boundary.

Both follow the repos existing per-module inline-loop + local-constant chunking convention (`plex-library.ts`). No row cap added — chunking returns complete data rather than truncating a users movies.

## Test plan

- `bun test server/db/repository/offers.test.ts` — new regression passes (3 tests)
- `bun test server/routes/movies.test.ts server/db/repository/tracked.test.ts server/db/repository/titles.test.ts` — no regressions (60 pass)
- `bun run check` — full CI gauntlet green (tsc + ESLint + all tests + build + wrangler dry-run)

Closes #1009

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@