### PR TITLE
feat(social,overlap): validate path params with zValidator

### DIFF
--- a/server/routes/overlap.test.ts
+++ b/server/routes/overlap.test.ts
@@ -249,3 +249,15 @@ describe("GET /overlap/:friendUsername — auth", () => {
     expect(res.status).toBe(401);
   });
 });
+
+describe("GET /overlap/:friendUsername — validation", () => {
+  it("rejects an over-long username (>50 chars) with 400", async () => {
+    const res = await app.request(`/overlap/${"a".repeat(51)}`, {
+      headers: authHeaders(aliceToken),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+});

--- a/server/routes/overlap.ts
+++ b/server/routes/overlap.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { z } from "zod";
 import { inArray, eq } from "drizzle-orm";
 import {
   getUserByUsername,
@@ -12,9 +13,14 @@ import { getDb } from "../db/schema";
 import { titles, scores, users } from "../db/schema";
 import type { AppEnv } from "../types";
 import { ok, err } from "./response";
+import { zValidator } from "../lib/validator";
 import { logger } from "../logger";
 
 const log = logger.child({ module: "overlap" });
+
+const friendUsernameParam = z.object({
+  friendUsername: z.string().min(1).max(50),
+});
 
 const app = new Hono<AppEnv>();
 
@@ -41,94 +47,256 @@ type SharedProvider = {
 };
 
 // GET /overlap/:friendUsername — requires auth (wired in index.ts / worker.ts)
-app.get("/:friendUsername", async (c) => {
-  const viewer = c.get("user")!;
-  const friendUsername = c.req.param("friendUsername");
+app.get(
+  "/:friendUsername",
+  zValidator("param", friendUsernameParam),
+  async (c) => {
+    const viewer = c.get("user")!;
+    const { friendUsername } = c.req.valid("param");
 
-  // 1. Look up the friend
-  const friendUser = await getUserByUsername(friendUsername);
-  if (!friendUser) {
-    return err(c, "User not found", 404);
-  }
-
-  const viewerId = viewer.id;
-  const friendId = friendUser.id;
-
-  // 2. Visibility check — replicate server/routes/profile.ts visibility ladder
-  const isSelf = viewerId === friendId;
-
-  if (!isSelf) {
-    const visibility = (friendUser.profile_visibility ?? "private") as
-      | "public"
-      | "friends_only"
-      | "private";
-    if (visibility === "private") {
-      return err(c, "This user's watchlist is private", 403);
+    // 1. Look up the friend
+    const friendUser = await getUserByUsername(friendUsername);
+    if (!friendUser) {
+      return err(c, "User not found", 404);
     }
-    if (visibility === "friends_only") {
-      const mutual = await areMutualFollowers(viewerId, friendId);
-      if (!mutual) {
-        return err(
-          c,
-          "This user's watchlist is only visible to mutual followers",
-          403,
-        );
+
+    const viewerId = viewer.id;
+    const friendId = friendUser.id;
+
+    // 2. Visibility check — replicate server/routes/profile.ts visibility ladder
+    const isSelf = viewerId === friendId;
+
+    if (!isSelf) {
+      const visibility = (friendUser.profile_visibility ?? "private") as
+        | "public"
+        | "friends_only"
+        | "private";
+      if (visibility === "private") {
+        return err(c, "This user's watchlist is private", 403);
+      }
+      if (visibility === "friends_only") {
+        const mutual = await areMutualFollowers(viewerId, friendId);
+        if (!mutual) {
+          return err(
+            c,
+            "This user's watchlist is only visible to mutual followers",
+            403,
+          );
+        }
+      }
+      // "public" — allow
+    }
+
+    // 3. Get tracked title IDs for both users
+    const viewerIds = await getTrackedTitleIds(viewerId);
+
+    let friendIds: Set<string>;
+    if (isSelf) {
+      friendIds = new Set(viewerIds);
+    } else {
+      const isMutual = await areMutualFollowers(viewerId, friendId);
+      if (isMutual) {
+        friendIds = await getTrackedTitleIds(friendId);
+      } else {
+        // Public profile — only public titles
+        const publicTitles = await getPublicTrackedTitles(friendId);
+        friendIds = new Set(publicTitles.map((t) => t.id));
       }
     }
-    // "public" — allow
-  }
 
-  // 3. Get tracked title IDs for both users
-  const viewerIds = await getTrackedTitleIds(viewerId);
-
-  let friendIds: Set<string>;
-  if (isSelf) {
-    friendIds = new Set(viewerIds);
-  } else {
-    const isMutual = await areMutualFollowers(viewerId, friendId);
-    if (isMutual) {
-      friendIds = await getTrackedTitleIds(friendId);
-    } else {
-      // Public profile — only public titles
-      const publicTitles = await getPublicTrackedTitles(friendId);
-      friendIds = new Set(publicTitles.map((t) => t.id));
+    // 4. Compute intersection
+    const intersectionIds: string[] = [];
+    for (const id of viewerIds) {
+      if (friendIds.has(id)) {
+        intersectionIds.push(id);
+      }
     }
-  }
 
-  // 4. Compute intersection
-  const intersectionIds: string[] = [];
-  for (const id of viewerIds) {
-    if (friendIds.has(id)) {
-      intersectionIds.push(id);
+    const counts = {
+      intersection: intersectionIds.length,
+      viewerOnly: viewerIds.size - intersectionIds.length,
+      friendOnly: friendIds.size - intersectionIds.length,
+    };
+
+    log.info("Overlap computed", {
+      viewerId,
+      friendId,
+      intersection: counts.intersection,
+      viewerOnly: counts.viewerOnly,
+      friendOnly: counts.friendOnly,
+    });
+
+    // Look up friend's image
+    const db = getDb();
+    const friendRow = await db
+      .select({ image: users.image })
+      .from(users)
+      .where(eq(users.id, friendId))
+      .get();
+
+    if (intersectionIds.length === 0) {
+      return ok(c, {
+        titles: [] as unknown[],
+        sharedProviders: [] as SharedProvider[],
+        counts,
+        friendUser: {
+          username: friendUser.username,
+          displayName: friendUser.display_name,
+          image: friendRow?.image ?? null,
+        },
+      });
     }
-  }
 
-  const counts = {
-    intersection: intersectionIds.length,
-    viewerOnly: viewerIds.size - intersectionIds.length,
-    friendOnly: friendIds.size - intersectionIds.length,
-  };
+    // 5. Get full title details for intersection
+    const titleRows = await db
+      .select({
+        id: titles.id,
+        object_type: titles.objectType,
+        title: titles.title,
+        original_title: titles.originalTitle,
+        release_year: titles.releaseYear,
+        release_date: titles.releaseDate,
+        runtime_minutes: titles.runtimeMinutes,
+        short_description: titles.shortDescription,
+        poster_url: titles.posterUrl,
+        age_certification: titles.ageCertification,
+        original_language: titles.originalLanguage,
+        tmdb_url: titles.tmdbUrl,
+        imdb_id: titles.imdbId,
+        tmdb_id: titles.tmdbId,
+        tmdb_score: scores.tmdbScore,
+        imdb_score: scores.imdbScore,
+        imdb_votes: scores.imdbVotes,
+      })
+      .from(titles)
+      .leftJoin(scores, eq(scores.titleId, titles.id))
+      .where(inArray(titles.id, intersectionIds))
+      .all();
 
-  log.info("Overlap computed", {
-    viewerId,
-    friendId,
-    intersection: counts.intersection,
-    viewerOnly: counts.viewerOnly,
-    friendOnly: counts.friendOnly,
-  });
+    // 6. Load offers for the intersection
+    const offersByTitle = await getOffersForTitles(intersectionIds);
 
-  // Look up friend's image
-  const db = getDb();
-  const friendRow = await db
-    .select({ image: users.image })
-    .from(users)
-    .where(eq(users.id, friendId))
-    .get();
+    // 7. Compute shared providers — flatrate offers across each user's FULL tracked set
+    //    so we derive "you're both on Netflix" even for non-intersection titles.
+    const [viewerAllOffers, friendAllOffers] = await Promise.all([
+      getOffersForTitles([...viewerIds]),
+      getOffersForTitles([...friendIds]),
+    ]);
 
-  if (intersectionIds.length === 0) {
+    const viewerFlatrateProviderIds = new Set<number>();
+    for (const offerList of viewerAllOffers.values()) {
+      for (const o of offerList) {
+        if (o.monetization_type === "flatrate" && o.provider_id !== null) {
+          viewerFlatrateProviderIds.add(o.provider_id);
+        }
+      }
+    }
+
+    const friendFlatrateProviderIds = new Set<number>();
+    for (const offerList of friendAllOffers.values()) {
+      for (const o of offerList) {
+        if (o.monetization_type === "flatrate" && o.provider_id !== null) {
+          friendFlatrateProviderIds.add(o.provider_id);
+        }
+      }
+    }
+
+    const sharedProviderIdSet = new Set<number>();
+    for (const id of viewerFlatrateProviderIds) {
+      if (friendFlatrateProviderIds.has(id)) {
+        sharedProviderIdSet.add(id);
+      }
+    }
+
+    // Build unique provider objects from offers appearing on intersection titles
+    const seenProviderIds = new Set<number>();
+    const sharedProviders: SharedProvider[] = [];
+
+    for (const offerList of offersByTitle.values()) {
+      for (const o of offerList) {
+        if (
+          o.provider_id !== null &&
+          sharedProviderIdSet.has(o.provider_id) &&
+          !seenProviderIds.has(o.provider_id)
+        ) {
+          seenProviderIds.add(o.provider_id);
+          sharedProviders.push({
+            id: o.provider_id,
+            name: o.provider_name ?? "",
+            technical_name: o.provider_technical_name ?? "",
+            icon_url: o.provider_icon_url ?? "",
+          });
+        }
+      }
+    }
+
+    // 8. Ratings for both users across intersection
+    const [viewerRatings, friendRatings] = await Promise.all([
+      Promise.all(
+        intersectionIds.map((id) =>
+          getUserRating(viewerId, id).then((r) => [id, r] as const),
+        ),
+      ),
+      Promise.all(
+        intersectionIds.map((id) =>
+          getUserRating(friendId, id).then((r) => [id, r] as const),
+        ),
+      ),
+    ]);
+
+    const viewerRatingMap = new Map(viewerRatings);
+    const friendRatingMap = new Map(friendRatings);
+
+    const ratingScore = (r: string | null): number => {
+      if (r === "LOVE") return 4;
+      if (r === "LIKE") return 3;
+      if (r === "DISLIKE") return 2;
+      if (r === "HATE") return 1;
+      return 0;
+    };
+
+    // Build title response with offers + ratings, sort by combined score descending
+    const titlesWithDetails = titleRows.map((row) => {
+      const titleOffers = (offersByTitle.get(row.id) ?? []) as Offer[];
+      return {
+        id: row.id,
+        object_type: row.object_type as string,
+        title: row.title as string,
+        original_title: row.original_title,
+        release_year: row.release_year,
+        release_date: row.release_date,
+        runtime_minutes: row.runtime_minutes,
+        short_description: row.short_description,
+        poster_url: row.poster_url,
+        age_certification: row.age_certification,
+        original_language: row.original_language,
+        tmdb_url: row.tmdb_url,
+        imdb_id: row.imdb_id,
+        tmdb_id: row.tmdb_id,
+        tmdb_score: row.tmdb_score,
+        imdb_score: row.imdb_score,
+        imdb_votes: row.imdb_votes,
+        is_tracked: true as const,
+        genres: [] as string[],
+        offers: titleOffers,
+        viewer_rating: viewerRatingMap.get(row.id) ?? null,
+        friend_rating: friendRatingMap.get(row.id) ?? null,
+        _sort_score:
+          ratingScore(viewerRatingMap.get(row.id) ?? null) +
+          ratingScore(friendRatingMap.get(row.id) ?? null) +
+          (row.tmdb_score ?? 0) / 10,
+      };
+    });
+
+    titlesWithDetails.sort((a, b) => b._sort_score - a._sort_score);
+
+    const titlesOut = titlesWithDetails.map(
+      ({ _sort_score: _s, ...rest }) => rest,
+    );
+
     return ok(c, {
-      titles: [] as unknown[],
-      sharedProviders: [] as SharedProvider[],
+      titles: titlesOut,
+      sharedProviders,
       counts,
       friendUser: {
         username: friendUser.username,
@@ -136,165 +304,7 @@ app.get("/:friendUsername", async (c) => {
         image: friendRow?.image ?? null,
       },
     });
-  }
-
-  // 5. Get full title details for intersection
-  const titleRows = await db
-    .select({
-      id: titles.id,
-      object_type: titles.objectType,
-      title: titles.title,
-      original_title: titles.originalTitle,
-      release_year: titles.releaseYear,
-      release_date: titles.releaseDate,
-      runtime_minutes: titles.runtimeMinutes,
-      short_description: titles.shortDescription,
-      poster_url: titles.posterUrl,
-      age_certification: titles.ageCertification,
-      original_language: titles.originalLanguage,
-      tmdb_url: titles.tmdbUrl,
-      imdb_id: titles.imdbId,
-      tmdb_id: titles.tmdbId,
-      tmdb_score: scores.tmdbScore,
-      imdb_score: scores.imdbScore,
-      imdb_votes: scores.imdbVotes,
-    })
-    .from(titles)
-    .leftJoin(scores, eq(scores.titleId, titles.id))
-    .where(inArray(titles.id, intersectionIds))
-    .all();
-
-  // 6. Load offers for the intersection
-  const offersByTitle = await getOffersForTitles(intersectionIds);
-
-  // 7. Compute shared providers — flatrate offers across each user's FULL tracked set
-  //    so we derive "you're both on Netflix" even for non-intersection titles.
-  const [viewerAllOffers, friendAllOffers] = await Promise.all([
-    getOffersForTitles([...viewerIds]),
-    getOffersForTitles([...friendIds]),
-  ]);
-
-  const viewerFlatrateProviderIds = new Set<number>();
-  for (const offerList of viewerAllOffers.values()) {
-    for (const o of offerList) {
-      if (o.monetization_type === "flatrate" && o.provider_id !== null) {
-        viewerFlatrateProviderIds.add(o.provider_id);
-      }
-    }
-  }
-
-  const friendFlatrateProviderIds = new Set<number>();
-  for (const offerList of friendAllOffers.values()) {
-    for (const o of offerList) {
-      if (o.monetization_type === "flatrate" && o.provider_id !== null) {
-        friendFlatrateProviderIds.add(o.provider_id);
-      }
-    }
-  }
-
-  const sharedProviderIdSet = new Set<number>();
-  for (const id of viewerFlatrateProviderIds) {
-    if (friendFlatrateProviderIds.has(id)) {
-      sharedProviderIdSet.add(id);
-    }
-  }
-
-  // Build unique provider objects from offers appearing on intersection titles
-  const seenProviderIds = new Set<number>();
-  const sharedProviders: SharedProvider[] = [];
-
-  for (const offerList of offersByTitle.values()) {
-    for (const o of offerList) {
-      if (
-        o.provider_id !== null &&
-        sharedProviderIdSet.has(o.provider_id) &&
-        !seenProviderIds.has(o.provider_id)
-      ) {
-        seenProviderIds.add(o.provider_id);
-        sharedProviders.push({
-          id: o.provider_id,
-          name: o.provider_name ?? "",
-          technical_name: o.provider_technical_name ?? "",
-          icon_url: o.provider_icon_url ?? "",
-        });
-      }
-    }
-  }
-
-  // 8. Ratings for both users across intersection
-  const [viewerRatings, friendRatings] = await Promise.all([
-    Promise.all(
-      intersectionIds.map((id) =>
-        getUserRating(viewerId, id).then((r) => [id, r] as const),
-      ),
-    ),
-    Promise.all(
-      intersectionIds.map((id) =>
-        getUserRating(friendId, id).then((r) => [id, r] as const),
-      ),
-    ),
-  ]);
-
-  const viewerRatingMap = new Map(viewerRatings);
-  const friendRatingMap = new Map(friendRatings);
-
-  const ratingScore = (r: string | null): number => {
-    if (r === "LOVE") return 4;
-    if (r === "LIKE") return 3;
-    if (r === "DISLIKE") return 2;
-    if (r === "HATE") return 1;
-    return 0;
-  };
-
-  // Build title response with offers + ratings, sort by combined score descending
-  const titlesWithDetails = titleRows.map((row) => {
-    const titleOffers = (offersByTitle.get(row.id) ?? []) as Offer[];
-    return {
-      id: row.id,
-      object_type: row.object_type as string,
-      title: row.title as string,
-      original_title: row.original_title,
-      release_year: row.release_year,
-      release_date: row.release_date,
-      runtime_minutes: row.runtime_minutes,
-      short_description: row.short_description,
-      poster_url: row.poster_url,
-      age_certification: row.age_certification,
-      original_language: row.original_language,
-      tmdb_url: row.tmdb_url,
-      imdb_id: row.imdb_id,
-      tmdb_id: row.tmdb_id,
-      tmdb_score: row.tmdb_score,
-      imdb_score: row.imdb_score,
-      imdb_votes: row.imdb_votes,
-      is_tracked: true as const,
-      genres: [] as string[],
-      offers: titleOffers,
-      viewer_rating: viewerRatingMap.get(row.id) ?? null,
-      friend_rating: friendRatingMap.get(row.id) ?? null,
-      _sort_score:
-        ratingScore(viewerRatingMap.get(row.id) ?? null) +
-        ratingScore(friendRatingMap.get(row.id) ?? null) +
-        (row.tmdb_score ?? 0) / 10,
-    };
-  });
-
-  titlesWithDetails.sort((a, b) => b._sort_score - a._sort_score);
-
-  const titlesOut = titlesWithDetails.map(
-    ({ _sort_score: _s, ...rest }) => rest,
-  );
-
-  return ok(c, {
-    titles: titlesOut,
-    sharedProviders,
-    counts,
-    friendUser: {
-      username: friendUser.username,
-      displayName: friendUser.display_name,
-      image: friendRow?.image ?? null,
-    },
-  });
-});
+  },
+);
 
 export default app;

--- a/server/routes/social.test.ts
+++ b/server/routes/social.test.ts
@@ -97,13 +97,27 @@ describe("POST /social/follow/:userId", () => {
   });
 
   it("returns 404 when target user does not exist", async () => {
-    const res = await app.request("/social/follow/nonexistent-id", {
-      method: "POST",
-      headers: authHeaders(userAToken),
-    });
+    const res = await app.request(
+      "/social/follow/00000000-0000-4000-8000-000000000000",
+      {
+        method: "POST",
+        headers: authHeaders(userAToken),
+      },
+    );
     expect(res.status).toBe(404);
     const body = await res.json();
     expect(body.error).toBe("User not found");
+  });
+
+  it("rejects a non-UUID :userId with 400", async () => {
+    const res = await app.request("/social/follow/not-a-uuid", {
+      method: "POST",
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
   });
 
   it("is idempotent — following twice returns 200", async () => {

--- a/server/routes/social.ts
+++ b/server/routes/social.ts
@@ -19,45 +19,56 @@ const friendsLovedQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(50).optional().default(20),
 });
 
+// User IDs are crypto.randomUUID() (see repository/users.ts).
+const userIdParamSchema = z.object({ userId: z.string().uuid() });
+
 const log = logger.child({ module: "social" });
 
 const app = new Hono<AppEnv>();
 
 // POST /follow/:userId — Follow a user
-app.post("/follow/:userId", async (c) => {
-  const currentUser = c.get("user")!;
-  const targetUserId = c.req.param("userId");
+app.post(
+  "/follow/:userId",
+  zValidator("param", userIdParamSchema),
+  async (c) => {
+    const currentUser = c.get("user")!;
+    const { userId: targetUserId } = c.req.valid("param");
 
-  if (currentUser.id === targetUserId) {
-    return err(c, "Cannot follow yourself", 400);
-  }
+    if (currentUser.id === targetUserId) {
+      return err(c, "Cannot follow yourself", 400);
+    }
 
-  const targetUser = await getUserById(targetUserId);
-  if (!targetUser) {
-    return err(c, "User not found", 404);
-  }
+    const targetUser = await getUserById(targetUserId);
+    if (!targetUser) {
+      return err(c, "User not found", 404);
+    }
 
-  await follow(currentUser.id, targetUserId);
-  log.info("User followed", {
-    followerId: currentUser.id,
-    followingId: targetUserId,
-  });
-  await onFollow(currentUser.id);
-  return ok(c, { success: true });
-});
+    await follow(currentUser.id, targetUserId);
+    log.info("User followed", {
+      followerId: currentUser.id,
+      followingId: targetUserId,
+    });
+    await onFollow(currentUser.id);
+    return ok(c, { success: true });
+  },
+);
 
 // DELETE /follow/:userId — Unfollow a user
-app.delete("/follow/:userId", async (c) => {
-  const currentUser = c.get("user")!;
-  const targetUserId = c.req.param("userId");
+app.delete(
+  "/follow/:userId",
+  zValidator("param", userIdParamSchema),
+  async (c) => {
+    const currentUser = c.get("user")!;
+    const { userId: targetUserId } = c.req.valid("param");
 
-  await unfollow(currentUser.id, targetUserId);
-  log.info("User unfollowed", {
-    followerId: currentUser.id,
-    followingId: targetUserId,
-  });
-  return ok(c, { success: true });
-});
+    await unfollow(currentUser.id, targetUserId);
+    log.info("User unfollowed", {
+      followerId: currentUser.id,
+      followingId: targetUserId,
+    });
+    return ok(c, { success: true });
+  },
+);
 
 // GET /followers — List current user's followers
 app.get("/followers", async (c) => {
@@ -94,32 +105,40 @@ app.get("/following", async (c) => {
 });
 
 // GET /followers/:userId — List a user's followers (public)
-app.get("/followers/:userId", async (c) => {
-  const targetUserId = c.req.param("userId");
+app.get(
+  "/followers/:userId",
+  zValidator("param", userIdParamSchema),
+  async (c) => {
+    const { userId: targetUserId } = c.req.valid("param");
 
-  const followers = await getFollowers(targetUserId);
-  const summary = followers.map(({ id, username, display_name, image }) => ({
-    id,
-    username,
-    display_name,
-    image,
-  }));
-  return ok(c, { followers: summary, count: summary.length });
-});
+    const followers = await getFollowers(targetUserId);
+    const summary = followers.map(({ id, username, display_name, image }) => ({
+      id,
+      username,
+      display_name,
+      image,
+    }));
+    return ok(c, { followers: summary, count: summary.length });
+  },
+);
 
 // GET /following/:userId — List a user's following (public)
-app.get("/following/:userId", async (c) => {
-  const targetUserId = c.req.param("userId");
+app.get(
+  "/following/:userId",
+  zValidator("param", userIdParamSchema),
+  async (c) => {
+    const { userId: targetUserId } = c.req.valid("param");
 
-  const following = await getFollowing(targetUserId);
-  const summary = following.map(({ id, username, display_name, image }) => ({
-    id,
-    username,
-    display_name,
-    image,
-  }));
-  return ok(c, { following: summary, count: summary.length });
-});
+    const following = await getFollowing(targetUserId);
+    const summary = following.map(({ id, username, display_name, image }) => ({
+      id,
+      username,
+      display_name,
+      image,
+    }));
+    return ok(c, { following: summary, count: summary.length });
+  },
+);
 
 // GET /friends-loved — Top-rated titles from followed users in the last 7 days
 app.get(


### PR DESCRIPTION
## Summary

`social.ts` and `overlap.ts` read path params via `c.req.param()` with no schema guard. This adds `zValidator("param", ...)` to all of them.

**social.ts** — user IDs are `crypto.randomUUID()`:
```ts
const userIdParamSchema = z.object({ userId: z.string().uuid() });
```
applied to `POST /follow/:userId`, `DELETE /follow/:userId`, `GET /followers/:userId`, `GET /following/:userId`.

**overlap.ts** — `:friendUsername` is a username:
```ts
const friendUsernameParam = z.object({ friendUsername: z.string().min(1).max(50) });
```
applied to `GET /:friendUsername`.

A non-UUID `userId` or an over-long (>50 char) username now returns `400` before reaching the DB.

> Note: the source issue suggested `z.string().min(1)`, but `min(1)` can't produce a reachable `400` (an empty path segment just fails to route) and `server/routes/CLAUDE.md` mandates a rejection test. `uuid()` / `max(50)` are both testable and tighter — and `uuid()` matches the existing admin convention.

## Tests

- New rejection test: non-UUID `userId` → `400` (social).
- New rejection test: 51-char username → `400` (overlap).
- Updated the existing social "user does not exist → 404" test to use a well-formed UUID.
- Existing happy-path tests preserved.

`bun run check` passes.

Closes #1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)