### PR TITLE
refactor: consolidate duplicated utilities into shared imports (#1046)

### DIFF
--- a/frontend/src/components/title-detail/utils.ts
+++ b/frontend/src/components/title-detail/utils.ts
@@ -72,6 +72,17 @@ export function isToday(dateStr: string | null | undefined): boolean {
   );
 }
 
+/** Whether an air date (YYYY-MM-DD) is on or before today, compared in UTC. */
+export function isReleased(airDate: string | null | undefined): boolean {
+  if (!airDate) return false;
+  return airDate <= new Date().toISOString().slice(0, 10);
+}
+
+/** Whether an air date (YYYY-MM-DD) equals today's UTC date. */
+export function isAiringToday(airDate: string | null | undefined): boolean {
+  return !!airDate && airDate === new Date().toISOString().slice(0, 10);
+}
+
 export function getCertification(
   results: { iso_3166_1: string; rating: string }[] | undefined,
   country: string,

--- a/frontend/src/lib/groupShows.ts
+++ b/frontend/src/lib/groupShows.ts
@@ -28,53 +28,46 @@ const LABEL_KEYS: Record<string, string> = {
   completed: "tracked.sections.completed",
 };
 
-function compareDatesDesc(
+function compareDates(
   a: string | null | undefined,
   b: string | null | undefined,
+  dir: "asc" | "desc" = "asc",
 ): number {
   if (!a && !b) return 0;
   if (!a) return 1;
   if (!b) return -1;
-  return b.localeCompare(a);
-}
-
-function compareDatesAsc(
-  a: string | null | undefined,
-  b: string | null | undefined,
-): number {
-  if (!a && !b) return 0;
-  if (!a) return 1;
-  if (!b) return -1;
-  return a.localeCompare(b);
+  return dir === "asc" ? a.localeCompare(b) : b.localeCompare(a);
 }
 
 function sortByTrackedAtDesc(a: Title, b: Title): number {
-  return compareDatesDesc(a.tracked_at, b.tracked_at);
+  return compareDates(a.tracked_at, b.tracked_at, "desc");
 }
 
 function sortGroup(key: string, titles: Title[]): Title[] {
   switch (key) {
     case "watching":
       return [...titles].sort((a, b) =>
-        compareDatesDesc(
+        compareDates(
           a.latest_released_air_date,
           b.latest_released_air_date,
+          "desc",
         ),
       );
     case "caught_up":
       return [...titles].sort((a, b) =>
-        compareDatesAsc(a.next_episode_air_date, b.next_episode_air_date),
+        compareDates(a.next_episode_air_date, b.next_episode_air_date, "asc"),
       );
     case "not_started":
       return [...titles].sort((a, b) =>
-        compareDatesDesc(
+        compareDates(
           a.latest_released_air_date,
           b.latest_released_air_date,
+          "desc",
         ),
       );
     case "unreleased":
       return [...titles].sort((a, b) =>
-        compareDatesAsc(a.release_date, b.release_date),
+        compareDates(a.release_date, b.release_date, "asc"),
       );
     case "completed":
     case "on_hold":

--- a/frontend/src/pages/EpisodeDetailPage.tsx
+++ b/frontend/src/pages/EpisodeDetailPage.tsx
@@ -16,13 +16,7 @@ import EpisodeRatingButtons from "../components/EpisodeRatingButtons";
 import { stillUrl as mkStillUrl } from "../lib/tmdb-images";
 import SectionErrorBoundary from "../components/SectionErrorBoundary";
 import EditWatchedAtDialog from "../components/EditWatchedAtDialog";
-import { formatDate } from "../components/title-detail/utils";
-
-function isReleased(airDate: string | null | undefined): boolean {
-  if (!airDate) return false;
-  const today = new Date().toISOString().slice(0, 10);
-  return airDate <= today;
-}
+import { formatDate, isReleased } from "../components/title-detail/utils";
 
 export default function EpisodeDetailPage() {
   const { id, season, episode } = useParams<{

--- a/frontend/src/pages/SeasonDetailPage.tsx
+++ b/frontend/src/pages/SeasonDetailPage.tsx
@@ -24,20 +24,11 @@ import {
   stillUrl as mkStillUrl,
 } from "../lib/tmdb-images";
 import SectionErrorBoundary from "../components/SectionErrorBoundary";
-import { formatDate } from "../components/title-detail/utils";
-
-function todayISO(): string {
-  return new Date().toISOString().slice(0, 10);
-}
-
-function isReleased(airDate: string | null | undefined): boolean {
-  if (!airDate) return false;
-  return airDate <= todayISO();
-}
-
-function isAiringToday(airDate: string | null | undefined): boolean {
-  return !!airDate && airDate === todayISO();
-}
+import {
+  formatDate,
+  isReleased,
+  isAiringToday,
+} from "../components/title-detail/utils";
 
 type EpisodeStatus = { id: number; is_watched: boolean };
 

--- a/frontend/src/pages/settings/AccountTab.tsx
+++ b/frontend/src/pages/settings/AccountTab.tsx
@@ -760,14 +760,7 @@ const ACTIVITY_KIND_LABELS: Record<ActivityType, string> = {
   recommendation: "Recommendations sent",
 };
 
-const ACTIVITY_KINDS: ActivityType[] = [
-  "rating_title",
-  "rating_episode",
-  "watched_title",
-  "watched_episode",
-  "tracked",
-  "recommendation",
-];
+const ACTIVITY_KINDS = Object.keys(ACTIVITY_KIND_LABELS) as ActivityType[];
 
 const KIND_VIS_OPTIONS: Array<{
   value: "public" | "friends_only" | "private";

--- a/server/jobs/migrate-backdrops.ts
+++ b/server/jobs/migrate-backdrops.ts
@@ -6,12 +6,9 @@ import { logger } from "../logger";
 const log = logger.child({ module: "migrate-backdrops" });
 import { fetchMovieDetails, fetchTvDetails } from "../tmdb/client";
 import { CONFIG } from "../config";
+import { sleep } from "../lib/http";
 
 const DELAY_MS = 500;
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 /**
  * One-time migration: fetches backdrop_path from TMDB for all existing
@@ -79,7 +76,7 @@ export async function migrateBackdrops(): Promise<{
       failed++;
     }
 
-    await delay(DELAY_MS);
+    await sleep(DELAY_MS);
   }
 
   log.info("Backdrop migration complete", { updated, skipped, failed });

--- a/server/jobs/migrate-offers.ts
+++ b/server/jobs/migrate-offers.ts
@@ -5,15 +5,12 @@ import { fetchMovieDetails, fetchTvDetails } from "../tmdb/client";
 import { parseMovieDetails, parseTvDetails } from "../tmdb/parser";
 import { upsertTitles } from "../db/repository";
 import { CONFIG } from "../config";
+import { sleep } from "../lib/http";
 
 const log = logger.child({ module: "migrate-offers" });
 
 const DELAY_MS = 500;
 const DEFAULT_BATCH_SIZE = 20;
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 /**
  * One-time migration: fetches watch provider offers from TMDB
@@ -88,7 +85,7 @@ export async function migrateOffers(batchSize = DEFAULT_BATCH_SIZE): Promise<{
       .set({ offersChecked: 1 })
       .where(eq(titles.id, row.id));
 
-    await delay(DELAY_MS);
+    await sleep(DELAY_MS);
   }
 
   log.info("Offers migration batch complete", {

--- a/server/jobs/migrate-titles.ts
+++ b/server/jobs/migrate-titles.ts
@@ -4,12 +4,9 @@ import { logger } from "../logger";
 const log = logger.child({ module: "migrate-titles" });
 import { fetchMovieDetails, fetchTvDetails } from "../tmdb/client";
 import { CONFIG } from "../config";
+import { sleep } from "../lib/http";
 
 const DELAY_MS = 500;
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 /**
  * One-time migration: fetches English titles and original titles from TMDB
@@ -65,7 +62,7 @@ export async function migrateTitles(): Promise<{
       failed++;
     }
 
-    await delay(DELAY_MS);
+    await sleep(DELAY_MS);
   }
 
   log.info("Migration complete", { updated, failed });

--- a/server/lib/http.ts
+++ b/server/lib/http.ts
@@ -70,6 +70,6 @@ function parseRetryAfter(header: string): number {
   return Math.max(diff, 1000);
 }
 
-function sleep(ms: number): Promise<void> {
+export function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }

--- a/server/routes/feed.ts
+++ b/server/routes/feed.ts
@@ -10,14 +10,9 @@ import { requireAuth } from "../middleware/auth";
 import type { AppEnv } from "../types";
 import { getCache } from "../cache";
 import { CONFIG } from "../config";
+import { addDays } from "../utils/timezone";
 
 const app = new Hono<AppEnv>();
-
-function addDays(dateStr: string, days: number): string {
-  const d = new Date(dateStr + "T00:00:00Z");
-  d.setUTCDate(d.getUTCDate() + days);
-  return d.toISOString().slice(0, 10);
-}
 
 function escapeIcal(str: string): string {
   return str

--- a/server/routes/import.ts
+++ b/server/routes/import.ts
@@ -5,6 +5,7 @@ import { upsertTitles, trackTitle } from "../db/repository";
 import type { AppEnv } from "../types";
 import { ok, err } from "./response";
 import { logger } from "../logger";
+import { sleep } from "../lib/http";
 
 const log = logger.child({ module: "import" });
 
@@ -185,10 +186,6 @@ export function extractImdbIdFromRow(
     default:
       return null;
   }
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 const app = new Hono<AppEnv>();

--- a/server/routes/profile.ts
+++ b/server/routes/profile.ts
@@ -30,14 +30,14 @@ import { logger } from "../logger";
 
 const log = logger.child({ module: "profile" });
 
-const ACTIVITY_KINDS: ActivityType[] = [
+const ACTIVITY_KINDS = [
   "rating_title",
   "rating_episode",
   "watched_title",
   "watched_episode",
   "tracked",
   "recommendation",
-];
+] as const satisfies readonly ActivityType[];
 
 const app = new Hono<AppEnv>();
 
@@ -116,14 +116,7 @@ app.patch("/me/profile", zValidator("json", profileSchema), async (c) => {
   );
 });
 
-const activityKindEnum = z.enum([
-  "rating_title",
-  "rating_episode",
-  "watched_title",
-  "watched_episode",
-  "tracked",
-  "recommendation",
-]);
+const activityKindEnum = z.enum(ACTIVITY_KINDS);
 const visibilityEnum = z.enum(["public", "friends_only", "private"]);
 
 const activitySettingsSchema = z.object({
@@ -341,5 +334,4 @@ app.put(
   },
 );
 
-export { ACTIVITY_KINDS };
 export default app;

--- a/server/tmdb/sync-utils.ts
+++ b/server/tmdb/sync-utils.ts
@@ -1,4 +1,5 @@
 import { Logger } from "../logger";
+import { sleep } from "../lib/http";
 
 /**
  * Directive returned from {@link SyncEachOptions.onError} to control how
@@ -45,10 +46,6 @@ export interface SyncEachResult<T, R> {
   failures: Array<{ item: T; error: unknown }>;
 }
 
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 /**
  * Run `onItem` for each entry in `items` with an inter-item delay and
  * per-item error isolation. Centralizes the
@@ -59,7 +56,7 @@ function delay(ms: number): Promise<void> {
  *   for each item:
  *     try onItem(item)
  *     handle error via onError or default (log + push to failures)
- *     await delay(delayMs) before next item
+ *     await sleep(delayMs) before next item
  *
  * Parallel semantics (concurrency > 1):
  *   A simple worker pool drains the items array. Each worker calls
@@ -106,7 +103,7 @@ export async function syncEachWithDelay<T, R>(
       if (stopped) break;
       await handleItem(item);
       if (stopped) break;
-      if (delayMs > 0) await delay(delayMs);
+      if (delayMs > 0) await sleep(delayMs);
     }
     return { results, failures };
   }
@@ -119,7 +116,7 @@ export async function syncEachWithDelay<T, R>(
       if (i >= items.length) return;
       await handleItem(items[i]);
       if (stopped) return;
-      if (delayMs > 0) await delay(delayMs);
+      if (delayMs > 0) await sleep(delayMs);
     }
   };
   const workers: Promise<void>[] = [];

--- a/server/tmdb/sync.ts
+++ b/server/tmdb/sync.ts
@@ -8,10 +8,7 @@ import { upsertEpisodes } from "../db/repository";
 import { fetchShowDetails, fetchSeasonEpisodes } from "./client";
 import { eq, and, count, isNotNull } from "drizzle-orm";
 import { syncEachWithDelay } from "./sync-utils";
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
+import { sleep } from "../lib/http";
 
 /** Extract the numeric TMDB ID from our internal title ID format "tv-12345" or the tmdb_id field */
 function extractTmdbId(titleId: string, tmdbIdField: string | null): string {
@@ -56,7 +53,7 @@ export async function syncEpisodesForShow(
   const allEpisodes: EpisodeRow[] = [];
 
   for (let season = 1; season <= details.number_of_seasons; season++) {
-    if (season > 1) await delay(CONFIG.EPISODE_SYNC_DELAY_MS);
+    if (season > 1) await sleep(CONFIG.EPISODE_SYNC_DELAY_MS);
 
     try {
       const seasonData = await fetchSeasonEpisodes(resolvedTmdbId, season);


### PR DESCRIPTION
Part of the over-engineering cleanup epic (#1049). Trivial utilities were copied per-file instead of imported once; in several cases the canonical version already existed.

## Done
- **`sleep()`** — exported the canonical `sleep` from `lib/http.ts` and deleted the 6 per-file `delay()`/`sleep()` copies (`tmdb/sync`, `tmdb/sync-utils`, `jobs/migrate-{titles,offers,backdrops}`, `routes/import`).
- **`addDays`** — `feed.ts` imports it from `utils/timezone` instead of a byte-identical local copy.
- **`ActivityType` tuple** — `profile.ts` makes `ACTIVITY_KINDS` `as const` and feeds it into `z.enum(ACTIVITY_KINDS)` (removing the repeated 6-value `z.enum` literal) and drops the dead `export { ACTIVITY_KINDS }`. `AccountTab` derives `ACTIVITY_KINDS` from `Object.keys(ACTIVITY_KIND_LABELS)`.
- **`isReleased`/`isAiringToday`** — extracted to `title-detail/utils` and imported by both `SeasonDetailPage` and `EpisodeDetailPage`.
- **`compareDates`** — `groupShows.ts` collapses `compareDatesAsc`/`compareDatesDesc` into one `compareDates(a, b, dir)`.

## Notes / deviations
- The issue suggested replacing `isAiringToday` with the existing `isToday()`. I didn't: `isToday()` compares in **local** time while the pages' helpers compare in **UTC** (`new Date().toISOString().slice(0,10)`), so swapping would shift "airing today"/"released" results at timezone boundaries. Instead I exported the UTC helpers as shared functions — same dedup, zero behavior change.
- Left `feed.ts`'s inline `new Date().toISOString().slice(0,10)` calls: `timezone.ts` has no exact `todayUtc()` helper, only `localDateForTimezone`/`addDays`.

`bun run check` passes locally.

Closes #1046