### PR TITLE
refactor: replace reinvented stdlib with native Intl/Drizzle (#1045)

### DIFF
--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -118,11 +118,7 @@ function MobileFeedHome({
   const alsoAiring = today.slice(1);
 
   // Group unwatched by show, take up to 8 shows
-  const cwByShow = new Map<string, Episode[]>();
-  for (const ep of unwatched) {
-    if (!cwByShow.has(ep.title_id)) cwByShow.set(ep.title_id, []);
-    cwByShow.get(ep.title_id)!.push(ep);
-  }
+  const cwByShow = groupByShow(unwatched);
   const cwEntries = Array.from(cwByShow.entries()).slice(0, 8);
 
   const today7 = upcoming.slice(0, 18);

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -2,21 +2,6 @@ import * as api from "../api";
 import { useQuery } from "@tanstack/react-query";
 import type { StatsResponse } from "../types";
 
-const MONTH_NAMES = [
-  "Jan",
-  "Feb",
-  "Mar",
-  "Apr",
-  "May",
-  "Jun",
-  "Jul",
-  "Aug",
-  "Sep",
-  "Oct",
-  "Nov",
-  "Dec",
-];
-
 export function formatEta(days: number | null): string {
   if (days === null) return "—";
   if (days === 0) return "< 1 day";
@@ -26,8 +11,14 @@ export function formatEta(days: number | null): string {
 }
 
 function formatMonth(ym: string): string {
-  const [, m] = ym.split("-");
-  return MONTH_NAMES[parseInt(m, 10) - 1] ?? ym;
+  const d = new Date(`${ym}-01`);
+  if (Number.isNaN(d.getTime())) return ym;
+  // ym is "YYYY-MM"; new Date parses it as UTC midnight, so format in UTC to
+  // avoid rolling back a day (and thus a month) in negative-offset timezones.
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    timeZone: "UTC",
+  }).format(d);
 }
 
 function formatTime(minutes: number): string {
@@ -172,28 +163,18 @@ function ShowStatusGrid({
   );
 }
 
-const LANGUAGE_NAMES: Record<string, string> = {
-  en: "English",
-  ja: "Japanese",
-  ko: "Korean",
-  fr: "French",
-  de: "German",
-  es: "Spanish",
-  it: "Italian",
-  pt: "Portuguese",
-  zh: "Chinese",
-  hi: "Hindi",
-  ar: "Arabic",
-  ru: "Russian",
-  tr: "Turkish",
-  nl: "Dutch",
-  sv: "Swedish",
-  da: "Danish",
-  fi: "Finnish",
-  no: "Norwegian",
-  pl: "Polish",
-  th: "Thai",
-};
+function languageLabel(code: string): string {
+  try {
+    return (
+      new Intl.DisplayNames(["en"], {
+        type: "language",
+        fallback: "none",
+      }).of(code) ?? code.toUpperCase()
+    );
+  } catch {
+    return code.toUpperCase();
+  }
+}
 
 export function StatsView() {
   const { data, isLoading: loading } = useQuery({
@@ -300,7 +281,7 @@ export function StatsView() {
               {languages.map((l) => (
                 <HorizontalBar
                   key={l.language}
-                  label={LANGUAGE_NAMES[l.language] ?? l.language.toUpperCase()}
+                  label={languageLabel(l.language)}
                   count={l.count}
                   max={maxLang}
                 />

--- a/server/db/repository/dismissed.ts
+++ b/server/db/repository/dismissed.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, count, eq } from "drizzle-orm";
 import { getDb, dismissedSuggestions } from "../schema";
 import { traceDbQuery } from "../../tracing";
 
@@ -51,11 +51,11 @@ export async function getDismissedTitleIds(
 export async function getDismissedCount(userId: string): Promise<number> {
   return traceDbQuery("getDismissedCount", async () => {
     const db = getDb();
-    const rows = await db
-      .select({ titleId: dismissedSuggestions.titleId })
+    const row = await db
+      .select({ count: count() })
       .from(dismissedSuggestions)
       .where(eq(dismissedSuggestions.userId, userId))
-      .all();
-    return rows.length;
+      .get();
+    return row?.count ?? 0;
   });
 }

--- a/server/db/repository/episodes.ts
+++ b/server/db/repository/episodes.ts
@@ -488,10 +488,7 @@ export async function getReleasedEpisodeIds(
       .from(episodes)
       .where(
         and(
-          sql`${episodes.id} IN (${sql.join(
-            episodeIds.map((id) => sql`${id}`),
-            sql`, `,
-          )})`,
+          inArray(episodes.id, episodeIds),
           sql`${episodes.airDate} IS NOT NULL`,
           sql`${episodes.airDate} <= ${today}`,
         ),

--- a/server/db/repository/streaks.ts
+++ b/server/db/repository/streaks.ts
@@ -287,11 +287,7 @@ export async function recomputeStreakFromHistory(
 
 /** Convert an ISO datetime string to a UTC date string (YYYY-MM-DD). */
 function toUtcDateString(isoString: string): string {
-  const d = new Date(isoString);
-  const year = d.getUTCFullYear();
-  const month = String(d.getUTCMonth() + 1).padStart(2, "0");
-  const day = String(d.getUTCDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
+  return new Date(isoString).toISOString().slice(0, 10);
 }
 
 /** Compute the signed difference in days between two UTC date strings (b - a). */

--- a/server/tmdb/sync-titles.ts
+++ b/server/tmdb/sync-titles.ts
@@ -52,7 +52,7 @@ export async function fetchNewReleases(options: {
   // Fetch movies
   if (!objectType || objectType === "MOVIE") {
     try {
-      const [movieGenres] = await Promise.all([getMovieGenres()]);
+      const movieGenres = await getMovieGenres();
 
       for (let page = 1; page <= maxPages; page++) {
         const result = await discoverMovies({
@@ -95,7 +95,7 @@ export async function fetchNewReleases(options: {
   // Fetch TV shows
   if (!objectType || objectType === "SHOW") {
     try {
-      const [tvGenres] = await Promise.all([getTvGenres()]);
+      const tvGenres = await getTvGenres();
 
       for (let page = 1; page <= maxPages; page++) {
         const result = await discoverTv({


### PR DESCRIPTION
Part of the over-engineering cleanup epic (#1049). Swaps hand-rolled code for native `Intl.*` / Drizzle equivalents already used in sibling files.

## Done
- **StatsPage** — `Intl.DisplayNames` for language labels (drops the 20-entry `LANGUAGE_NAMES` map); `Intl.DateTimeFormat` for month abbreviations (drops `MONTH_NAMES` + `formatMonth` body). Used `timeZone: "UTC"` so `new Date("YYYY-MM-01")` (UTC midnight) doesn't roll back a day — and thus a month — in negative-offset timezones.
- **HomePage** — `MobileFeedHome` reuses the already-imported `groupByShow(unwatched)` instead of an inline `Map`.
- **dismissed.ts** — `getDismissedCount` uses `count()` instead of selecting every row and reading `.length`.
- **streaks.ts** — `toUtcDateString` → `new Date(iso).toISOString().slice(0, 10)`.
- **sync-titles.ts** — drop the two `await Promise.all([single])` wrappers.
- **episodes.ts** — `getReleasedEpisodeIds` uses `inArray(episodes.id, episodeIds)`.

## Deliberately skipped (not mechanical / would change behavior)
- **Relative-time trio** (`DiscoveryPage`, `EarnHistoryList`, `RecentlyEarnedStrip`) — the three formatters produce *different* output (`Xm/Xh/Xd ago` + date fallback vs `Today/Yesterday/X days/X months ago` vs `…/Xmo/Xy ago`). A single `Intl.RelativeTimeFormat` helper would change user-visible text in all three and can't reproduce the compact `3d ago` style. Belongs in its own UI-reviewed PR.
- **`groupByShow` → `Map.groupBy`** — `Map.groupBy` is ES2024; the frontend `tsconfig` lib is ES2022. Would require a lib bump (scope creep) plus a browser API newer than the project baseline. (The issue's "already used in sibling files" claim doesn't hold — there are no existing uses.)
- **`getUniqueProviders` one-liner** — `[...new Map(filtered.map(...)).values()]` changes dedup from first-wins to **last-wins**, so a provider appearing as both FLATRATE and ADS would render a different offer. The original is already a correct first-wins dedupe.

`bun run check` passes locally.

Closes #1045