### PR TITLE
perf(feed): add covering index for calendar movies query

### DIFF
--- a/drizzle/0053_idx_titles_type_release.sql
+++ b/drizzle/0053_idx_titles_type_release.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `idx_titles_type_release` ON `titles` (`object_type`,`release_date`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -372,6 +372,13 @@
       "when": 1747785600000,
       "tag": "0052_idx_up_next_perf",
       "breakpoints": true
+    },
+    {
+      "idx": 53,
+      "version": "6",
+      "when": 1750550400000,
+      "tag": "0053_idx_titles_type_release",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/bun-db.test.ts
+++ b/server/db/bun-db.test.ts
@@ -131,6 +131,6 @@ describe("fixSkippedMigrations", () => {
     const migrations = rawDb
       .prepare("SELECT COUNT(*) as cnt FROM __drizzle_migrations")
       .get() as { cnt: number };
-    expect(migrations.cnt).toBe(53);
+    expect(migrations.cnt).toBe(54);
   });
 });

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -54,6 +54,7 @@ export const titles = sqliteTable(
   (table) => [
     index("idx_titles_release_date").on(table.releaseDate),
     index("idx_titles_object_type").on(table.objectType),
+    index("idx_titles_type_release").on(table.objectType, table.releaseDate),
   ],
 );
 


### PR DESCRIPTION
## Summary

`GET /api/feed/calendar.ics` was slow because `getUpcomingTrackedMovies` (`server/db/repository/tracked.ts`) joins `tracked` (filtered by `user_id`) to `titles` filtering `object_type='MOVIE' AND release_date >= ? AND release_date < ?` and ordering by `release_date`. The only matching index was `idx_titles_release_date` (release_date alone), so SQLite used it for the date range and then filtered `object_type` row-by-row — scanning both MOVIE and SHOW rows in range, plus an extra sort.

This adds a composite covering index `idx_titles_type_release (object_type, release_date)`.

## Changes

- `server/db/schema.ts` — add `index("idx_titles_type_release").on(table.objectType, table.releaseDate)` to the `titles` table.
- `drizzle/0053_idx_titles_type_release.sql` — `CREATE INDEX idx_titles_type_release` (index-only; no table recreate, safe for CF D1 per `server/db/CLAUDE.md`).
- `drizzle/meta/_journal.json` — journal entry for the new migration (used by the Bun runtime migrator).
- `server/db/bun-db.test.ts` — bump migration-count guard 53 → 54.

## EXPLAIN QUERY PLAN

Built a throwaway in-memory SQLite, ran all migrations, seeded 2000 titles (1000 MOVIE / 1000 SHOW) + tracked rows, `ANALYZE`, then ran the movies query.

**Before** (without the new index):
```
SEARCH titles USING INDEX idx_titles_release_date (release_date>? AND release_date<?)
SEARCH tracked USING COVERING INDEX sqlite_autoindex_tracked_1 (title_id=? AND user_id=?)
```

**After**:
```
SEARCH titles USING INDEX idx_titles_type_release (object_type=? AND release_date>? AND release_date<?)
SEARCH tracked USING COVERING INDEX sqlite_autoindex_tracked_1 (title_id=? AND user_id=?)
```

The new index drives all three predicates (object_type + release_date range) and supplies rows already in `release_date` order, eliminating the row-by-row object_type filter and the sort.

## Tests

- `server/db/migrations.test.ts` runs all `drizzle/` migrations with `foreign_keys=ON` — covers the new migration automatically. Passes.
- `server/routes/feed.test.ts` still passes (correctness unchanged).
- `bun run check` passes (server 2246 pass, frontend 1135 pass, build + wrangler dry-run OK).

## Ops follow-up

After merge, apply the index to prod D1: `bun run db:migrate:cf` (runs `wrangler d1 migrations apply remindarr --remote`, which picks up `drizzle/0053_*.sql`).

Note: #1027 may be partly low-traffic statistical noise per the issue, but this index addresses the recurring `calendar.ics` slowness regardless.

Closes #1027

🤖 Generated with [Claude Code](https://claude.com/claude-code)