### PR TITLE
fix(person): rank Known For by vote_count and drop Self appearances

### DIFF
--- a/frontend/src/pages/PersonPage.test.tsx
+++ b/frontend/src/pages/PersonPage.test.tsx
@@ -47,28 +47,109 @@ describe("PersonPage", () => {
 });
 
 describe("selectKnownFor", () => {
-  it("ranks by popularity descending", () => {
+  it("ranks by vote_count descending (rating volume, not trending popularity)", () => {
     const result = selectKnownFor([
-      castCredit({ id: 1, media_type: "movie", popularity: 10 }),
-      castCredit({ id: 2, media_type: "movie", popularity: 50 }),
-      castCredit({ id: 3, media_type: "movie", popularity: 30 }),
+      castCredit({
+        id: 1,
+        media_type: "movie",
+        vote_count: 10,
+        popularity: 999,
+      }),
+      castCredit({ id: 2, media_type: "movie", vote_count: 50, popularity: 1 }),
+      castCredit({ id: 3, media_type: "movie", vote_count: 30, popularity: 1 }),
     ]);
     expect(result.map((c) => c.id)).toEqual([2, 3, 1]);
   });
 
-  it("de-duplicates across roles by media_type-id, keeping the highest-popularity occurrence", () => {
+  it("breaks vote_count ties by popularity descending", () => {
     const result = selectKnownFor([
-      castCredit({ id: 7, media_type: "movie", popularity: 20 }),
-      crewCredit({ id: 7, media_type: "movie", popularity: 90 }),
+      castCredit({
+        id: 1,
+        media_type: "movie",
+        vote_count: 100,
+        popularity: 5,
+      }),
+      castCredit({
+        id: 2,
+        media_type: "movie",
+        vote_count: 100,
+        popularity: 9,
+      }),
+    ]);
+    expect(result.map((c) => c.id)).toEqual([2, 1]);
+  });
+
+  it("excludes non-narrative Self appearances (talk-show guest/host spots)", () => {
+    const result = selectKnownFor([
+      castCredit({
+        id: 1,
+        media_type: "movie",
+        character: "Evelyn",
+        vote_count: 100,
+      }),
+      castCredit({
+        id: 2,
+        media_type: "tv",
+        character: "Self",
+        vote_count: 9000,
+      }),
+      castCredit({
+        id: 3,
+        media_type: "tv",
+        character: "Self - Guest",
+        vote_count: 9000,
+      }),
+      castCredit({
+        id: 4,
+        media_type: "tv",
+        character: "Self - Host",
+        vote_count: 9000,
+      }),
+      castCredit({
+        id: 5,
+        media_type: "tv",
+        character: "Herself",
+        vote_count: 9000,
+      }),
+    ]);
+    expect(result.map((c) => c.id)).toEqual([1]);
+  });
+
+  it("keeps crew credits (no character field) even though they lack a role to self-match", () => {
+    const result = selectKnownFor([
+      crewCredit({
+        id: 9,
+        media_type: "movie",
+        job: "Director",
+        vote_count: 500,
+      }),
+    ]);
+    expect(result.map((c) => c.id)).toEqual([9]);
+  });
+
+  it("de-duplicates across roles by media_type-id, keeping the highest-ranked occurrence", () => {
+    const result = selectKnownFor([
+      castCredit({
+        id: 7,
+        media_type: "movie",
+        vote_count: 20,
+        popularity: 90,
+      }),
+      crewCredit({
+        id: 7,
+        media_type: "movie",
+        vote_count: 90,
+        popularity: 20,
+      }),
     ]);
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe(7);
-    expect(result[0].popularity).toBe(90);
+    expect(result[0].vote_count).toBe(90);
   });
 
   it("caps at KNOWN_FOR_LIMIT (10)", () => {
     const many = Array.from({ length: 25 }, (_, i) =>
-      castCredit({ id: i + 1, media_type: "movie", popularity: i }),
+      castCredit({ id: i + 1, media_type: "movie", vote_count: i }),
     );
     const result = selectKnownFor(many);
     expect(result).toHaveLength(KNOWN_FOR_LIMIT);
@@ -77,8 +158,8 @@ describe("selectKnownFor", () => {
 
   it("returns fewer-than-limit verbatim with no padding", () => {
     const result = selectKnownFor([
-      castCredit({ id: 1, media_type: "movie", popularity: 5 }),
-      castCredit({ id: 2, media_type: "tv", popularity: 9 }),
+      castCredit({ id: 1, media_type: "movie", vote_count: 5 }),
+      castCredit({ id: 2, media_type: "tv", vote_count: 9 }),
     ]);
     expect(result).toHaveLength(2);
   });
@@ -89,8 +170,8 @@ describe("selectKnownFor", () => {
 
   it("does NOT collapse a movie and a TV title that share the same numeric id", () => {
     const result = selectKnownFor([
-      castCredit({ id: 42, media_type: "movie", popularity: 10 }),
-      castCredit({ id: 42, media_type: "tv", popularity: 8 }),
+      castCredit({ id: 42, media_type: "movie", vote_count: 10 }),
+      castCredit({ id: 42, media_type: "tv", vote_count: 8 }),
     ]);
     expect(result).toHaveLength(2);
     expect(result.map((c) => c.media_type).sort()).toEqual(["movie", "tv"]);

--- a/frontend/src/pages/PersonPage.tsx
+++ b/frontend/src/pages/PersonPage.tsx
@@ -35,17 +35,43 @@ function creditSubtitle(credit: PersonCastCredit | PersonCrewCredit): string {
 export const KNOWN_FOR_LIMIT = 10;
 
 /**
+ * True for non-narrative "Self" appearances (talk-show guest/host spots, award
+ * shows, etc.). These inherit the high `popularity` of long-running shows but
+ * are not roles a person is "known for", so they are excluded — mirroring how
+ * TMDB's own Known For omits them. Only cast credits carry `character`; crew
+ * credits (which have `job`) are never treated as self-appearances.
+ */
+function isSelfAppearance(
+  credit: PersonCastCredit | PersonCrewCredit,
+): boolean {
+  if (!("character" in credit)) return false;
+  const role = credit.character.trim().toLowerCase();
+  return (
+    role === "self" ||
+    role === "himself" ||
+    role === "herself" ||
+    role === "themselves" ||
+    role.startsWith("self ") ||
+    role.startsWith("self-")
+  );
+}
+
+/**
  * Selects a person's most notable titles for the "Known For" row: merges the
- * already-combined cast + crew credits, ranks by `popularity` descending,
+ * already-combined cast + crew credits, drops non-narrative "Self" appearances,
+ * ranks by `vote_count` descending (rating volume is TMDB's notability signal —
+ * `popularity` is trending velocity, which lets daily talk shows dominate),
  * de-duplicates by the `${media_type}-${id}` title key (keeping the
- * highest-popularity occurrence so a title held in multiple roles appears
- * once), and caps the result at `limit`. Pure — no padding, no fabrication.
+ * highest-ranked occurrence so a title held in multiple roles appears once),
+ * and caps the result at `limit`. Pure — no padding, no fabrication.
  */
 export function selectKnownFor(
   credits: (PersonCastCredit | PersonCrewCredit)[],
   limit = KNOWN_FOR_LIMIT,
 ): (PersonCastCredit | PersonCrewCredit)[] {
-  const sorted = [...credits].sort((a, b) => b.popularity - a.popularity);
+  const sorted = credits
+    .filter((credit) => !isSelfAppearance(credit))
+    .sort((a, b) => b.vote_count - a.vote_count || b.popularity - a.popularity);
   const seen = new Set<string>();
   const result: (PersonCastCredit | PersonCrewCredit)[] = [];
   for (const credit of sorted) {

--- a/specs/002-person-known-for/contracts/known-for-ui.md
+++ b/specs/002-person-known-for/contracts/known-for-ui.md
@@ -33,14 +33,15 @@ Each card:
 
 ## Content rules
 
-| Rule                                                                          | Requirement    |
-| ----------------------------------------------------------------------------- | -------------- |
-| Entries ranked by `popularity` descending (most notable first)                | FR-003         |
-| At most 10 entries (default `KNOWN_FOR_LIMIT`)                                | FR-004, SC-002 |
-| Fewer than 10 shown verbatim when the person has fewer credits (no padding)   | FR-004         |
-| Each title appears at most once even across acting + crew roles               | FR-005, SC-002 |
-| Section hidden entirely (no heading) when the person has no credits           | FR-008         |
-| Behavior identical to Acting/Crew rows: card style, scroll, click-to-navigate | FR-009, SC-005 |
+| Rule                                                                                       | Requirement    |
+| ------------------------------------------------------------------------------------------ | -------------- |
+| Entries ranked by `vote_count` descending, tie-broken by `popularity` (most notable first) | FR-003         |
+| Non-narrative "Self" appearances (talk/award-show guest & host spots) excluded             | FR-003         |
+| At most 10 entries (default `KNOWN_FOR_LIMIT`)                                             | FR-004, SC-002 |
+| Fewer than 10 shown verbatim when the person has fewer credits (no padding)                | FR-004         |
+| Each title appears at most once even across acting + crew roles                            | FR-005, SC-002 |
+| Section hidden entirely (no heading) when the person has no credits                        | FR-008         |
+| Behavior identical to Acting/Crew rows: card style, scroll, click-to-navigate              | FR-009, SC-005 |
 
 ## Error / empty behavior
 

--- a/specs/002-person-known-for/data-model.md
+++ b/specs/002-person-known-for/data-model.md
@@ -19,8 +19,8 @@ the inputs and the derived output.
 | `first_air_date?` | `string`          | TV date                                      |
 | `poster_path`     | `string \| null`  | `null` → text fallback in the card           |
 | `vote_average`    | `number`          | Not used for ranking                         |
-| `vote_count`      | `number`          | Not used for ranking                         |
-| `popularity`      | `number`          | **Ranking signal**                           |
+| `vote_count`      | `number`          | **Primary ranking signal** (rating volume)   |
+| `popularity`      | `number`          | Tie-breaker only (trending velocity)         |
 
 ### `PersonCrewCredit` (`types.ts:407`)
 
@@ -46,19 +46,26 @@ No new type is strictly required; the helper returns `KnownForCredit[]`.
 Input: `cast: PersonCastCredit[]`, `crew: PersonCrewCredit[]`, `limit = 10`.
 
 1. **Merge** cast and crew into one list.
-2. **Sort** by `popularity` descending. (Stable enough for our purpose; ties keep
-   input order.)
-3. **De-duplicate** by title key `` `${media_type}-${id}` `` — keep the first
-   (highest-popularity) occurrence. Guarantees a title held in multiple roles
+2. **Exclude** non-narrative "Self" appearances — cast credits whose
+   `character` is `"Self"`, `"Himself"`, `"Herself"`, `"Themselves"`, or begins
+   with `"Self "` / `"Self-"` (talk-show/award-show guest & host spots). Crew
+   credits (no `character`) are never excluded here.
+3. **Sort** by `vote_count` descending, tie-broken by `popularity` descending.
+   Rating volume approximates notability far better than raw `popularity`, which
+   is a trending-velocity signal that lets daily talk shows dominate. (Stable
+   enough for our purpose; remaining ties keep input order.)
+4. **De-duplicate** by title key `` `${media_type}-${id}` `` — keep the first
+   (highest-ranked) occurrence. Guarantees a title held in multiple roles
    appears once (FR-005, SC-002).
-4. **Cap** to at most `limit` entries (default 10). Never pad (FR-004).
-5. Result may be empty → the section is hidden (FR-008).
+5. **Cap** to at most `limit` entries (default 10). Never pad (FR-004).
+6. Result may be empty → the section is hidden (FR-008).
 
 ### Validation / invariants
 
 - Output length ≤ `limit`.
 - No two output entries share the same `` `${media_type}-${id}` `` key.
-- Output is ordered by descending `popularity` (most notable first) — FR-003.
+- Output contains no "Self" appearances.
+- Output is ordered by descending `vote_count` (most notable first) — FR-003.
 - Output ⊆ the person's existing credits (no fabricated titles).
 - Each entry exposes a poster (or `null` for fallback), a display title
   (`title` ‖ `name` ‖ "Untitled"), and a year derived from

--- a/specs/002-person-known-for/spec.md
+++ b/specs/002-person-known-for/spec.md
@@ -46,6 +46,7 @@ A user browsing the "Known For" section experiences the same look, navigation, a
 - **Person with no credits**: When a person has no acting or crew credits, the "Known For" section is hidden entirely (no empty header).
 - **Person with very few credits**: When a person has only one or two credits, "Known For" shows just those titles rather than padding to a fixed count.
 - **Duplicate titles across roles**: When the same title appears in both acting and crew credits (or multiple times), it appears at most once in "Known For".
+- **Non-narrative self-appearances**: Talk-show, award-show, and similar guest/host appearances where the person plays themselves ("Self") are excluded from "Known For" — they are not titles a person is recognized for, even when the show is very popular.
 - **Missing poster art**: When a notable title has no poster image, the card falls back to a readable text placeholder, matching existing credit cards.
 - **Missing release date**: When a title has no release/air date, the year is simply omitted from the card.
 - **Data unavailable**: When the person's credit data cannot be loaded, the page behaves as it does today (existing not-found / error handling) and no broken "Known For" section is rendered.
@@ -83,7 +84,7 @@ A user browsing the "Known For" section experiences the same look, navigation, a
 
 ## Assumptions
 
-- "Most notable" is determined by the same popularity/notability signal already used to order the existing Acting and Crew credit rows; no new external data source is required.
+- "Most notable" is determined by each title's rating volume (the number of ratings a title has accumulated), which approximates how recognized a title is. This is preferred over the raw popularity/trending signal used to order the existing Acting and Crew rows, because trending popularity lets perennially-airing shows (e.g. daily talk shows) outrank a person's defining films. No new external data source is required — both signals already arrive with the existing credit data.
 - The default maximum of 10 "Known For" titles is a reasonable, adjustable default; the exact number is not business-critical.
 - "Known For" is derived from the person's existing credit data already available to the detail page; no additional data collection from users is needed.
 - The feature is presentation-only for end users (read-only browsing); no permissions, settings, or per-user configuration are involved.


### PR DESCRIPTION
## Problem

The Known For section (merged in #1023) ranked credits by TMDB `popularity`. But `popularity` is a **trending-velocity** signal — daily talk shows and long-running series carry enormous popularity, so a person's one-off **"Self" guest spots** outranked their defining films.

For Emily Blunt the row was Disclosure Day, The Simpsons, then seven talk-show appearances (Watch What Happens Live, Late Show, Seth Meyers, Kelly Clarkson, Letterman, Graham Norton, SNL) — with The Devil Wears Prada only at #10:


## Fix

Match how TMDB actually derives Known For:

- **Exclude** non-narrative `"Self"` / `"Himself"` / `"Herself"` / `"Themselves"` cast appearances (talk/award-show guest & host spots). Crew credits (no `character`) are unaffected.
- **Rank by `vote_count`** (rating volume ≈ notability), tie-broken by `popularity`, instead of raw `popularity`.

Both signals already arrive with the existing person payload — no server change, no new API call.

## Verification

Checked against live TMDB data (person `5081`). New order:

> A Quiet Place · Edge of Tomorrow · The Devil Wears Prada · Oppenheimer · Looper · The Simpsons · Sicario · A Quiet Place Part II · Jungle Cruise · The Girl on the Train

— which matches TMDB's curated `known_for` (A Quiet Place / Sicario / Edge of Tomorrow) and the TMDB website's Known For row.

## Tests

Updated `selectKnownFor` unit tests: vote_count ranking, popularity tie-break, **Self-appearance exclusion**, crew passthrough, dedupe keeps highest-ranked, cap, empty, movie-vs-tv same id (13 passing). Updated spec / data-model / contract notes. `bun run check` passes.

Follow-up to #1023.

🤖 Generated with [Claude Code](https://claude.com/claude-code)