### PR TITLE
feat(home): Trending section (movies, TV, people) on home

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/001-trending-home"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ To bypass: `git push --no-verify`
 <!-- SPECKIT START -->
 
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the current plan
+shell commands, and other important information, read the current plan:
+`specs/001-trending-home/plan.md`
 
 <!-- SPECKIT END -->

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -38,6 +38,7 @@ import type {
   LeaderboardEntry,
   StreakData,
   CollectionDetails,
+  TrendingSnapshot,
 } from "./types";
 import { ApiError } from "./lib/api-error";
 
@@ -168,6 +169,12 @@ export async function browseTitles(
   if (params.minRating != null) qs.set("min_rating", String(params.minRating));
   if (params.onlyMine) qs.set("onlyMine", "true");
   return fetchJson(`/browse?${qs}`, { signal });
+}
+
+export async function getTrending(
+  signal?: AbortSignal,
+): Promise<TrendingSnapshot> {
+  return fetchJson("/trending", { signal });
 }
 
 export async function syncReleases(

--- a/frontend/src/components/TrendingSection.test.tsx
+++ b/frontend/src/components/TrendingSection.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { render, screen, cleanup } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router";
+import TrendingSection from "./TrendingSection";
+import type { TrendingTitle, TrendingPerson } from "../types";
+
+// FullBleedCarousel observes its scroll container; happy-dom lacks ResizeObserver.
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+Object.defineProperty(globalThis, "ResizeObserver", {
+  value: MockResizeObserver,
+  writable: true,
+  configurable: true,
+});
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
+
+const movie: TrendingTitle = {
+  id: "movie-1",
+  objectType: "MOVIE",
+  title: "Trending Movie",
+  posterUrl: "https://image.tmdb.org/t/p/w342/poster.jpg",
+  releaseDate: "2026-01-01",
+  isTracked: false,
+};
+
+const show: TrendingTitle = {
+  id: "tv-2",
+  objectType: "SHOW",
+  title: "Trending Show",
+  posterUrl: "https://image.tmdb.org/t/p/w342/show.jpg",
+  releaseDate: null,
+  isTracked: false,
+};
+
+const movieNoPoster: TrendingTitle = {
+  ...movie,
+  id: "movie-5",
+  title: "No Poster Movie",
+  posterUrl: null,
+};
+
+const person: TrendingPerson = {
+  id: 3,
+  name: "Trending Actor",
+  profileUrl: "https://image.tmdb.org/t/p/w185/actor.jpg",
+  knownForDepartment: "Acting",
+};
+
+const personNoPhoto: TrendingPerson = {
+  id: 4,
+  name: "Zelda Nophoto",
+  profileUrl: null,
+  knownForDepartment: null,
+};
+
+afterEach(() => cleanup());
+
+describe("TrendingSection — titles (US1)", () => {
+  it("renders movie and TV rows with titles", () => {
+    render(<TrendingSection movies={[movie]} shows={[show]} people={[]} />, {
+      wrapper: Wrapper,
+    });
+    expect(screen.getByText("Trending Now")).toBeTruthy();
+    expect(screen.getByText("Movies")).toBeTruthy();
+    expect(screen.getByText("TV Shows")).toBeTruthy();
+    expect(screen.getByText("Trending Movie")).toBeTruthy();
+    expect(screen.getByText("Trending Show")).toBeTruthy();
+  });
+
+  it("links a title to its detail view /title/:id", () => {
+    render(<TrendingSection movies={[movie]} shows={[]} people={[]} />, {
+      wrapper: Wrapper,
+    });
+    const link = screen.getByText("Trending Movie").closest("a");
+    expect(link?.getAttribute("href")).toBe("/title/movie-1");
+  });
+
+  it("renders a placeholder (no <img>) when a poster is missing", () => {
+    const { container } = render(
+      <TrendingSection movies={[movieNoPoster]} shows={[]} people={[]} />,
+      { wrapper: Wrapper },
+    );
+    expect(container.querySelector("img")).toBeNull();
+    expect(screen.getByText("No Poster Movie")).toBeTruthy();
+  });
+
+  it("shows a tracked badge for tracked titles (FR-012)", () => {
+    render(
+      <TrendingSection
+        movies={[{ ...movie, isTracked: true }]}
+        shows={[]}
+        people={[]}
+      />,
+      { wrapper: Wrapper },
+    );
+    expect(screen.getByText("Tracking")).toBeTruthy();
+  });
+});
+
+describe("TrendingSection — people (US2)", () => {
+  it("renders person rows with name and department", () => {
+    render(<TrendingSection movies={[]} shows={[]} people={[person]} />, {
+      wrapper: Wrapper,
+    });
+    expect(screen.getByText("People")).toBeTruthy();
+    expect(screen.getByText("Trending Actor")).toBeTruthy();
+    expect(screen.getByText("Acting")).toBeTruthy();
+  });
+
+  it("links a person to /person/:id", () => {
+    render(<TrendingSection movies={[]} shows={[]} people={[person]} />, {
+      wrapper: Wrapper,
+    });
+    const link = screen.getByText("Trending Actor").closest("a");
+    expect(link?.getAttribute("href")).toBe("/person/3");
+  });
+
+  it("renders a placeholder (no <img>) when a profile photo is missing", () => {
+    const { container } = render(
+      <TrendingSection movies={[]} shows={[]} people={[personNoPhoto]} />,
+      { wrapper: Wrapper },
+    );
+    expect(container.querySelector("img")).toBeNull();
+    // Placeholder is the first letter of the name
+    expect(screen.getByText("Z")).toBeTruthy();
+  });
+
+  it("omits the people group entirely when there are no people (FR-013)", () => {
+    render(<TrendingSection movies={[movie]} shows={[]} people={[]} />, {
+      wrapper: Wrapper,
+    });
+    expect(screen.queryByText("People")).toBeNull();
+    expect(screen.queryByText("TV Shows")).toBeNull();
+  });
+});
+
+describe("TrendingSection — loading & empty states (US3)", () => {
+  it("renders a non-blocking loading placeholder that does not block siblings", () => {
+    const { container } = render(
+      <>
+        <TrendingSection movies={[]} shows={[]} people={[]} isLoading />
+        <div>Sibling content</div>
+      </>,
+      { wrapper: Wrapper },
+    );
+    expect(container.querySelector('section[aria-busy="true"]')).not.toBeNull();
+    // Siblings still render — trending never blocks the rest of home (FR-009).
+    expect(screen.getByText("Sibling content")).toBeTruthy();
+  });
+
+  it("hides the whole section when all groups are empty and not loading", () => {
+    const { container } = render(
+      <TrendingSection movies={[]} shows={[]} people={[]} />,
+      { wrapper: Wrapper },
+    );
+    expect(container.querySelector("section")).toBeNull();
+    expect(screen.queryByText("Trending Now")).toBeNull();
+  });
+});

--- a/frontend/src/components/TrendingSection.tsx
+++ b/frontend/src/components/TrendingSection.tsx
@@ -1,0 +1,156 @@
+import { Link } from "react-router";
+import FullBleedCarousel from "./FullBleedCarousel";
+import { MediaCard } from "./MediaCard";
+import { Kicker } from "./design";
+import type { TrendingTitle, TrendingPerson } from "../types";
+
+interface TrendingSectionProps {
+  movies: TrendingTitle[];
+  shows: TrendingTitle[];
+  people: TrendingPerson[];
+  isLoading?: boolean;
+}
+
+function TitleCardItem({ title }: { title: TrendingTitle }) {
+  return (
+    <div className="w-44 flex-shrink-0" style={{ scrollSnapAlign: "start" }}>
+      <MediaCard
+        aspect="poster"
+        to={`/title/${title.id}`}
+        imageUrl={title.posterUrl}
+        imageAlt={title.title}
+        title={title.title}
+        titleClamp={2}
+        badge={
+          title.isTracked
+            ? { label: "Tracking", tone: "accent", position: "top-left" }
+            : {
+                label: title.objectType === "MOVIE" ? "Movie" : "TV",
+                tone: "neutral",
+                position: "top-left",
+              }
+        }
+      />
+    </div>
+  );
+}
+
+/**
+ * People render as circular avatar cards — visually distinct from the poster
+ * title cards (FR-004) — linking to the existing person detail page (FR-006).
+ */
+function PersonCardItem({ person }: { person: TrendingPerson }) {
+  return (
+    <Link
+      to={`/person/${person.id}`}
+      className="group w-32 flex-shrink-0 text-center"
+      style={{ scrollSnapAlign: "start" }}
+    >
+      <div className="mx-auto mb-2 h-28 w-28 overflow-hidden rounded-full bg-zinc-800 transition-all group-hover:ring-2 group-hover:ring-amber-400">
+        {person.profileUrl ? (
+          <img
+            src={person.profileUrl}
+            alt={person.name}
+            loading="lazy"
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center bg-gradient-to-b from-zinc-800 to-zinc-950 text-3xl text-zinc-500">
+            {person.name.charAt(0)}
+          </div>
+        )}
+      </div>
+      <p className="truncate text-sm font-medium text-white transition-colors group-hover:text-amber-400">
+        {person.name}
+      </p>
+      {person.knownForDepartment && (
+        <p className="truncate text-xs text-zinc-400">
+          {person.knownForDepartment}
+        </p>
+      )}
+    </Link>
+  );
+}
+
+function GroupHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="mb-2 font-mono text-[11px] uppercase tracking-[0.12em] text-zinc-400">
+      {children}
+    </h3>
+  );
+}
+
+export default function TrendingSection({
+  movies,
+  shows,
+  people,
+  isLoading = false,
+}: TrendingSectionProps) {
+  const hasAny = movies.length > 0 || shows.length > 0 || people.length > 0;
+
+  // Non-blocking loading placeholder (FR-009). Rendered alongside other home
+  // sections — it never delays them.
+  if (isLoading && !hasAny) {
+    return (
+      <section aria-label="Trending" aria-busy="true">
+        <div className="mb-4">
+          <Kicker>Trending</Kicker>
+          <h2 className="text-xl font-bold tracking-[-0.01em]">Trending Now</h2>
+        </div>
+        <div className="flex gap-3 overflow-hidden">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="aspect-[2/3] w-44 flex-shrink-0 animate-pulse rounded-xl bg-zinc-800/60"
+            />
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  // Hide the whole section when there is nothing to show (FR-008 fail-soft /
+  // FR-013 empty groups).
+  if (!hasAny) return null;
+
+  return (
+    <section aria-label="Trending">
+      <div className="mb-4">
+        <Kicker>Trending</Kicker>
+        <h2 className="text-xl font-bold tracking-[-0.01em]">Trending Now</h2>
+      </div>
+      <div className="space-y-6">
+        {movies.length > 0 && (
+          <div>
+            <GroupHeading>Movies</GroupHeading>
+            <FullBleedCarousel>
+              {movies.map((m) => (
+                <TitleCardItem key={m.id} title={m} />
+              ))}
+            </FullBleedCarousel>
+          </div>
+        )}
+        {shows.length > 0 && (
+          <div>
+            <GroupHeading>TV Shows</GroupHeading>
+            <FullBleedCarousel>
+              {shows.map((s) => (
+                <TitleCardItem key={s.id} title={s} />
+              ))}
+            </FullBleedCarousel>
+          </div>
+        )}
+        {people.length > 0 && (
+          <div>
+            <GroupHeading>People</GroupHeading>
+            <FullBleedCarousel>
+              {people.map((p) => (
+                <PersonCardItem key={p.id} person={p} />
+              ))}
+            </FullBleedCarousel>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -54,9 +54,10 @@ Object.defineProperty(globalThis, "ResizeObserver", {
   configurable: true,
 });
 
-// Ensure useIsMobile returns false so desktop layout renders in tests
+// useIsMobile is controllable per-test; defaults to false (desktop layout).
+let mockIsMobile = false;
 mock.module("../hooks/useIsMobile", () => ({
-  useIsMobile: () => false,
+  useIsMobile: () => mockIsMobile,
 }));
 
 function makeSearchTitle(i: number) {
@@ -127,6 +128,7 @@ function applyHomeDefaults() {
   apiMock.getHomepageLayout.mockImplementation(() =>
     Promise.resolve({
       homepage_layout: [
+        { id: "trending", enabled: true },
         { id: "today", enabled: true },
         { id: "upcoming", enabled: true },
         { id: "unwatched", enabled: true },
@@ -134,6 +136,9 @@ function applyHomeDefaults() {
         { id: "friends_loved", enabled: true },
       ],
     }),
+  );
+  apiMock.getTrending.mockImplementation(() =>
+    Promise.resolve({ movies: [], shows: [], people: [], refreshedAt: "" }),
   );
   apiMock.getUpNext.mockImplementation(() => Promise.resolve({ items: [] }));
   apiMock.getFriendsLoved.mockImplementation(() =>
@@ -166,6 +171,7 @@ afterEach(() => {
   cleanup();
   mockUser = null;
   mockAuthLoading = false;
+  mockIsMobile = false;
   resetApiMock();
 });
 
@@ -256,6 +262,97 @@ describe("HomePage — unauthenticated landing", () => {
 
     expect(screen.queryByText("Recommended for You")).toBeNull();
     expect(apiMock.getRecommendations).not.toHaveBeenCalled();
+  });
+});
+
+describe("HomePage — trending section", () => {
+  function trendingMovie() {
+    return {
+      id: "movie-99",
+      objectType: "MOVIE" as const,
+      title: "Trending Pick",
+      posterUrl: null,
+      releaseDate: "2026-02-02",
+      isTracked: false,
+    };
+  }
+
+  it("shows the trending section to signed-out visitors", async () => {
+    apiMock.getTrending.mockImplementation(() =>
+      Promise.resolve({
+        movies: [trendingMovie()],
+        shows: [],
+        people: [],
+        refreshedAt: "2026-06-17T05:00:00.000Z",
+      }),
+    );
+
+    render(<HomePage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Trending Now")).toBeDefined();
+    });
+    expect(screen.getByText("Trending Pick")).toBeDefined();
+  });
+
+  it("shows the trending section to authenticated users via the home layout", async () => {
+    mockUser = {
+      id: "u1",
+      username: "testuser",
+      display_name: null,
+      auth_provider: "local",
+      is_admin: false,
+    };
+    apiMock.getTrending.mockImplementation(() =>
+      Promise.resolve({
+        movies: [],
+        shows: [
+          {
+            id: "tv-77",
+            objectType: "SHOW" as const,
+            title: "Trending Series",
+            posterUrl: null,
+            releaseDate: null,
+            isTracked: false,
+          },
+        ],
+        people: [],
+        refreshedAt: "2026-06-17T05:00:00.000Z",
+      }),
+    );
+
+    render(<HomePage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Trending Now")).toBeDefined();
+    });
+    expect(screen.getByText("Trending Series")).toBeDefined();
+  });
+
+  it("shows the trending section to authenticated users on a mobile viewport", async () => {
+    mockUser = {
+      id: "u1",
+      username: "testuser",
+      display_name: null,
+      auth_provider: "local",
+      is_admin: false,
+    };
+    mockIsMobile = true;
+    apiMock.getTrending.mockImplementation(() =>
+      Promise.resolve({
+        movies: [trendingMovie()],
+        shows: [],
+        people: [],
+        refreshedAt: "2026-06-17T05:00:00.000Z",
+      }),
+    );
+
+    render(<HomePage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Trending Now")).toBeDefined();
+    });
+    expect(screen.getByText("Trending Pick")).toBeDefined();
   });
 });
 

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -15,6 +15,7 @@ import type {
   HomepageSection,
   FriendsLovedItem,
   StreakData,
+  TrendingSnapshot,
 } from "../types";
 import { normalizeSearchTitle, DEFAULT_HOMEPAGE_LAYOUT } from "../types";
 import StreakCounter from "../components/profile/StreakCounter";
@@ -36,6 +37,7 @@ import UpNextRow from "../components/UpNextRow";
 import FriendsLovedRow from "../components/FriendsLovedRow";
 import SuggestedForYouRow from "../components/SuggestedForYouRow";
 import MovieRow from "../components/MovieRow";
+import TrendingSection from "../components/TrendingSection";
 import { MediaCard } from "../components/MediaCard";
 import type { UpNextItem, MovieTrackResponse } from "../api";
 
@@ -101,12 +103,16 @@ function MobileFeedHome({
   upcoming,
   unwatched,
   streak,
+  trending,
+  trendingLoading,
 }: {
   user: NonNullable<ReturnType<typeof useAuth>["user"]>;
   today: Episode[];
   upcoming: Episode[];
   unwatched: Episode[];
   streak: StreakData | null;
+  trending: TrendingSnapshot;
+  trendingLoading: boolean;
 }) {
   const tonightEp = today[0] ?? null;
   const alsoAiring = today.slice(1);
@@ -391,6 +397,16 @@ function MobileFeedHome({
           </div>
         </>
       )}
+
+      {/* Trending — discovery row (movies, TV, people) */}
+      <div className="px-5 pt-5">
+        <TrendingSection
+          movies={trending.movies}
+          shows={trending.shows}
+          people={trending.people}
+          isLoading={trendingLoading}
+        />
+      </div>
     </div>
   );
 }
@@ -414,6 +430,20 @@ export default function HomePage() {
         .then((res) => res.titles.map(normalizeSearchTitle))
         .catch(() => [] as Title[]),
   });
+
+  // Trending snapshot — shared by the signed-in and signed-out home paths
+  // (FR-011). Fails soft: a rejected fetch yields an empty section, never an
+  // error that blocks the rest of home (FR-008).
+  const { data: trendingData, isLoading: trendingLoading } = useQuery({
+    queryKey: ["trending"],
+    queryFn: ({ signal }) => api.getTrending(signal),
+  });
+  const trending = trendingData ?? {
+    movies: [],
+    shows: [],
+    people: [],
+    refreshedAt: "",
+  };
 
   const {
     data: authData,
@@ -698,6 +728,14 @@ export default function HomePage() {
           </div>
         </div>
 
+        {/* Trending (movies, TV, people) — available to signed-out visitors */}
+        <TrendingSection
+          movies={trending.movies}
+          shows={trending.shows}
+          people={trending.people}
+          isLoading={trendingLoading}
+        />
+
         {/* Popular titles */}
         <section>
           <div className="flex items-baseline justify-between mb-4">
@@ -736,6 +774,8 @@ export default function HomePage() {
         upcoming={upcoming}
         unwatched={unwatched}
         streak={streakData}
+        trending={trending}
+        trendingLoading={trendingLoading}
       />
     );
   }
@@ -1072,6 +1112,17 @@ export default function HomePage() {
             <StreakCounter variant="home" streak={streakData} />
           </section>
         ) : null;
+
+      case "trending":
+        return (
+          <TrendingSection
+            key="trending"
+            movies={trending.movies}
+            shows={trending.shows}
+            people={trending.people}
+            isLoading={trendingLoading}
+          />
+        );
 
       default:
         return null;

--- a/frontend/src/test-utils/apiMock.ts
+++ b/frontend/src/test-utils/apiMock.ts
@@ -51,6 +51,12 @@ const defaults: Record<string, (...args: unknown[]) => Promise<unknown>> = {
   getTitles: async () => emptyPage(),
   searchTitles: async () => ({ titles: [] }),
   browseTitles: async () => emptyBrowse(),
+  getTrending: async () => ({
+    movies: [],
+    shows: [],
+    people: [],
+    refreshedAt: "",
+  }),
   syncReleases: async () => ({}),
   resolveImdb: async () => null,
   getProviders: async () => ({ providers: [], regionProviderIds: [] }),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -805,7 +805,36 @@ export interface AppearanceSettings {
   autoplayTrailers: number;
 }
 
+// ─── Trending (home screen) ───────────────────────────────────────────────────
+
+/** A trending movie or TV show. `posterUrl` is a full image URL (or null). */
+export interface TrendingTitle {
+  id: string;
+  objectType: "MOVIE" | "SHOW";
+  title: string;
+  posterUrl: string | null;
+  releaseDate: string | null;
+  isTracked: boolean;
+}
+
+/** A trending person. `profileUrl` is a full image URL (or null). Not trackable. */
+export interface TrendingPerson {
+  id: number;
+  name: string;
+  profileUrl: string | null;
+  knownForDepartment: string | null;
+}
+
+/** The trending snapshot returned by GET /api/trending. Any group may be empty. */
+export interface TrendingSnapshot {
+  movies: TrendingTitle[];
+  shows: TrendingTitle[];
+  people: TrendingPerson[];
+  refreshedAt: string;
+}
+
 export type HomepageSectionId =
+  | "trending"
   | "up_next"
   | "unwatched"
   | "recommendations"
@@ -824,6 +853,7 @@ export interface HomepageSection {
 
 export const DEFAULT_HOMEPAGE_LAYOUT: HomepageSection[] = [
   { id: "streak", enabled: true },
+  { id: "trending", enabled: true },
   { id: "up_next", enabled: true },
   { id: "unwatched", enabled: true },
   { id: "movies_to_watch", enabled: true },

--- a/server/config.ts
+++ b/server/config.ts
@@ -26,6 +26,12 @@ export const CONFIG = {
   SYNC_TITLES_CRON: process.env.SYNC_TITLES_CRON || "0 3 * * *",
   SYNC_EPISODES_CRON: process.env.SYNC_EPISODES_CRON || "30 3 * * *",
 
+  // Trending (home screen)
+  SYNC_TRENDING_CRON: process.env.SYNC_TRENDING_CRON || "0 5 * * *",
+  TRENDING_TIME_WINDOW: (process.env.TRENDING_TIME_WINDOW || "week") as
+    | "day"
+    | "week",
+
   // Backup
   BACKUP_DIR: process.env.BACKUP_DIR || "",
   BACKUP_CRON: process.env.BACKUP_CRON || "0 2 * * *",
@@ -101,6 +107,7 @@ export const CONFIG = {
   CACHE_TTL_BROWSE: Number(process.env.CACHE_TTL_BROWSE) || 900,
   CACHE_TTL_FEED_ICS: Number(process.env.CACHE_TTL_FEED_ICS) || 300,
   CACHE_TTL_STREAMING: Number(process.env.CACHE_TTL_STREAMING) || 86400,
+  CACHE_TTL_TRENDING: Number(process.env.CACHE_TTL_TRENDING) || 86400,
   CACHE_MAX_MEMORY_ENTRIES:
     Number(process.env.CACHE_MAX_MEMORY_ENTRIES) || 1000,
 };

--- a/server/index.ts
+++ b/server/index.ts
@@ -26,6 +26,7 @@ import adminRoutes, { setOnOidcSettingsChanged } from "./routes/admin";
 import adminMaintenanceRoutes from "./routes/admin-maintenance";
 import jobsRoutes from "./routes/jobs";
 import browseRoutes from "./routes/browse";
+import trendingRoutes from "./routes/trending";
 import detailsRoutes from "./routes/details";
 import notifierRoutes from "./routes/notifiers";
 import integrationRoutes from "./routes/integrations";
@@ -292,6 +293,11 @@ const browseRateLimiter = rateLimiter({
 app.use("/api/browse/*", browseRateLimiter, optionalAuth);
 app.use("/api/browse", browseRateLimiter, optionalAuth);
 app.route("/api/browse", browseRoutes);
+
+// Trending (home screen) — optionalAuth for per-user isTracked overlay
+app.use("/api/trending/*", optionalAuth);
+app.use("/api/trending", optionalAuth);
+app.route("/api/trending", trendingRoutes);
 
 app.use("/api/calendar/*", optionalAuth);
 app.use("/api/calendar", optionalAuth);

--- a/server/jobs/backend.test.ts
+++ b/server/jobs/backend.test.ts
@@ -550,7 +550,7 @@ describe("cleanupOld (D1 mode)", () => {
 });
 
 describe("cleanupOld (DO mode)", () => {
-  it("fans out POST /cleanup to all 5 cron DOs and sums counts", async () => {
+  it("fans out POST /cleanup to all 6 cron DOs and sums counts", async () => {
     CONFIG.JOB_QUEUE_BACKEND = "durable-object";
     const ns = makeFakeDoNamespace(() => ({ count: 2 }));
     const env = {
@@ -560,15 +560,15 @@ describe("cleanupOld (DO mode)", () => {
 
     const total = await cleanupOld(env, 30);
 
-    // 4 CRON_JOB_NAMES + "cleanup" = 5 DOs
-    expect(ns.calls).toHaveLength(5);
+    // 5 CRON_JOB_NAMES + "cleanup" = 6 DOs
+    expect(ns.calls).toHaveLength(6);
     expect(
       ns.calls.every((c) => c.path === "/cleanup" && c.method === "POST"),
     ).toBe(true);
     expect(ns.calls.every((c) => (c.body as any).retentionDays === 30)).toBe(
       true,
     );
-    expect(total).toBe(10); // 5 × 2
+    expect(total).toBe(12); // 6 × 2
     expect(mockCleanupOldJobs).not.toHaveBeenCalled();
   });
 
@@ -597,10 +597,10 @@ describe("cleanupOld (DO mode)", () => {
 
     const total = await cleanupOld(env, 30);
 
-    // All 5 DOs were attempted despite one failure
-    expect(attempted).toHaveLength(5);
+    // All 6 DOs were attempted despite one failure
+    expect(attempted).toHaveLength(6);
     expect(attempted).toContain("send-notifications");
-    // Only 4 fulfilled × 3 = 12 (send-notifications rejected, excluded)
-    expect(total).toBe(12);
+    // Only 5 fulfilled × 3 = 15 (send-notifications rejected, excluded)
+    expect(total).toBe(15);
   });
 });

--- a/server/jobs/backend.ts
+++ b/server/jobs/backend.ts
@@ -48,6 +48,7 @@ function getEnvOrNull(): CFEnv | null {
 export const CRON_JOBS = [
   { name: "sync-titles", cron: "0 3 * * *" },
   { name: "sync-episodes", cron: "30 3 * * *" },
+  { name: "sync-trending", cron: "0 5 * * *" },
   { name: "sync-deep-links", cron: "0 4 * * *" },
   { name: "send-notifications", cron: "*/5 * * * *" },
   { name: "cleanup", cron: "0 0 * * *" },

--- a/server/jobs/durable-object.ts
+++ b/server/jobs/durable-object.ts
@@ -81,6 +81,7 @@ export interface DOEnv extends CfConfigEnv {
 export const CRON_JOB_NAMES = [
   "sync-titles",
   "sync-episodes",
+  "sync-trending",
   "sync-deep-links",
   "send-notifications",
 ] as const;

--- a/server/jobs/processor.test.ts
+++ b/server/jobs/processor.test.ts
@@ -37,12 +37,41 @@ const mockSyncEpisodesForShow = spyOn(
   "syncEpisodesForShow",
 ).mockResolvedValue(0);
 
+import * as tmdbClientModule from "../tmdb/client";
+const emptyTrendingPage = {
+  results: [],
+  total_pages: 1,
+  total_results: 0,
+  page: 1,
+};
+const mockFetchTrendingMovies = spyOn(
+  tmdbClientModule,
+  "fetchTrendingMovies",
+).mockResolvedValue(emptyTrendingPage as any);
+const mockFetchTrendingTv = spyOn(
+  tmdbClientModule,
+  "fetchTrendingTv",
+).mockResolvedValue(emptyTrendingPage as any);
+const mockFetchTrendingPeople = spyOn(
+  tmdbClientModule,
+  "fetchTrendingPeople",
+).mockResolvedValue(emptyTrendingPage as any);
+
 import { CONFIG } from "../config";
+import { initCache, getCache } from "../cache";
+import { MemoryCache } from "../cache/memory";
+import { CRON_JOBS } from "./backend";
+import { trendingCacheKey } from "../routes/trending";
+import { makeTmdbDiscoverMovie } from "../test-utils/fixtures";
+
+// Trending sync writes to the distributed cache — initialize an in-memory one.
+initCache(new MemoryCache(100));
 
 import {
   processPendingJobs,
   enqueueCronJob,
   cleanupOldJobs,
+  handlers,
 } from "./processor";
 
 // ─── Setup ───────────────────────────────────────────────────────────────────
@@ -57,6 +86,10 @@ beforeEach(() => {
   mockSyncEpisodes.mockClear();
   mockSyncEpisodesForShow.mockClear();
   mockDeleteExpiredSessions.mockClear();
+  mockFetchTrendingMovies.mockClear();
+  mockFetchTrendingTv.mockClear();
+  mockFetchTrendingPeople.mockClear();
+  initCache(new MemoryCache(100));
 });
 
 afterAll(() => {
@@ -67,6 +100,9 @@ afterAll(() => {
   mockSyncEpisodes.mockRestore();
   mockSyncEpisodesForShow.mockRestore();
   mockDeleteExpiredSessions.mockRestore();
+  mockFetchTrendingMovies.mockRestore();
+  mockFetchTrendingTv.mockRestore();
+  mockFetchTrendingPeople.mockRestore();
 });
 
 async function insertJob(
@@ -617,5 +653,55 @@ describe("processor Sentry capture on permanent failure", () => {
     expect(typeof permanentLog!.runAt).toBe("string");
 
     consoleErrorSpy.mockRestore();
+  });
+});
+
+// ─── CF handler parity ───────────────────────────────────────────────────────
+// The CF runtime dispatches every job through the `handlers` record (D1 mode via
+// processPendingJobs, DO mode via durable-object runJob). A cron in CRON_JOBS
+// with no handler here fails with "Unknown job type" on every tick — this guard
+// catches that class of dual-runtime parity gap.
+
+describe("CF handler parity", () => {
+  it("every cron job in CRON_JOBS has a CF processor handler", () => {
+    for (const { name } of CRON_JOBS) {
+      expect(handlers[name]).toBeDefined();
+    }
+  });
+
+  it("includes a sync-trending handler", () => {
+    expect(handlers["sync-trending"]).toBeDefined();
+  });
+});
+
+// ─── sync-trending (CF path) ─────────────────────────────────────────────────
+
+describe("sync-trending handler (CF path)", () => {
+  it("builds the snapshot and writes the cache via processPendingJobs", async () => {
+    mockFetchTrendingMovies.mockResolvedValueOnce({
+      results: [makeTmdbDiscoverMovie({ id: 1 })],
+      total_pages: 1,
+      total_results: 1,
+      page: 1,
+    } as any);
+
+    await insertJob("sync-trending");
+    await processPendingJobs();
+
+    expect(mockFetchTrendingMovies).toHaveBeenCalledTimes(1);
+    const cached = (await getCache().get(trendingCacheKey("week"))) as any;
+    expect(cached).not.toBeNull();
+    expect(cached.movies).toHaveLength(1);
+    expect(cached.movies[0].id).toBe("movie-1");
+  });
+
+  it("skips and writes nothing when TMDB_API_KEY is unset", async () => {
+    CONFIG.TMDB_API_KEY = "";
+    await insertJob("sync-trending");
+    await processPendingJobs();
+
+    expect(mockFetchTrendingMovies).not.toHaveBeenCalled();
+    expect(await getCache().get(trendingCacheKey("week"))).toBeNull();
+    CONFIG.TMDB_API_KEY = "test-key";
   });
 });

--- a/server/jobs/processor.ts
+++ b/server/jobs/processor.ts
@@ -21,6 +21,8 @@ import { fetchNewReleases } from "../tmdb/sync-titles";
 import { syncEpisodes, syncEpisodesForShow } from "../tmdb/sync";
 import { fetchMovieDetails, fetchTvDetails } from "../tmdb/client";
 import { parseMovieDetails, parseTvDetails } from "../tmdb/parser";
+import { getCache } from "../cache";
+import { buildTrendingSnapshot, trendingCacheKey } from "../routes/trending";
 import { getProvider } from "../notifications/registry";
 import { buildNotificationContent } from "../notifications/content";
 import { SubscriptionExpiredError } from "../notifications/webpush";
@@ -75,6 +77,29 @@ async function handleSyncEpisodes(): Promise<void> {
   }
   const result = await syncEpisodes();
   log.info("Synced episodes", { synced: result.synced, shows: result.shows });
+}
+
+async function handleSyncTrending(): Promise<void> {
+  if (!CONFIG.TMDB_API_KEY) {
+    log.info("Skipping trending sync", {
+      reason: "TMDB_API_KEY not configured",
+    });
+    return;
+  }
+  const timeWindow = CONFIG.TRENDING_TIME_WINDOW;
+  // buildTrendingSnapshot throws on upstream failure, so the cache write below
+  // is skipped — the previously cached (stale) snapshot survives the outage.
+  const snapshot = await buildTrendingSnapshot(timeWindow);
+  await getCache().set(
+    trendingCacheKey(timeWindow),
+    snapshot,
+    CONFIG.CACHE_TTL_TRENDING,
+  );
+  log.info("Refreshed trending snapshot", {
+    movies: snapshot.movies.length,
+    shows: snapshot.shows.length,
+    people: snapshot.people.length,
+  });
 }
 
 async function handleSyncShowEpisodes(data: string | null): Promise<void> {
@@ -551,6 +576,7 @@ export const handlers: Record<string, (data: string | null) => Promise<void>> =
   {
     "sync-titles": () => handleSyncTitles(),
     "sync-episodes": () => handleSyncEpisodes(),
+    "sync-trending": () => handleSyncTrending(),
     "sync-show-episodes": (data) => handleSyncShowEpisodes(data),
     "send-notifications": () => handleSendNotifications(),
     "backfill-title-offers": (data) => handleBackfillTitleOffers(data),

--- a/server/jobs/sync.test.ts
+++ b/server/jobs/sync.test.ts
@@ -62,6 +62,26 @@ const mockFetchTvDetails = spyOn(
   "fetchTvDetails",
 ).mockResolvedValue({} as any);
 
+// Mock TMDB trending fetchers for the sync-trending handler
+const emptyTrendingPage = {
+  results: [],
+  total_pages: 1,
+  total_results: 0,
+  page: 1,
+};
+const mockFetchTrendingMovies = spyOn(
+  tmdbClient,
+  "fetchTrendingMovies",
+).mockResolvedValue(emptyTrendingPage as any);
+const mockFetchTrendingTv = spyOn(
+  tmdbClient,
+  "fetchTrendingTv",
+).mockResolvedValue(emptyTrendingPage as any);
+const mockFetchTrendingPeople = spyOn(
+  tmdbClient,
+  "fetchTrendingPeople",
+).mockResolvedValue(emptyTrendingPage as any);
+
 // Mock parser
 import * as parser from "../tmdb/parser";
 const mockParseMovieDetails = spyOn(
@@ -130,6 +150,13 @@ const mockGetEnabledIntegrations = spyOn(
 );
 
 import { CONFIG } from "../config";
+import { initCache, getCache } from "../cache";
+import { MemoryCache } from "../cache/memory";
+import { trendingCacheKey } from "../routes/trending";
+import { makeTmdbDiscoverMovie } from "../test-utils/fixtures";
+
+// Trending sync writes to the distributed cache — initialize an in-memory one.
+initCache(new MemoryCache(100));
 
 // Import after mocks are set up
 import { registerSyncJobs } from "./sync";
@@ -148,6 +175,9 @@ beforeEach(() => {
   mockMigrateOffers.mockClear();
   mockFetchMovieDetails.mockClear();
   mockFetchTvDetails.mockClear();
+  mockFetchTrendingMovies.mockClear();
+  mockFetchTrendingTv.mockClear();
+  mockFetchTrendingPeople.mockClear();
   mockParseMovieDetails.mockClear();
   mockParseTvDetails.mockClear();
   captureExceptionSpy.mockClear();
@@ -172,6 +202,9 @@ afterAll(() => {
   mockMigrateOffers.mockRestore();
   mockFetchMovieDetails.mockRestore();
   mockFetchTvDetails.mockRestore();
+  mockFetchTrendingMovies.mockRestore();
+  mockFetchTrendingTv.mockRestore();
+  mockFetchTrendingPeople.mockRestore();
   mockParseMovieDetails.mockRestore();
   mockParseTvDetails.mockRestore();
   mockSyncPlexWatched.mockRestore();
@@ -192,17 +225,20 @@ describe("registerSyncJobs", () => {
 
     expect(names).toContain("sync-titles");
     expect(names).toContain("sync-episodes");
+    expect(names).toContain("sync-trending");
   });
 
-  it("uses CONFIG cron expressions for sync-titles and sync-episodes", () => {
+  it("uses CONFIG cron expressions for sync-titles, sync-episodes, and sync-trending", () => {
     registerSyncJobs();
 
     const crons = getCronJobs();
     const syncTitles = crons.find((c) => c.name === "sync-titles");
     const syncEpisodes = crons.find((c) => c.name === "sync-episodes");
+    const syncTrending = crons.find((c) => c.name === "sync-trending");
 
     expect(syncTitles?.cron).toBe(CONFIG.SYNC_TITLES_CRON);
     expect(syncEpisodes?.cron).toBe(CONFIG.SYNC_EPISODES_CRON);
+    expect(syncTrending?.cron).toBe(CONFIG.SYNC_TRENDING_CRON);
   });
 
   it("enqueues a one-time migrate-titles job on registration", () => {
@@ -411,6 +447,79 @@ describe("sync-episodes handler", () => {
     await processJobs();
 
     expect(captureExceptionSpy).toHaveBeenCalledWith(error);
+  });
+});
+
+// ─── sync-trending handler ───────────────────────────────────────────────────
+
+describe("sync-trending handler", () => {
+  const originalApiKey = CONFIG.TMDB_API_KEY;
+
+  beforeEach(() => {
+    // Fresh cache per test so pre-seeded snapshots don't leak between cases.
+    initCache(new MemoryCache(100));
+    CONFIG.TMDB_API_KEY = "test-key";
+    registerSyncJobs();
+    claimNextJob("migrate-titles");
+    claimNextJob("migrate-backdrops");
+    claimNextJob("migrate-offers");
+  });
+
+  afterAll(() => {
+    CONFIG.TMDB_API_KEY = originalApiKey;
+  });
+
+  it("builds the snapshot and populates the cache", async () => {
+    mockFetchTrendingMovies.mockResolvedValueOnce({
+      results: [makeTmdbDiscoverMovie({ id: 1 })],
+      total_pages: 1,
+      total_results: 1,
+      page: 1,
+    } as any);
+
+    enqueueJob("sync-trending");
+    await processJobs();
+
+    expect(mockFetchTrendingMovies).toHaveBeenCalledTimes(1);
+    const cached = (await getCache().get(trendingCacheKey("week"))) as any;
+    expect(cached).not.toBeNull();
+    expect(cached.movies).toHaveLength(1);
+    expect(cached.movies[0].id).toBe("movie-1");
+  });
+
+  it("skips when TMDB_API_KEY is not set", async () => {
+    CONFIG.TMDB_API_KEY = "";
+
+    enqueueJob("sync-trending");
+    await processJobs();
+
+    expect(mockFetchTrendingMovies).not.toHaveBeenCalled();
+    expect(await getCache().get(trendingCacheKey("week"))).toBeNull();
+  });
+
+  it("does not overwrite a warm cache when the TMDB build fails (stale survives)", async () => {
+    const stale = {
+      movies: [
+        {
+          id: "movie-9",
+          objectType: "MOVIE",
+          title: "Stale",
+          posterUrl: null,
+          releaseDate: null,
+        },
+      ],
+      shows: [],
+      people: [],
+      refreshedAt: "2026-01-01T00:00:00.000Z",
+    };
+    await getCache().set(trendingCacheKey("week"), stale, 86400);
+    mockFetchTrendingMovies.mockRejectedValueOnce(new Error("TMDB down"));
+
+    enqueueJob("sync-trending");
+    await processJobs();
+
+    const cached = await getCache().get(trendingCacheKey("week"));
+    expect(cached).toEqual(stale);
   });
 });
 

--- a/server/jobs/sync.ts
+++ b/server/jobs/sync.ts
@@ -28,6 +28,8 @@ import { BreakerOpenError } from "../lib/circuit-breaker";
 import { getTitlesNeedingSaEnrichment } from "../db/repository";
 import { syncEachWithDelay } from "../tmdb/sync-utils";
 import { handleReleaseReminder } from "./release-reminders";
+import { getCache } from "../cache";
+import { buildTrendingSnapshot, trendingCacheKey } from "../routes/trending";
 
 export function registerSyncJobs() {
   // ─── Handlers ───────────────────────────────────────────────────────────
@@ -78,6 +80,29 @@ export function registerSyncJobs() {
     }
     const result = await syncEpisodes();
     log.info("Synced episodes", { synced: result.synced, shows: result.shows });
+  });
+
+  registerHandler("sync-trending", async () => {
+    if (!CONFIG.TMDB_API_KEY) {
+      log.info("Skipping trending sync", {
+        reason: "TMDB_API_KEY not configured",
+      });
+      return;
+    }
+    const timeWindow = CONFIG.TRENDING_TIME_WINDOW;
+    // buildTrendingSnapshot throws on upstream failure, so the cache write below
+    // is skipped — the previously cached (stale) snapshot survives the outage.
+    const snapshot = await buildTrendingSnapshot(timeWindow);
+    await getCache().set(
+      trendingCacheKey(timeWindow),
+      snapshot,
+      CONFIG.CACHE_TTL_TRENDING,
+    );
+    log.info("Refreshed trending snapshot", {
+      movies: snapshot.movies.length,
+      shows: snapshot.shows.length,
+      people: snapshot.people.length,
+    });
   });
 
   registerHandler("sync-show-episodes", async (job) => {
@@ -268,6 +293,7 @@ export function registerSyncJobs() {
 
   registerCron("sync-titles", CONFIG.SYNC_TITLES_CRON);
   registerCron("sync-episodes", CONFIG.SYNC_EPISODES_CRON);
+  registerCron("sync-trending", CONFIG.SYNC_TRENDING_CRON);
   registerCron("sync-plex-watched", CONFIG.SYNC_PLEX_CRON);
   registerCron("sync-plex-library", CONFIG.SYNC_PLEX_LIBRARY_CRON);
 

--- a/server/metrics/index.ts
+++ b/server/metrics/index.ts
@@ -93,6 +93,13 @@ export const browseCacheTotal = new Counter(
   "Browse response cache hit/miss",
 );
 
+// ─── Trending Cache Metrics ───────────────────────────────────────────────────
+
+export const trendingCacheTotal = new Counter(
+  "trending_cache_total",
+  "Trending response cache hit/miss",
+);
+
 // ─── TMDB Timeout Metrics ─────────────────────────────────────────────────────
 
 export const tmdbTimeoutsTotal = new Counter(
@@ -117,6 +124,7 @@ const allMetrics = [
   circuitBreakerStateChangesTotal,
   notificationsSentTotal,
   browseCacheTotal,
+  trendingCacheTotal,
   tmdbTimeoutsTotal,
 ];
 

--- a/server/routes/jobs-cf.test.ts
+++ b/server/routes/jobs-cf.test.ts
@@ -68,7 +68,7 @@ afterAll(() => {
 });
 
 describe("GET /jobs (CF)", () => {
-  it("returns stats, crons (4 entries), and recentJobs with snake_case fields", async () => {
+  it("returns stats, crons (6 entries), and recentJobs with snake_case fields", async () => {
     const res = await app.request("/jobs", {
       headers: { Cookie: adminCookie },
     });
@@ -77,11 +77,12 @@ describe("GET /jobs (CF)", () => {
     const body = await res.json();
     expect(body.stats).toBeDefined();
     expect(body.crons).toBeArray();
-    expect(body.crons).toHaveLength(5);
+    expect(body.crons).toHaveLength(6);
 
     const names = body.crons.map((c: any) => c.name);
     expect(names).toContain("sync-titles");
     expect(names).toContain("sync-episodes");
+    expect(names).toContain("sync-trending");
     expect(names).toContain("sync-deep-links");
     expect(names).toContain("send-notifications");
 

--- a/server/routes/trending.test.ts
+++ b/server/routes/trending.test.ts
@@ -1,0 +1,219 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  afterAll,
+  spyOn,
+} from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "../types";
+import { setupTestDb, teardownTestDb } from "../test-utils/setup";
+import { upsertTitles, trackTitle, createUser } from "../db/repository";
+import {
+  makeParsedTitle,
+  makeTmdbDiscoverMovie,
+  makeTmdbDiscoverTv,
+  makeTmdbTrendingPerson,
+} from "../test-utils/fixtures";
+import * as tmdbClient from "../tmdb/client";
+import { initCache } from "../cache";
+import { MemoryCache } from "../cache/memory";
+
+const trendingApp = (await import("./trending")).default;
+
+const emptyPage = { results: [], total_pages: 1, total_results: 0, page: 1 };
+
+let app: Hono<AppEnv>;
+let spies: ReturnType<typeof spyOn>[] = [];
+
+function authedApp(userId: string) {
+  const a = new Hono<AppEnv>();
+  a.use("*", async (c, next) => {
+    c.set("user", {
+      id: userId,
+      username: "trendinguser",
+      name: null,
+      role: null,
+      is_admin: false,
+    });
+    await next();
+  });
+  a.route("/trending", trendingApp);
+  return a;
+}
+
+beforeEach(() => {
+  setupTestDb();
+  initCache(new MemoryCache(1000));
+
+  app = new Hono<AppEnv>();
+  app.route("/trending", trendingApp);
+
+  spies = [
+    spyOn(tmdbClient, "fetchTrendingMovies").mockResolvedValue({
+      ...emptyPage,
+    } as never),
+    spyOn(tmdbClient, "fetchTrendingTv").mockResolvedValue({
+      ...emptyPage,
+    } as never),
+    spyOn(tmdbClient, "fetchTrendingPeople").mockResolvedValue({
+      ...emptyPage,
+    } as never),
+  ];
+});
+
+afterEach(() => {
+  for (const s of spies) s.mockRestore();
+  spies = [];
+});
+
+afterAll(() => {
+  teardownTestDb();
+});
+
+describe("GET /trending — validation", () => {
+  it("rejects an invalid time_window with 400 + issues", async () => {
+    const res = await app.request("/trending?time_window=bogus");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("accepts time_window=day and forwards it to the fetchers", async () => {
+    const res = await app.request("/trending?time_window=day");
+    expect(res.status).toBe(200);
+    expect(tmdbClient.fetchTrendingMovies).toHaveBeenCalledWith("day");
+    expect(tmdbClient.fetchTrendingTv).toHaveBeenCalledWith("day");
+    expect(tmdbClient.fetchTrendingPeople).toHaveBeenCalledWith("day");
+  });
+});
+
+describe("GET /trending — happy path", () => {
+  it("returns 200 with movies/shows/people and calls the trending fetchers", async () => {
+    (tmdbClient.fetchTrendingMovies as any).mockResolvedValueOnce({
+      ...emptyPage,
+      results: [makeTmdbDiscoverMovie({ id: 1 })],
+    });
+    (tmdbClient.fetchTrendingTv as any).mockResolvedValueOnce({
+      ...emptyPage,
+      results: [makeTmdbDiscoverTv({ id: 2 })],
+    });
+    (tmdbClient.fetchTrendingPeople as any).mockResolvedValueOnce({
+      ...emptyPage,
+      results: [makeTmdbTrendingPerson({ id: 3, name: "Jane Doe" })],
+    });
+
+    const res = await app.request("/trending");
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.movies).toHaveLength(1);
+    expect(body.shows).toHaveLength(1);
+    expect(body.people).toHaveLength(1);
+    expect(body.movies[0].id).toBe("movie-1");
+    expect(body.movies[0].objectType).toBe("MOVIE");
+    expect(body.movies[0].posterUrl).toContain("https://image.tmdb.org");
+    expect(body.movies[0].isTracked).toBe(false);
+    expect(body.shows[0].id).toBe("tv-2");
+    expect(body.people[0].id).toBe(3);
+    expect(body.people[0].name).toBe("Jane Doe");
+    expect(typeof body.refreshedAt).toBe("string");
+
+    expect(tmdbClient.fetchTrendingMovies).toHaveBeenCalledTimes(1);
+    expect(tmdbClient.fetchTrendingTv).toHaveBeenCalledTimes(1);
+    expect(tmdbClient.fetchTrendingPeople).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("GET /trending — isTracked overlay", () => {
+  it("returns isTracked=true for a tracked title when authed, false for anon", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-100" })]);
+    const userId = await createUser("trendinguser", "hash");
+    await trackTitle("movie-100", userId);
+
+    (tmdbClient.fetchTrendingMovies as any).mockResolvedValue({
+      ...emptyPage,
+      results: [makeTmdbDiscoverMovie({ id: 100 })],
+    });
+
+    const anonRes = await app.request("/trending");
+    const anonBody = await anonRes.json();
+    expect(anonBody.movies[0].isTracked).toBe(false);
+
+    // Second request (authed) hits the cache, but isTracked is overlaid per
+    // request — the cached snapshot itself is user-agnostic.
+    const authRes = await authedApp(userId).request("/trending");
+    const authBody = await authRes.json();
+    expect(authBody.movies[0].isTracked).toBe(true);
+  });
+});
+
+describe("GET /trending — cache", () => {
+  it("serves the second request from cache without re-calling TMDB", async () => {
+    (tmdbClient.fetchTrendingMovies as any).mockResolvedValue({
+      ...emptyPage,
+      results: [makeTmdbDiscoverMovie({ id: 11 })],
+    });
+
+    await app.request("/trending");
+    await app.request("/trending");
+
+    expect(tmdbClient.fetchTrendingMovies).toHaveBeenCalledTimes(1);
+    expect(tmdbClient.fetchTrendingTv).toHaveBeenCalledTimes(1);
+    expect(tmdbClient.fetchTrendingPeople).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("GET /trending — dedupe + empty groups", () => {
+  it("collapses duplicate ids within a group and returns [] for empty types", async () => {
+    (tmdbClient.fetchTrendingMovies as any).mockResolvedValueOnce({
+      ...emptyPage,
+      results: [
+        makeTmdbDiscoverMovie({ id: 7 }),
+        makeTmdbDiscoverMovie({ id: 7 }),
+      ],
+    });
+
+    const res = await app.request("/trending");
+    const body = await res.json();
+
+    expect(body.movies).toHaveLength(1);
+    expect(body.movies[0].id).toBe("movie-7");
+    expect(body.shows).toEqual([]);
+    expect(body.people).toEqual([]);
+  });
+});
+
+describe("GET /trending — fail soft", () => {
+  it("returns 200 with empty groups when TMDB rejects and the cache is cold", async () => {
+    (tmdbClient.fetchTrendingMovies as any).mockRejectedValueOnce(
+      new Error("TMDB unavailable"),
+    );
+
+    const res = await app.request("/trending");
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.movies).toEqual([]);
+    expect(body.shows).toEqual([]);
+    expect(body.people).toEqual([]);
+    expect(typeof body.refreshedAt).toBe("string");
+
+    // An empty fail-soft response must NOT be edge-cached for the full TTL —
+    // otherwise the section stays empty for a day after TMDB recovers.
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("sets a public edge cache for anonymous requests on the success path", async () => {
+    (tmdbClient.fetchTrendingMovies as any).mockResolvedValueOnce({
+      ...emptyPage,
+      results: [makeTmdbDiscoverMovie({ id: 12 })],
+    });
+    const res = await app.request("/trending");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toContain("public");
+  });
+});

--- a/server/routes/trending.ts
+++ b/server/routes/trending.ts
@@ -1,0 +1,177 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import {
+  fetchTrendingMovies,
+  fetchTrendingTv,
+  fetchTrendingPeople,
+  tmdbLanguage,
+  type TrendingTimeWindow,
+} from "../tmdb/client";
+import {
+  parseDiscoverMovie,
+  parseDiscoverTv,
+  parseTrendingPerson,
+  type ParsedTitle,
+  type TrendingPerson,
+} from "../tmdb/parser";
+import { getTrackedTitleIds } from "../db/repository";
+import type { AppEnv } from "../types";
+import { logger } from "../logger";
+import { syncFailureTotal, trendingCacheTotal } from "../metrics";
+import { ok } from "./response";
+import { setPublicCacheIfAnon } from "./cache-headers";
+import { zValidator } from "../lib/validator";
+import { getCache } from "../cache";
+import { CONFIG } from "../config";
+
+const log = logger.child({ module: "trending" });
+
+// ─── Snapshot shapes ────────────────────────────────────────────────────────
+
+/** A trending movie/TV show in the user-agnostic snapshot (no `isTracked`). */
+export interface TrendingTitleSnapshot {
+  id: string;
+  objectType: "MOVIE" | "SHOW";
+  title: string;
+  posterUrl: string | null;
+  releaseDate: string | null;
+}
+
+/** The cached, user-agnostic trending snapshot. Any group may be empty. */
+export interface TrendingSnapshot {
+  movies: TrendingTitleSnapshot[];
+  shows: TrendingTitleSnapshot[];
+  people: TrendingPerson[];
+  refreshedAt: string;
+}
+
+// parseDiscoverMovie/Tv need a genre map; trending doesn't surface genres so we
+// pass an empty one (avoids an extra TMDB round-trip for genre lists).
+const EMPTY_GENRES = new Map<number, string>();
+
+const trendingQuerySchema = z.object({
+  time_window: z.enum(["day", "week"]).optional(),
+});
+
+/** Cache key for a snapshot. Includes language + window so configs don't collide. */
+export function trendingCacheKey(timeWindow: TrendingTimeWindow): string {
+  return `trending:v1:${tmdbLanguage()}:${timeWindow}`;
+}
+
+function toTrendingTitle(t: ParsedTitle): TrendingTitleSnapshot {
+  return {
+    id: t.id,
+    objectType: t.objectType,
+    title: t.title,
+    posterUrl: t.posterUrl,
+    releaseDate: t.releaseDate,
+  };
+}
+
+/** De-duplicate by `id`, preserving first occurrence (FR-014). */
+function dedupeById<T extends { id: string | number }>(items: T[]): T[] {
+  const seen = new Set<string | number>();
+  const out: T[] = [];
+  for (const item of items) {
+    if (seen.has(item.id)) continue;
+    seen.add(item.id);
+    out.push(item);
+  }
+  return out;
+}
+
+/**
+ * Build the trending snapshot from TMDB. Throws if any upstream fetch fails —
+ * callers decide whether to fail soft (route) or preserve stale cache (job).
+ */
+export async function buildTrendingSnapshot(
+  timeWindow: TrendingTimeWindow,
+): Promise<TrendingSnapshot> {
+  const [movieRes, tvRes, peopleRes] = await Promise.all([
+    fetchTrendingMovies(timeWindow),
+    fetchTrendingTv(timeWindow),
+    fetchTrendingPeople(timeWindow),
+  ]);
+
+  const movies = dedupeById(
+    movieRes.results.map((m) =>
+      toTrendingTitle(parseDiscoverMovie(m, EMPTY_GENRES)),
+    ),
+  );
+  const shows = dedupeById(
+    tvRes.results.map((t) => toTrendingTitle(parseDiscoverTv(t, EMPTY_GENRES))),
+  );
+  const people = dedupeById(peopleRes.results.map(parseTrendingPerson));
+
+  return {
+    movies,
+    shows,
+    people,
+    refreshedAt: new Date().toISOString(),
+  };
+}
+
+const EMPTY_SNAPSHOT = (): TrendingSnapshot => ({
+  movies: [],
+  shows: [],
+  people: [],
+  refreshedAt: new Date().toISOString(),
+});
+
+const app = new Hono<AppEnv>();
+
+app.get("/", zValidator("query", trendingQuerySchema), async (c) => {
+  const { time_window } = c.req.valid("query");
+  const timeWindow = (time_window ??
+    CONFIG.TRENDING_TIME_WINDOW) as TrendingTimeWindow;
+  const cacheKey = trendingCacheKey(timeWindow);
+  const user = c.get("user");
+
+  // ── Snapshot cache (lazy populate on miss) ───────────────────────────────
+  let snapshot = await getCache().get<TrendingSnapshot>(cacheKey);
+  let failedSoft = false;
+  if (snapshot !== null) {
+    trendingCacheTotal.inc({ result: "hit" });
+  } else {
+    trendingCacheTotal.inc({ result: "miss" });
+    try {
+      snapshot = await buildTrendingSnapshot(timeWindow);
+      await getCache().set(cacheKey, snapshot, CONFIG.CACHE_TTL_TRENDING);
+    } catch (e: unknown) {
+      // Fail soft (FR-008, SC-003): cold cache + upstream error → empty groups,
+      // HTTP 200. The home screen must still render; never 5xx for trending.
+      log.warn("Trending build failed, serving empty snapshot", {
+        error: e instanceof Error ? e.message : String(e),
+        timeWindow,
+      });
+      syncFailureTotal.inc({ source: "tmdb" });
+      snapshot = EMPTY_SNAPSHOT();
+      failedSoft = true;
+    }
+  }
+
+  // ── Per-request isTracked overlay (snapshot is user-agnostic) ─────────────
+  const trackedIds = user
+    ? await getTrackedTitleIds(user.id)
+    : new Set<string>();
+  const overlay = (t: TrendingTitleSnapshot) => ({
+    ...t,
+    isTracked: trackedIds.has(t.id),
+  });
+
+  if (failedSoft) {
+    // Don't let the edge cache pin an empty fail-soft response for the full TTL —
+    // retry on the next request so the section recovers promptly once TMDB is back.
+    c.header("Cache-Control", "no-store");
+  } else {
+    setPublicCacheIfAnon(c, CONFIG.CACHE_TTL_TRENDING);
+  }
+  return ok(c, {
+    movies: snapshot.movies.map(overlay),
+    shows: snapshot.shows.map(overlay),
+    people: snapshot.people,
+    refreshedAt: snapshot.refreshedAt,
+  });
+});
+
+export default app;

--- a/server/routes/user-settings.test.ts
+++ b/server/routes/user-settings.test.ts
@@ -162,8 +162,8 @@ describe("PUT /user/settings/homepage-layout", () => {
 
     const res = await app.request("/user/settings/homepage-layout");
     const body = await res.json();
-    // All 10 sections returned; the 8 missing ones are appended from DEFAULT_HOMEPAGE_LAYOUT
-    expect(body.homepage_layout).toHaveLength(10);
+    // All 11 sections returned; the 9 missing ones are appended from DEFAULT_HOMEPAGE_LAYOUT
+    expect(body.homepage_layout).toHaveLength(11);
     expect(body.homepage_layout[0].id).toBe("today");
     expect(body.homepage_layout[1].id).toBe("unwatched");
   });
@@ -266,13 +266,14 @@ describe("validation", () => {
 // so parseLayout() doesn't strip them. See frontend/src/types.ts for canonical list.
 
 describe("homepage-layout — new section IDs (regression #803)", () => {
-  it("HOMEPAGE_SECTION_IDS contains all 10 sections including movies_to_watch, upcoming_movies, streak, friends_loved", () => {
+  it("HOMEPAGE_SECTION_IDS contains all 11 sections including trending, movies_to_watch, upcoming_movies, streak, friends_loved", () => {
     const ids = [...HOMEPAGE_SECTION_IDS];
+    expect(ids).toContain("trending");
     expect(ids).toContain("movies_to_watch");
     expect(ids).toContain("upcoming_movies");
     expect(ids).toContain("streak");
     expect(ids).toContain("friends_loved");
-    expect(ids).toHaveLength(10);
+    expect(ids).toHaveLength(11);
   });
 
   it("default layout for new user includes movies_to_watch and upcoming_movies", async () => {
@@ -281,11 +282,12 @@ describe("homepage-layout — new section IDs (regression #803)", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     const ids = body.homepage_layout.map((s: { id: string }) => s.id);
+    expect(ids).toContain("trending");
     expect(ids).toContain("movies_to_watch");
     expect(ids).toContain("upcoming_movies");
     expect(ids).toContain("streak");
     expect(ids).toContain("friends_loved");
-    expect(body.homepage_layout).toHaveLength(10);
+    expect(body.homepage_layout).toHaveLength(11);
   });
 
   it("parseLayout preserves movies_to_watch, upcoming_movies, streak, friends_loved from stored layout", async () => {
@@ -347,7 +349,7 @@ describe("homepage-layout — new section IDs (regression #803)", () => {
     });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.homepage_layout).toHaveLength(10);
+    expect(body.homepage_layout).toHaveLength(11);
     for (const id of HOMEPAGE_SECTION_IDS) {
       expect(
         body.homepage_layout.some((s: { id: string }) => s.id === id),

--- a/server/routes/user-settings.ts
+++ b/server/routes/user-settings.ts
@@ -25,6 +25,7 @@ const log = logger.child({ module: "user-settings" });
 
 // Keep in sync with frontend/src/types.ts HomepageSectionId / DEFAULT_HOMEPAGE_LAYOUT.
 export const HOMEPAGE_SECTION_IDS = [
+  "trending",
   "streak",
   "up_next",
   "unwatched",
@@ -45,6 +46,7 @@ export interface HomepageSection {
 
 export const DEFAULT_HOMEPAGE_LAYOUT: HomepageSection[] = [
   { id: "streak", enabled: true },
+  { id: "trending", enabled: true },
   { id: "up_next", enabled: true },
   { id: "unwatched", enabled: true },
   { id: "movies_to_watch", enabled: true },

--- a/server/test-utils/fixtures.ts
+++ b/server/test-utils/fixtures.ts
@@ -5,6 +5,7 @@ import type {
   TmdbDiscoverMovieResult,
   TmdbDiscoverTvResult,
   TmdbSearchMultiResult,
+  TmdbTrendingPersonResult,
 } from "../tmdb/types";
 
 export function makeParsedTitle(overrides?: Partial<ParsedTitle>): ParsedTitle {
@@ -128,6 +129,20 @@ export function makeTmdbDiscoverTv(
     vote_count: 800,
     popularity: 40,
     original_language: "en",
+    ...overrides,
+  };
+}
+
+export function makeTmdbTrendingPerson(
+  overrides?: Partial<TmdbTrendingPersonResult>,
+): TmdbTrendingPersonResult {
+  return {
+    id: 555,
+    name: "Trending Actor",
+    media_type: "person",
+    profile_path: "/actor.jpg",
+    known_for_department: "Acting",
+    popularity: 99,
     ...overrides,
   };
 }

--- a/server/tmdb/client.test.ts
+++ b/server/tmdb/client.test.ts
@@ -63,6 +63,9 @@ import {
   fetchOnTheAirTv,
   fetchTopRatedMovies,
   fetchTopRatedTv,
+  fetchTrendingMovies,
+  fetchTrendingTv,
+  fetchTrendingPeople,
   searchMulti,
   findByImdbId,
   getMovieGenres,
@@ -531,6 +534,94 @@ describe("category endpoints", () => {
     await fetchTopRatedTv();
     const url = new URL((fetchSpy.mock.calls[0] as [string])[0]);
     expect(url.pathname).toBe("/3/tv/top_rated");
+  });
+});
+
+// ─── Trending endpoints ─────────────────────────────────────────────────────
+
+describe("trending endpoints", () => {
+  const emptyPage = { page: 1, total_pages: 1, total_results: 0, results: [] };
+
+  it("fetchTrendingMovies calls /trending/movie/week by default", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(emptyPage));
+    await fetchTrendingMovies();
+    const url = new URL((fetchSpy.mock.calls[0] as [string])[0]);
+    expect(url.pathname).toBe("/3/trending/movie/week");
+    expect(url.searchParams.get("language")).toBeTruthy();
+  });
+
+  it("fetchTrendingMovies honors the time window argument", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(emptyPage));
+    await fetchTrendingMovies("day");
+    const url = new URL((fetchSpy.mock.calls[0] as [string])[0]);
+    expect(url.pathname).toBe("/3/trending/movie/day");
+  });
+
+  it("fetchTrendingTv calls /trending/tv/week by default", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(emptyPage));
+    await fetchTrendingTv();
+    const url = new URL((fetchSpy.mock.calls[0] as [string])[0]);
+    expect(url.pathname).toBe("/3/trending/tv/week");
+  });
+
+  it("fetchTrendingPeople calls /trending/person/week by default", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(emptyPage));
+    await fetchTrendingPeople();
+    const url = new URL((fetchSpy.mock.calls[0] as [string])[0]);
+    expect(url.pathname).toBe("/3/trending/person/week");
+  });
+
+  it("parses trending movie results from the response", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({
+        page: 1,
+        total_pages: 1,
+        total_results: 1,
+        results: [
+          {
+            id: 42,
+            title: "Trending Movie",
+            original_title: "Trending Movie",
+            overview: null,
+            release_date: "2026-01-01",
+            poster_path: "/p.jpg",
+            genre_ids: [],
+            vote_average: 8,
+            vote_count: 100,
+            popularity: 90,
+            adult: false,
+            original_language: "en",
+            media_type: "movie",
+          },
+        ],
+      }),
+    );
+    const result = await fetchTrendingMovies();
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].title).toBe("Trending Movie");
+  });
+
+  it("parses trending person results from the response", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({
+        page: 1,
+        total_pages: 1,
+        total_results: 1,
+        results: [
+          {
+            id: 7,
+            name: "Trending Actor",
+            media_type: "person",
+            profile_path: "/a.jpg",
+            known_for_department: "Acting",
+            popularity: 99,
+          },
+        ],
+      }),
+    );
+    const result = await fetchTrendingPeople();
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].name).toBe("Trending Actor");
   });
 });
 

--- a/server/tmdb/client.ts
+++ b/server/tmdb/client.ts
@@ -23,7 +23,12 @@ import type {
   TmdbEpisodeDetails,
   TmdbPersonDetails,
   TmdbCollectionDetails,
+  TmdbTrendingMovieResult,
+  TmdbTrendingTvResult,
+  TmdbTrendingPersonResult,
 } from "./types";
+
+export type TrendingTimeWindow = "day" | "week";
 
 async function tmdbRequest<T>(
   path: string,
@@ -346,6 +351,35 @@ export async function fetchTopRatedTv(
       language: tmdbLanguage(),
       page: String(page),
     },
+  );
+}
+
+// ─── Trending endpoints (movies, TV, people) ───────────────────────────────
+
+export async function fetchTrendingMovies(
+  timeWindow: TrendingTimeWindow = "week",
+): Promise<TmdbDiscoverResponse<TmdbTrendingMovieResult>> {
+  return tmdbRequest<TmdbDiscoverResponse<TmdbTrendingMovieResult>>(
+    `/trending/movie/${timeWindow}`,
+    { language: tmdbLanguage() },
+  );
+}
+
+export async function fetchTrendingTv(
+  timeWindow: TrendingTimeWindow = "week",
+): Promise<TmdbDiscoverResponse<TmdbTrendingTvResult>> {
+  return tmdbRequest<TmdbDiscoverResponse<TmdbTrendingTvResult>>(
+    `/trending/tv/${timeWindow}`,
+    { language: tmdbLanguage() },
+  );
+}
+
+export async function fetchTrendingPeople(
+  timeWindow: TrendingTimeWindow = "week",
+): Promise<TmdbDiscoverResponse<TmdbTrendingPersonResult>> {
+  return tmdbRequest<TmdbDiscoverResponse<TmdbTrendingPersonResult>>(
+    `/trending/person/${timeWindow}`,
+    { language: tmdbLanguage() },
   );
 }
 

--- a/server/tmdb/parser.test.ts
+++ b/server/tmdb/parser.test.ts
@@ -6,6 +6,7 @@ import {
   parseDiscoverMovie,
   parseDiscoverTv,
   parseSearchResult,
+  parseTrendingPerson,
   extractProviders,
 } from "./parser";
 import {
@@ -15,9 +16,43 @@ import {
   makeTmdbDiscoverTv,
   makeTmdbSearchMultiMovie,
   makeTmdbSearchMultiTv,
+  makeTmdbTrendingPerson,
   makeParsedTitle,
   makeParsedOffer,
 } from "../test-utils/fixtures";
+
+describe("parseTrendingPerson", () => {
+  it("maps id, name, knownForDepartment and builds a full profile URL", () => {
+    const result = parseTrendingPerson(
+      makeTmdbTrendingPerson({
+        id: 7,
+        name: "Jane Doe",
+        profile_path: "/jane.jpg",
+        known_for_department: "Directing",
+      }),
+    );
+    expect(result.id).toBe(7);
+    expect(result.name).toBe("Jane Doe");
+    expect(result.knownForDepartment).toBe("Directing");
+    expect(result.profileUrl).toBe(
+      `${CONFIG.TMDB_IMAGE_BASE_URL}/w185/jane.jpg`,
+    );
+  });
+
+  it("returns null profileUrl when the person has no profile photo", () => {
+    const result = parseTrendingPerson(
+      makeTmdbTrendingPerson({ profile_path: null }),
+    );
+    expect(result.profileUrl).toBeNull();
+  });
+
+  it("returns null knownForDepartment when absent", () => {
+    const result = parseTrendingPerson(
+      makeTmdbTrendingPerson({ known_for_department: null }),
+    );
+    expect(result.knownForDepartment).toBeNull();
+  });
+});
 
 describe("parseMovieDetails", () => {
   it("parses movie with correct fields", () => {

--- a/server/tmdb/parser.ts
+++ b/server/tmdb/parser.ts
@@ -8,6 +8,7 @@ import type {
   TmdbDiscoverMovieResult,
   TmdbDiscoverTvResult,
   TmdbSearchMultiResult,
+  TmdbTrendingPersonResult,
 } from "./types";
 
 // ─── Shared types (previously in justwatch/parser.ts) ───────────────────────
@@ -59,6 +60,14 @@ export interface ParsedProvider {
   name: string;
   technicalName: string;
   iconUrl: string;
+}
+
+/** A trending person (home discovery row). Not trackable, no DB persistence. */
+export interface TrendingPerson {
+  id: number;
+  name: string;
+  profileUrl: string | null;
+  knownForDepartment: string | null;
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -344,6 +353,24 @@ export function parseSearchResult(
       imdbVotes: null,
       tmdbScore: result.vote_average || null,
     },
+  };
+}
+
+// ─── Parse trending people (lightweight, no DB persistence) ─────────────────
+
+function profileImageUrl(path: string | null): string | null {
+  if (!path) return null;
+  return `${CONFIG.TMDB_IMAGE_BASE_URL}/w185${path}`;
+}
+
+export function parseTrendingPerson(
+  person: TmdbTrendingPersonResult,
+): TrendingPerson {
+  return {
+    id: person.id,
+    name: person.name,
+    profileUrl: profileImageUrl(person.profile_path),
+    knownForDepartment: person.known_for_department || null,
   };
 }
 

--- a/server/tmdb/types.ts
+++ b/server/tmdb/types.ts
@@ -140,6 +140,23 @@ export interface TmdbDiscoverResponse<T> {
   results: T[];
 }
 
+// ─── Trending types ─────────────────────────────────────────────────────────
+// The /trending/{movie,tv}/{window} endpoints return discover-shaped results
+// (plus a `media_type` field we don't consume), so they reuse the discover
+// result types. /trending/person/{window} returns the person shape below.
+
+export type TmdbTrendingMovieResult = TmdbDiscoverMovieResult;
+export type TmdbTrendingTvResult = TmdbDiscoverTvResult;
+
+export interface TmdbTrendingPersonResult {
+  id: number;
+  name: string;
+  media_type: "person";
+  profile_path: string | null;
+  known_for_department: string | null;
+  popularity: number;
+}
+
 export interface TmdbSearchMultiResult {
   id: number;
   media_type: "movie" | "tv" | "person";

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -72,6 +72,7 @@ import adminRoutes, { setOnOidcSettingsChanged } from "./routes/admin";
 // jobsRoutes excluded: uses Bun-only in-memory job queue (bun:sqlite).
 // CF Workers uses cron triggers instead (see scheduled handler below).
 import browseRoutes from "./routes/browse";
+import trendingRoutes from "./routes/trending";
 import detailsRoutes from "./routes/details";
 import notifierRoutes from "./routes/notifiers";
 import integrationRoutes from "./routes/integrations";
@@ -442,6 +443,11 @@ function createApp(env: Env) {
   app.use("/api/browse/*", browseRateLimiter, optionalAuth);
   app.use("/api/browse", browseRateLimiter, optionalAuth);
   app.route("/api/browse", browseRoutes);
+
+  // Trending (home screen) — optionalAuth for per-user isTracked overlay
+  app.use("/api/trending/*", optionalAuth);
+  app.use("/api/trending", optionalAuth);
+  app.route("/api/trending", trendingRoutes);
 
   app.use("/api/calendar/*", optionalAuth);
   app.use("/api/calendar", optionalAuth);

--- a/specs/001-trending-home/checklists/requirements.md
+++ b/specs/001-trending-home/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Trending on Home
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- TMDB is named in the spec as the data **source/dependency** (an assumption and a
+  named upstream system the user explicitly requested), not as an implementation
+  choice for how the feature is built. The provider is a product constraint, so it
+  is retained in Assumptions and FR-002 rather than treated as a leaked tech detail.
+- All ambiguities were resolved via informed defaults documented in the Assumptions
+  section (trending window, placement, region, caching cadence, people interaction).
+  No blocking clarifications were required.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.

--- a/specs/001-trending-home/contracts/trending-api.md
+++ b/specs/001-trending-home/contracts/trending-api.md
@@ -1,0 +1,121 @@
+# Contract: `GET /api/trending`
+
+Public, optional-auth endpoint that returns the current trending snapshot
+(movies, TV shows, people) for the home screen.
+
+## Registration (dual-runtime — both required)
+
+- **Bun**: `server/index.ts` — `app.use("/api/trending", optionalAuth)` +
+  `app.use("/api/trending/*", optionalAuth)` then `app.route("/api/trending", trendingRoutes)`.
+- **CF Workers**: `server/worker.ts` — the identical registration block (parity
+  invariant; CI/`check-route-sync` enforces this).
+
+Auth tier: **optional auth** (same as `/api/browse`) — signed-out users get the
+snapshot with `isTracked: false`; signed-in users get the `isTracked` overlay.
+
+## Request
+
+```
+GET /api/trending
+```
+
+### Query parameters (validated with `zValidator("query", …)`)
+
+| Param         | Type                         | Default  | Notes                                              |
+| ------------- | ---------------------------- | -------- | -------------------------------------------------- |
+| `time_window` | `"day" \| "week"` (zod enum) | `"week"` | Optional override of the configured default window |
+
+No body. No path params. Unknown params ignored. Invalid `time_window` → HTTP 400
+with `{ error: "Validation failed", issues: ZodIssue[] }` (standard validator).
+
+## Response — 200 OK
+
+```jsonc
+{
+  "movies": [
+    {
+      "id": "movie-123",
+      "objectType": "MOVIE",
+      "title": "Example Movie",
+      "posterUrl": "/abc.jpg",
+      "releaseDate": "2026-01-01",
+      "isTracked": false,
+    },
+  ],
+  "shows": [
+    {
+      "id": "tv-456",
+      "objectType": "SHOW",
+      "title": "Example Show",
+      "posterUrl": null,
+      "releaseDate": null,
+      "isTracked": true,
+    },
+  ],
+  "people": [
+    {
+      "id": 789,
+      "name": "Example Person",
+      "profileUrl": "/p.jpg",
+      "knownForDepartment": "Acting",
+    },
+  ],
+  "refreshedAt": "2026-06-17T05:00:00.000Z",
+}
+```
+
+### Guarantees
+
+- Any of `movies` / `shows` / `people` MAY be `[]` (empty group omitted by the
+  client, FR-013).
+- No duplicate `id` within any group (FR-014).
+- `posterUrl` / `profileUrl` MAY be `null` (client renders placeholder, FR-003/4).
+- `isTracked` present only on title items; `true` only for the requesting
+  signed-in user (FR-012). Always `false` for anonymous requests.
+
+### Caching headers
+
+`setPublicCacheIfAnon(c, <CACHE_TTL_TRENDING>)` — anonymous responses are edge-
+cacheable; authenticated responses are `private, no-store` (because of the
+per-user `isTracked` overlay).
+
+## Fail-soft contract (FR-008, SC-003)
+
+- Upstream TMDB error **with a warm cache** → serve the cached snapshot (stale
+  tolerated within the cache lifetime).
+- Upstream TMDB error **with a cold cache** → HTTP **200** with
+  `{ movies: [], shows: [], people: [], refreshedAt: <now> }`. The endpoint MUST
+  NOT return 5xx for upstream trending failures; the home screen must still render.
+- A warning is logged (`logger.child({ module: "trending" })`) and
+  `syncFailureTotal{source:"tmdb"}` incremented.
+
+## Observability
+
+- `trendingCacheTotal{result="hit"|"miss"}` Prometheus counter (mirrors
+  `browseCacheTotal`).
+- Structured logs on miss/build and on upstream failure.
+
+## Required tests (`server/routes/trending.test.ts`)
+
+1. **validation** — invalid `time_window` → 400 with `issues` array.
+2. **happy path** — default request → 200 with `movies`/`shows`/`people` arrays
+   (TMDB mocked); asserts the TMDB trending fetchers were called.
+3. **isTracked overlay** — authenticated user tracking a returned title → that
+   title's `isTracked === true`; anonymous → all `false`.
+4. **cache hit** — second request does not re-call TMDB (counter/spy assertion).
+5. **fail-soft** — TMDB fetch rejects + cold cache → 200 with all-empty groups.
+6. **dedupe / empty group** — duplicate ids collapsed; empty type returns `[]`.
+
+## Related scheduled job — `sync-trending`
+
+Not an HTTP contract, but part of the feature surface:
+
+- Handler registered via `registerHandler("sync-trending", …)` (shared runtime).
+- Bun cron: `registerCron("sync-trending", CONFIG.SYNC_TRENDING_CRON)`.
+- CF cron: add `{ name: "sync-trending", cron: <same> }` to `CRON_JOBS` in
+  `server/jobs/backend.ts`.
+- Behavior: builds the snapshot and writes the cache; no-op (logged) when
+  `TMDB_API_KEY` is unset; only overwrites cache on success (preserves stale data
+  on failure).
+- Test (`server/jobs/sync.test.ts`): running the handler populates the cache;
+  unset API key skips without throwing.

--- a/specs/001-trending-home/data-model.md
+++ b/specs/001-trending-home/data-model.md
@@ -1,0 +1,111 @@
+# Phase 1 Data Model: Trending on Home
+
+**No database schema changes.** All entities below are in-memory / cache / API
+shapes. The `titles` and `tracked` tables are read-only inputs; nothing is
+written by this feature (existing background syncs continue to own `titles`).
+
+## Entity: TrendingTitle
+
+A movie or TV show currently trending per TMDB.
+
+| Field         | Type                | Notes                                                                                |
+| ------------- | ------------------- | ------------------------------------------------------------------------------------ |
+| `id`          | `string`            | `movie-<tmdbId>` or `tv-<tmdbId>` — links to `/title/:id`, matches `tracked.titleId` |
+| `objectType`  | `"MOVIE" \| "SHOW"` | Drives badge + which TMDB endpoint produced it                                       |
+| `title`       | `string`            | Display title                                                                        |
+| `posterUrl`   | `string \| null`    | TMDB poster path; `null` → placeholder (FR-003)                                      |
+| `releaseDate` | `string \| null`    | Optional, for subtitle/meta                                                          |
+| `isTracked`   | `boolean`           | Overlaid per request from `getTrackedTitleIds`; `false` for anon (FR-012)            |
+
+- **Source/derivation**: `parseDiscoverMovie` / `parseDiscoverTv` over TMDB
+  trending results (reused from `server/tmdb/parser.ts`). The user-agnostic cached
+  form omits `isTracked`; it is added after the cache read.
+- **Validation rules**: FR-014 — the section MUST NOT show the same item twice;
+  de-duplicate by `id` when assembling each group.
+
+## Entity: TrendingPerson
+
+An actor or creator currently trending per TMDB. Not trackable (spec Assumption).
+
+| Field                | Type             | Notes                                                      |
+| -------------------- | ---------------- | ---------------------------------------------------------- |
+| `id`                 | `number`         | TMDB person id — links to `/person/:id` (FR-006)           |
+| `name`               | `string`         | Display name (FR-004)                                      |
+| `profileUrl`         | `string \| null` | TMDB profile path; `null` → placeholder (FR-004 edge case) |
+| `knownForDepartment` | `string \| null` | Optional, for subtitle                                     |
+
+- **Source/derivation**: `parseTrendingPerson` over TMDB `/trending/person/week`
+  results (new lightweight parser; no DB persistence, no detail fan-out).
+- **Validation rules**: de-duplicate by `id`; omit the people group entirely when
+  empty rather than rendering an empty labeled group (FR-013).
+
+## Entity: TrendingSnapshot
+
+The cached, user-agnostic collection serving the section quickly (FR-010).
+
+| Field         | Type                               | Notes                                         |
+| ------------- | ---------------------------------- | --------------------------------------------- |
+| `movies`      | `TrendingTitle[]` (no `isTracked`) | May be empty                                  |
+| `shows`       | `TrendingTitle[]` (no `isTracked`) | May be empty                                  |
+| `people`      | `TrendingPerson[]`                 | May be empty                                  |
+| `refreshedAt` | `string` (ISO)                     | When the snapshot was built; bounds staleness |
+
+- **Storage**: single cache entry via `getCache()`; key
+  `trending:v1:<tmdbLanguage()>:<timeWindow>`; TTL `CACHE_TTL_TRENDING` (default
+  86400s). Written by the endpoint (lazy, on miss) and by the `sync-trending` job
+  (proactive). Only overwritten on a successful TMDB build → survives outages.
+
+## API response shape (per request)
+
+The endpoint returns the snapshot with `isTracked` overlaid onto title groups:
+
+```jsonc
+{
+  "movies": [
+    {
+      "id": "movie-123",
+      "objectType": "MOVIE",
+      "title": "...",
+      "posterUrl": "/x.jpg",
+      "releaseDate": "2026-01-01",
+      "isTracked": false,
+    },
+  ],
+  "shows": [
+    {
+      "id": "tv-456",
+      "objectType": "SHOW",
+      "title": "...",
+      "posterUrl": null,
+      "releaseDate": null,
+      "isTracked": true,
+    },
+  ],
+  "people": [
+    {
+      "id": 789,
+      "name": "...",
+      "profileUrl": "/p.jpg",
+      "knownForDepartment": "Acting",
+    },
+  ],
+  "refreshedAt": "2026-06-17T05:00:00.000Z",
+}
+```
+
+On total upstream failure with a cold cache, all three arrays are empty and the
+section is hidden client-side (fail-soft, FR-008).
+
+## Frontend type additions (`frontend/src/types.ts`)
+
+- `TrendingTitle`, `TrendingPerson`, `TrendingSnapshot` interfaces mirroring the
+  response above (snake/camel handled per the existing `normalizeSearchTitle`
+  convention if needed).
+- `HomepageSectionId` gains `"trending"`; `DEFAULT_HOMEPAGE_LAYOUT` gains
+  `{ id: "trending", enabled: true }` near the top.
+
+## State transitions
+
+The snapshot has no per-record lifecycle. Its only "state" is fresh vs. expired,
+governed by the cache TTL and the refresh job. There are no user-mutable states
+introduced by this feature.

--- a/specs/001-trending-home/plan.md
+++ b/specs/001-trending-home/plan.md
@@ -1,0 +1,137 @@
+# Implementation Plan: Trending on Home
+
+**Branch**: `001-trending-home` | **Date**: 2026-06-17 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/001-trending-home/spec.md`
+
+## Summary
+
+Surface currently-trending movies, TV shows, and people from TMDB as a new
+section on the home screen, for both signed-in and signed-out users. The data
+is served from a **cache-backed, user-agnostic "trending snapshot"** exposed by
+a dedicated public `GET /api/trending` endpoint, with per-request `isTracked`
+overlay for titles. A scheduled `sync-trending` job refreshes the snapshot daily
+(configurable) so the section stays fresh without hitting TMDB on every load. The
+endpoint and section **fail soft**: on cache miss + upstream error, empty groups
+are returned and the section is hidden, never blocking the rest of home.
+
+No database schema change is required — the snapshot lives in the existing cache
+abstraction (MemoryCache on Bun, Cloudflare KV on Workers), which sidesteps
+migration-safety risk entirely.
+
+## Technical Context
+
+**Language/Version**: TypeScript (strict mode), Bun runtime + Cloudflare Workers
+
+**Primary Dependencies**: Hono (server), Drizzle ORM (read-only here), TMDB API,
+React 19 + Vite + Tailwind 4 + shadcn/ui + TanStack Query (frontend)
+
+**Storage**: No new persistence. Trending snapshot stored via the cache
+abstraction (`server/cache/` — MemoryCache / RedisCache / CloudflareKvCache).
+Existing `tracked` table is read for `isTracked` overlay.
+
+**Testing**: `bun:test` with in-memory SQLite (`setupTestDb`/`teardownTestDb`),
+`@testing-library/react` + happy-dom for frontend. TMDB mocked via `spyOn` with
+`afterEach` restore.
+
+**Target Platform**: Bun server (Docker) AND Cloudflare Workers (D1 + KV) — dual
+runtime parity required.
+
+**Project Type**: Web application (frontend + server in one repo).
+
+**Performance Goals**: Trending section visible (content or placeholder) within
+2s of home appearing (SC-002); cached reads serve in well under that.
+
+**Constraints**: Must respect TMDB rate limits (no per-load fan-out); fail soft
+so 100% of home loads render even when TMDB is down (SC-003); content no older
+than the freshness window — default daily refresh (SC-004).
+
+**Scale/Scope**: ~10 trending items per type (movie/TV/person) per snapshot;
+single default region/language; one new endpoint, one new job, one home section.
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design._
+
+| Principle                                       | Status  | Notes                                                                                                                                                                                                                                                                                                                                               |
+| ----------------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| I. Test-Driven Quality (NON-NEGOTIABLE)         | ✅ PASS | Colocated tests planned: `trending.test.ts` (route, validation + happy path + isTracked + fail-soft), TMDB client fetch tests, `sync-trending` job test, frontend section component test. All TMDB HTTP mocked with `afterEach` restore.                                                                                                            |
+| II. Dual-Runtime Parity (Bun + CF)              | ✅ PASS | Route registered in BOTH `server/index.ts` and `server/worker.ts` with `optionalAuth`. Job handler via shared `registerHandler`; cron scheduled in `server/jobs/sync.ts` (`registerCron`, Bun) AND added to `CRON_JOBS` in `server/jobs/backend.ts` (CF). Cache via `getCache()` abstraction — no Bun-specific APIs. Config via `server/config.ts`. |
+| III. Database Migration Safety (NON-NEGOTIABLE) | ✅ PASS | **No schema change.** Snapshot is a cache entry; `tracked`/`titles` read-only. `migrations.test.ts` unaffected.                                                                                                                                                                                                                                     |
+| IV. Type Safety & Lint Discipline               | ✅ PASS | Typed TMDB person/trending responses in `server/tmdb/types.ts`; zod `zValidator` on query; no `any` in source; frontend ESLint clean.                                                                                                                                                                                                               |
+| V. Observability & Structured Logging           | ✅ PASS | `logger.child({ module: "trending" })` in route + job; `trendingCacheTotal{result}` Prometheus counter (hit/miss) mirroring `browseCacheTotal`; job logs counts; upstream failures `log.warn` + `syncFailureTotal{source:"tmdb"}`.                                                                                                                  |
+
+**Result**: No violations. Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-trending-home/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── trending-api.md  # GET /api/trending contract
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+server/
+├── tmdb/
+│   ├── client.ts            # + fetchTrendingMovies / fetchTrendingTv / fetchTrendingPeople
+│   ├── client.test.ts       # + trending fetch tests (mocked HTTP)
+│   ├── types.ts             # + TmdbTrendingPersonResult / response types
+│   └── parser.ts            # + parseTrendingPerson (reuse parseDiscoverMovie/Tv)
+├── routes/
+│   ├── trending.ts          # NEW — GET /api/trending (snapshot build + cache + isTracked)
+│   └── trending.test.ts     # NEW — validation + happy path + isTracked + fail-soft
+├── jobs/
+│   ├── sync.ts              # + registerHandler("sync-trending") + registerCron
+│   ├── sync.test.ts         # + sync-trending warms cache
+│   └── backend.ts           # + { name: "sync-trending", cron } in CRON_JOBS (CF parity)
+├── config.ts               # + CACHE_TTL_TRENDING, SYNC_TRENDING_CRON, TRENDING_TIME_WINDOW
+├── index.ts                # + register /api/trending (optionalAuth) — Bun
+├── worker.ts               # + register /api/trending (optionalAuth) — CF parity
+└── metrics/                # + trendingCacheTotal counter
+
+frontend/
+├── src/
+│   ├── api.ts                       # + getTrending(signal) fetcher
+│   ├── types.ts                     # + "trending" in HomepageSectionId + DEFAULT layout; TrendingSnapshot types
+│   ├── components/
+│   │   ├── TrendingSection.tsx      # NEW — renders movie/TV/person rows (FullBleedCarousel + MediaCard/PersonCard)
+│   │   └── TrendingSection.test.tsx # NEW — renders rows, hides empty groups, person/title links, placeholders
+│   └── pages/
+│       ├── HomePage.tsx             # + render TrendingSection in anon + auth paths; ["trending"] query
+│       └── HomePage.test.tsx        # + trending section appears; fail-soft (absent on error)
+```
+
+**Structure Decision**: Web application layout — existing `server/` (Hono, dual
+entry points) and `frontend/` (React). The feature adds one server route, TMDB
+client functions, one scheduled job, and one frontend section component plus the
+home-layout wiring. No new top-level directories.
+
+## Architecture Decisions (summary; see research.md)
+
+1. **Dedicated `/api/trending` endpoint, not a new `browse` category.** `browse`
+   does an expensive per-title detail fan-out (watch-provider deep links) and
+   handles only movies/TV. Trending needs a lightweight poster+title row plus
+   people, served from a single cached snapshot — a different altitude.
+2. **Snapshot = cache entry, not a DB table.** The spec's "Trending Snapshot"
+   maps to a `getCache()` value with a TTL. This satisfies FR-010 caching and
+   avoids any migration (Constitution III) entirely.
+3. **User-agnostic payload + per-request `isTracked` overlay** — the exact proven
+   pattern from `browse.ts:223-231` / `:379-385`. People carry no tracked state.
+4. **Lazy cache + scheduled warm.** The endpoint populates the cache on miss
+   (daily TTL); `sync-trending` proactively refreshes it on a cron so the first
+   post-expiry visitor doesn't pay TMDB latency (SC-002).
+5. **Fail soft.** Cache miss + TMDB error → return `{ movies: [], shows: [], people: [] }`; the section renders nothing rather than erroring (FR-008, SC-003).
+
+## Complexity Tracking
+
+No constitution violations — section intentionally empty.

--- a/specs/001-trending-home/quickstart.md
+++ b/specs/001-trending-home/quickstart.md
@@ -1,0 +1,89 @@
+# Quickstart & Validation: Trending on Home
+
+Runnable validation for the Trending on Home feature. See
+[contracts/trending-api.md](./contracts/trending-api.md) and
+[data-model.md](./data-model.md) for shapes; this guide proves the feature works
+end-to-end.
+
+## Prerequisites
+
+- `bun install` at repo root and in `frontend/`.
+- `TMDB_API_KEY` set in env for live manual checks (tests mock TMDB and need no key).
+
+## 1. Run the automated gate
+
+```bash
+bun run check
+```
+
+Must pass: server tsc + frontend tsc + ESLint (zero warnings) + all tests +
+frontend build + wrangler dry-run. This is the authoritative pre-PR gate.
+
+Focused runs during development:
+
+```bash
+bun test server/routes/trending.test.ts   # endpoint: validation, happy path, isTracked, cache, fail-soft
+bun test server/tmdb/client.test.ts        # TMDB trending fetchers (mocked HTTP)
+bun test server/jobs/sync.test.ts          # sync-trending warms the cache
+bun test frontend/src/components/TrendingSection.test.tsx
+bun test frontend/src/pages/HomePage.test.tsx
+```
+
+## 2. Manual API check (Bun)
+
+```bash
+bun run dev:server          # port 3000
+curl -s "http://localhost:3000/api/trending" | jq '{movies: (.movies|length), shows: (.shows|length), people: (.people|length), refreshedAt}'
+curl -s "http://localhost:3000/api/trending?time_window=day" | jq '.movies[0]'
+curl -s "http://localhost:3000/api/trending?time_window=bogus" -o /dev/null -w "%{http_code}\n"   # expect 400
+```
+
+Expected: arrays of movies/shows/people (each may be empty); a `400` for the bad
+`time_window`. A second call should be served from cache (watch server logs for a
+cache-hit / no TMDB call).
+
+## 3. Manual UI check
+
+```bash
+bun run dev                 # server + Vite (frontend on :5173)
+```
+
+- **Signed out**: open `/` → a labeled "Trending" section shows trending movies,
+  shows, and people with posters/photos. Clicking a title → `/title/:id`;
+  clicking a person → `/person/:id`. (FR-001, FR-005, FR-006, FR-011)
+- **Signed in**: open `/` → same section; a title already on your watchlist shows
+  its tracked state (FR-012). Toggle the section off via the home layout settings
+  and confirm it disappears (home-layout integration).
+- **Mobile viewport** (DevTools narrow): the rows are horizontally scrollable and
+  the layout doesn't break (FR-007, SC-006).
+- **Missing artwork**: a title/person without an image shows a placeholder, not a
+  broken image (FR-003, FR-004).
+
+## 4. Fail-soft validation (FR-008, SC-003)
+
+Simulate the upstream being unavailable:
+
+- Unit: the `fail-soft` test in `trending.test.ts` rejects the TMDB fetch with a
+  cold cache and asserts HTTP 200 with all-empty groups.
+- Manual: temporarily unset `TMDB_API_KEY` (cold cache) and load `/` → the rest
+  of the home screen renders normally and the trending section is gracefully
+  absent (no page-blocking error).
+
+## 5. Freshness validation (FR-010, SC-004)
+
+- Trigger the refresh job and confirm the cache is repopulated:
+  - Bun: enqueue/await `sync-trending` (see `server/jobs/sync.test.ts` for the
+    programmatic path) or wait for the `SYNC_TRENDING_CRON` schedule.
+- Confirm `refreshedAt` advances after a refresh and that reads between refreshes
+  are served from cache (no per-load TMDB calls).
+
+## Success criteria mapping
+
+| Criterion                                    | Validated by                              |
+| -------------------------------------------- | ----------------------------------------- |
+| SC-001 section visible on first load         | Step 3 (signed-in) + HomePage test        |
+| SC-002 visible within 2s                     | Step 2 cache hit + warm job (step 5)      |
+| SC-003 100% render during outage             | Step 4                                    |
+| SC-004 freshness ≤ window                    | Step 5                                    |
+| SC-005 correct navigation targets            | Step 3 link checks + TrendingSection test |
+| SC-006 no layout breakage across breakpoints | Step 3 mobile + responsive check          |

--- a/specs/001-trending-home/research.md
+++ b/specs/001-trending-home/research.md
@@ -1,0 +1,108 @@
+# Phase 0 Research: Trending on Home
+
+All Technical Context items were resolvable from the existing codebase and the
+constitution — no open `NEEDS CLARIFICATION` remained. This document records the
+decisions and the alternatives weighed.
+
+## D1: Data source & endpoints
+
+- **Decision**: Use TMDB's `/trending/{movie,tv,person}/{time_window}` endpoints
+  via new functions in `server/tmdb/client.ts` (`fetchTrendingMovies`,
+  `fetchTrendingTv`, `fetchTrendingPeople`), defaulting to the `week` window.
+- **Rationale**: Spec Assumption pins the source to the existing TMDB integration
+  and a weekly window default. The client already exposes `fetchPopularMovies`,
+  `discoverMovies`, etc., and a `tmdbRequest` helper with `tmdbLanguage()` — the
+  trending calls follow the identical shape.
+- **Alternatives considered**: Reusing `discoverMovies({ sortBy: "popularity.desc" })`
+  (what `browse` "popular" does) — rejected because TMDB "popular" ≠ "trending"
+  and it cannot return people.
+
+## D2: Endpoint shape — new route vs. extend `browse`
+
+- **Decision**: A dedicated public `GET /api/trending` returning three groups
+  (`movies`, `shows`, `people`) in one payload.
+- **Rationale**: `browse.ts` performs a 5-concurrent per-title detail fan-out to
+  attach watch-provider deep links (`browse.ts:310-349`) — heavy and irrelevant
+  to a discovery row — and has no concept of people. A separate endpoint keeps
+  trending lightweight, single-round-trip, and people-capable.
+- **Alternatives considered**: Add `category=trending` to `browseQuerySchema`
+  — rejected (inherits the fan-out cost and still can't do people; would force
+  two endpoints anyway).
+
+## D3: Caching / the "Trending Snapshot" entity
+
+- **Decision**: Store the user-agnostic snapshot as a single cache entry via
+  `getCache()` (key e.g. `trending:v1:<lang>:<window>`), TTL = `CACHE_TTL_TRENDING`
+  (default 86400s / 1 day). Apply `isTracked` to titles per request after the
+  cache read.
+- **Rationale**: Mirrors the proven `browse` cache pattern
+  (`browse.ts:195-232, 372-385`) and the `Cache` interface in `server/cache/`.
+  The cache abstraction already has Bun (memory/redis) and CF (KV) backends, so
+  this is dual-runtime-safe and needs no schema/migration (Constitution III).
+- **Alternatives considered**: A `trending_snapshot` DB table — rejected: adds a
+  migration and a write path for data that is inherently ephemeral and already
+  has a caching home. KV/memory persistence matches the freshness model better.
+
+## D4: Freshness — lazy TTL vs. scheduled job
+
+- **Decision**: Both. Endpoint lazily builds + caches on miss; a `sync-trending`
+  cron job proactively refreshes the cache on the freshness cadence.
+- **Rationale**: Lazy TTL alone makes the first visitor after expiry pay full
+  TMDB latency, risking SC-002 (2s). A warm job keeps the entry fresh. FR-010
+  explicitly requires scheduled refresh.
+- **Dual-runtime cron**: Bun schedules via `registerCron("sync-trending", CONFIG.SYNC_TRENDING_CRON)`
+  in `server/jobs/sync.ts`; CF requires the same name added to the `CRON_JOBS`
+  single-source-of-truth array in `server/jobs/backend.ts`. The handler is
+  registered once via `registerHandler` (shared by both runtimes).
+- **Default cadence**: `0 5 * * *` (daily). Tunable via `SYNC_TRENDING_CRON`.
+
+## D5: `isTracked` derivation
+
+- **Decision**: For signed-in users, fetch `getTrackedTitleIds(user.id)` and set
+  `isTracked` per title; people never carry tracked state.
+- **Rationale**: Identical to `browse.ts:223-231`. Title IDs use the existing
+  `movie-<tmdbId>` / `tv-<tmdbId>` convention so they match the `tracked` table
+  and link to `/title/:id`.
+- **Anonymous**: `isTracked` is always `false`; response is fully cacheable at the
+  edge via `setPublicCacheIfAnon` (FR-011).
+
+## D6: Fail-soft behavior
+
+- **Decision**: On cache miss where the TMDB build throws, log a warning, bump
+  `syncFailureTotal{source:"tmdb"}`, and return `{ movies: [], shows: [], people: [] }`
+  with HTTP 200. Frontend hides any empty group and the whole section when all
+  three are empty.
+- **Rationale**: FR-008 / SC-003 require the rest of home to render and forbid a
+  page-blocking error. Returning 200-with-empty (not 5xx) keeps the frontend
+  query simple and the section gracefully absent.
+- **Stale-during-outage**: Because the refresh job only overwrites the cache on a
+  successful fetch, a previously cached snapshot survives a transient TMDB outage
+  and continues to serve (edge case "Stale cache during outage").
+
+## D7: Frontend placement & home-layout integration
+
+- **Decision**: Add `"trending"` to `HomepageSectionId` and to
+  `DEFAULT_HOMEPAGE_LAYOUT` (enabled, placed near the top). Render a new
+  `TrendingSection` component in both the authenticated `renderSection` switch
+  and the anonymous home path.
+- **Rationale**: The home screen already has a customizable, per-user toggleable
+  section system (`types.ts:808-836`, `HomePage.tsx renderSection`). Adding a
+  section id makes trending individually toggleable for signed-in users (resolves
+  the spec's open "toggleable?" design detail) while anonymous users — who have no
+  layout settings — get it unconditionally, consistent with how they already see
+  "Popular".
+- **Reuse**: `FullBleedCarousel` for horizontal browsability (FR-007/SC-006),
+  `MediaCard` for titles (gradient placeholder when `imageUrl` null — FR-003),
+  `PersonCard` for people (FR-004 visual distinction + placeholder), `posterUrl()`
+  for image URLs. Data fetched with a TanStack Query `["trending"]` key shared by
+  both paths.
+
+## D8: Region / language
+
+- **Decision**: Single default region/language via existing `tmdbLanguage()`; no
+  per-user personalization (spec Assumption, out of scope v1). Included in the
+  cache key so a future multi-language config doesn't collide.
+
+## Outstanding
+
+None. All Phase 0 unknowns resolved; design proceeds to Phase 1.

--- a/specs/001-trending-home/spec.md
+++ b/specs/001-trending-home/spec.md
@@ -1,0 +1,117 @@
+# Feature Specification: Trending on Home
+
+**Feature Branch**: `001-trending-home`
+
+**Created**: 2026-06-17
+
+**Status**: Draft
+
+**Input**: User description: "I want to show currently trending movies, people, and tv shows using data from TMDB API. On home screen primarily."
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Discover trending movies and TV shows on the home screen (Priority: P1)
+
+A viewer opens the home screen and sees what is popular right now across movies and TV shows, so they can decide what to watch and start tracking it without searching first.
+
+**Why this priority**: This is the core of the request — surfacing currently-trending titles where people land first. Movies and TV shows are the trackable content the product is built around, so trending titles directly feed the primary "find something and track it" loop. This slice alone delivers a usable, valuable feature.
+
+**Independent Test**: Open the home screen as a signed-in user and confirm a clearly labeled trending section appears with current movies and TV shows, each showing a poster and title; selecting one opens its detail view where it can be tracked.
+
+**Acceptance Scenarios**:
+
+1. **Given** a signed-in user on the home screen, **When** the page loads, **Then** a "Trending" section is shown containing currently-trending movies and TV shows with poster art and titles.
+2. **Given** the trending section is displayed, **When** the user selects a trending movie or TV show, **Then** they are taken to that title's detail view where they can track it.
+3. **Given** a trending title the user already tracks, **When** it appears in the trending section, **Then** its tracked state is reflected consistent with how tracked titles appear elsewhere in the app.
+4. **Given** the home screen on a narrow (mobile) viewport, **When** the trending section renders, **Then** the items are browsable (e.g. horizontally scrollable) without breaking the layout.
+
+---
+
+### User Story 2 - Discover trending people on the home screen (Priority: P2)
+
+A viewer browsing the home screen also sees which actors and creators are trending right now and can open a person to explore their work.
+
+**Why this priority**: People round out the "what's hot" picture the user asked for, but a person is not directly trackable the way a title is, so it adds discovery value rather than feeding the core tracking loop. It builds on the same home surface delivered in P1.
+
+**Independent Test**: Open the home screen and confirm trending people are presented (name and photo); selecting a person opens their existing detail page showing their filmography.
+
+**Acceptance Scenarios**:
+
+1. **Given** a signed-in user on the home screen, **When** the trending content loads, **Then** trending people are shown with name and profile photo, visually distinguishable from titles.
+2. **Given** trending people are displayed, **When** the user selects a person, **Then** they are taken to that person's detail page.
+3. **Given** a trending person has no profile photo, **When** they are displayed, **Then** a sensible placeholder is shown instead of a broken image.
+
+---
+
+### User Story 3 - Reliable, fresh, and unobtrusive trending content (Priority: P3)
+
+A viewer relies on the trending content being reasonably fresh and never sees the home screen broken or stuck because trending data was slow or unavailable.
+
+**Why this priority**: This hardens the feature for everyday use. It is not required to demonstrate value but is required for the feature to be trustworthy in production, where the upstream data source can be slow, rate-limited, or temporarily down.
+
+**Independent Test**: Simulate the trending data source being unavailable and confirm the rest of the home screen still renders normally with the trending section gracefully absent or showing a non-blocking empty/error state; confirm trending content reflects current data within the defined freshness window.
+
+**Acceptance Scenarios**:
+
+1. **Given** the upstream trending data is unavailable, **When** the home screen loads, **Then** the rest of the home screen renders normally and the trending section fails softly (hidden or showing a brief, non-blocking message) without errors that block the page.
+2. **Given** trending data is being fetched, **When** there is a delay, **Then** a loading placeholder is shown for the trending section and it does not block the rest of the home screen from rendering.
+3. **Given** trending data was last refreshed within the freshness window, **When** the user revisits the home screen, **Then** cached trending content is served quickly rather than refetched on every visit.
+
+---
+
+### Edge Cases
+
+- **Source unavailable or rate-limited**: The trending section fails softly; the rest of the home screen is unaffected (see User Story 3).
+- **Empty or partial results**: If one media type returns no items (e.g. no trending people), only the available types are shown rather than an empty labeled group.
+- **Missing artwork**: Titles or people without poster/profile images show a placeholder, never a broken image.
+- **Duplicate or already-tracked items**: A trending title the user already tracks still appears but reflects its tracked state; the same item is not shown twice within the section.
+- **Stale cache during outage**: If fresh data cannot be fetched, recently cached trending content may be shown rather than nothing, provided it is within an acceptable staleness bound.
+- **Signed-out visitors**: Trending content is available to visitors who are not signed in, consistent with the home screen already showing popular titles to anonymous users; tracking actions still require sign-in.
+- **Localization / region**: Trending results are presented for a single default audience/region; per-user regional personalization is out of scope for this feature.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The home screen MUST display a clearly labeled trending section that surfaces content that is currently trending.
+- **FR-002**: The trending section MUST include trending movies, trending TV shows, and trending people, drawn from the external media data source (TMDB).
+- **FR-003**: Each trending title MUST display at minimum its title text and poster image (or a placeholder when no image exists).
+- **FR-004**: Each trending person MUST display at minimum their name and profile photo (or a placeholder when no image exists), and MUST be visually distinguishable from titles.
+- **FR-005**: Selecting a trending movie or TV show MUST navigate the user to that title's detail view, from which the title can be tracked.
+- **FR-006**: Selecting a trending person MUST navigate the user to that person's detail page.
+- **FR-007**: The trending section MUST render correctly across supported viewport sizes, including mobile, and provide a browsable layout when items exceed the visible area.
+- **FR-008**: The trending section MUST fail softly: if trending data cannot be retrieved, the rest of the home screen MUST still render and the trending section MUST NOT produce a page-blocking error.
+- **FR-009**: The trending section MUST show a non-blocking loading state while data is being retrieved and MUST NOT delay rendering of the rest of the home screen.
+- **FR-010**: Trending content MUST be cached and refreshed on a defined cadence so it stays reasonably current without refetching from the external source on every page load.
+- **FR-011**: Trending content MUST be available to both signed-in and signed-out users; actions requiring an account (e.g. tracking) MUST continue to require sign-in.
+- **FR-012**: A trending title that the user already tracks MUST reflect its tracked state consistently with how tracked titles are shown elsewhere in the app.
+- **FR-013**: When a media type returns no trending items, the section MUST omit that group rather than show an empty labeled group.
+- **FR-014**: The same trending item MUST NOT appear more than once within the trending section.
+
+### Key Entities _(include if data involved)_
+
+- **Trending Title**: A movie or TV show currently trending per the external source. Key attributes: media type (movie/TV), title text, poster image reference, external identifier used to open its detail view, and a flag/derivation indicating whether the current user already tracks it.
+- **Trending Person**: An actor or creator currently trending per the external source. Key attributes: name, profile photo reference, external identifier used to open their detail page.
+- **Trending Snapshot**: The cached collection of currently-trending titles and people, with the time it was last refreshed, used to serve content quickly and bound its staleness.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: On the home screen, a trending section with current movies, TV shows, and people is visible to a signed-in user on first load in at least 95% of normal sessions.
+- **SC-002**: The trending section becomes visible (with content or a loading placeholder) within 2 seconds of the home screen appearing on a typical broadband connection.
+- **SC-003**: When the external trending source is unavailable, 100% of home-screen loads still render the rest of the page successfully, with no page-blocking errors attributable to trending.
+- **SC-004**: Trending content reflects data no older than the defined freshness window (default: refreshed at least once per day) on at least 95% of loads.
+- **SC-005**: At least 90% of users who select a trending item reach the correct destination (title detail for titles, person page for people) without error.
+- **SC-006**: The trending section renders without layout breakage across all supported viewport sizes, verified at the project's standard breakpoints.
+
+## Assumptions
+
+- **Source**: "Trending" data comes from the existing external media provider (TMDB) already used elsewhere in the app; no new data provider is introduced.
+- **Trending window**: A weekly trending window is used by default as the definition of "currently trending"; this is a tunable detail, not a scope boundary.
+- **Placement**: Trending appears as a new section on the existing home screen, fitting the home screen's existing section/layout model; it does not replace existing home content. Whether it is individually toggleable within the customizable home layout is a design detail to be settled at planning.
+- **People interaction**: People are surfaced for discovery only; opening a person uses the app's existing person detail page. People are not made independently "trackable" by this feature.
+- **Region/language**: A single default region/language is used for trending results; per-user regional personalization is out of scope for v1.
+- **Anonymous access**: Trending is shown to signed-out visitors, consistent with the home screen already showing popular titles to anonymous users.
+- **Caching**: Trending results are cached server-side and refreshed on a schedule to respect the external source's rate limits and keep the home screen fast; exact cadence is a tunable detail with a daily-refresh default.
+- **Existing detail surfaces are reused**: Title detail and person detail pages already exist and are the navigation targets; this feature does not create new detail pages.

--- a/specs/001-trending-home/tasks.md
+++ b/specs/001-trending-home/tasks.md
@@ -1,0 +1,197 @@
+# Tasks: Trending on Home
+
+**Input**: Design documents from `/specs/001-trending-home/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/trending-api.md
+
+**Tests**: INCLUDED — Constitution Principle I (Test-Driven Quality) is NON-NEGOTIABLE and `contracts/trending-api.md` enumerates required tests. Test tasks precede their implementation within each story.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+> **Scope note (FR-002 / SC-001)**: FR-002 (movies + TV + people) and SC-001 (all three visible on first load) are MUST-level but are fully satisfied only after **US2 (P2)**. The US1 MVP intentionally ships movies + TV shows; people are an incremental P2 addition per the spec's prioritization.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: US1 / US2 / US3 (maps to spec.md user stories); omitted for Setup / Foundational / Polish
+- Exact file paths are included in every task
+
+## Path Conventions
+
+Web app (single repo): server code under `server/`, frontend under `frontend/src/`. Tests are colocated (`foo.ts` → `foo.test.ts`).
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Configuration and observability scaffolding touched by all stories.
+
+- [x] T001 Add `CACHE_TTL_TRENDING` (default `86400`), `SYNC_TRENDING_CRON` (default `"0 5 * * *"`), and `TRENDING_TIME_WINDOW` (default `"week"`) to the config schema in `server/config.ts`
+- [x] T002 [P] Add a `trendingCacheTotal{result="hit"|"miss"}` Prometheus counter mirroring `browseCacheTotal` in `server/metrics/index.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Frontend type + fetcher plumbing that every user-story phase depends on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [x] T003 [P] Add `TrendingTitle`, `TrendingPerson`, and `TrendingSnapshot` interfaces, add `"trending"` to `HomepageSectionId`, and add `{ id: "trending", enabled: true }` near the top of `DEFAULT_HOMEPAGE_LAYOUT` in `frontend/src/types.ts`
+- [x] T004 Add `getTrending(signal?)` fetcher (calls `GET /api/trending`, returns `TrendingSnapshot`) to `frontend/src/api.ts` (depends on T003 types)
+
+**Checkpoint**: Config, metrics, and shared frontend types/fetcher exist — story implementation can begin.
+
+---
+
+## Phase 3: User Story 1 - Discover trending movies and TV shows on the home screen (Priority: P1) 🎯 MVP
+
+**Goal**: A labeled "Trending" section on home shows currently-trending movies and TV shows (poster + title), each linking to `/title/:id`; tracked titles reflect their tracked state.
+
+**Independent Test**: Load `/` (signed-in) → "Trending" section shows movies and TV shows with posters/titles; clicking a title opens its detail view; an already-tracked title shows its tracked state.
+
+### Tests for User Story 1 ⚠️ (write first, ensure they fail)
+
+- [x] T005 [P] [US1] TMDB client tests for `fetchTrendingMovies` / `fetchTrendingTv` (mocked HTTP via `spyOn`, `afterEach` restore; assert correct endpoint + parsing) in `server/tmdb/client.test.ts`
+- [x] T006 [P] [US1] Route tests in `server/routes/trending.test.ts`: validation (`time_window=bogus` → 400 with `issues`), happy path (200 with `movies`/`shows` arrays; trending fetchers called), `isTracked` overlay (signed-in tracker → `true`, anon → `false`), cache hit (2nd request does not re-call TMDB), dedupe + empty group (duplicate ids collapsed, empty type → `[]`)
+- [x] T007 [P] [US1] `TrendingSection` test: renders movie/TV rows, title links to `/title/:id`, missing poster → placeholder (no broken image) in `frontend/src/components/TrendingSection.test.tsx`
+- [x] T008 [P] [US1] `HomePage` test: trending section appears in both anonymous and authenticated paths in `frontend/src/pages/HomePage.test.tsx`
+
+### Implementation for User Story 1
+
+- [x] T009 [P] [US1] Add typed TMDB trending movie/TV response types to `server/tmdb/types.ts`
+- [x] T010 [US1] Add `fetchTrendingMovies` and `fetchTrendingTv` (using `tmdbRequest` + `tmdbLanguage()`, default `week` window) to `server/tmdb/client.ts`, reusing `parseDiscoverMovie` / `parseDiscoverTv` from `server/tmdb/parser.ts` (depends on T009)
+- [x] T011 [US1] Create `GET /api/trending` in `server/routes/trending.ts`: `zValidator("query", …)` for `time_window`, build movies/shows groups, cache via `getCache()` (key `trending:v1:<lang>:<window>`, TTL `CACHE_TTL_TRENDING`), overlay `isTracked` from `getTrackedTitleIds(user.id)` (`server/db/repository`), de-dupe by `id`, bump `trendingCacheTotal`, `logger.child({ module: "trending" })` (depends on T001, T002, T010)
+- [x] T012 [US1] Register `/api/trending` with `optionalAuth` (`app.use("/api/trending", …)` + `app.use("/api/trending/*", …)` + `app.route`) in `server/index.ts` (Bun)
+- [x] T013 [US1] Register the identical `/api/trending` + `optionalAuth` block in `server/worker.ts` (CF parity — enforced by `check-route-sync`)
+- [x] T014 [P] [US1] Create `TrendingSection` component rendering title rows with `FullBleedCarousel` + `MediaCard` (gradient placeholder when `posterUrl` null) in `frontend/src/components/TrendingSection.tsx`
+- [x] T015 [US1] Render `TrendingSection` in both the anonymous home path and the authenticated `renderSection` switch, fed by a TanStack Query `["trending"]` key calling `getTrending`, in `frontend/src/pages/HomePage.tsx` (depends on T004, T014)
+
+**Checkpoint**: Trending movies + TV shows are live on home, signed-in and signed-out, with tracked-state overlay. MVP is shippable.
+
+---
+
+## Phase 4: User Story 2 - Discover trending people on the home screen (Priority: P2)
+
+**Goal**: The trending section also shows trending people (name + profile photo), visually distinct from titles, each linking to `/person/:id`. Completes FR-002 / SC-001.
+
+**Independent Test**: Load `/` → trending people appear with name and photo (placeholder when no photo); clicking a person opens `/person/:id`.
+
+### Tests for User Story 2 ⚠️ (write first, ensure they fail)
+
+- [x] T016 [P] [US2] `parseTrendingPerson` + `fetchTrendingPeople` tests (mocked HTTP, `afterEach` restore) in `server/tmdb/client.test.ts` / `server/tmdb/parser.test.ts`
+- [x] T017 [P] [US2] Extend `frontend/src/components/TrendingSection.test.tsx`: renders person rows, person links to `/person/:id`, missing profile photo → placeholder, people group omitted when empty (FR-013)
+
+### Implementation for User Story 2
+
+- [x] T018 [P] [US2] Add `TmdbTrendingPersonResult` and trending-person response type to `server/tmdb/types.ts`
+- [x] T019 [US2] Add `parseTrendingPerson` (maps to `TrendingPerson`: `id`, `name`, `profileUrl`, `knownForDepartment`; no DB persistence) to `server/tmdb/parser.ts` (depends on T018)
+- [x] T020 [US2] Add `fetchTrendingPeople` (TMDB `/trending/person/<window>`) to `server/tmdb/client.ts` (depends on T019)
+- [x] T021 [US2] Add the `people` group (de-duped by `id`) to the snapshot build in `server/routes/trending.ts` (depends on T011, T020)
+- [x] T022 [US2] Render a `PersonCard` people row (visually distinct, placeholder for missing photo, links to `/person/:id`) in `frontend/src/components/TrendingSection.tsx` (depends on T014)
+
+**Checkpoint**: Movies, TV shows, AND people render in the trending section; each navigates to the correct detail surface. FR-002 / SC-001 fully satisfied.
+
+---
+
+## Phase 5: User Story 3 - Reliable, fresh, and unobtrusive trending content (Priority: P3)
+
+**Goal**: The section fails soft on upstream errors, shows a non-blocking loading state, and stays fresh via cache + a scheduled refresh job — never blocking the rest of home.
+
+**Independent Test**: Simulate TMDB unavailable with a cold cache → `/` still renders fully and the trending section is gracefully absent; trigger `sync-trending` → cache repopulates and `refreshedAt` advances.
+
+### Tests for User Story 3 ⚠️ (write first, ensure they fail)
+
+- [x] T023 [P] [US3] Fail-soft route test in `server/routes/trending.test.ts`: TMDB fetch rejects + cold cache → HTTP 200 with `{ movies: [], shows: [], people: [] }` (no 5xx)
+- [x] T024 [P] [US3] `sync-trending` job test in `server/jobs/sync.test.ts`: running the handler populates the cache; unset `TMDB_API_KEY` skips without throwing; cache not overwritten on TMDB failure (stale survives)
+- [x] T025 [P] [US3] Loading + empty-state test in `frontend/src/components/TrendingSection.test.tsx`: loading placeholder renders while the query is pending and does NOT block siblings; the whole section is hidden when all groups are empty (FR-008, FR-009, FR-013)
+
+### Implementation for User Story 3
+
+- [x] T026 [US3] Add fail-soft handling to `server/routes/trending.ts`: on cache miss + TMDB build error, log warn, increment `syncFailureTotal{source:"tmdb"}`, return all-empty groups with `refreshedAt: now`; serve stale cache on error when warm; apply `setPublicCacheIfAnon(c, CACHE_TTL_TRENDING)` from `server/routes/cache-headers.ts` (depends on T011)
+- [x] T027 [US3] Add a non-blocking loading placeholder and hide-when-all-empty / omit-empty-group behavior to `frontend/src/components/TrendingSection.tsx` (depends on T014)
+- [x] T028 [P] [US3] Register `sync-trending` via `registerHandler` (builds snapshot, writes cache, no-op on unset key, only overwrites on success) and schedule `registerCron("sync-trending", CONFIG.SYNC_TRENDING_CRON)` in `server/jobs/sync.ts` (depends on T010, T020)
+- [x] T029 [US3] Add `{ name: "sync-trending", cron: CONFIG.SYNC_TRENDING_CRON }` to the `CRON_JOBS` array in `server/jobs/backend.ts` (CF parity) (depends on T028)
+
+**Checkpoint**: Feature is production-hardened — fail-soft, loading state, cached, and refreshed on schedule across both runtimes.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [x] T030 [P] Verify the dual-runtime route-sync invariant with `bun run check-route-sync` (or the `/check-route-sync` skill) — `/api/trending` registered identically in `server/index.ts` and `server/worker.ts`
+- [x] T031 [P] Run the `quickstart.md` manual validation, incl. mobile-viewport / breakpoint check for FR-007 + SC-006 (no automated viewport test; manual or `/ux-review` is the coverage of record)
+- [x] T032 Run `bun run check` — full CI gate (server tsc + frontend tsc + ESLint zero-warning + all tests + frontend build + wrangler dry-run) before opening the PR
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately.
+- **Foundational (Phase 2)**: Depends on Setup — BLOCKS all user stories.
+- **User Stories (Phase 3–5)**: All depend on Foundational. US1 → US2 → US3 in priority order; US2 and US3 build on the US1 route + component files.
+- **Polish (Phase 6)**: Depends on all targeted stories being complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Independent after Foundational — the MVP.
+- **US2 (P2)**: Extends US1's `trending.ts` route and `TrendingSection.tsx`; independently testable (people rows) but shares those files.
+- **US3 (P3)**: Hardens US1's route + component and adds the refresh job; independently testable (fail-soft + job).
+
+### Within Each User Story
+
+- Tests are written first and must fail before implementation.
+- TMDB types → parser → client functions → route → registration.
+- Frontend types/fetcher (Foundational) → component → HomePage wiring.
+
+### Parallel Opportunities
+
+- T002 (metrics) runs parallel to T001.
+- All US1 test tasks (T005–T008) run in parallel; T009 and T014 run in parallel with the tests and each other.
+- US2 tests T016–T017 in parallel; T018 parallels them.
+- US3 tests T023–T025 in parallel; T028 parallels T026/T027.
+- Polish T030 + T031 run in parallel; T032 runs last.
+- US1/US2/US3 share the route + `TrendingSection` files, so coordinate those edits; the TMDB-type/client and job tasks are the cleanest parallel splits.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch all US1 tests together (write first, expect red):
+Task: "client tests for fetchTrendingMovies/fetchTrendingTv in server/tmdb/client.test.ts"
+Task: "route tests in server/routes/trending.test.ts"
+Task: "TrendingSection test in frontend/src/components/TrendingSection.test.tsx"
+Task: "HomePage test in frontend/src/pages/HomePage.test.tsx"
+
+# Then independent implementation files in parallel:
+Task: "TMDB trending types in server/tmdb/types.ts"
+Task: "TrendingSection component in frontend/src/components/TrendingSection.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Phase 1 Setup → Phase 2 Foundational.
+2. Phase 3 (US1): trending movies + TV shows on home, dual-runtime route, tracked overlay.
+3. **STOP and VALIDATE** US1 independently (signed-in/out, tracked state, navigation).
+4. Ship the MVP. (Note: FR-002/SC-001 — which require people — complete at US2.)
+
+### Incremental Delivery
+
+1. Setup + Foundational → foundation ready.
+2. US1 → test → ship (movies + TV). **MVP**
+3. US2 → test → ship (adds people; completes FR-002/SC-001).
+4. US3 → test → ship (fail-soft, loading, cache refresh job).
+
+### Notes
+
+- [P] = different files, no incomplete dependencies.
+- Each story is an independently testable increment; commit after each task or logical group.
+- Mock all TMDB HTTP (`spyOn` + `afterEach` restore) — never make real calls in tests.
+- No DB migration is introduced — the snapshot lives in `getCache()`.


### PR DESCRIPTION
## Summary

Adds a **Trending** section to the home screen surfacing currently-trending movies, TV shows, and people from TMDB — for both signed-in and signed-out visitors. Implements `specs/001-trending-home` (FR-001..FR-014, SC-001..SC-006).

Data is served from a cache-backed, **user-agnostic snapshot** via a new public `GET /api/trending`, with a per-request `isTracked` overlay for titles. A daily `sync-trending` job keeps the snapshot warm. The endpoint and section **fail soft** — on cache-miss + upstream error they return/render empty rather than blocking the rest of home.

No DB migration: the snapshot lives in the existing cache abstraction (MemoryCache / Redis / CF KV).

## What's included

**Server**
- `GET /api/trending` — snapshot cache, `isTracked` overlay, dedupe-by-id, fail-soft (200 empty, `Cache-Control: no-store` on the empty fail-soft response so a CDN can't pin it), `setPublicCacheIfAnon` for warm responses. Registered identically in `index.ts` (Bun) and `worker.ts` (CF).
- TMDB `fetchTrendingMovies/Tv/People` + `parseTrendingPerson` (reuses `parseDiscoverMovie/Tv`).
- `sync-trending` job + cron on **both** runtimes — Bun (`registerCron`) and CF (`CRON_JOBS` + `CRON_JOB_NAMES` + the `processor.ts` handler map). Only overwrites the cache on success, so a stale snapshot survives a TMDB outage.
- `config`: `CACHE_TTL_TRENDING`, `SYNC_TRENDING_CRON`, `TRENDING_TIME_WINDOW`. `metrics`: `trendingCacheTotal`.

**Frontend**
- `TrendingSection` — `FullBleedCarousel` + `MediaCard` poster rows + circular person cards, image placeholders, tracked badge, loading skeleton, hide-when-empty / omit-empty-group.
- Rendered in the desktop, signed-out, **and** mobile home paths via a shared `["trending"]` query.
- New `"trending"` home-layout section (frontend + server `user-settings` kept in sync; existing users pick it up via the layout merge).

## Adversarial review → fixes

A multi-agent review of the diff surfaced and I fixed:
- **🔴 Blocker:** `sync-trending` was wired only into the Bun worker's handler map; Cloudflare dispatches jobs via a separate `processor.ts` `handlers` record, so the daily cron would have failed every tick on CF ("Unknown job type"). Added the handler there, plus a functional CF-path test and a handler-parity guard.
- **🟠 Authed mobile users** got no Trending section (early `MobileFeedHome` return). Now rendered there too.
- **🟠** Added the missing cron-registration and CF-dispatch regression tests.

## Test plan

- `bun run check` — full gate (server tsc + frontend tsc + ESLint zero-warning + all tests + frontend build + wrangler dry-run): **green** (server 2246, frontend 1126).
- New tests: `server/routes/trending.test.ts` (validation, happy path, `isTracked` overlay, cache hit, dedupe/empty, fail-soft, cache headers), TMDB client + parser, `sync-trending` on both Bun (`sync.test.ts`) and CF (`processor.test.ts`) paths, `TrendingSection.test.tsx`, and HomePage trending (desktop / auth / mobile).
- Manual / `/ux-review` across breakpoints remains the coverage of record for FR-007 / SC-006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
