### PR TITLE
[auto-review] refactor(calendar): replace getCrowdedWeekSettings useEffect with useQuery

### DIFF
--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -635,8 +635,6 @@ function GridCalendar({
     return new Date(y, m - 1, 1);
   }, [monthParam]);
 
-  const [crowdedWeekThreshold, setCrowdedWeekThreshold] = useState(5);
-  const [crowdedWeekBadgeEnabled, setCrowdedWeekBadgeEnabled] = useState(true);
   const qc = useQueryClient();
   const calendarMonthKey = formatMonth(currentMonth);
   const calendarTypeKey = typeFilter || undefined;
@@ -648,25 +646,18 @@ function GridCalendar({
         signal,
       ),
   });
+  const { data: crowdedWeekData } = useQuery({
+    queryKey: ["crowded-week-settings"],
+    queryFn: ({ signal }) => getCrowdedWeekSettings(signal),
+  });
+  const crowdedWeekThreshold = crowdedWeekData?.crowdedWeekThreshold ?? 5;
+  const crowdedWeekBadgeEnabled =
+    (crowdedWeekData?.crowdedWeekBadgeEnabled ?? 1) !== 0;
   const titles = useMemo(() => calendarData?.titles ?? [], [calendarData]);
   const episodes = useMemo(() => calendarData?.episodes ?? [], [calendarData]);
 
   const year = currentMonth.getFullYear();
   const month = currentMonth.getMonth();
-
-  // Load crowded week settings once on mount
-  useEffect(() => {
-    const controller = new AbortController();
-    getCrowdedWeekSettings(controller.signal)
-      .then((s) => {
-        if (!controller.signal.aborted) {
-          setCrowdedWeekThreshold(s.crowdedWeekThreshold);
-          setCrowdedWeekBadgeEnabled(s.crowdedWeekBadgeEnabled !== 0);
-        }
-      })
-      .catch(() => {});
-    return () => controller.abort();
-  }, []);
 
   const itemsByDate = useMemo(() => {
     const map = new Map<string, CalendarItem[]>();


### PR DESCRIPTION
## Summary

`GridCalendar` in `frontend/src/pages/CalendarPage.tsx` was fetching crowded-week settings via a direct `getCrowdedWeekSettings()` call inside `useEffect` — a pattern explicitly prohibited by `frontend/CLAUDE.md`:

> "functions in `api.ts` are the raw fetchers — they belong inside `queryFn`/`mutationFn`, never called directly from a component's `useEffect`"

This PR replaces the two `useState` declarations + the `useEffect` block (16 lines) with a single `useQuery` (7 lines), bringing this path in line with the rest of the data-fetching layer.

## Changes

- `frontend/src/pages/CalendarPage.tsx` — swap `useState` + `useEffect` for `useQuery(["crowded-week-settings"], ...)` in `GridCalendar`; default values preserved (`threshold: 5`, `enabled: true`)

## Test plan

- [ ] `bun run check` passes (run locally — all type checks, lint, tests, build, wrangler dry-run ✅)
- [ ] Manually verify the crowded-week badge still appears on the calendar grid when a week exceeds the configured threshold

---
_Source: ux_

---
_Generated by [Claude Code](https://claude.ai/code/session_01LP1y9c2KbywEVxNVwNPEE8)_