### PR TITLE
fix(jobs): make admin "Run now" execute regardless of cron schedule

### DIFF
--- a/server/jobs/backend.test.ts
+++ b/server/jobs/backend.test.ts
@@ -305,7 +305,11 @@ describe("triggerCron (DO mode)", () => {
     expect(result.jobId).toBeNull();
     const paths = ns.calls.map((c) => c.path);
     expect(paths).toContain("/arm");
+    expect(paths).toContain("/enqueue");
     expect(paths).toContain("/tick");
+    // The forced job row must be enqueued before the tick that drains it,
+    // otherwise tick() finds nothing to run when the cron isn't due.
+    expect(paths.indexOf("/enqueue")).toBeLessThan(paths.indexOf("/tick"));
   });
 
   it("returns jobId null for an unknown job without dispatching", async () => {

--- a/server/jobs/backend.ts
+++ b/server/jobs/backend.ts
@@ -521,8 +521,14 @@ export async function triggerCron(
     const jobDef = CRON_JOBS.find((j) => j.name === name);
     if (!jobDef || !env.JOB_QUEUE_DO) return { jobId: null };
     await doFetch(env, name, "/arm", "POST", { name, cron: jobDef.cron });
-    // Arming only (re)schedules an alarm, which is unreliable (#795). Drive the
-    // job immediately via the working fetch path so "Run now" actually executes.
+    // "Run now" must execute regardless of cron schedule. tick() honors cron timing
+    // and won't auto-create a job when the cron isn't due, so force a real pending
+    // row first; runJob then claims and runs it on the tick below (#795-followup).
+    await doFetch(env, name, "/enqueue", "POST", {
+      name,
+      data: null,
+      idempotent: true,
+    });
     await doFetch(env, name, "/tick", "POST", {});
     return { jobId: null };
   }

--- a/server/jobs/durable-object.test.ts
+++ b/server/jobs/durable-object.test.ts
@@ -980,6 +980,36 @@ describe("JobQueueDO", () => {
     epState.close();
   });
 
+  it("tick() runs a pre-enqueued job even when the cron is NOT due ('Run now' path)", async () => {
+    // Regression for triggerCron: "Run now" enqueues a real job row first, then ticks.
+    // tick() honors cron timing and won't auto-create a job, but runJob still claims
+    // any existing pending row regardless of schedule — so the forced run executes.
+    let called = false;
+    const { do_: epDo, state: epState } = makeDO("sync-episodes");
+    processorModule.handlers["sync-episodes"] = async () => {
+      called = true;
+    };
+    await epDo.armCron("sync-episodes", "30 3 * * *");
+    // A completed run timestamped now → the daily cron is NOT due again
+    epState.rawDb
+      .prepare(
+        "INSERT INTO jobs (name, status, run_at, completed_at) VALUES ('sync-episodes','completed',?,?)",
+      )
+      .run(new Date().toISOString(), new Date().toISOString());
+
+    // triggerCron forces a pending row before ticking
+    await epDo.enqueue("sync-episodes", null, undefined, undefined, true);
+    const result = await epDo.tick();
+
+    expect(called).toBe(true);
+    expect(result.ran).toBe(true);
+    const completed = epDo
+      .getRecentJobs()
+      .filter((r) => r.status === "completed");
+    expect(completed.length).toBe(2); // the seeded run + the forced "Run now" run
+    epState.close();
+  });
+
   it("tick() drains a pending ad-hoc job without calling alarm()", async () => {
     const calledWith: (string | null)[] = [];
     processorModule.handlers["sync-show-episodes"] = async (data) => {

--- a/server/routes/jobs-cf.test.ts
+++ b/server/routes/jobs-cf.test.ts
@@ -208,7 +208,7 @@ describe("POST /jobs/:name (CF)", () => {
     expect(res.status).toBe(401);
   });
 
-  it("arms AND ticks the DO in durable-object mode so 'Run now' executes (#795)", async () => {
+  it("arms, enqueues, AND ticks the DO in durable-object mode so 'Run now' executes (#795)", async () => {
     const original = CONFIG.JOB_QUEUE_BACKEND;
     CONFIG.JOB_QUEUE_BACKEND = "durable-object";
     const calls: { path: string; method: string }[] = [];
@@ -233,7 +233,10 @@ describe("POST /jobs/:name (CF)", () => {
       expect(res.status).toBe(200);
       const paths = calls.map((c) => c.path);
       expect(paths).toContain("/arm");
+      expect(paths).toContain("/enqueue");
       expect(paths).toContain("/tick");
+      // The forced job row must be enqueued before the draining tick.
+      expect(paths.indexOf("/enqueue")).toBeLessThan(paths.indexOf("/tick"));
     } finally {
       CONFIG.JOB_QUEUE_BACKEND = original;
     }


### PR DESCRIPTION
## Problem

In admin settings → Background jobs, clicking **Run now** appears to do nothing — the job never actually executes. Regression from the DO-alarm fix (`2be38a0`, #795).

## Root cause

In Durable-Object mode, `triggerCron()` (`server/jobs/backend.ts`) fired `/arm` + `/tick`. But `/tick` (`JobQueueDO.tick()`) deliberately **honors the cron schedule**: for a cron singleton with no pending rows it only fabricates a job when the cron is _due right now_. So daily jobs that already ran today (`sync-titles`, `sync-episodes`, `sync-deep-links`, `cleanup`) were no-ops; only `send-notifications` (every 5 min, almost always due) appeared to work.

`/tick` honoring the schedule is correct for the every-5-min watchdog, but a manual trigger must force a run regardless of schedule.

## Fix

`triggerCron` now `/enqueue`s a real pending job row (idempotent, to guard double-clicks) before `/tick`. `runJob` always claims an existing pending row regardless of `skipCronAutoCreate`, so the manual run executes immediately. D1 mode and Bun mode are unaffected.

## Tests

- `server/jobs/backend.test.ts` — assert `/enqueue` is dispatched before `/tick`.
- `server/jobs/durable-object.test.ts` — new regression test: a forced run executes even when the daily cron is **not** due (pairs with the existing "does NOT run a daily cron that already ran today" test that proves the bug).
- `server/routes/jobs-cf.test.ts` — assert `/enqueue` in the Run-now RPC set.

`bun run check` passes (type checks, lint, all tests, frontend build, wrangler dry-run).

## Verification

In admin settings (CF/DO deploy), click **Run now** on a daily job that already ran today and confirm a fresh `completed` run appears in the jobs panel immediately — not just `send-notifications`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
