### PR TITLE
[auto-review] fix(a11y): add role=progressbar and aria attributes to TitleCard progress bars

### DIFF
--- a/frontend/src/components/TitleCard.test.tsx
+++ b/frontend/src/components/TitleCard.test.tsx
@@ -347,8 +347,14 @@ describe("TitleCard", () => {
       wrapper: NoUserWrapper,
     });
 
-    const progressTrack = container.querySelector(".bg-zinc-700");
+    const progressTrack = container.querySelector(
+      ".bg-zinc-700",
+    ) as HTMLElement;
     expect(progressTrack).not.toBeNull();
+    expect(progressTrack.getAttribute("role")).toBe("progressbar");
+    expect(progressTrack.getAttribute("aria-valuenow")).toBe("6");
+    expect(progressTrack.getAttribute("aria-valuemin")).toBe("0");
+    expect(progressTrack.getAttribute("aria-valuemax")).toBe("12");
     const progressFill = progressTrack!.querySelector(
       ".bg-amber-500",
     ) as HTMLElement;
@@ -415,8 +421,14 @@ describe("TitleCard", () => {
       wrapper: NoUserWrapper,
     });
 
-    const progressTrack = container.querySelector(".bg-zinc-700");
+    const progressTrack = container.querySelector(
+      ".bg-zinc-700",
+    ) as HTMLElement;
     expect(progressTrack).not.toBeNull();
+    expect(progressTrack.getAttribute("role")).toBe("progressbar");
+    expect(progressTrack.getAttribute("aria-valuenow")).toBe("3");
+    expect(progressTrack.getAttribute("aria-valuemin")).toBe("0");
+    expect(progressTrack.getAttribute("aria-valuemax")).toBe("10");
     const progressFill = progressTrack!.querySelector(".bg-amber-500");
     expect(progressFill).not.toBeNull();
   });

--- a/frontend/src/components/TitleCard.tsx
+++ b/frontend/src/components/TitleCard.tsx
@@ -146,7 +146,16 @@ const TitleCard = memo(function TitleCard({
           <>
             {showProgressBar &&
             (title.released_episodes_count ?? title.total_episodes ?? 0) > 0 ? (
-              <div className="absolute bottom-0 left-0 right-0 h-1 bg-zinc-700">
+              <div
+                className="absolute bottom-0 left-0 right-0 h-1 bg-zinc-700"
+                role="progressbar"
+                aria-label={`${title.watched_episodes_count ?? 0} of ${title.released_episodes_count ?? title.total_episodes ?? 1} episodes watched`}
+                aria-valuenow={title.watched_episodes_count ?? 0}
+                aria-valuemin={0}
+                aria-valuemax={
+                  title.released_episodes_count ?? title.total_episodes ?? 1
+                }
+              >
                 <div
                   className="h-full bg-amber-500 transition-all duration-300"
                   style={{
@@ -196,7 +205,16 @@ const TitleCard = memo(function TitleCard({
           title.object_type === "SHOW" &&
           title.total_episodes != null &&
           title.total_episodes > 0 && (
-            <div className="absolute bottom-0 left-0 right-0 h-1 bg-zinc-700">
+            <div
+              className="absolute bottom-0 left-0 right-0 h-1 bg-zinc-700"
+              role="progressbar"
+              aria-label={`${title.watched_episodes_count ?? 0} of ${title.released_episodes_count ?? title.total_episodes} episodes watched`}
+              aria-valuenow={title.watched_episodes_count ?? 0}
+              aria-valuemin={0}
+              aria-valuemax={
+                title.released_episodes_count ?? title.total_episodes
+              }
+            >
               <div
                 className="h-full bg-amber-500 transition-all duration-300"
                 style={{


### PR DESCRIPTION
## Summary

- Both episode-progress `<div>` elements in `TitleCard.tsx` were plain decorative divs with no ARIA semantics — screen readers had no way to announce watch progress
- Added `role="progressbar"`, `aria-valuenow`, `aria-valuemin`, `aria-valuemax`, and `aria-label` to both instances (one inside `show_status === "watching"` path, one inside the fallback no-status path)
- Existing progress-bar unit tests in `TitleCard.test.tsx` extended to assert the new attributes

## Scope

2 files changed, ~15 LOC added. No logic changes — pure attribute additions.

## Test plan
- [x] `cd frontend && bun test src/components/TitleCard.test.tsx` — 26 pass, 0 fail
- [x] `bunx tsc -b --noEmit` — no type errors
- [x] `bun run lint` — no ESLint warnings or errors
- [x] Pre-push hook (types-and-lint + changed-tests) — all passed

---
_Source: ux_

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrPUyzdcQAuGBAng4wY7Pe)_