### PR TITLE
feat(admin): validate user :id path param as UUID

### DIFF
--- a/server/routes/admin.test.ts
+++ b/server/routes/admin.test.ts
@@ -285,9 +285,12 @@ describe("GET /admin/users/:id", () => {
   });
 
   it("returns 404 for non-existent user", async () => {
-    const res = await app.request("/admin/users/nonexistent-id", {
-      headers: { Cookie: adminCookie },
-    });
+    const res = await app.request(
+      "/admin/users/00000000-0000-4000-8000-000000000000",
+      {
+        headers: { Cookie: adminCookie },
+      },
+    );
     expect(res.status).toBe(404);
   });
 });
@@ -362,6 +365,32 @@ describe("validation", () => {
     const body = await res.json();
     expect(body.error).toBe("Validation failed");
     expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects a non-UUID :id on the user routes", async () => {
+    for (const path of [
+      "/admin/users/not-a-uuid",
+      "/admin/users/not-a-uuid/role",
+      "/admin/users/not-a-uuid/ban",
+      "/admin/users/not-a-uuid/unban",
+    ]) {
+      const res = await app.request(path, {
+        method: path === "/admin/users/not-a-uuid" ? "GET" : "PUT",
+        headers: { Cookie: adminCookie, "Content-Type": "application/json" },
+        body:
+          path === "/admin/users/not-a-uuid" ? undefined : JSON.stringify({}),
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("Validation failed");
+      expect(Array.isArray(body.issues)).toBe(true);
+    }
+
+    const del = await app.request("/admin/users/not-a-uuid", {
+      method: "DELETE",
+      headers: { Cookie: adminCookie },
+    });
+    expect(del.status).toBe(400);
   });
 });
 
@@ -471,10 +500,13 @@ describe("DELETE /admin/users/:id", () => {
   });
 
   it("returns 404 for non-existent user", async () => {
-    const res = await app.request("/admin/users/nonexistent", {
-      method: "DELETE",
-      headers: { Cookie: adminCookie },
-    });
+    const res = await app.request(
+      "/admin/users/00000000-0000-4000-8000-000000000000",
+      {
+        method: "DELETE",
+        headers: { Cookie: adminCookie },
+      },
+    );
     expect(res.status).toBe(404);
   });
 

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -56,6 +56,9 @@ const banUserSchema = z.object({
   reason: z.string().nullish(),
 });
 
+// User IDs are crypto.randomUUID() (see repository/users.ts).
+const userIdParam = z.object({ id: z.string().uuid() });
+
 /**
  * Callback to recreate the auth instance after OIDC settings change.
  * Registered by the entry point (index.ts on Bun, no-op on CF Workers).
@@ -197,8 +200,8 @@ app.get("/users", zValidator("query", usersQuerySchema), async (c) => {
 });
 
 // GET /api/admin/users/:id
-app.get("/users/:id", async (c) => {
-  const id = c.req.param("id");
+app.get("/users/:id", zValidator("param", userIdParam), async (c) => {
+  const { id } = c.req.valid("param");
   const user = await getUserById(id);
   if (!user) return c.json({ error: "User not found" }, 404);
 
@@ -207,35 +210,40 @@ app.get("/users/:id", async (c) => {
 });
 
 // PUT /api/admin/users/:id/role  { role: "admin" | "user" }
-app.put("/users/:id/role", zValidator("json", updateRoleSchema), async (c) => {
-  const id = c.req.param("id");
-  const actingUser = c.get("user")!;
+app.put(
+  "/users/:id/role",
+  zValidator("param", userIdParam),
+  zValidator("json", updateRoleSchema),
+  async (c) => {
+    const { id } = c.req.valid("param");
+    const actingUser = c.get("user")!;
 
-  if (id === actingUser.id) {
-    return c.json({ error: "Cannot change your own role" }, 400);
-  }
+    if (id === actingUser.id) {
+      return c.json({ error: "Cannot change your own role" }, 400);
+    }
 
-  const { role } = c.req.valid("json");
+    const { role } = c.req.valid("json");
 
-  const target = await getUserById(id);
-  if (!target) return c.json({ error: "User not found" }, 404);
+    const target = await getUserById(id);
+    if (!target) return c.json({ error: "User not found" }, 404);
 
-  await updateUserAdmin(id, role === "admin");
-  log.info("Admin role changed", {
-    targetUserId: id,
-    newRole: role,
-    by: actingUser.id,
-  });
-  return ok(c, { message: `User role updated to ${role}` });
-});
+    await updateUserAdmin(id, role === "admin");
+    log.info("Admin role changed", {
+      targetUserId: id,
+      newRole: role,
+      by: actingUser.id,
+    });
+    return ok(c, { message: `User role updated to ${role}` });
+  },
+);
 
 // PUT /api/admin/users/:id/ban  { reason?: string }
 //
 // `reason` is optional and can be omitted entirely (no body), so we safe-parse
 // against an empty-object fallback rather than wiring `zValidator` as
 // middleware (which would 400 on missing Content-Length).
-app.put("/users/:id/ban", async (c) => {
-  const id = c.req.param("id");
+app.put("/users/:id/ban", zValidator("param", userIdParam), async (c) => {
+  const { id } = c.req.valid("param");
   const actingUser = c.get("user")!;
 
   if (id === actingUser.id) {
@@ -260,8 +268,8 @@ app.put("/users/:id/ban", async (c) => {
 });
 
 // PUT /api/admin/users/:id/unban
-app.put("/users/:id/unban", async (c) => {
-  const id = c.req.param("id");
+app.put("/users/:id/unban", zValidator("param", userIdParam), async (c) => {
+  const { id } = c.req.valid("param");
   const target = await getUserById(id);
   if (!target) return c.json({ error: "User not found" }, 404);
 
@@ -452,8 +460,8 @@ app.get("/logs", zValidator("query", logsQuerySchema), async (c) => {
 });
 
 // DELETE /api/admin/users/:id
-app.delete("/users/:id", async (c) => {
-  const id = c.req.param("id");
+app.delete("/users/:id", zValidator("param", userIdParam), async (c) => {
+  const { id } = c.req.valid("param");
   const actingUser = c.get("user")!;
 
   if (id === actingUser.id) {


### PR DESCRIPTION
## Summary

Five admin user routes read `:id` via `c.req.param("id")` with no schema guard:

- `GET /api/admin/users/:id`
- `PUT /api/admin/users/:id/role`
- `PUT /api/admin/users/:id/ban`
- `PUT /api/admin/users/:id/unban`
- `DELETE /api/admin/users/:id`

User IDs are `crypto.randomUUID()` (`repository/users.ts`), so this adds a shared param schema and applies it to all five:

```ts
const userIdParam = z.object({ id: z.string().uuid() });
```

A non-UUID `:id` now returns `400` before any DB lookup. The ban/unban routes keep their existing manual `safeParse()` on the optional JSON body — only the param read changed to `c.req.valid("param").id`.

## Tests

- New rejection test asserting `400` for a non-UUID `:id` across GET/role/ban/unban/DELETE.
- Updated the two existing "non-existent user → 404" tests to use a well-formed UUID so they still exercise the `404` path (they previously passed non-UUID strings).
- Existing happy-path tests already use real UUIDs.

`bun run check` passes.

Closes #1018

🤖 Generated with [Claude Code](https://claude.com/claude-code)