### PR TITLE
fix(e2e): use relative expiry date in invite-accept fixtures

### DIFF
--- a/e2e/invite-accept.spec.ts
+++ b/e2e/invite-accept.spec.ts
@@ -4,11 +4,15 @@ import { InvitePage } from "./pages/invite-page";
 
 test.describe.configure({ mode: "serial" });
 
+// Relative dates so the fixtures never rot — getStatus() in InvitePage compares
+// expires_at against `now`, so a hardcoded date eventually flips Pending → Expired.
+const FUTURE = new Date(Date.now() + 7 * 86400000).toISOString(); // +7 days
+
 const MOCK_INVITATION_PENDING = {
   id: "inv-001",
   code: "ABCD1234",
   created_at: "2026-05-20T10:00:00Z",
-  expires_at: "2026-06-20T10:00:00Z",
+  expires_at: FUTURE,
   used_at: null,
   used_by: null,
 };
@@ -92,7 +96,7 @@ test.describe("Invite / Accept flow", () => {
           json: {
             id: "inv-001",
             code: "ABCD1234",
-            expires_at: "2026-06-20T10:00:00Z",
+            expires_at: FUTURE,
           },
         });
       } else {


### PR DESCRIPTION
@
## Summary

`invite-accept.spec.ts::TC-02` was failing in nightly CI because the newly-created invite rendered an **"Expired"** badge instead of **"Pending"**. Not a product bug — date rot in the test fixture.

`getStatus()` in `frontend/src/pages/InvitePage.tsx` returns `"expired"` whenever `expires_at < now`. The spec hardcoded `expires_at: 2026-06-20`, which is now in the past, so the badge flipped.

## Fix

Use a relative `+7d` date (`new Date(Date.now() + 7 * 86400000)`) for the pending fixtures — the same approach the colocated `InvitePage.test.tsx` already uses — so the fixture never rots again. `MOCK_INVITATION_USED` is untouched: `getStatus()` short-circuits to `"used"` when `used_at` is set, so its expiry is irrelevant.

No source/product changes.

## Verification

`bunx playwright test --project=chromium e2e/invite-accept.spec.ts` → **7 passed**.

Closes #1033

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@