### PR TITLE
fix(jobs): patch CONFIG from env inside the job Durable Object

### DIFF
--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { CONFIG, patchConfig } from "./config";
+import { CONFIG, patchConfig, cfEnvToConfigOverrides } from "./config";
 
 describe("patchConfig", () => {
   it("overrides specified keys", () => {
@@ -28,5 +28,28 @@ describe("patchConfig", () => {
     expect(CONFIG.COUNTRY).toBe("DE");
     // Restore
     patchConfig({ TMDB_API_KEY: origKey, COUNTRY: origCountry });
+  });
+});
+
+describe("cfEnvToConfigOverrides", () => {
+  it("maps CF env secrets/vars onto CONFIG keys", () => {
+    const overrides = cfEnvToConfigOverrides({
+      TMDB_API_KEY: "tmdb-secret",
+      TMDB_COUNTRY: "US",
+      TMDB_LANGUAGE: "de",
+      STREAMING_AVAILABILITY_API_KEY: "sa-secret",
+      JOB_QUEUE_BACKEND: "durable-object",
+    });
+    expect(overrides.TMDB_API_KEY).toBe("tmdb-secret");
+    expect(overrides.COUNTRY).toBe("US");
+    expect(overrides.LANGUAGE).toBe("de");
+    expect(overrides.STREAMING_AVAILABILITY_API_KEY).toBe("sa-secret");
+    expect(overrides.JOB_QUEUE_BACKEND).toBe("durable-object");
+  });
+
+  it("defaults missing TMDB_API_KEY to empty string (handlers guard on falsy)", () => {
+    const overrides = cfEnvToConfigOverrides({});
+    expect(overrides.TMDB_API_KEY).toBe("");
+    expect(overrides.JOB_QUEUE_BACKEND).toBe("d1");
   });
 });

--- a/server/config.ts
+++ b/server/config.ts
@@ -113,3 +113,70 @@ export const CONFIG = {
 export function patchConfig(overrides: Partial<typeof CONFIG>): void {
   Object.assign(CONFIG, overrides);
 }
+
+/** CF Workers env bindings (secrets + vars) that map onto CONFIG. */
+export interface CfConfigEnv {
+  TMDB_API_KEY?: string;
+  TMDB_COUNTRY?: string;
+  TMDB_LANGUAGE?: string;
+  LOG_LEVEL?: string;
+  CORS_ORIGIN?: string;
+  SENTRY_DSN?: string;
+  OIDC_ISSUER_URL?: string;
+  OIDC_CLIENT_ID?: string;
+  OIDC_CLIENT_SECRET?: string;
+  OIDC_REDIRECT_URI?: string;
+  OIDC_ADMIN_CLAIM?: string;
+  OIDC_ADMIN_VALUE?: string;
+  VAPID_PUBLIC_KEY?: string;
+  VAPID_PRIVATE_KEY?: string;
+  VAPID_SUBJECT?: string;
+  BETTER_AUTH_SECRET?: string;
+  BASE_URL?: string;
+  PASSKEY_RP_ID?: string;
+  PASSKEY_RP_NAME?: string;
+  PASSKEY_ORIGIN?: string;
+  STREAMING_AVAILABILITY_API_KEY?: string;
+  JOB_QUEUE_BACKEND?: string;
+}
+
+/**
+ * Map CF Workers env bindings to a CONFIG override object. Pure — apply the
+ * result with patchConfig().
+ *
+ * Shared by the Worker entry (server/worker.ts) AND the job Durable Object
+ * (server/jobs/durable-object.ts). The DO runs in its own isolate where CONFIG
+ * was never patched, so it must call this independently — otherwise job handlers
+ * see empty secrets (e.g. TMDB_API_KEY) and skip all work (episodes/titles never
+ * sync). Keep both call sites using this one function so the lists can't drift.
+ */
+export function cfEnvToConfigOverrides(
+  env: CfConfigEnv,
+): Partial<typeof CONFIG> {
+  return {
+    TMDB_API_KEY: env.TMDB_API_KEY || "",
+    COUNTRY: env.TMDB_COUNTRY || undefined,
+    LANGUAGE: env.TMDB_LANGUAGE || undefined,
+    LOG_LEVEL:
+      (env.LOG_LEVEL as "debug" | "info" | "warn" | "error") || undefined,
+    CORS_ORIGIN: env.CORS_ORIGIN || undefined,
+    SENTRY_DSN: env.SENTRY_DSN || "",
+    OIDC_ISSUER_URL: env.OIDC_ISSUER_URL || "",
+    OIDC_CLIENT_ID: env.OIDC_CLIENT_ID || "",
+    OIDC_CLIENT_SECRET: env.OIDC_CLIENT_SECRET || "",
+    OIDC_REDIRECT_URI: env.OIDC_REDIRECT_URI || "",
+    OIDC_ADMIN_CLAIM: env.OIDC_ADMIN_CLAIM || "",
+    OIDC_ADMIN_VALUE: env.OIDC_ADMIN_VALUE || "",
+    VAPID_PUBLIC_KEY: env.VAPID_PUBLIC_KEY || "",
+    VAPID_PRIVATE_KEY: env.VAPID_PRIVATE_KEY || "",
+    VAPID_SUBJECT: env.VAPID_SUBJECT || "",
+    BETTER_AUTH_SECRET: env.BETTER_AUTH_SECRET || "",
+    BASE_URL: env.BASE_URL || undefined,
+    PASSKEY_RP_ID: env.PASSKEY_RP_ID || undefined,
+    PASSKEY_RP_NAME: env.PASSKEY_RP_NAME || undefined,
+    PASSKEY_ORIGIN: env.PASSKEY_ORIGIN || undefined,
+    STREAMING_AVAILABILITY_API_KEY: env.STREAMING_AVAILABILITY_API_KEY || "",
+    JOB_QUEUE_BACKEND:
+      (env.JOB_QUEUE_BACKEND as "d1" | "durable-object") || "d1",
+  };
+}

--- a/server/jobs/durable-object.test.ts
+++ b/server/jobs/durable-object.test.ts
@@ -25,6 +25,8 @@ import * as processorModule from "./processor";
 import * as repository from "../db/repository";
 import Sentry from "../sentry";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { withConfigGuard } from "../test-utils/config";
+import { CONFIG } from "../config";
 
 // ─── Fake CF storage ──────────────────────────────────────────────────────────
 
@@ -173,6 +175,10 @@ describe("JobQueueDO", () => {
   let state: FakeDurableObjectState;
   let do_: JobQueueDO;
 
+  // The DO constructor patches the global CONFIG from its env; guard so those
+  // mutations (e.g. TMDB_API_KEY -> "") never leak across tests or files.
+  withConfigGuard();
+
   beforeEach(() => {
     setupTestDb(); // keep the shared DB fresh for processor imports
     ({ do_, state } = makeDO("sync-titles"));
@@ -192,6 +198,25 @@ describe("JobQueueDO", () => {
     for (const key of Object.keys(originalHandlers)) {
       (processorModule.handlers as any)[key] = originalHandlers[key];
     }
+  });
+
+  // ── config patching (#795 follow-up: jobs ran but skipped, no secrets) ─────
+
+  it("patches global CONFIG from its env on construction so handlers see secrets", () => {
+    // Regression: the DO runs in its own isolate where CONFIG is never patched.
+    // Without this, sync handlers see CONFIG.TMDB_API_KEY === "" and skip all work.
+    const envState = new FakeDurableObjectState("sync-titles");
+    new JobQueueDO(
+      envState as any,
+      {
+        DB: {} as D1Database,
+        TMDB_API_KEY: "do-isolate-key",
+        STREAMING_AVAILABILITY_API_KEY: "do-sa-key",
+      } as any,
+    );
+    expect(CONFIG.TMDB_API_KEY).toBe("do-isolate-key");
+    expect(CONFIG.STREAMING_AVAILABILITY_API_KEY).toBe("do-sa-key");
+    envState.close();
   });
 
   // ── enqueue ──────────────────────────────────────────────────────────────

--- a/server/jobs/durable-object.ts
+++ b/server/jobs/durable-object.ts
@@ -14,9 +14,11 @@ import { runWithDb, schemaExports, titles, settings } from "../db/schema";
 import { runWithCache } from "../cache";
 import { CloudflareKvCache } from "../cache/cloudflare-kv";
 import { MemoryCache } from "../cache/memory";
-import { logger } from "../logger";
+import { logger, resetLogLevel } from "../logger";
 import Sentry from "../sentry";
 import { handlers } from "./processor";
+import { patchConfig, cfEnvToConfigOverrides } from "../config";
+import type { CfConfigEnv } from "../config";
 import type { DrizzleDb } from "../platform/types";
 
 // ─── Inline CF type declarations ───────────────────────────────────────────
@@ -67,7 +69,9 @@ declare global {
 }
 
 // ─── Minimal CF env shape needed by the DO ─────────────────────────────────
-export interface DOEnv {
+// Extends CfConfigEnv: at runtime CF passes the full env (secrets + vars) to the
+// DO constructor, and the DO must patch CONFIG from it (see constructor).
+export interface DOEnv extends CfConfigEnv {
   DB: D1Database;
   CACHE_KV?: KVNamespace;
   JOB_QUEUE_DO?: DurableObjectNamespace;
@@ -109,6 +113,14 @@ export class JobQueueDO {
   constructor(ctx: DurableObjectState, env: DOEnv) {
     this.ctx = ctx;
     this.env = env;
+    // The DO runs in its own isolate where the global CONFIG was never patched —
+    // worker.ts patchConfigFromEnv() only runs in the Worker fetch/scheduled
+    // handlers, not here. Without this, job handlers read empty secrets (e.g.
+    // CONFIG.TMDB_API_KEY) and skip all work, so episodes/titles never sync.
+    patchConfig(cfEnvToConfigOverrides(env));
+    if (env.LOG_LEVEL) {
+      resetLogLevel(env.LOG_LEVEL as "debug" | "info" | "warn" | "error");
+    }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.alarms = new Alarms(ctx, this as any);
   }

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -98,7 +98,7 @@ import achievementsRoutes, {
 } from "./routes/achievements";
 import type { AppEnv } from "./types";
 import { logger, requestLogger, resetLogLevel } from "./logger";
-import { patchConfig, CONFIG } from "./config";
+import { patchConfig, CONFIG, cfEnvToConfigOverrides } from "./config";
 import { classifyError } from "./lib/error-classifier";
 import { isFileLikePath } from "./lib/spa-fallback";
 import { errorsByCategory } from "./metrics";
@@ -178,32 +178,7 @@ function patchConfigFromEnv(env: Env): void {
   if (configPatched) return;
   configPatched = true;
 
-  patchConfig({
-    TMDB_API_KEY: env.TMDB_API_KEY || "",
-    COUNTRY: env.TMDB_COUNTRY || undefined,
-    LANGUAGE: env.TMDB_LANGUAGE || undefined,
-    LOG_LEVEL:
-      (env.LOG_LEVEL as "debug" | "info" | "warn" | "error") || undefined,
-    CORS_ORIGIN: env.CORS_ORIGIN || undefined,
-    SENTRY_DSN: env.SENTRY_DSN || "",
-    OIDC_ISSUER_URL: env.OIDC_ISSUER_URL || "",
-    OIDC_CLIENT_ID: env.OIDC_CLIENT_ID || "",
-    OIDC_CLIENT_SECRET: env.OIDC_CLIENT_SECRET || "",
-    OIDC_REDIRECT_URI: env.OIDC_REDIRECT_URI || "",
-    OIDC_ADMIN_CLAIM: env.OIDC_ADMIN_CLAIM || "",
-    OIDC_ADMIN_VALUE: env.OIDC_ADMIN_VALUE || "",
-    VAPID_PUBLIC_KEY: env.VAPID_PUBLIC_KEY || "",
-    VAPID_PRIVATE_KEY: env.VAPID_PRIVATE_KEY || "",
-    VAPID_SUBJECT: env.VAPID_SUBJECT || "",
-    BETTER_AUTH_SECRET: env.BETTER_AUTH_SECRET || "",
-    BASE_URL: env.BASE_URL || undefined,
-    PASSKEY_RP_ID: env.PASSKEY_RP_ID || undefined,
-    PASSKEY_RP_NAME: env.PASSKEY_RP_NAME || undefined,
-    PASSKEY_ORIGIN: env.PASSKEY_ORIGIN || undefined,
-    STREAMING_AVAILABILITY_API_KEY: env.STREAMING_AVAILABILITY_API_KEY || "",
-    JOB_QUEUE_BACKEND:
-      (env.JOB_QUEUE_BACKEND as "d1" | "durable-object") || "d1",
-  });
+  patchConfig(cfEnvToConfigOverrides(env));
 
   // Reinitialize logger in case LOG_LEVEL changed
   if (env.LOG_LEVEL) {


### PR DESCRIPTION
## Problem

After #1012 made admin **Run now** actually trigger jobs, the jobs ran but **didn't sync anything**. Production logs from a manual run showed:

```
Running job → Skipping episode sync (reason: "TMDB_API_KEY not configured") → Completed job
Running job → Skipping deep link sync (reason: "STREAMING_AVAILABILITY_API_KEY not configured") → Completed job
```

The job executed to completion but the handler bailed immediately because its required secret was empty.

## Root cause

The job `JobQueueDO` runs in its **own isolate**, separate from the Worker's `fetch`/`scheduled` handlers. `patchConfigFromEnv()` (which injects CF secrets/vars into the global `CONFIG`) is only called in those handlers — **never in the DO**. So inside the DO, `CONFIG.TMDB_API_KEY` / `CONFIG.STREAMING_AVAILABILITY_API_KEY` were the empty defaults, and every sync handler skipped its work. At runtime CF _does_ pass the full env (secrets included) to the DO constructor; the DO just never read it into `CONFIG`.

This affected **all** DO-mode job execution (watchdog `/tick` and `/alarm`), not just "Run now" — episodes/titles/deep-links never synced in DO mode.

## Fix

- Extract the env→CONFIG mapping into a shared, pure `cfEnvToConfigOverrides(env)` in `server/config.ts`.
- `server/worker.ts` now uses it (no behavior change — same mapping).
- `JobQueueDO` constructor now calls `patchConfig(cfEnvToConfigOverrides(env))` (and resets log level) so handlers in the DO isolate see real secrets.
- `DOEnv` extends the new `CfConfigEnv` so the secret bindings are typed.

Keeping both call sites on one function prevents the two lists from drifting.

## Tests

- `server/config.test.ts` — `cfEnvToConfigOverrides` maps secrets/vars and defaults missing `TMDB_API_KEY` to `""`.
- `server/jobs/durable-object.test.ts` — constructing the DO patches `CONFIG.TMDB_API_KEY` / `STREAMING_AVAILABILITY_API_KEY` from its env; added `withConfigGuard()` so the construction-time CONFIG mutation can't leak across test files.

`bun run check` passes (type checks, lint, all tests, frontend build, wrangler dry-run).

## Verification

After deploy, click **Run now** on `sync-episodes`/`sync-titles` and confirm the DO logs show `Running job → Synced episodes …` (no more "Skipping … not configured"), and tracked shows get episodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
