### PR TITLE
test(db): guard sessions.impersonated_by column after migrations

### DIFF
--- a/server/db/migrations.test.ts
+++ b/server/db/migrations.test.ts
@@ -91,6 +91,47 @@ describe("migrations FK-cascade regression", () => {
   });
 });
 
+/**
+ * Regression guard for issue #1025: better-auth writes `impersonated_by` to the
+ * sessions table on every session update. The column is defined in schema.ts and
+ * in the CREATE TABLE in drizzle/0000, so any DB built from the migrations must
+ * have it.
+ *
+ * Production failed because prod D1 was created from an OLDER 0000 that predated
+ * the column; since 0000 is already marked applied, `db:migrate:cf` won't re-add
+ * it (the prod fix is a one-time manual ALTER). This test guards the code path:
+ * a fresh DB built from all `drizzle/` migrations must expose `impersonated_by`.
+ */
+describe("sessions.impersonated_by column (issue #1025)", () => {
+  it("exists on the sessions table after applying all migrations", () => {
+    const db = new Database(":memory:");
+    db.exec("PRAGMA foreign_keys = ON");
+
+    const sqlFiles = fs
+      .readdirSync(MIGRATIONS_DIR)
+      .filter((f) => f.endsWith(".sql"))
+      .sort();
+
+    for (const file of sqlFiles) {
+      const content = fs.readFileSync(path.join(MIGRATIONS_DIR, file), "utf-8");
+      const statements = content
+        .split("--> statement-breakpoint")
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .filter((s) => !/^PRAGMA\s+foreign_keys\s*=/i.test(s));
+      for (const stmt of statements) db.exec(stmt);
+    }
+
+    const columns = (
+      db.prepare("PRAGMA table_info(sessions)").all() as { name: string }[]
+    ).map((c) => c.name);
+
+    expect(columns).toContain("impersonated_by");
+
+    db.close();
+  });
+});
+
 describe("0043 consolidate duplicate providers", () => {
   it("merges offers/user_subscribed_providers and deletes duplicate provider rows", () => {
     const db = new Database(":memory:");


### PR DESCRIPTION
## Summary

better-auth writes `impersonated_by` to the `sessions` table on every session update. In production this fails with a "no such column: impersonated_by" error during session update.

`Closes #1025`

## Root cause

This is an **ops-state problem, not a code bug**:

- The `impersonated_by` column IS already defined in `server/db/schema.ts` (`impersonatedBy: text("impersonated_by")`) and in the `CREATE TABLE sessions` in `drizzle/0000_skinny_vulcan.sql`. Any DB built from the current migrations already has it.
- Prod D1 was created from an **OLDER `0000`** that predated the column.
- Because `0000` is already marked applied in prod, `bun run db:migrate:cf` will **NOT** re-add the column. There is no migration that adds it after the fact.
- A normal Drizzle `ALTER TABLE ... ADD COLUMN` migration can't fix this either: dev/local DBs already have the column, so the ALTER would fail there.

The real prod fix is therefore a one-time manual ALTER on the remote D1 (see Ops follow-up below), kept out of the migration chain on purpose.

## Code change

Adds a regression guard to `server/db/migrations.test.ts` that applies every `drizzle/` migration to a fresh in-memory SQLite, then asserts via `PRAGMA table_info(sessions)` that the `sessions` table exposes `impersonated_by`. This locks in the code-path invariant so the column can never silently disappear from the schema/migrations again.

Test follows the existing file conventions (same migration-replay helpers, same `PRAGMA foreign_keys` no-op filtering).

## Ops follow-up (required to actually fix prod)

The code change above does NOT fix the production database. Run these once against the remote D1:

```
wrangler d1 execute remindarr --remote --command "ALTER TABLE sessions ADD COLUMN impersonated_by text"
wrangler d1 execute remindarr --remote --command "SELECT impersonated_by FROM sessions LIMIT 1"
```

The second command should succeed (return rows / empty set) rather than erroring with "no such column".

Watch CF Observability for recurrence of error fingerprint `63b351dc0564750852ccc227575ccf38` after applying.

## Testing

- `bun test server/db/migrations.test.ts` — 4 pass
- `bun run check:fast` — type checks, prettier, ESLint all pass
- Full `bun run check` had one unrelated pre-existing flaky timing failure (`server/tmdb/sync-utils.test.ts`: 24.34ms vs 25ms threshold); passes in isolation and is untouched by this change.
