### PR TITLE
feat(share): validate watchlist share token path param

### DIFF
--- a/server/routes/share.test.ts
+++ b/server/routes/share.test.ts
@@ -170,8 +170,10 @@ describe("DELETE /share/token (auth)", () => {
 });
 
 describe("GET /share/watchlist/:token (public)", () => {
-  it("returns 404 for unknown token", async () => {
-    const res = await app.request("/share/watchlist/unknowntoken12345");
+  it("returns 404 for a well-formed but unknown token", async () => {
+    const res = await app.request(
+      "/share/watchlist/0123456789abcdef0123456789abcdef",
+    );
     expect(res.status).toBe(404);
   });
 
@@ -191,10 +193,11 @@ describe("GET /share/watchlist/:token (public)", () => {
 });
 
 describe("validation", () => {
-  it("unknown token returns 404", async () => {
-    const res = await app.request("/share/watchlist/notarealtoken");
-    expect(res.status).toBe(404);
+  it("rejects a malformed token (not 32-char hex) with 400", async () => {
+    const res = await app.request("/share/watchlist/not-a-valid-token");
+    expect(res.status).toBe(400);
     const body = (await res.json()) as any;
-    expect(body.error).toBeDefined();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
   });
 });

--- a/server/routes/share.ts
+++ b/server/routes/share.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { z } from "zod";
 import {
   getUserByWatchlistShareToken,
   getWatchlistShareToken,
@@ -6,10 +7,14 @@ import {
   getTrackedTitles,
 } from "../db/repository";
 import { requireAuth } from "../middleware/auth";
+import { zValidator } from "../lib/validator";
 import { logger } from "../logger";
 import type { AppEnv } from "../types";
 
 const log = logger.child({ module: "share" });
+
+// Share tokens are 32-char hex (crypto.randomUUID() with dashes stripped).
+const shareTokenParam = z.object({ token: z.string().regex(/^[a-f0-9]{32}$/) });
 
 const app = new Hono<AppEnv>();
 
@@ -38,19 +43,23 @@ app.delete("/token", requireAuth, async (c) => {
 });
 
 // GET /api/share/watchlist/:token  (public)
-app.get("/watchlist/:token", async (c) => {
-  const token = c.req.param("token");
-  const user = await getUserByWatchlistShareToken(token);
-  if (!user) {
-    return c.json({ error: "Not found" }, 404);
-  }
-  const titles = await getTrackedTitles(user.id);
-  const username = user.displayUsername ?? user.username;
-  log.debug("Shared watchlist served", {
-    userId: user.id,
-    count: titles.length,
-  });
-  return c.json({ username, titles });
-});
+app.get(
+  "/watchlist/:token",
+  zValidator("param", shareTokenParam),
+  async (c) => {
+    const { token } = c.req.valid("param");
+    const user = await getUserByWatchlistShareToken(token);
+    if (!user) {
+      return c.json({ error: "Not found" }, 404);
+    }
+    const titles = await getTrackedTitles(user.id);
+    const username = user.displayUsername ?? user.username;
+    log.debug("Shared watchlist served", {
+      userId: user.id,
+      count: titles.length,
+    });
+    return c.json({ username, titles });
+  },
+);
 
 export default app;


### PR DESCRIPTION
## Summary

Adds `zValidator("param", ...)` to the public `GET /api/share/watchlist/:token` endpoint. The `:token` param was previously read via `c.req.param("token")` with no schema guard — any string of any length was forwarded straight to the DB query.

Share tokens are 32-char hex (`crypto.randomUUID()` with dashes stripped), so the schema is:

```ts
const shareTokenParam = z.object({ token: z.string().regex(/^[a-f0-9]{32}$/) });
```

A malformed token now short-circuits with `400 { error: "Validation failed", issues: [...] }`.

## Tests

- New rejection test: malformed token → `400`.
- Updated the existing "unknown token" test to use a well-formed-but-unregistered token so it still exercises the `404` path.
- Happy-path (valid generated token → `200`) preserved.

`bun run check` passes (server+frontend tsc, ESLint, all tests, build, wrangler dry-run).

Closes #1017

🤖 Generated with [Claude Code](https://claude.com/claude-code)