### PR TITLE
fix(jobs): stop "Run now" double-queueing cron jobs and unblock admin page (CF/DO)

### DIFF
--- a/server/jobs/backend.test.ts
+++ b/server/jobs/backend.test.ts
@@ -32,6 +32,7 @@ import {
   enqueueOnce,
   processPending,
   recoverStale,
+  getJobsOverview,
   CRON_JOBS,
   CRON_BY_EXPRESSION,
   runWithEnv,
@@ -292,15 +293,21 @@ describe("tickCron", () => {
 });
 
 describe("triggerCron (DO mode)", () => {
-  it("arms AND ticks the named DO so 'Run now' actually executes", async () => {
+  it("arms, enqueues, AND ticks the named DO so 'Run now' actually executes", async () => {
     CONFIG.JOB_QUEUE_BACKEND = "durable-object";
     const ns = makeFakeDoNamespace();
     const env = {
       ...d1Env,
       JOB_QUEUE_DO: ns as unknown as DurableObjectNamespace,
     };
+    const deferred: Promise<unknown>[] = [];
 
-    const result = await triggerCron(env, "sync-episodes");
+    const result = await triggerCron(env, "sync-episodes", (p) =>
+      deferred.push(p),
+    );
+    // The tick is deferred to waitUntil so the caller can respond immediately;
+    // await it here to assert the full dispatch happened.
+    await Promise.all(deferred);
 
     expect(result.jobId).toBeNull();
     const paths = ns.calls.map((c) => c.path);
@@ -310,6 +317,24 @@ describe("triggerCron (DO mode)", () => {
     // The forced job row must be enqueued before the tick that drains it,
     // otherwise tick() finds nothing to run when the cron isn't due.
     expect(paths.indexOf("/enqueue")).toBeLessThan(paths.indexOf("/tick"));
+  });
+
+  it("defers /tick to waitUntil instead of awaiting it inline (non-blocking 'Run now')", async () => {
+    CONFIG.JOB_QUEUE_BACKEND = "durable-object";
+    const ns = makeFakeDoNamespace();
+    const env = {
+      ...d1Env,
+      JOB_QUEUE_DO: ns as unknown as DurableObjectNamespace,
+    };
+    const deferred: Promise<unknown>[] = [];
+
+    // /arm and /enqueue are awaited; /tick is handed to waitUntil.
+    await triggerCron(env, "sync-episodes", (p) => deferred.push(p));
+
+    expect(deferred).toHaveLength(1);
+    const armEnqueue = ns.calls.map((c) => c.path);
+    expect(armEnqueue).toContain("/arm");
+    expect(armEnqueue).toContain("/enqueue");
   });
 
   it("returns jobId null for an unknown job without dispatching", async () => {
@@ -325,6 +350,43 @@ describe("triggerCron (DO mode)", () => {
     expect(result.jobId).toBeNull();
     expect(ns.calls).toHaveLength(0);
   });
+});
+
+describe("getJobsOverview (DO mode) read-RPC timeout", () => {
+  it("returns promptly with empty stats when a DO's read RPCs hang", async () => {
+    CONFIG.JOB_QUEUE_BACKEND = "durable-object";
+    // A DO blocked running a long job never responds to its read RPCs. The stub honors
+    // the abort signal doFetch attaches, so each read aborts after READ_RPC_TIMEOUT_MS
+    // and the .catch falls back to empty — the overview must not hang.
+    const stub = {
+      fetch: (req: Request) =>
+        new Promise<Response>((_resolve, reject) => {
+          req.signal?.addEventListener("abort", () =>
+            reject(new Error("aborted")),
+          );
+          // never resolve otherwise
+        }),
+    };
+    const env = {
+      ...d1Env,
+      JOB_QUEUE_DO: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => stub,
+      } as unknown as DurableObjectNamespace,
+    };
+
+    const start = Date.now();
+    const overview = await getJobsOverview(env);
+    const elapsed = Date.now() - start;
+
+    // Resolves around the 3s timeout, well short of the platform's ~30s hang.
+    expect(elapsed).toBeLessThan(10_000);
+    // Every cron DO degraded to empty stats rather than blocking the page.
+    for (const s of Object.values(overview.stats)) {
+      expect(s).toEqual({ pending: 0, running: 0, completed: 0, failed: 0 });
+    }
+    expect(overview.crons.every((c) => c.last_run === null)).toBe(true);
+  }, 15_000);
 });
 
 describe("processPending (DO mode)", () => {

--- a/server/jobs/backend.ts
+++ b/server/jobs/backend.ts
@@ -88,6 +88,10 @@ function getDoId(
   return doNamespace.idFromName(key);
 }
 
+/** Per-RPC deadline for the read fan-out in getJobsData, so a DO busy running a job
+ *  can't stall the admin page (the .catch falls back to empty after this elapses). */
+const READ_RPC_TIMEOUT_MS = 3000;
+
 async function doFetch<T>(
   env: CFEnv,
   name: string,
@@ -95,19 +99,34 @@ async function doFetch<T>(
   method: "GET" | "POST",
   body?: unknown,
   partitionKey?: string | number | null,
+  timeoutMs?: number,
 ): Promise<T> {
   const id = getDoId(env, name, partitionKey);
   const stub = env.JOB_QUEUE_DO!.get(id);
-  const resp = await stub.fetch(
-    new Request(`https://do${path}`, {
-      method,
-      headers: body ? { "content-type": "application/json" } : undefined,
-      body: body ? JSON.stringify(body) : undefined,
-    }),
-  );
-  if (!resp.ok)
-    throw new Error(`DO fetch failed: ${resp.status} ${await resp.text()}`);
-  return resp.json() as Promise<T>;
+  // Optional timeout: a DO is single-threaded, so while it runs a long job body its
+  // read RPCs (/stats, /cron-info, /recent-jobs) would otherwise hang until the platform
+  // timeout and stall the admin page. AbortController lets the caller's .catch fall back
+  // to empty quickly. Write RPCs pass no timeout — they must reach the DO.
+  const controller = timeoutMs != null ? new AbortController() : undefined;
+  const timer =
+    controller != null
+      ? setTimeout(() => controller.abort(), timeoutMs)
+      : undefined;
+  try {
+    const resp = await stub.fetch(
+      new Request(`https://do${path}`, {
+        method,
+        headers: body ? { "content-type": "application/json" } : undefined,
+        body: body ? JSON.stringify(body) : undefined,
+        signal: controller?.signal,
+      }),
+    );
+    if (!resp.ok)
+      throw new Error(`DO fetch failed: ${resp.status} ${await resp.text()}`);
+    return resp.json() as Promise<T>;
+  } finally {
+    if (timer != null) clearTimeout(timer);
+  }
 }
 
 // ─── Public API ──────────────────────────────────────────────────────────────
@@ -437,7 +456,15 @@ async function getJobsOverviewDO(env: CFEnv): Promise<{
   const [statsResults, cronInfoResults, recentResults] = await Promise.all([
     Promise.all(
       doNames.map((name) =>
-        doFetch<JobStats>(env, name, "/stats", "GET")
+        doFetch<JobStats>(
+          env,
+          name,
+          "/stats",
+          "GET",
+          undefined,
+          null,
+          READ_RPC_TIMEOUT_MS,
+        )
           .then((s) => ({ name, stats: s }))
           .catch((err) => {
             log.warn("DO stats unavailable", { name, err });
@@ -452,7 +479,7 @@ async function getJobsOverviewDO(env: CFEnv): Promise<{
           nextRun: string | null;
           lastRun: string | null;
           alarmLastCompletedAt: string | null;
-        }>(env, name, "/cron-info", "GET")
+        }>(env, name, "/cron-info", "GET", undefined, null, READ_RPC_TIMEOUT_MS)
           .then((info) => ({ name, info }))
           .catch((err) => {
             log.warn("DO cron-info unavailable", { name, err });
@@ -462,7 +489,15 @@ async function getJobsOverviewDO(env: CFEnv): Promise<{
     ),
     Promise.all(
       doNames.map((name) =>
-        doFetch<DOJobRow[]>(env, name, "/recent-jobs?limit=5", "GET")
+        doFetch<DOJobRow[]>(
+          env,
+          name,
+          "/recent-jobs?limit=5",
+          "GET",
+          undefined,
+          null,
+          READ_RPC_TIMEOUT_MS,
+        )
           .then((rows) => rows.map((r) => ({ ...r, name })))
           .catch((err) => {
             log.warn("DO recent-jobs unavailable", { name, err });
@@ -516,6 +551,7 @@ async function getJobsOverviewDO(env: CFEnv): Promise<{
 export async function triggerCron(
   env: CFEnv,
   name: string,
+  waitUntil?: (promise: Promise<unknown>) => void,
 ): Promise<{ jobId: number | null }> {
   if (CONFIG.JOB_QUEUE_BACKEND === "durable-object") {
     const jobDef = CRON_JOBS.find((j) => j.name === name);
@@ -523,13 +559,25 @@ export async function triggerCron(
     await doFetch(env, name, "/arm", "POST", { name, cron: jobDef.cron });
     // "Run now" must execute regardless of cron schedule. tick() honors cron timing
     // and won't auto-create a job when the cron isn't due, so force a real pending
-    // row first; runJob then claims and runs it on the tick below (#795-followup).
+    // row first; runJob then claims and runs it on the tick (#795-followup).
     await doFetch(env, name, "/enqueue", "POST", {
       name,
       data: null,
       idempotent: true,
     });
-    await doFetch(env, name, "/tick", "POST", {});
+    // Drive the job via /tick WITHOUT blocking the HTTP response: running a full sync
+    // body inline made the POST take 140s+. Defer it to waitUntil so the request returns
+    // immediately while the job runs promptly (not waiting on unreliable alarm delivery).
+    // runJob's due/in-flight guards ensure this tick + the enqueue's 1s alarm can't
+    // double-run. When no executionCtx is available (e.g. tests), fall back to detached.
+    const tick = doFetch(env, name, "/tick", "POST", {}).catch((err) => {
+      log.warn("DO tick failed", {
+        name,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+    if (waitUntil) waitUntil(tick);
+    else void tick;
     return { jobId: null };
   }
   const jobId = await enqueueJobReturningId(name);

--- a/server/jobs/durable-object.test.ts
+++ b/server/jobs/durable-object.test.ts
@@ -290,6 +290,76 @@ describe("JobQueueDO", () => {
     expect(rows[0].status).toBe("completed");
   });
 
+  it("runJob (alarm path) does NOT auto-create a duplicate when the cron just ran (not due)", async () => {
+    // Regression for the "Run now queues twice" bug: triggerCron's /enqueue schedules a
+    // 1-second delayed alarm; after /tick runs the job, that leftover alarm fires and
+    // invokes runJob via the alarm path with NO opts. Without an intrinsic due-check it
+    // fabricated a fresh cron run → "2 running". Here a completed row timestamped now makes
+    // the daily cron not due, so the alarm-path runJob must create nothing.
+    let calls = 0;
+    processorModule.handlers["sync-titles"] = async () => {
+      calls++;
+    };
+    await do_.armCron("sync-titles", "0 3 * * *");
+    const now = new Date().toISOString();
+    state.rawDb
+      .prepare(
+        "INSERT INTO jobs (name, status, run_at, completed_at) VALUES ('sync-titles','completed',?,?)",
+      )
+      .run(now, now);
+
+    await do_.runJob(null); // alarm-path invocation (no opts)
+
+    expect(calls).toBe(0);
+    expect(do_.getRecentJobs()).toHaveLength(1); // only the seeded completed row
+  });
+
+  it("runJob does NOT fabricate a duplicate while a run is already in flight", async () => {
+    // A concurrent /tick may have claimed the row (status='running') with no terminal row
+    // yet, so the cron still looks due. The 'running' guard must still block a second run.
+    let calls = 0;
+    processorModule.handlers["sync-titles"] = async () => {
+      calls++;
+    };
+    await do_.armCron("sync-titles", "0 3 * * *");
+    const now = new Date().toISOString();
+    state.rawDb
+      .prepare(
+        "INSERT INTO jobs (name, status, run_at, started_at) VALUES ('sync-titles','running',?,?)",
+      )
+      .run(now, now);
+
+    await do_.runJob(null);
+
+    expect(calls).toBe(0);
+    const rows = do_.getRecentJobs();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("running"); // untouched
+  });
+
+  it("tick() reclaims a stale 'running' row (DO-reset orphan) and drains it", async () => {
+    // A deploy ("Durable Object reset because its code was updated") can kill an in-flight
+    // runJob, orphaning a row in 'running'. tick() runs on the reliable watchdog path and
+    // must reclaim it (recover) before draining so it doesn't stay stuck forever.
+    let calls = 0;
+    processorModule.handlers["sync-titles"] = async () => {
+      calls++;
+    };
+    await do_.armCron("sync-titles", "0 3 * * *");
+    const stale = new Date(Date.now() - 20 * 60 * 1000).toISOString();
+    state.rawDb
+      .prepare(
+        "INSERT INTO jobs (name, status, run_at, started_at) VALUES ('sync-titles','running',?,?)",
+      )
+      .run(stale, stale);
+
+    const result = await do_.tick();
+
+    expect(result.ran).toBe(true);
+    expect(calls).toBe(1);
+    expect(do_.getRecentJobs()[0].status).toBe("completed");
+  });
+
   it("runJob skips jobs not yet ready (future run_at)", async () => {
     let called = false;
     processorModule.handlers["sync-show-episodes"] = async () => {

--- a/server/jobs/durable-object.ts
+++ b/server/jobs/durable-object.ts
@@ -252,14 +252,28 @@ export class JobQueueDO {
     >[];
 
     if (rows.length === 0) {
-      if (cron && !opts.skipCronAutoCreate) {
-        // Cron singleton: alarm fires at each scheduled tick. Auto-create the job for
-        // this tick if no pending rows exist (including future-scheduled ones).
-        const anyPending =
+      // Cron singleton: alarm fires at each scheduled tick. Auto-create the job for
+      // this tick only when the cron is genuinely DUE and no pending/running row exists.
+      //
+      // The native cron alarm and the 1-second "drain" alarm (scheduled by enqueue/
+      // rearmIfPending) share this runJob callback and are indistinguishable here. Without
+      // an intrinsic due-check, a drain alarm that fires right after a manual "Run now"
+      // (the enqueued row already claimed by /tick) would fabricate a duplicate run — the
+      // cause of "2 running" after a single click. tick() also passes skipCronAutoCreate as
+      // belt-and-suspenders, but the alarm path never receives opts, so the load-bearing
+      // guard is this internal isCronDue() check. The 'running' guard additionally stops a
+      // second fabrication while a run is still in flight.
+      const due =
+        cron != null &&
+        this.isCronDue(cron, this.lastTerminalRun(), new Date());
+      if (cron && due && !opts.skipCronAutoCreate) {
+        const anyActive =
           this.ctx.storage.sql
-            .exec("SELECT 1 FROM jobs WHERE status = 'pending' LIMIT 1")
+            .exec(
+              "SELECT 1 FROM jobs WHERE status IN ('pending', 'running') LIMIT 1",
+            )
             .toArray().length > 0;
-        if (!anyPending) {
+        if (!anyActive) {
           this.ctx.storage.sql.exec(
             "INSERT INTO jobs (name, run_at, max_attempts) VALUES (?, ?, 3)",
             name,
@@ -466,20 +480,34 @@ export class JobQueueDO {
     if (!name) return { ran: false };
     const cron = (await this.ctx.storage.get<string>("cron")) ?? null;
 
+    // Reclaim rows orphaned in 'running' (e.g. a DO reset "because its code was updated"
+    // killed an in-flight runJob callback). This runs on the watchdog-driven /tick path,
+    // which fires reliably every 5 min, so orphans recover even when the separate
+    // /recover RPC is starved by a busy DO.
+    this.recover();
+
     let skipCronAutoCreate = false;
     if (cron) {
-      const lastRows = this.ctx.storage.sql
-        .exec(
-          "SELECT completed_at FROM jobs WHERE status IN ('completed', 'failed') ORDER BY id DESC LIMIT 1",
-        )
-        .toArray() as Array<{ completed_at: string | null }>;
-      const lastRun = lastRows[0]?.completed_at ?? null;
-      skipCronAutoCreate = !this.isCronDue(cron, lastRun, new Date());
+      skipCronAutoCreate = !this.isCronDue(
+        cron,
+        this.lastTerminalRun(),
+        new Date(),
+      );
     }
 
     const terminalBefore = this.terminalCount();
     await this.runJob(null, { skipCronAutoCreate });
     return { ran: this.terminalCount() > terminalBefore };
+  }
+
+  /** completed_at of the most recent terminal (completed/failed) row, or null if none. */
+  private lastTerminalRun(): string | null {
+    const rows = this.ctx.storage.sql
+      .exec(
+        "SELECT completed_at FROM jobs WHERE status IN ('completed', 'failed') ORDER BY id DESC LIMIT 1",
+      )
+      .toArray() as Array<{ completed_at: string | null }>;
+    return rows[0]?.completed_at ?? null;
   }
 
   /** Count of rows that have reached a terminal state (used to detect tick execution). */
@@ -683,17 +711,12 @@ export class JobQueueDO {
       const schedule = cronSchedules[0] as { time: number };
       nextRun = new Date(schedule.time * 1000).toISOString();
     }
-    const lastRows = this.ctx.storage.sql
-      .exec(
-        "SELECT completed_at FROM jobs WHERE status IN ('completed', 'failed') ORDER BY id DESC LIMIT 1",
-      )
-      .toArray() as Array<{ completed_at: string | null }>;
     const alarmLastCompletedAt =
       (await this.ctx.storage.get<string>("alarm_last_completed_at")) ?? null;
     return {
       cron,
       nextRun,
-      lastRun: lastRows[0]?.completed_at ?? null,
+      lastRun: this.lastTerminalRun(),
       alarmLastCompletedAt,
     };
   }

--- a/server/routes/jobs-cf.test.ts
+++ b/server/routes/jobs-cf.test.ts
@@ -224,13 +224,23 @@ describe("POST /jobs/:name (CF)", () => {
         },
       }),
     };
+    const deferred: Promise<unknown>[] = [];
+    const executionCtx = {
+      waitUntil: (p: Promise<unknown>) => deferred.push(p),
+      passThroughOnException: () => {},
+    };
     try {
       const res = await app.request(
         "/jobs/sync-episodes",
         { method: "POST", headers: { Cookie: adminCookie } },
         { JOB_QUEUE_DO: fakeNs, DB: {} } as unknown as Record<string, unknown>,
+        executionCtx as unknown as Parameters<typeof app.request>[3],
       );
       expect(res.status).toBe(200);
+      // The tick is deferred to executionCtx.waitUntil so the response returns
+      // immediately instead of blocking on the (potentially multi-minute) job.
+      expect(deferred).toHaveLength(1);
+      await Promise.all(deferred);
       const paths = calls.map((c) => c.path);
       expect(paths).toContain("/arm");
       expect(paths).toContain("/enqueue");

--- a/server/routes/jobs-cf.ts
+++ b/server/routes/jobs-cf.ts
@@ -32,7 +32,18 @@ app.post("/:name", zValidator("param", jobNameParamSchema), async (c) => {
   if (!VALID_JOB_NAMES.has(name as (typeof CRON_JOBS)[number]["name"])) {
     return err(c, `Unknown job: ${name}`, 400);
   }
-  const result = await triggerCron(c.env as unknown as CFEnv, name);
+  // Pass executionCtx.waitUntil so triggerCron can run the job in the background
+  // instead of blocking this response until the (potentially multi-minute) job finishes.
+  // c.executionCtx throws when no ExecutionContext is bound (e.g. some test harnesses);
+  // fall back to undefined so triggerCron detaches the tick instead.
+  let waitUntil: ((p: Promise<unknown>) => void) | undefined;
+  try {
+    const ctx = c.executionCtx;
+    waitUntil = (p) => ctx.waitUntil(p);
+  } catch {
+    waitUntil = undefined;
+  }
+  const result = await triggerCron(c.env as unknown as CFEnv, name, waitUntil);
   return ok(c, { jobId: result.jobId, success: true });
 });
 


### PR DESCRIPTION
## Problem

On the Cloudflare / Durable Object backend, clicking **Run now** once on the admin Jobs page made a cron job run **twice** (UI showed `2 running`, piling up to `5 running` for Sync Deep Links), the page took **30–49s** to load, and the POST itself took **142s**. Confirmed against Cloudflare Workers logs.

### Root causes
- **Duplicate runs.** `runJob`'s cron auto-create branch fired on the alarm path with no `opts`, so it ignored cron-due timing and only checked for `pending` (not `running`) rows. The 1s "drain" alarm scheduled by `/enqueue` — woken every 15s by the admin page's `/recent-jobs` poll — then fabricated a fresh run after `/tick` already claimed the row.
- **Slow page.** `doFetch` had no timeout, so `getJobsOverview`'s read fan-out hung on DOs blocked running long jobs synchronously (`DO recent-jobs unavailable`, `Slow request: GET /api/jobs (49359ms)`).
- **Slow Run now.** `triggerCron` `await`ed `/tick` (the full job body) inline.
- **Orphaned rows.** A `Durable Object reset because its code was updated` deploy killed in-flight `runJob` callbacks, leaving rows stuck in `running`.

## Fixes
1. **`runJob` auto-create gating** — only fabricate a per-tick cron job when `isCronDue(...)` **and** no `pending`/`running` row exists. Adds `lastTerminalRun()` helper, reused in `tick()`/`getCronInfo()`.
2. **`doFetch` timeout** — optional `timeoutMs` via `AbortController`; the three read RPCs use 3s, so a busy DO degrades to empty stats fast instead of hanging.
3. **Async Run now** — `triggerCron` defers `/tick` to `executionCtx.waitUntil`; the POST returns immediately while the job runs in the background.
4. **Orphan recovery** — `tick()` runs `recover()` for stale `running` rows before draining, on the reliable watchdog path.

## Tests
- `durable-object.test.ts`: no-duplicate-when-not-due, no-fabricate-while-running, tick reclaims stale `running` row.
- `backend.test.ts`: `/tick` deferred to `waitUntil`, read-RPC timeout degrades gracefully.
- `jobs-cf.test.ts`: route defers tick to `executionCtx.waitUntil`.

`bun run check` passes (tsc + lint + full suites + build + wrangler dry-run + bundle budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)