### PR TITLE
fix(jobs): bound sync-episodes via per-show fan-out to stop DO crash loop

### DIFF
--- a/server/jobs/durable-object.test.ts
+++ b/server/jobs/durable-object.test.ts
@@ -276,6 +276,39 @@ describe("JobQueueDO", () => {
     expect(rows[0].completed_at).not.toBeNull();
   });
 
+  it("runJob still completes the job and writes state when self-heal armCron throws (#1020)", async () => {
+    // Regression: a long sync-episodes run made armCron()'s blockConcurrencyWhile()
+    // exceed the 30s CF limit, resetting the DO before job state was written and
+    // crash-looping. The self-heal re-arm is now best-effort: a throwing armCron
+    // must not abort runJob or leave the job stuck in 'running'.
+    let called = false;
+    processorModule.handlers["sync-titles"] = async () => {
+      called = true;
+    };
+    await do_.armCron("sync-titles", "0 3 * * *");
+    spyOn(do_, "armCron").mockRejectedValue(
+      new Error("blockConcurrencyWhile timeout"),
+    );
+
+    await do_.enqueue("sync-titles", null);
+    await do_.runJob(null);
+
+    expect(called).toBe(true);
+    const rows = do_.getRecentJobs();
+    expect(rows[0].status).toBe("completed");
+    expect(rows[0].completed_at).not.toBeNull();
+
+    // Failure is recorded as a best-effort breadcrumb, not a captured exception.
+    expect(captureExceptionSpy).not.toHaveBeenCalled();
+    expect(
+      addBreadcrumbSpy.mock.calls.some(
+        ([crumb]) =>
+          (crumb as { message?: string })?.message ===
+          "Self-heal armCron failed (best-effort)",
+      ),
+    ).toBe(true);
+  });
+
   it("runJob auto-creates and runs a job for cron DOs when no pending rows exist", async () => {
     let called = false;
     processorModule.handlers["sync-titles"] = async () => {

--- a/server/jobs/durable-object.ts
+++ b/server/jobs/durable-object.ts
@@ -459,7 +459,31 @@ export class JobQueueDO {
     // Self-heal: re-register the cron schedule after every execution so a dropped
     // schedule (e.g. due to DO eviction or a wrapped entrypoint interfering with
     // @cloudflare/actors/alarms) recovers within the next alarm cycle (#795).
-    if (cron) await this.armCron(name, cron);
+    // Best-effort: armCron() calls blockConcurrencyWhile(), which can exceed the
+    // 30s CF limit after a long job and reset the DO before job state is durably
+    // written, crash-looping (#1020). The */5 watchdog re-arms independently, so
+    // swallow failures here rather than abort runJob or leave state inconsistent.
+    if (cron) {
+      try {
+        await this.armCron(name, cron);
+      } catch (err) {
+        Sentry.addBreadcrumb({
+          category: "jobs",
+          message: "Self-heal armCron failed (best-effort)",
+          level: "warning",
+          data: {
+            name,
+            cron,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        });
+        log.warn("Self-heal armCron failed, relying on watchdog", {
+          name,
+          cron,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
     await this.rearmIfPending(cron);
   }
 

--- a/server/jobs/processor.test.ts
+++ b/server/jobs/processor.test.ts
@@ -36,6 +36,17 @@ const mockSyncEpisodesForShow = spyOn(
   syncModule,
   "syncEpisodesForShow",
 ).mockResolvedValue(0);
+const mockListTrackedShows = spyOn(
+  syncModule,
+  "listTrackedShowsForEpisodeSync",
+).mockResolvedValue([]);
+
+// Mock enqueueAdhoc so the sync-episodes fan-out can be asserted without
+// inserting real sync-show-episodes rows back into the jobs table.
+import * as backendModule from "./backend";
+const mockEnqueueAdhoc = spyOn(backendModule, "enqueueAdhoc").mockResolvedValue(
+  undefined,
+);
 
 import * as tmdbClientModule from "../tmdb/client";
 const emptyTrendingPage = {
@@ -85,6 +96,8 @@ beforeEach(() => {
   mockUpsertTitles.mockClear();
   mockSyncEpisodes.mockClear();
   mockSyncEpisodesForShow.mockClear();
+  mockListTrackedShows.mockClear();
+  mockEnqueueAdhoc.mockClear();
   mockDeleteExpiredSessions.mockClear();
   mockFetchTrendingMovies.mockClear();
   mockFetchTrendingTv.mockClear();
@@ -99,6 +112,8 @@ afterAll(() => {
   mockUpsertTitles.mockRestore();
   mockSyncEpisodes.mockRestore();
   mockSyncEpisodesForShow.mockRestore();
+  mockListTrackedShows.mockRestore();
+  mockEnqueueAdhoc.mockRestore();
   mockDeleteExpiredSessions.mockRestore();
   mockFetchTrendingMovies.mockRestore();
   mockFetchTrendingTv.mockRestore();
@@ -176,14 +191,30 @@ describe("processPendingJobs", () => {
     expect(allJobs[0].status).toBe("completed");
   });
 
-  it("processes sync-episodes job", async () => {
-    mockSyncEpisodes.mockResolvedValueOnce({ synced: 10, shows: 3 });
+  it("fans out one sync-show-episodes adhoc job per tracked show", async () => {
+    mockListTrackedShows.mockResolvedValueOnce([
+      { id: "tv-1", tmdb_id: "1", title: "Show One" },
+      { id: "tv-2", tmdb_id: "2", title: "Show Two" },
+    ]);
 
     await insertJob("sync-episodes");
     const count = await processPendingJobs();
 
     expect(count).toBe(1);
-    expect(mockSyncEpisodes).toHaveBeenCalledTimes(1);
+    expect(mockEnqueueAdhoc).toHaveBeenCalledTimes(2);
+    expect(mockEnqueueAdhoc).toHaveBeenCalledWith("sync-show-episodes", {
+      titleId: "tv-1",
+      tmdbId: "1",
+      title: "Show One",
+    });
+    expect(mockEnqueueAdhoc).toHaveBeenCalledWith("sync-show-episodes", {
+      titleId: "tv-2",
+      tmdbId: "2",
+      title: "Show Two",
+    });
+    // Fan-out only — no inline per-show sync in the cron handler.
+    expect(mockSyncEpisodesForShow).not.toHaveBeenCalled();
+    expect(mockSyncEpisodes).not.toHaveBeenCalled();
   });
 
   it("processes sync-show-episodes job with data", async () => {
@@ -322,7 +353,7 @@ describe("processPendingJobs", () => {
   it("processes multiple jobs in order", async () => {
     mockFetchNewReleases.mockResolvedValue([]);
     mockUpsertTitles.mockResolvedValue(0);
-    mockSyncEpisodes.mockResolvedValue({ synced: 0, shows: 0 });
+    mockListTrackedShows.mockResolvedValue([]);
 
     await insertJob("sync-titles");
     await insertJob("sync-episodes");
@@ -330,7 +361,7 @@ describe("processPendingJobs", () => {
     const count = await processPendingJobs();
     expect(count).toBe(2);
     expect(mockFetchNewReleases).toHaveBeenCalledTimes(1);
-    expect(mockSyncEpisodes).toHaveBeenCalledTimes(1);
+    expect(mockListTrackedShows).toHaveBeenCalledTimes(1);
   });
 
   it("skips episode sync when TMDB_API_KEY is not set", async () => {
@@ -340,7 +371,8 @@ describe("processPendingJobs", () => {
     const count = await processPendingJobs();
 
     expect(count).toBe(1); // Still completes, just skips the actual sync
-    expect(mockSyncEpisodes).not.toHaveBeenCalled();
+    expect(mockListTrackedShows).not.toHaveBeenCalled();
+    expect(mockEnqueueAdhoc).not.toHaveBeenCalled();
   });
 
   it("claims jobs atomically — handler runs at most once if two invocations race on the same pending job", async () => {

--- a/server/jobs/processor.ts
+++ b/server/jobs/processor.ts
@@ -18,7 +18,11 @@ import {
   recordDelivery,
 } from "../db/repository";
 import { fetchNewReleases } from "../tmdb/sync-titles";
-import { syncEpisodes, syncEpisodesForShow } from "../tmdb/sync";
+import {
+  syncEpisodesForShow,
+  listTrackedShowsForEpisodeSync,
+} from "../tmdb/sync";
+import { enqueueAdhoc } from "./backend";
 import { fetchMovieDetails, fetchTvDetails } from "../tmdb/client";
 import { parseMovieDetails, parseTvDetails } from "../tmdb/parser";
 import { getCache } from "../cache";
@@ -75,8 +79,21 @@ async function handleSyncEpisodes(): Promise<void> {
     });
     return;
   }
-  const result = await syncEpisodes();
-  log.info("Synced episodes", { synced: result.synced, shows: result.shows });
+  // ponytail: fan out one sync-show-episodes job per tracked show instead of
+  // syncing all shows inline. The old inline path took ~79s, which blew the 30s
+  // CF Durable Object alarm/CPU budget and crash-looped the JobQueueDO (#1020).
+  // Per-show is the established safe unit (see track.ts) and the partitioned DOs
+  // drain via the */5 watchdog; this replaces the sequential EPISODE_SYNC_DELAY_MS
+  // pacing. Revisit if TMDB starts rate-limiting the fan-out.
+  const shows = await listTrackedShowsForEpisodeSync();
+  for (const show of shows) {
+    await enqueueAdhoc("sync-show-episodes", {
+      titleId: show.id,
+      tmdbId: show.tmdb_id,
+      title: show.title,
+    });
+  }
+  log.info("Dispatched per-show episode sync jobs", { shows: shows.length });
 }
 
 async function handleSyncTrending(): Promise<void> {

--- a/server/jobs/sync.test.ts
+++ b/server/jobs/sync.test.ts
@@ -50,6 +50,17 @@ const mockSyncEpisodesForShow = spyOn(
   syncModule,
   "syncEpisodesForShow",
 ).mockResolvedValue(0);
+const mockListTrackedShows = spyOn(
+  syncModule,
+  "listTrackedShowsForEpisodeSync",
+).mockResolvedValue([]);
+
+// Mock enqueueAdhoc so the sync-episodes fan-out can be asserted without
+// touching the DO/jobs backend.
+import * as backendModule from "./backend";
+const mockEnqueueAdhoc = spyOn(backendModule, "enqueueAdhoc").mockResolvedValue(
+  undefined,
+);
 
 // Mock TMDB client for backfill-title-offers
 import * as tmdbClient from "../tmdb/client";
@@ -169,6 +180,8 @@ beforeEach(() => {
   mockUpsertTitles.mockClear();
   mockSyncEpisodes.mockClear();
   mockSyncEpisodesForShow.mockClear();
+  mockListTrackedShows.mockClear();
+  mockEnqueueAdhoc.mockClear();
   mockGetEpisodeIdsBySE.mockClear();
   mockWatchEpisodesBulk.mockClear();
   mockMigrateTitles.mockClear();
@@ -196,6 +209,8 @@ afterAll(() => {
   mockUpsertTitles.mockRestore();
   mockSyncEpisodes.mockRestore();
   mockSyncEpisodesForShow.mockRestore();
+  mockListTrackedShows.mockRestore();
+  mockEnqueueAdhoc.mockRestore();
   mockGetEpisodeIdsBySE.mockRestore();
   mockWatchEpisodesBulk.mockRestore();
   mockMigrateTitles.mockRestore();
@@ -419,14 +434,30 @@ describe("sync-episodes handler", () => {
     CONFIG.TMDB_API_KEY = originalApiKey;
   });
 
-  it("calls syncEpisodes when TMDB_API_KEY is configured", async () => {
+  it("fans out one sync-show-episodes adhoc job per tracked show", async () => {
     CONFIG.TMDB_API_KEY = "test-api-key";
-    mockSyncEpisodes.mockResolvedValueOnce({ synced: 5, shows: 2 });
+    mockListTrackedShows.mockResolvedValueOnce([
+      { id: "tv-1", tmdb_id: "1", title: "Show One" },
+      { id: "tv-2", tmdb_id: "2", title: "Show Two" },
+    ]);
 
     enqueueJob("sync-episodes");
     await processJobs();
 
-    expect(mockSyncEpisodes).toHaveBeenCalledTimes(1);
+    expect(mockEnqueueAdhoc).toHaveBeenCalledTimes(2);
+    expect(mockEnqueueAdhoc).toHaveBeenCalledWith("sync-show-episodes", {
+      titleId: "tv-1",
+      tmdbId: "1",
+      title: "Show One",
+    });
+    expect(mockEnqueueAdhoc).toHaveBeenCalledWith("sync-show-episodes", {
+      titleId: "tv-2",
+      tmdbId: "2",
+      title: "Show Two",
+    });
+    // Fan-out only — no inline per-show sync in the cron handler.
+    expect(mockSyncEpisodesForShow).not.toHaveBeenCalled();
+    expect(mockSyncEpisodes).not.toHaveBeenCalled();
   });
 
   it("skips episode sync when TMDB_API_KEY is not set", async () => {
@@ -435,13 +466,14 @@ describe("sync-episodes handler", () => {
     enqueueJob("sync-episodes");
     await processJobs();
 
-    expect(mockSyncEpisodes).not.toHaveBeenCalled();
+    expect(mockListTrackedShows).not.toHaveBeenCalled();
+    expect(mockEnqueueAdhoc).not.toHaveBeenCalled();
   });
 
-  it("handles syncEpisodes failure gracefully (job fails)", async () => {
+  it("handles fan-out failure gracefully (job fails)", async () => {
     CONFIG.TMDB_API_KEY = "test-api-key";
-    const error = new Error("Episode sync failed");
-    mockSyncEpisodes.mockRejectedValueOnce(error);
+    const error = new Error("Episode fan-out failed");
+    mockListTrackedShows.mockRejectedValueOnce(error);
 
     enqueueJob("sync-episodes");
     await processJobs();

--- a/server/jobs/sync.ts
+++ b/server/jobs/sync.ts
@@ -16,7 +16,11 @@ import {
   getEpisodeIdsBySE,
   watchEpisodesBulk,
 } from "../db/repository";
-import { syncEpisodes, syncEpisodesForShow } from "../tmdb/sync";
+import {
+  syncEpisodesForShow,
+  listTrackedShowsForEpisodeSync,
+} from "../tmdb/sync";
+import { enqueueAdhoc } from "./backend";
 import { fetchMovieDetails, fetchTvDetails } from "../tmdb/client";
 import { parseMovieDetails, parseTvDetails } from "../tmdb/parser";
 import { migrateTitles } from "./migrate-titles";
@@ -78,8 +82,21 @@ export function registerSyncJobs() {
       });
       return;
     }
-    const result = await syncEpisodes();
-    log.info("Synced episodes", { synced: result.synced, shows: result.shows });
+    // ponytail: fan out one sync-show-episodes job per tracked show instead of
+    // syncing all shows inline. The old inline path took ~79s, which blew the 30s
+    // CF Durable Object alarm/CPU budget and crash-looped the JobQueueDO (#1020).
+    // Per-show is the established safe unit (see track.ts) and the partitioned DOs
+    // drain via the */5 watchdog; this replaces the sequential EPISODE_SYNC_DELAY_MS
+    // pacing. Revisit if TMDB starts rate-limiting the fan-out.
+    const shows = await listTrackedShowsForEpisodeSync();
+    for (const show of shows) {
+      await enqueueAdhoc("sync-show-episodes", {
+        titleId: show.id,
+        tmdbId: show.tmdb_id,
+        title: show.title,
+      });
+    }
+    log.info("Dispatched per-show episode sync jobs", { shows: shows.length });
   });
 
   registerHandler("sync-trending", async () => {

--- a/server/tmdb/sync.ts
+++ b/server/tmdb/sync.ts
@@ -88,14 +88,16 @@ export async function syncEpisodesForShow(
   return allEpisodes.length;
 }
 
-export async function syncEpisodes(): Promise<{
-  synced: number;
-  shows: number;
-}> {
+/**
+ * List all tracked shows that have a TMDB id, for per-show episode sync fan-out.
+ * Shared by syncEpisodes() (inline manual sync) and the sync-episodes cron
+ * handlers, which fan out one sync-show-episodes adhoc job per row.
+ */
+export async function listTrackedShowsForEpisodeSync(): Promise<
+  { id: string; tmdb_id: string; title: string }[]
+> {
   const db = getDb();
-
-  // Get all tracked shows with tmdb_id
-  const trackedShows = (await db
+  return (await db
     .select({
       id: titles.id,
       tmdb_id: titles.tmdbId,
@@ -105,6 +107,13 @@ export async function syncEpisodes(): Promise<{
     .innerJoin(titles, eq(titles.id, tracked.titleId))
     .where(and(eq(titles.objectType, "SHOW"), isNotNull(titles.tmdbId)))
     .all()) as { id: string; tmdb_id: string; title: string }[];
+}
+
+export async function syncEpisodes(): Promise<{
+  synced: number;
+  shows: number;
+}> {
+  const trackedShows = await listTrackedShowsForEpisodeSync();
 
   if (trackedShows.length === 0) {
     return { synced: 0, shows: 0 };


### PR DESCRIPTION
## Summary

Fixes the `JobQueueDO` `blockConcurrencyWhile()` crash loop (#1020).

**Root cause:** the `sync-episodes` cron handler synced ALL tracked shows inline (`syncEpisodes()`, ~79s). On Cloudflare Workers the JobQueueDO then re-armed its cron via `armCron()` → `this.alarms.schedule()` → `blockConcurrencyWhile()`, which exceeded CF's 30s limit after the long job. CF reset the DO before `alarm()`'s finally block wrote `alarm_last_completed_at`, so the stale alarm re-fired in a loop.

## Fix

**Part 1 — bound the job by fan-out (root cause):**
- Extracted `listTrackedShowsForEpisodeSync()` in `server/tmdb/sync.ts` (the existing tracked-shows select).
- Changed BOTH `sync-episodes` cron entry points — `handleSyncEpisodes` in `server/jobs/processor.ts` and the `registerHandler("sync-episodes", ...)` in `server/jobs/sync.ts` — to enqueue one `enqueueAdhoc("sync-show-episodes", {titleId, tmdbId, title})` per tracked show instead of running inline. Per-show is the established safe unit (`track.ts`) and partitioned DOs drain via the */5 watchdog. This replaces the sequential `EPISODE_SYNC_DELAY_MS` pacing.
- `syncEpisodes()` is kept (still used by the manual `POST /episodes/sync` route).

**Part 2 — DO safety net:**
- Wrapped the self-heal `armCron` re-arm in `runJob()` (`server/jobs/durable-object.ts`) in try/catch so a `blockConcurrencyWhile` failure can't abort `runJob` or leave job state inconsistent. Failures emit a Sentry breadcrumb; the */5 watchdog re-arms independently, so this re-arm is best-effort.

## Tests
- `server/jobs/processor.test.ts` & `server/jobs/sync.test.ts`: assert the `sync-episodes` handler fans out one `sync-show-episodes` adhoc job per tracked show and does NOT call `syncEpisodesForShow`/`syncEpisodes` inline; skip path asserts no fan-out when `TMDB_API_KEY` is unset.
- `server/jobs/durable-object.test.ts`: regression test that `runJob` still completes and writes job state (and emits a breadcrumb, not a captured exception) when `armCron` throws.

`bun run check` passes cleanly (server 2247 tests, frontend 1135 tests, 0 fail; tsc + eslint + build + wrangler dry-run all green).

## Ops follow-up
The underlying trigger was `sync-episodes` wall time; fan-out keeps each DO invocation under the 30s limit. No secret/migration ops needed.

Closes #1020