### PR TITLE
refactor: extract copy-pasted blocks into shared helpers (#1047)

### DIFF
--- a/frontend/src/components/LegalSection.tsx
+++ b/frontend/src/components/LegalSection.tsx
@@ -1,0 +1,14 @@
+export function LegalSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-3">
+      <h2 className="text-lg font-semibold text-zinc-100">{title}</h2>
+      {children}
+    </section>
+  );
+}

--- a/frontend/src/components/TitleCard.tsx
+++ b/frontend/src/components/TitleCard.tsx
@@ -22,6 +22,34 @@ interface Props {
   showRating?: boolean;
 }
 
+/** Thin amber progress bar overlay showing watched/total episode progress. */
+function ProgressBar({ watched, max }: { watched: number; max: number }) {
+  return (
+    <div
+      className="absolute bottom-0 left-0 right-0 h-1 bg-zinc-700"
+      role="progressbar"
+      aria-label={`${watched} of ${max} episodes watched`}
+      aria-valuenow={watched}
+      aria-valuemin={0}
+      aria-valuemax={max}
+    >
+      <div
+        className="h-full bg-amber-500 transition-all duration-300"
+        style={{ width: `${(watched / max) * 100}%` }}
+      />
+    </div>
+  );
+}
+
+/** "X/Y ep" count pill overlay. */
+function EpCount({ watched, total }: { watched: number; total: number }) {
+  return (
+    <span className="absolute bottom-2 left-2 bg-zinc-800/90 text-white text-[10px] font-bold px-1.5 py-0.5 rounded">
+      {watched}/{total} ep
+    </span>
+  );
+}
+
 const TitleCard = memo(function TitleCard({
   title,
   onTrackToggle,
@@ -146,28 +174,17 @@ const TitleCard = memo(function TitleCard({
           <>
             {showProgressBar &&
             (title.released_episodes_count ?? title.total_episodes ?? 0) > 0 ? (
-              <div
-                className="absolute bottom-0 left-0 right-0 h-1 bg-zinc-700"
-                role="progressbar"
-                aria-label={`${title.watched_episodes_count ?? 0} of ${title.released_episodes_count ?? title.total_episodes ?? 1} episodes watched`}
-                aria-valuenow={title.watched_episodes_count ?? 0}
-                aria-valuemin={0}
-                aria-valuemax={
-                  title.released_episodes_count ?? title.total_episodes ?? 1
-                }
-              >
-                <div
-                  className="h-full bg-amber-500 transition-all duration-300"
-                  style={{
-                    width: `${((title.watched_episodes_count ?? 0) / (title.released_episodes_count ?? title.total_episodes ?? 1)) * 100}%`,
-                  }}
-                />
-              </div>
+              <ProgressBar
+                watched={title.watched_episodes_count ?? 0}
+                max={title.released_episodes_count ?? title.total_episodes ?? 1}
+              />
             ) : (
-              <span className="absolute bottom-2 left-2 bg-zinc-800/90 text-white text-[10px] font-bold px-1.5 py-0.5 rounded">
-                {title.watched_episodes_count ?? 0}/
-                {title.released_episodes_count ?? title.total_episodes ?? 0} ep
-              </span>
+              <EpCount
+                watched={title.watched_episodes_count ?? 0}
+                total={
+                  title.released_episodes_count ?? title.total_episodes ?? 0
+                }
+              />
             )}
           </>
         )}
@@ -194,10 +211,10 @@ const TitleCard = memo(function TitleCard({
           title.object_type === "SHOW" &&
           title.total_episodes != null &&
           title.total_episodes > 0 && (
-            <span className="absolute bottom-2 left-2 bg-zinc-800/90 text-white text-[10px] font-bold px-1.5 py-0.5 rounded">
-              {title.watched_episodes_count ?? 0}/
-              {title.released_episodes_count ?? title.total_episodes} ep
-            </span>
+            <EpCount
+              watched={title.watched_episodes_count ?? 0}
+              total={title.released_episodes_count ?? title.total_episodes}
+            />
           )}
         {!title.show_status &&
           !title.is_watched &&
@@ -205,23 +222,10 @@ const TitleCard = memo(function TitleCard({
           title.object_type === "SHOW" &&
           title.total_episodes != null &&
           title.total_episodes > 0 && (
-            <div
-              className="absolute bottom-0 left-0 right-0 h-1 bg-zinc-700"
-              role="progressbar"
-              aria-label={`${title.watched_episodes_count ?? 0} of ${title.released_episodes_count ?? title.total_episodes} episodes watched`}
-              aria-valuenow={title.watched_episodes_count ?? 0}
-              aria-valuemin={0}
-              aria-valuemax={
-                title.released_episodes_count ?? title.total_episodes
-              }
-            >
-              <div
-                className="h-full bg-amber-500 transition-all duration-300"
-                style={{
-                  width: `${((title.watched_episodes_count ?? 0) / (title.released_episodes_count ?? title.total_episodes)) * 100}%`,
-                }}
-              />
-            </div>
+            <ProgressBar
+              watched={title.watched_episodes_count ?? 0}
+              max={title.released_episodes_count ?? title.total_episodes}
+            />
           )}
         {title.imdb_score && !showVisibilityToggle && !showRating && (
           <span className="absolute top-2 right-2 bg-yellow-500 text-black text-[11px] font-bold px-1.5 py-0.5 rounded">

--- a/frontend/src/pages/DiscoveryPage.tsx
+++ b/frontend/src/pages/DiscoveryPage.tsx
@@ -32,11 +32,15 @@ function formatRelativeTime(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString();
 }
 
+function becausePrefix(reason: SuggestionSeedReason): string {
+  if (reason === "loved") return "Because you loved";
+  if (reason === "liked") return "Because you liked";
+  if (reason === "watched") return "Because you watched";
+  return "Because you tracked";
+}
+
 function becauseLabel(reason: SuggestionSeedReason, title: string): string {
-  if (reason === "loved") return `Because you loved ${title}`;
-  if (reason === "liked") return `Because you liked ${title}`;
-  if (reason === "watched") return `Because you watched ${title}`;
-  return `Because you tracked ${title}`;
+  return `${becausePrefix(reason)} ${title}`;
 }
 
 // ─── Small primitives ─────────────────────────────────────────────────────────
@@ -356,13 +360,7 @@ function DiscoveryHero({
                 )}
                 <div className="min-w-0">
                   <p className="font-mono text-[9px] uppercase tracking-wider text-zinc-500 mb-0.5">
-                    {algoGroup.source.reason === "loved"
-                      ? "Because you loved"
-                      : algoGroup.source.reason === "liked"
-                        ? "Because you liked"
-                        : algoGroup.source.reason === "watched"
-                          ? "Because you watched"
-                          : "Because you tracked"}
+                    {becausePrefix(algoGroup.source.reason)}
                   </p>
                   <p className="text-[13px] text-zinc-200 font-semibold truncate">
                     {algoGroup.source.title}

--- a/frontend/src/pages/KioskPage.tsx
+++ b/frontend/src/pages/KioskPage.tsx
@@ -14,6 +14,10 @@ import {
 
 const FIDELITY_VALUES: KioskFidelity[] = ["rich", "lite", "epaper"];
 
+const Mono: React.CSSProperties = {
+  fontFamily: "ui-monospace, 'JetBrains Mono', Menlo, monospace",
+};
+
 type KioskPalette = {
   bg: string;
   surface: string;
@@ -28,33 +32,25 @@ type KioskPalette = {
   chip: string;
 };
 
+// `rich` and `lite` share the same dark palette; the visual difference between
+// them lives in animation flags at the render site (e.g. `breathe`), not colors.
+const DARK_PALETTE: KioskPalette = {
+  bg: "#09090b",
+  surface: "#18181b",
+  surfaceAlt: "#27272a",
+  text: "#fafafa",
+  dim: "#a1a1aa",
+  veryDim: "#8c8c99",
+  border: "rgba(255,255,255,0.06)",
+  borderSoft: "rgba(255,255,255,0.06)",
+  accent: "#fbbf24",
+  accentInk: "#000",
+  chip: "rgba(255,255,255,0.06)",
+};
+
 const PALETTE: Record<KioskFidelity, KioskPalette> = {
-  rich: {
-    bg: "#09090b",
-    surface: "#18181b",
-    surfaceAlt: "#27272a",
-    text: "#fafafa",
-    dim: "#a1a1aa",
-    veryDim: "#8c8c99",
-    border: "rgba(255,255,255,0.06)",
-    borderSoft: "rgba(255,255,255,0.06)",
-    accent: "#fbbf24",
-    accentInk: "#000",
-    chip: "rgba(255,255,255,0.06)",
-  },
-  lite: {
-    bg: "#09090b",
-    surface: "#18181b",
-    surfaceAlt: "#27272a",
-    text: "#fafafa",
-    dim: "#a1a1aa",
-    veryDim: "#8c8c99",
-    border: "rgba(255,255,255,0.06)",
-    borderSoft: "rgba(255,255,255,0.06)",
-    accent: "#fbbf24",
-    accentInk: "#000",
-    chip: "rgba(255,255,255,0.06)",
-  },
+  rich: DARK_PALETTE,
+  lite: DARK_PALETTE,
   epaper: {
     bg: "#f6f3e8",
     surface: "#f6f3e8",
@@ -242,9 +238,6 @@ function KioskHeader({
   date: string;
   clock: string;
 }) {
-  const Mono: React.CSSProperties = {
-    fontFamily: "ui-monospace, 'JetBrains Mono', Menlo, monospace",
-  };
   return (
     <div
       style={{
@@ -348,9 +341,6 @@ function HeroCard({
   breathe: boolean;
   slot: KioskAiringSlot;
 }) {
-  const Mono: React.CSSProperties = {
-    fontFamily: "ui-monospace, 'JetBrains Mono', Menlo, monospace",
-  };
   const backdropUrl = kioskImageUrl(
     slot.backdrop_url ?? slot.poster_url,
     "w780",
@@ -530,9 +520,6 @@ function HeroFeatured({
   item: FeaturedItem;
   kicker: string;
 }) {
-  const Mono: React.CSSProperties = {
-    fontFamily: "ui-monospace, 'JetBrains Mono', Menlo, monospace",
-  };
   const backdropSrc = kioskImageUrl(
     item.backdrop_url ?? item.poster_url,
     "w780",
@@ -749,9 +736,6 @@ function PanelHeader({
   kicker: string;
   right: string;
 }) {
-  const Mono: React.CSSProperties = {
-    fontFamily: "ui-monospace, 'JetBrains Mono', Menlo, monospace",
-  };
   return (
     <div
       style={{
@@ -795,10 +779,6 @@ function ReleasingTodayPanel({
   releases: KioskRelease[];
   nowMs: number;
 }) {
-  const Mono: React.CSSProperties = {
-    fontFamily: "ui-monospace, 'JetBrains Mono', Menlo, monospace",
-  };
-
   return (
     <Panel C={C} epaper={epaper}>
       <PanelHeader
@@ -960,10 +940,6 @@ function UnwatchedQueuePanel({
   queue: KioskQueueItem[];
   nowMs: number;
 }) {
-  const Mono: React.CSSProperties = {
-    fontFamily: "ui-monospace, 'JetBrains Mono', Menlo, monospace",
-  };
-
   return (
     <Panel C={C} epaper={epaper}>
       <PanelHeader
@@ -1237,9 +1213,6 @@ export default function KioskPage() {
   const C = PALETTE[fidelity];
   const epaper = fidelity === "epaper";
   const breathe = fidelity === "rich";
-  const Mono: React.CSSProperties = {
-    fontFamily: "ui-monospace, 'JetBrains Mono', Menlo, monospace",
-  };
 
   const household = data?.meta.household ?? "";
   const refreshSec =

--- a/frontend/src/pages/LeaderboardPage.tsx
+++ b/frontend/src/pages/LeaderboardPage.tsx
@@ -101,18 +101,20 @@ export default function LeaderboardPage() {
     );
   }
 
+  const header = (
+    <div>
+      <div className="font-mono text-[11px] uppercase tracking-[0.15em] text-amber-400 font-semibold mb-1">
+        Leaderboard
+      </div>
+      <h1 className="text-2xl font-extrabold tracking-tight">Leaderboard</h1>
+      <p className="text-zinc-400 text-sm mt-1">Among people you follow</p>
+    </div>
+  );
+
   if (!entries || entries.length <= 1) {
     return (
       <div className="w-full max-w-2xl mx-auto space-y-6">
-        <div>
-          <div className="font-mono text-[11px] uppercase tracking-[0.15em] text-amber-400 font-semibold mb-1">
-            Leaderboard
-          </div>
-          <h1 className="text-2xl font-extrabold tracking-tight">
-            Leaderboard
-          </h1>
-          <p className="text-zinc-400 text-sm mt-1">Among people you follow</p>
-        </div>
+        {header}
         <div className="text-center py-12">
           <Trophy size={40} className="text-zinc-600 mx-auto mb-3" />
           <p className="text-zinc-400 mb-1">No rankings yet.</p>
@@ -133,13 +135,7 @@ export default function LeaderboardPage() {
 
   return (
     <div className="w-full max-w-2xl mx-auto space-y-6">
-      <div>
-        <div className="font-mono text-[11px] uppercase tracking-[0.15em] text-amber-400 font-semibold mb-1">
-          Leaderboard
-        </div>
-        <h1 className="text-2xl font-extrabold tracking-tight">Leaderboard</h1>
-        <p className="text-zinc-400 text-sm mt-1">Among people you follow</p>
-      </div>
+      {header}
 
       {/* Podium */}
       <div

--- a/frontend/src/pages/PrivacyPolicyPage.tsx
+++ b/frontend/src/pages/PrivacyPolicyPage.tsx
@@ -1,21 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router";
 import { PageHeader } from "../components/design";
-
-function Section({
-  title,
-  children,
-}: {
-  title: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <section className="space-y-3">
-      <h2 className="text-lg font-semibold text-zinc-100">{title}</h2>
-      {children}
-    </section>
-  );
-}
+import { LegalSection } from "../components/LegalSection";
 
 export default function PrivacyPolicyPage() {
   const { t } = useTranslation();
@@ -49,7 +35,7 @@ export default function PrivacyPolicyPage() {
           agree with this policy, please do not use the Service.
         </p>
 
-        <Section title="Information we collect">
+        <LegalSection title="Information we collect">
           <p>We collect the information needed to operate the Service:</p>
           <ul className="list-disc space-y-1 pl-5 marker:text-zinc-600">
             <li>
@@ -84,9 +70,9 @@ export default function PrivacyPolicyPage() {
               part of normal operation and used for security and debugging.
             </li>
           </ul>
-        </Section>
+        </LegalSection>
 
-        <Section title="Third-party data and services">
+        <LegalSection title="Third-party data and services">
           <p>
             Title, season, episode, and person metadata shown in the Service is
             sourced from{" "}
@@ -108,9 +94,9 @@ export default function PrivacyPolicyPage() {
             transmitted to those third-party services only when you enable them,
             and is then governed by their respective policies.
           </p>
-        </Section>
+        </LegalSection>
 
-        <Section title="How we use information">
+        <LegalSection title="How we use information">
           <p>We use the information we collect to:</p>
           <ul className="list-disc space-y-1 pl-5 marker:text-zinc-600">
             <li>provide, maintain, and secure the Service;</li>
@@ -121,9 +107,9 @@ export default function PrivacyPolicyPage() {
             <li>personalize discovery, recommendations, and statistics;</li>
             <li>diagnose problems and prevent abuse.</li>
           </ul>
-        </Section>
+        </LegalSection>
 
-        <Section title="How information is shared">
+        <LegalSection title="How information is shared">
           <p>
             We do not sell your personal information. Information is only
             exposed to others in the ways you choose:
@@ -142,43 +128,43 @@ export default function PrivacyPolicyPage() {
               protect the rights, safety, and integrity of the Service.
             </li>
           </ul>
-        </Section>
+        </LegalSection>
 
-        <Section title="Data retention and deletion">
+        <LegalSection title="Data retention and deletion">
           <p>
             We retain your information for as long as your account exists. You
             can delete your account, which removes your associated data, subject
             to backups and legal obligations. For deletion requests or
             questions, contact the operator using the details below.
           </p>
-        </Section>
+        </LegalSection>
 
-        <Section title="Security">
+        <LegalSection title="Security">
           <p>
             Authentication is handled with industry-standard libraries, and
             credentials are stored in hashed or tokenized form. No method of
             transmission or storage is completely secure, but we take reasonable
             measures to protect your information.
           </p>
-        </Section>
+        </LegalSection>
 
-        <Section title="Children">
+        <LegalSection title="Children">
           <p>
             The Service is not directed to children under the age required by
             applicable law in your jurisdiction, and we do not knowingly collect
             information from them.
           </p>
-        </Section>
+        </LegalSection>
 
-        <Section title="Changes to this policy">
+        <LegalSection title="Changes to this policy">
           <p>
             We may update this Privacy Policy from time to time. Material
             changes will be reflected by updating the &quot;last updated&quot;
             date above.
           </p>
-        </Section>
+        </LegalSection>
 
-        <Section title="Contact">
+        <LegalSection title="Contact">
           <p>
             Questions about this policy can be directed to us at{" "}
             <a
@@ -189,7 +175,7 @@ export default function PrivacyPolicyPage() {
             </a>
             .
           </p>
-        </Section>
+        </LegalSection>
 
         <p className="text-zinc-400">
           See also our{" "}

--- a/frontend/src/pages/TermsOfServicePage.tsx
+++ b/frontend/src/pages/TermsOfServicePage.tsx
@@ -1,21 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router";
 import { PageHeader } from "../components/design";
-
-function Section({
-  title,
-  children,
-}: {
-  title: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <section className="space-y-3">
-      <h2 className="text-lg font-semibold text-zinc-100">{title}</h2>
-      {children}
-    </section>
-  );
-}
+import { LegalSection } from "../components/LegalSection";
 
 export default function TermsOfServicePage() {
   const { t } = useTranslation();
@@ -42,25 +28,25 @@ export default function TermsOfServicePage() {
           whoever runs them.
         </p>
 
-        <Section title="1. Acceptance of terms">
+        <LegalSection title="1. Acceptance of terms">
           <p>
             By accessing or using the Remindarr service (the
             &quot;Service&quot;), operated by Remindarr, you agree to be bound
             by these Terms of Service. If you do not agree, do not use the
             Service.
           </p>
-        </Section>
+        </LegalSection>
 
-        <Section title="2. The service">
+        <LegalSection title="2. The service">
           <p>
             Remindarr is an application for tracking streaming media releases.
             It lets you track titles, record watch history and ratings, and
             receive reminders about upcoming releases. Features may change over
             time.
           </p>
-        </Section>
+        </LegalSection>
 
-        <Section title="3. Accounts">
+        <LegalSection title="3. Accounts">
           <p>
             You are responsible for maintaining the confidentiality of your
             account credentials and for all activity that occurs under your
@@ -68,9 +54,9 @@ export default function TermsOfServicePage() {
             must provide accurate information and meet any minimum age required
             by applicable law.
           </p>
-        </Section>
+        </LegalSection>
 
-        <Section title="4. Acceptable use">
+        <LegalSection title="4. Acceptable use">
           <p>You agree not to:</p>
           <ul className="list-disc space-y-1 pl-5 marker:text-zinc-600">
             <li>use the Service for any unlawful purpose;</li>
@@ -83,9 +69,9 @@ export default function TermsOfServicePage() {
             </li>
             <li>interfere with other users&apos; use of the Service.</li>
           </ul>
-        </Section>
+        </LegalSection>
 
-        <Section title="5. Your content">
+        <LegalSection title="5. Your content">
           <p>
             You retain ownership of the content you create, such as ratings,
             tags, and profile details. You grant the operator a limited license
@@ -93,9 +79,9 @@ export default function TermsOfServicePage() {
             Service, including to other users in accordance with your visibility
             and sharing settings.
           </p>
-        </Section>
+        </LegalSection>
 
-        <Section title="6. Third-party services">
+        <LegalSection title="6. Third-party services">
           <p>
             Title metadata is provided by{" "}
             <a
@@ -111,9 +97,9 @@ export default function TermsOfServicePage() {
             Discord, Telegram, or Gotify) are operated by third parties and
             governed by their own terms.
           </p>
-        </Section>
+        </LegalSection>
 
-        <Section title="7. Disclaimers">
+        <LegalSection title="7. Disclaimers">
           <p>
             The Service is provided on an &quot;as is&quot; and &quot;as
             available&quot; basis, without warranties of any kind, whether
@@ -122,43 +108,43 @@ export default function TermsOfServicePage() {
             will be uninterrupted, error-free, or that any data will be
             preserved.
           </p>
-        </Section>
+        </LegalSection>
 
-        <Section title="8. Limitation of liability">
+        <LegalSection title="8. Limitation of liability">
           <p>
             To the maximum extent permitted by law, the operator shall not be
             liable for any indirect, incidental, special, consequential, or
             punitive damages, or any loss of data, arising out of or related to
             your use of the Service.
           </p>
-        </Section>
+        </LegalSection>
 
-        <Section title="9. Termination">
+        <LegalSection title="9. Termination">
           <p>
             You may stop using the Service and delete your account at any time.
             The operator may suspend or terminate access to the Service for
             conduct that violates these Terms or that may harm the Service or
             other users.
           </p>
-        </Section>
+        </LegalSection>
 
-        <Section title="10. Changes to these terms">
+        <LegalSection title="10. Changes to these terms">
           <p>
             We may update these Terms from time to time. Material changes will
             be reflected by updating the &quot;last updated&quot; date above.
             Continued use of the Service after changes take effect constitutes
             acceptance of the revised Terms.
           </p>
-        </Section>
+        </LegalSection>
 
-        <Section title="11. Governing law">
+        <LegalSection title="11. Governing law">
           <p>
             These Terms are governed by the laws of the Republic of Croatia,
             without regard to its conflict of law provisions.
           </p>
-        </Section>
+        </LegalSection>
 
-        <Section title="12. Contact">
+        <LegalSection title="12. Contact">
           <p>
             Questions about these Terms can be directed to us at{" "}
             <a
@@ -169,7 +155,7 @@ export default function TermsOfServicePage() {
             </a>
             .
           </p>
-        </Section>
+        </LegalSection>
 
         <p className="text-zinc-400">
           See also our{" "}

--- a/frontend/src/pages/settings/AdminTab.tsx
+++ b/frontend/src/pages/settings/AdminTab.tsx
@@ -53,22 +53,12 @@ function BootstrapFreshnessBadge({
   lastSeenAt: string | null;
 }) {
   const mins = minutesSince(lastSeenAt);
-  let kind: "ok" | "amber" | "error" | "neutral";
-  let label: string;
   if (mins === null) {
-    kind = "error";
-    label = "Bootstrap: Never";
-  } else if (mins <= 10) {
-    kind = "ok";
-    label = `Bootstrap: ${mins}m ago`;
-  } else if (mins <= 30) {
-    kind = "amber";
-    label = `Bootstrap: ${mins}m ago`;
-  } else {
-    kind = "error";
-    label = `Bootstrap: ${mins}m ago`;
+    return <SStatusPill kind="error">Bootstrap: Never</SStatusPill>;
   }
-  return <SStatusPill kind={kind}>{label}</SStatusPill>;
+  const kind: "ok" | "amber" | "error" | "neutral" =
+    mins <= 10 ? "ok" : mins <= 30 ? "amber" : "error";
+  return <SStatusPill kind={kind}>{`Bootstrap: ${mins}m ago`}</SStatusPill>;
 }
 
 function AlarmFreshnessBadge({
@@ -79,23 +69,13 @@ function AlarmFreshnessBadge({
   cron: string;
 }) {
   const mins = minutesSince(alarmLastCompletedAt);
-  const interval = cronIntervalMinutes(cron);
-  let kind: "ok" | "amber" | "error" | "neutral";
-  let label: string;
   if (mins === null) {
-    kind = "neutral";
-    label = "Alarm: Never";
-  } else if (mins <= interval * 2) {
-    kind = "ok";
-    label = `Alarm: ${mins}m ago`;
-  } else if (mins <= interval * 4) {
-    kind = "amber";
-    label = `Alarm: ${mins}m ago`;
-  } else {
-    kind = "error";
-    label = `Alarm: ${mins}m ago`;
+    return <SStatusPill kind="neutral">Alarm: Never</SStatusPill>;
   }
-  return <SStatusPill kind={kind}>{label}</SStatusPill>;
+  const interval = cronIntervalMinutes(cron);
+  const kind: "ok" | "amber" | "error" | "neutral" =
+    mins <= interval * 2 ? "ok" : mins <= interval * 4 ? "amber" : "error";
+  return <SStatusPill kind={kind}>{`Alarm: ${mins}m ago`}</SStatusPill>;
 }
 
 function BackgroundJobsSection() {

--- a/server/db/migrate-auth.ts
+++ b/server/db/migrate-auth.ts
@@ -98,18 +98,11 @@ export async function migrateAuthData(): Promise<void> {
       }
     }
 
-    // Set role from is_admin
+    // Set role from is_admin; populate name from username if missing
     const role = user.isAdmin ? "admin" : "user";
-    if (!user.name && user.username) {
-      // Populate name from username if missing
-      await db
-        .update(users)
-        .set({ role, name: user.username })
-        .where(eq(users.id, user.id))
-        .run();
-    } else {
-      await db.update(users).set({ role }).where(eq(users.id, user.id)).run();
-    }
+    const set =
+      !user.name && user.username ? { role, name: user.username } : { role };
+    await db.update(users).set(set).where(eq(users.id, user.id)).run();
     rolesSet++;
   }
 

--- a/server/db/repository/profile.ts
+++ b/server/db/repository/profile.ts
@@ -354,28 +354,14 @@ export async function getActivitySettings(userId: string): Promise<{
 }> {
   return traceDbQuery("getActivitySettings", async () => {
     const db = getDb();
-    const [userRow, kindRows] = await Promise.all([
+    const [userRow, kind_visibility] = await Promise.all([
       db
         .select({ activity_stream_enabled: users.activityStreamEnabled })
         .from(users)
         .where(eq(users.id, userId))
         .get(),
-      db
-        .select({
-          kind: activityKindVisibility.kind,
-          visibility: activityKindVisibility.visibility,
-        })
-        .from(activityKindVisibility)
-        .where(eq(activityKindVisibility.userId, userId))
-        .all(),
+      getActivityKindVisibilityMap(userId),
     ]);
-    const kind_visibility: ActivityKindVisibilityMap = {};
-    for (const row of kindRows) {
-      kind_visibility[row.kind as ActivityType] = row.visibility as
-        | "public"
-        | "friends_only"
-        | "private";
-    }
     return {
       enabled: Boolean(userRow?.activity_stream_enabled),
       kind_visibility,

--- a/server/db/repository/recommendations.ts
+++ b/server/db/repository/recommendations.ts
@@ -1,4 +1,5 @@
 import { eq, and, sql, desc, count, inArray, isNull, or } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
 import { getDb } from "../schema";
 import {
   recommendations,
@@ -8,6 +9,35 @@ import {
   follows,
 } from "../schema";
 import { traceDbQuery } from "../../tracing";
+
+/**
+ * Builds the visibility filter for a user's discovery feed.
+ *
+ * A recommendation is visible if:
+ *   a) it is directly targeted at this user, OR
+ *   b) it is a broadcast (no target) from someone the user follows
+ */
+async function buildVisibilityCondition(userId: string): Promise<SQL> {
+  const db = getDb();
+  // Get IDs of users the current user follows
+  const followedUsers = await db
+    .select({ id: follows.followingId })
+    .from(follows)
+    .where(eq(follows.followerId, userId))
+    .all();
+
+  const followedIds = followedUsers.map((u) => u.id);
+
+  return followedIds.length === 0
+    ? eq(recommendations.targetUserId, userId)
+    : or(
+        eq(recommendations.targetUserId, userId),
+        and(
+          isNull(recommendations.targetUserId),
+          inArray(recommendations.fromUserId, followedIds),
+        ),
+      )!;
+}
 
 export async function createRecommendation(
   fromUserId: string,
@@ -60,28 +90,7 @@ export async function getUserRecommendation(
 export async function getDiscoveryFeed(userId: string, limit = 20, offset = 0) {
   return traceDbQuery("getDiscoveryFeed", async () => {
     const db = getDb();
-    // Get IDs of users the current user follows
-    const followedUsers = await db
-      .select({ id: follows.followingId })
-      .from(follows)
-      .where(eq(follows.followerId, userId))
-      .all();
-
-    const followedIds = followedUsers.map((u) => u.id);
-
-    // A recommendation is visible if:
-    //   a) it is directly targeted at this user, OR
-    //   b) it is a broadcast (no target) from someone the user follows
-    const visibilityCondition =
-      followedIds.length === 0
-        ? eq(recommendations.targetUserId, userId)
-        : or(
-            eq(recommendations.targetUserId, userId),
-            and(
-              isNull(recommendations.targetUserId),
-              inArray(recommendations.fromUserId, followedIds),
-            ),
-          );
+    const visibilityCondition = await buildVisibilityCondition(userId);
 
     return await db
       .select({
@@ -120,24 +129,7 @@ export async function getDiscoveryFeed(userId: string, limit = 20, offset = 0) {
 export async function getDiscoveryFeedCount(userId: string): Promise<number> {
   return traceDbQuery("getDiscoveryFeedCount", async () => {
     const db = getDb();
-    const followedUsers = await db
-      .select({ id: follows.followingId })
-      .from(follows)
-      .where(eq(follows.followerId, userId))
-      .all();
-
-    const followedIds = followedUsers.map((u) => u.id);
-
-    const visibilityCondition =
-      followedIds.length === 0
-        ? eq(recommendations.targetUserId, userId)
-        : or(
-            eq(recommendations.targetUserId, userId),
-            and(
-              isNull(recommendations.targetUserId),
-              inArray(recommendations.fromUserId, followedIds),
-            ),
-          );
+    const visibilityCondition = await buildVisibilityCondition(userId);
 
     const row = await db
       .select({ count: count() })
@@ -215,25 +207,7 @@ export async function deleteRecommendation(id: string, userId: string) {
 export async function getUnreadCount(userId: string): Promise<number> {
   return traceDbQuery("getUnreadRecommendationCount", async () => {
     const db = getDb();
-    // Get IDs of users the current user follows
-    const followedUsers = await db
-      .select({ id: follows.followingId })
-      .from(follows)
-      .where(eq(follows.followerId, userId))
-      .all();
-
-    const followedIds = followedUsers.map((u) => u.id);
-
-    const visibilityCondition =
-      followedIds.length === 0
-        ? eq(recommendations.targetUserId, userId)
-        : or(
-            eq(recommendations.targetUserId, userId),
-            and(
-              isNull(recommendations.targetUserId),
-              inArray(recommendations.fromUserId, followedIds),
-            ),
-          );
+    const visibilityCondition = await buildVisibilityCondition(userId);
 
     const row = await db
       .select({ count: count() })

--- a/server/jobs/backfill-achievements.ts
+++ b/server/jobs/backfill-achievements.ts
@@ -106,12 +106,8 @@ export async function runBackfillAchievements(
                   windowHours,
                   c.title_id,
                 );
-                if (r.earned) {
-                  anyEarned = true;
-                  maxProgress = Math.max(maxProgress, r.progress);
-                } else {
-                  maxProgress = Math.max(maxProgress, r.progress);
-                }
+                if (r.earned) anyEarned = true;
+                maxProgress = Math.max(maxProgress, r.progress);
               }
 
               result = { progress: maxProgress, earned: anyEarned };

--- a/server/jobs/durable-object.ts
+++ b/server/jobs/durable-object.ts
@@ -17,6 +17,7 @@ import { MemoryCache } from "../cache/memory";
 import { logger, resetLogLevel } from "../logger";
 import Sentry from "../sentry";
 import { handlers } from "./processor";
+import { nextRetryAt } from "./time-utils";
 import { patchConfig, cfEnvToConfigOverrides } from "../config";
 import type { CfConfigEnv } from "../config";
 import type { DrizzleDb } from "../platform/types";
@@ -392,8 +393,7 @@ export class JobQueueDO {
 
       if (newAttempts < job.max_attempts) {
         // Exponential backoff: 2^attempts × 30 s — mirrors processor.ts
-        const delaySec = Math.pow(2, newAttempts) * 30;
-        const retryAt = new Date(Date.now() + delaySec * 1000).toISOString();
+        const retryAt = nextRetryAt(newAttempts);
         this.ctx.storage.sql.exec(
           "UPDATE jobs SET status = 'pending', error = ?, run_at = ? WHERE id = ?",
           message,

--- a/server/jobs/processor.ts
+++ b/server/jobs/processor.ts
@@ -30,7 +30,7 @@ import { buildTrendingSnapshot, trendingCacheKey } from "../routes/trending";
 import { getProvider } from "../notifications/registry";
 import { buildNotificationContent } from "../notifications/content";
 import { SubscriptionExpiredError } from "../notifications/webpush";
-import { getCurrentTimeInTimezone } from "./time-utils";
+import { getCurrentTimeInTimezone, nextRetryAt } from "./time-utils";
 import {
   listEarnedSince,
   markAchievementsNotified,
@@ -684,8 +684,7 @@ export async function processPendingJobs(): Promise<number> {
 
       if (newAttempts < job.maxAttempts) {
         // Re-queue with exponential backoff: 2^attempts * 30 seconds
-        const delaySec = Math.pow(2, newAttempts) * 30;
-        const retryAt = new Date(Date.now() + delaySec * 1000).toISOString();
+        const retryAt = nextRetryAt(newAttempts);
         await db
           .update(jobs)
           .set({ status: "pending", error: message, runAt: retryAt })

--- a/server/jobs/queue.ts
+++ b/server/jobs/queue.ts
@@ -1,6 +1,7 @@
 import { CronExpressionParser } from "cron-parser";
 import { getRawDb } from "../db/bun-db";
 import { logger } from "../logger";
+import { nextRetryDelaySec } from "./time-utils";
 
 const log = logger.child({ module: "jobs" });
 
@@ -99,7 +100,7 @@ export function failJob(id: number, error: string) {
 
   if (job && job.attempts < job.max_attempts) {
     // Re-queue with exponential backoff: 2^attempts * 30 seconds
-    const delaySec = Math.pow(2, job.attempts) * 30;
+    const delaySec = nextRetryDelaySec(job.attempts);
     db.prepare(
       `UPDATE jobs SET status = 'pending', error = ?,
        run_at = datetime('now', '+' || ? || ' seconds')

--- a/server/jobs/time-utils.ts
+++ b/server/jobs/time-utils.ts
@@ -21,41 +21,48 @@ export function getCurrentTimeInTimezone(
     return ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].indexOf(weekday);
   }
 
+  // Validate the timezone once; fall back to UTC if it is invalid so that
+  // time, date, and dayOfWeek all use the same (valid) zone.
+  let zone = "UTC";
   try {
-    const timeFormatter = new Intl.DateTimeFormat("en-GB", {
-      timeZone: tz,
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    });
-    const dateFormatter = new Intl.DateTimeFormat("en-CA", {
-      timeZone: tz,
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-    });
-    return {
-      time: timeFormatter.format(now),
-      date: dateFormatter.format(now),
-      dayOfWeek: dayOfWeekInTz(tz),
-    };
+    new Intl.DateTimeFormat("en-GB", { timeZone: tz });
+    zone = tz;
   } catch {
-    const timeFormatter = new Intl.DateTimeFormat("en-GB", {
-      timeZone: "UTC",
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    });
-    const dateFormatter = new Intl.DateTimeFormat("en-CA", {
-      timeZone: "UTC",
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-    });
-    return {
-      time: timeFormatter.format(now),
-      date: dateFormatter.format(now),
-      dayOfWeek: dayOfWeekInTz("UTC"),
-    };
+    zone = "UTC";
   }
+
+  const timeFormatter = new Intl.DateTimeFormat("en-GB", {
+    timeZone: zone,
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  const dateFormatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: zone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  return {
+    time: timeFormatter.format(now),
+    date: dateFormatter.format(now),
+    dayOfWeek: dayOfWeekInTz(zone),
+  };
+}
+
+/**
+ * Exponential-backoff retry delay in seconds: `2^attempts × 30`.
+ * Shared by the Bun queue, the portable processor, and the CF Durable Object.
+ */
+export function nextRetryDelaySec(attempts: number): number {
+  return Math.pow(2, attempts) * 30;
+}
+
+/**
+ * ISO-8601 timestamp `nextRetryDelaySec(attempts)` seconds from now.
+ */
+export function nextRetryAt(attempts: number): string {
+  return new Date(
+    Date.now() + nextRetryDelaySec(attempts) * 1000,
+  ).toISOString();
 }

--- a/server/notifications/content.ts
+++ b/server/notifications/content.ts
@@ -3,7 +3,68 @@ import {
   getTrackedMoviesByReleaseDate,
   getTrackedMoviesByReleaseDateRange,
 } from "../db/repository";
-import type { NotificationContent } from "./types";
+import type {
+  NotificationContent,
+  NotificationEpisode,
+  NotificationMovie,
+} from "./types";
+
+type RawEpisode = Awaited<ReturnType<typeof getEpisodesByDateRange>>[number];
+type RawMovie = Awaited<
+  ReturnType<typeof getTrackedMoviesByReleaseDate>
+>[number];
+
+/**
+ * Filters out snoozed/muted episodes and maps the rest to notification shape.
+ * `now` is passed in so callers share a single timestamp.
+ */
+function mapEpisodes(
+  rawEpisodes: RawEpisode[],
+  now: Date,
+): NotificationEpisode[] {
+  return rawEpisodes
+    .filter((ep) => {
+      // Skip snoozed titles
+      if (ep.snooze_until && new Date(ep.snooze_until) > now) return false;
+      const mode = ep.notification_mode;
+      if (mode === "none") return false;
+      if (mode === "premieres_only") return ep.episode_number === 1;
+      return true; // "all" or null
+    })
+    .map((ep) => ({
+      showTitle: ep.show_title,
+      seasonNumber: ep.season_number,
+      episodeNumber: ep.episode_number,
+      episodeName: ep.name,
+      posterUrl: ep.poster_url,
+      offers: (ep.offers || []).map((o) => ({
+        providerName: o.provider_name,
+        providerIconUrl: o.provider_icon_url,
+      })),
+    }));
+}
+
+/**
+ * Filters out snoozed movies and maps the rest to notification shape.
+ * `now` is passed in so callers share a single timestamp.
+ */
+function mapMovies(rawMovies: RawMovie[], now: Date): NotificationMovie[] {
+  return rawMovies
+    .filter((m) => {
+      // Skip snoozed titles
+      if (m.snooze_until && new Date(m.snooze_until) > now) return false;
+      return true;
+    })
+    .map((m) => ({
+      title: m.title,
+      releaseYear: m.release_year,
+      posterUrl: m.poster_url,
+      offers: (m.offers || []).map((o) => ({
+        providerName: o.provider_name,
+        providerIconUrl: o.provider_icon_url,
+      })),
+    }));
+}
 
 /**
  * Formats a human-readable "leaving" copy for departure alerts.
@@ -44,44 +105,11 @@ export async function buildNotificationContent(
 
   // Episodes airing today for tracked shows
   const rawEpisodes = await getEpisodesByDateRange(date, nextDay, userId);
-  const episodes = rawEpisodes
-    .filter((ep) => {
-      // Skip snoozed titles
-      if (ep.snooze_until && new Date(ep.snooze_until) > now) return false;
-      const mode = ep.notification_mode;
-      if (mode === "none") return false;
-      if (mode === "premieres_only") return ep.episode_number === 1;
-      return true; // "all" or null
-    })
-    .map((ep) => ({
-      showTitle: ep.show_title,
-      seasonNumber: ep.season_number,
-      episodeNumber: ep.episode_number,
-      episodeName: ep.name,
-      posterUrl: ep.poster_url,
-      offers: (ep.offers || []).map((o) => ({
-        providerName: o.provider_name,
-        providerIconUrl: o.provider_icon_url,
-      })),
-    }));
+  const episodes = mapEpisodes(rawEpisodes, now);
 
   // Tracked movies releasing today
   const rawMovies = await getTrackedMoviesByReleaseDate(date, userId);
-  const movies = rawMovies
-    .filter((m) => {
-      // Skip snoozed titles
-      if (m.snooze_until && new Date(m.snooze_until) > now) return false;
-      return true;
-    })
-    .map((m) => ({
-      title: m.title,
-      releaseYear: m.release_year,
-      posterUrl: m.poster_url,
-      offers: (m.offers || []).map((o) => ({
-        providerName: o.provider_name,
-        providerIconUrl: o.provider_icon_url,
-      })),
-    }));
+  const movies = mapMovies(rawMovies, now);
 
   return { episodes, movies, date };
 }
@@ -99,26 +127,7 @@ export async function buildWeeklyDigestContent(
 
   // Episodes airing in the range for tracked shows
   const rawEpisodes = await getEpisodesByDateRange(startDate, endDate, userId);
-  const episodes = rawEpisodes
-    .filter((ep) => {
-      // Skip snoozed titles
-      if (ep.snooze_until && new Date(ep.snooze_until) > now) return false;
-      const mode = ep.notification_mode;
-      if (mode === "none") return false;
-      if (mode === "premieres_only") return ep.episode_number === 1;
-      return true; // "all" or null
-    })
-    .map((ep) => ({
-      showTitle: ep.show_title,
-      seasonNumber: ep.season_number,
-      episodeNumber: ep.episode_number,
-      episodeName: ep.name,
-      posterUrl: ep.poster_url,
-      offers: (ep.offers || []).map((o) => ({
-        providerName: o.provider_name,
-        providerIconUrl: o.provider_icon_url,
-      })),
-    }));
+  const episodes = mapEpisodes(rawEpisodes, now);
 
   // Tracked movies releasing in the range
   const rawMovies = await getTrackedMoviesByReleaseDateRange(
@@ -126,21 +135,7 @@ export async function buildWeeklyDigestContent(
     endDate,
     userId,
   );
-  const movies = rawMovies
-    .filter((m) => {
-      // Skip snoozed titles
-      if (m.snooze_until && new Date(m.snooze_until) > now) return false;
-      return true;
-    })
-    .map((m) => ({
-      title: m.title,
-      releaseYear: m.release_year,
-      posterUrl: m.poster_url,
-      offers: (m.offers || []).map((o) => ({
-        providerName: o.provider_name,
-        providerIconUrl: o.provider_icon_url,
-      })),
-    }));
+  const movies = mapMovies(rawMovies, now);
 
   return { episodes, movies, date: startDate };
 }

--- a/server/routes/notifiers.ts
+++ b/server/routes/notifiers.ts
@@ -14,6 +14,7 @@ import {
 } from "../db/repository";
 import { getProvider, getAvailableProviders } from "../notifications/registry";
 import { buildNotificationContent } from "../notifications/content";
+import type { NotificationContent } from "../notifications/types";
 import { refreshNotificationSchedule } from "../jobs/schedule";
 import { getVapidPublicKey } from "../notifications/vapid";
 import { SubscriptionExpiredError } from "../notifications/webpush";
@@ -30,6 +31,38 @@ function isValidTimezone(tz: string): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Builds today's digest content for a notifier preview / test.
+ * Falls back to a single sample episode when nothing is releasing today,
+ * so the test/preview always renders something meaningful.
+ */
+async function buildPreviewContent(
+  userId: string,
+  today: string,
+): Promise<NotificationContent> {
+  const content = await buildNotificationContent(userId, today);
+
+  // If nothing is releasing today, send sample content
+  if (content.episodes.length === 0 && content.movies.length === 0) {
+    return {
+      date: today,
+      episodes: [
+        {
+          showTitle: "Sample Show",
+          seasonNumber: 1,
+          episodeNumber: 1,
+          episodeName: "Pilot",
+          posterUrl: null,
+          offers: [{ providerName: "Netflix", providerIconUrl: null }],
+        },
+      ],
+      movies: [],
+    };
+  }
+
+  return content;
 }
 
 const HHMM = /^([01]\d|2[0-3]):[0-5]\d$/;
@@ -319,25 +352,7 @@ app.post("/:id/test", async (c) => {
   }
 
   const today = new Date().toISOString().slice(0, 10);
-  let content = await buildNotificationContent(user.id, today);
-
-  // If nothing is releasing today, send sample content
-  if (content.episodes.length === 0 && content.movies.length === 0) {
-    content = {
-      date: today,
-      episodes: [
-        {
-          showTitle: "Sample Show",
-          seasonNumber: 1,
-          episodeNumber: 1,
-          episodeName: "Pilot",
-          posterUrl: null,
-          offers: [{ providerName: "Netflix", providerIconUrl: null }],
-        },
-      ],
-      movies: [],
-    };
-  }
+  const content = await buildPreviewContent(user.id, today);
 
   const start = Date.now();
   try {
@@ -376,24 +391,7 @@ app.get("/:id/preview", requireAuth, async (c) => {
   }
 
   const today = new Date().toISOString().slice(0, 10);
-  let content = await buildNotificationContent(user.id, today);
-
-  if (content.episodes.length === 0 && content.movies.length === 0) {
-    content = {
-      date: today,
-      episodes: [
-        {
-          showTitle: "Sample Show",
-          seasonNumber: 1,
-          episodeNumber: 1,
-          episodeName: "Pilot",
-          posterUrl: null,
-          offers: [{ providerName: "Netflix", providerIconUrl: null }],
-        },
-      ],
-      movies: [],
-    };
-  }
+  const content = await buildPreviewContent(user.id, today);
 
   return c.json(content);
 });


### PR DESCRIPTION
Part of the over-engineering cleanup epic (#1049). Collapses multi-line blocks duplicated verbatim into shared helpers/components. All behavior-preserving.

## Done (13 of 14)
- **recommendations.ts** — `buildVisibilityCondition(userId)` replaces the 3 copy-pasted followed-IDs + visibility-OR blocks.
- **notifications/content.ts** — `mapEpisodes`/`mapMovies` shared by `buildNotificationContent` and `buildWeeklyDigestContent`.
- **jobs/time-utils.ts** — `getCurrentTimeInTimezone` validates the tz once and falls back to UTC, instead of a try/catch whose catch was a verbatim UTC copy.
- **backoff math** — `nextRetryDelaySec`/`nextRetryAt` in `time-utils`, reused by `durable-object`, `processor`, `queue` (queue keeps `job.attempts`, not `+1`).
- **notifiers.ts** — `buildPreviewContent(userId, today)` shared by `POST /:id/test` and `GET /:id/preview`.
- **TitleCard.tsx** — `ProgressBar`/`EpCount` reused across the 3 progress sites (per-site `?? 1`/`?? 0` fallbacks preserved at call sites).
- **AdminTab.tsx** — freshness badges compute the `${mins}m ago` label once; `kind` from thresholds.
- **Legal pages** — shared `LegalSection` component; Terms + Privacy import it.
- **LeaderboardPage.tsx** — header hoisted into one JSX const.
- **profile.ts** — `getActivitySettings` reuses `getActivityKindVisibilityMap`.
- **migrate-auth.ts** — single conditional `set` object.
- **backfill-achievements.ts** — collapsed if/else where both arms ran the same `Math.max`.
- **KioskPage.tsx / DiscoveryPage.tsx** — `Mono` declared once at module scope; `rich`/`lite` share one `DARK_PALETTE`; `becausePrefix` shared by `becauseLabel` and the inline hero label.

## Deliberately skipped
- **`HeroCard`/`HeroFeatured` merge (KioskPage)** — beyond the documented "Airing now" kicker + blink-dot, the kicker **separator semantics differ** (one always renders a trailing separator when the provider is empty, the other doesn't) and the blink `animation` exists only in `HeroCard`. The KioskPage test asserts text only, so a ~170-line visual-component merge can't be verified behavior-preserving here. Belongs in its own visually-reviewed PR.
- **`SuggestionCard` Track/Dismiss button-pair collapse** — the buttons differ by className, label **and** handler; collapsing needs a fully-parameterized button and wouldn't meaningfully reduce code while hurting readability.

`bun run check` passes locally.

Closes #1047