### PR TITLE
refactor: remove speculative flexibility & one-call abstractions (#1048)

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -82,12 +82,6 @@ async function fetchBlob(
   return doFetch(url, { credentials: "include", ...options });
 }
 
-/** Posts multipart form data and parses the JSON response. */
-async function fetchForm<T>(url: string, form: FormData): Promise<T> {
-  const res = await doFetch(url, { method: "POST", body: form });
-  return res.json();
-}
-
 export async function getTitles(
   params: {
     daysBack?: number;
@@ -255,7 +249,8 @@ export async function importCsv(file: File): Promise<{
 }> {
   const form = new FormData();
   form.append("file", file);
-  return fetchForm("/import/csv", form);
+  const res = await doFetch("/import/csv", { method: "POST", body: form });
+  return res.json();
 }
 
 // ─── User Profile ──────────────────────────────────────────────────────────

--- a/frontend/src/components/AgendaCalendar.tsx
+++ b/frontend/src/components/AgendaCalendar.tsx
@@ -85,12 +85,6 @@ export function pickFeaturedItem(items: CalendarItem[]): CalendarItem | null {
   return items[0];
 }
 
-/** Get poster URL for a calendar item (show poster for episodes, title poster for movies) */
-export function getItemPosterUrl(item: CalendarItem): string | null {
-  if (item.type === "episode") return item.data.poster_url;
-  return item.data.poster_url;
-}
-
 /** Determine cell border color based on item types */
 export function getCellBorderColor(items: CalendarItem[]): string {
   const hasEpisodes = items.some((i) => i.type === "episode");
@@ -243,7 +237,7 @@ const DayHeader = memo(function DayHeader({
   isToday: boolean;
 }) {
   const featured = pickFeaturedItem(items);
-  const posterUrl = featured ? getItemPosterUrl(featured) : null;
+  const posterUrl = featured ? featured.data.poster_url : null;
 
   return (
     <div

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -19,10 +19,9 @@ const VALID_THEMES: Theme[] = [
   "plum",
   "auto",
 ];
-const BASE_THEMES: Theme[] = [...VALID_THEMES];
 
 export function isValidTheme(value: string | null): value is Theme {
-  return BASE_THEMES.includes(value as Theme);
+  return VALID_THEMES.includes(value as Theme);
 }
 
 /** Resolves "auto" to dark or light based on prefers-color-scheme. */

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -41,6 +41,13 @@ import TrendingSection from "../components/TrendingSection";
 import { MediaCard } from "../components/MediaCard";
 import type { UpNextItem, MovieTrackResponse } from "../api";
 
+// Module-scope stable empty defaults so downstream memo/effect deps don't see
+// a fresh [] each render when authData is absent.
+const EMPTY_EPISODES: Episode[] = [];
+const EMPTY_RECOMMENDATIONS: Recommendation[] = [];
+const EMPTY_UP_NEXT_ITEMS: UpNextItem[] = [];
+const EMPTY_FRIENDS_LOVED_ITEMS: FriendsLovedItem[] = [];
+
 export interface UnwatchedCardEntry {
   episode: Episode;
   totalEpisodeCount: number;
@@ -604,36 +611,14 @@ export default function HomePage() {
     [confirmingTitleId, markAllWatchedMutation],
   );
 
-  const {
-    today,
-    upcoming,
-    unwatched,
-    recommendations,
-    layout,
-    upNextItems,
-    friendsLovedItems,
-  } = useMemo(() => {
-    if (authData) {
-      return {
-        today: authData.today,
-        upcoming: authData.upcoming,
-        unwatched: authData.unwatched,
-        recommendations: authData.recommendations,
-        layout: authData.layout,
-        upNextItems: authData.upNextItems,
-        friendsLovedItems: authData.friendsLovedItems,
-      };
-    }
-    return {
-      today: [] as Episode[],
-      upcoming: [] as Episode[],
-      unwatched: [] as Episode[],
-      recommendations: [] as Recommendation[],
-      layout: DEFAULT_HOMEPAGE_LAYOUT,
-      upNextItems: [] as UpNextItem[],
-      friendsLovedItems: [] as FriendsLovedItem[],
-    };
-  }, [authData]);
+  const today = authData?.today ?? EMPTY_EPISODES;
+  const upcoming = authData?.upcoming ?? EMPTY_EPISODES;
+  const unwatched = authData?.unwatched ?? EMPTY_EPISODES;
+  const recommendations = authData?.recommendations ?? EMPTY_RECOMMENDATIONS;
+  const layout = authData?.layout ?? DEFAULT_HOMEPAGE_LAYOUT;
+  const upNextItems = authData?.upNextItems ?? EMPTY_UP_NEXT_ITEMS;
+  const friendsLovedItems =
+    authData?.friendsLovedItems ?? EMPTY_FRIENDS_LOVED_ITEMS;
 
   const streakData = authData?.streakData ?? null;
   const movieData = authData?.movieData ?? { to_watch: [], upcoming: [] };

--- a/frontend/src/pages/SeasonDetailPage.tsx
+++ b/frontend/src/pages/SeasonDetailPage.tsx
@@ -273,6 +273,9 @@ export default function SeasonDetailPage() {
   const releasedWithStatus = episodes.filter(
     (ep) => isReleased(ep.air_date) && statusMap.has(ep.episode_number),
   );
+  const watchedCount = releasedWithStatus.filter(
+    (ep) => statusMap.get(ep.episode_number)?.is_watched,
+  ).length;
   const allReleasedWatched =
     hasStatus &&
     releasedWithStatus.length > 0 &&
@@ -390,17 +393,8 @@ export default function SeasonDetailPage() {
             <div className="flex items-center gap-4">
               {hasStatus && releasedWithStatus.length > 0 && (
                 <span className="text-[11px] font-mono text-zinc-500 tracking-wide whitespace-nowrap">
-                  {
-                    releasedWithStatus.filter(
-                      (ep) => statusMap.get(ep.episode_number)?.is_watched,
-                    ).length
-                  }{" "}
-                  of {episodes.length} watched ·{" "}
-                  {episodes.length -
-                    releasedWithStatus.filter(
-                      (ep) => statusMap.get(ep.episode_number)?.is_watched,
-                    ).length}{" "}
-                  remaining
+                  {watchedCount} of {episodes.length} watched ·{" "}
+                  {episodes.length - watchedCount} remaining
                 </span>
               )}
               {hasStatus &&

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -60,16 +60,9 @@ export default function SettingsPage() {
     );
   }
 
-  const TABS = [
-    { value: "account", label: t("settings.tabs.account") },
-    { value: "appearance", label: t("settings.tabs.appearance") },
-    { value: "subscriptions", label: t("settings.tabs.subscriptions") },
-    { value: "notifications", label: t("settings.tabs.notifications") },
-    { value: "integrations", label: t("settings.tabs.integrations") },
-    ...(user.is_admin
-      ? [{ value: "admin", label: t("settings.tabs.admin") }]
-      : []),
-  ];
+  const TABS = VALID_TABS.filter(
+    (value) => value !== "admin" || user.is_admin,
+  ).map((value) => ({ value, label: t(`settings.tabs.${value}`) }));
 
   const breadcrumbLabel =
     TABS.find((x) => x.value === activeTab)?.label ?? activeTab;

--- a/frontend/src/pages/TrackedPage.tsx
+++ b/frontend/src/pages/TrackedPage.tsx
@@ -184,10 +184,10 @@ export default function TrackedPage() {
   const toggleSelectMode = useCallback(() => {
     if (selectMode) {
       exitSelectMode();
-    } else {
-      setSelectMode(true);
-      setSelectedIds(new Set());
+      return;
     }
+    setSelectMode(true);
+    setSelectedIds(new Set());
   }, [selectMode, exitSelectMode]);
 
   // Ctrl/Cmd+A selects all visible titles when in select mode

--- a/frontend/src/pages/settings/AccountTab.tsx
+++ b/frontend/src/pages/settings/AccountTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useReducer } from "react";
+import { useState, useEffect } from "react";
 import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -314,97 +314,62 @@ interface PasskeyItem {
   createdAt: string | Date | null;
 }
 
-type PasskeyState = {
-  status: "loading" | "idle" | "adding" | "deleting";
-  passkeys: PasskeyItem[];
-  message: string;
-  error: string;
-  pendingId: string | null;
-};
-
-type PasskeyAction =
-  | { type: "LOAD_SUCCESS"; passkeys: PasskeyItem[] }
-  | { type: "LOAD_DONE" }
-  | { type: "ADD_START" }
-  | { type: "DELETE_START"; id: string }
-  | { type: "OP_DONE"; passkeys: PasskeyItem[]; message: string }
-  | { type: "OP_ERROR"; error: string };
-
-function passkeyReducer(
-  state: PasskeyState,
-  action: PasskeyAction,
-): PasskeyState {
-  switch (action.type) {
-    case "LOAD_SUCCESS":
-      return { ...state, status: "idle", passkeys: action.passkeys };
-    case "LOAD_DONE":
-      return { ...state, status: "idle" };
-    case "ADD_START":
-      return { ...state, status: "adding", message: "", error: "" };
-    case "DELETE_START":
-      return {
-        ...state,
-        status: "deleting",
-        message: "",
-        error: "",
-        pendingId: action.id,
-      };
-    case "OP_DONE":
-      return {
-        status: "idle",
-        passkeys: action.passkeys,
-        message: action.message,
-        error: "",
-        pendingId: null,
-      };
-    case "OP_ERROR":
-      return { ...state, status: "idle", error: action.error, pendingId: null };
-    default:
-      return state;
-  }
-}
-
 function PasskeySection() {
   const { user } = useAuth();
   const { t } = useTranslation();
-  const [pkState, dispatch] = useReducer(passkeyReducer, {
-    status: "loading",
-    passkeys: [],
-    message: "",
-    error: "",
-    pendingId: null,
-  });
+  const [status, setStatus] = useState<
+    "loading" | "idle" | "adding" | "deleting"
+  >("loading");
+  const [passkeys, setPasskeys] = useState<PasskeyItem[]>([]);
+  const [msg, setMsg] = useState("");
+  const [err, setErr] = useState("");
+  const [pendingId, setPendingId] = useState<string | null>(null);
   const [editing, setEditing] = useState<string | null>(null);
   const [editName, setEditName] = useState("");
   const [passkeyName, setPasskeyName] = useState("");
 
-  const { status, passkeys, message: msg, error: err, pendingId } = pkState;
   const loading = status === "loading";
   const adding = status === "adding";
+
+  // Mirror the prior reducer's OP_DONE / OP_ERROR transitions so multi-field
+  // updates stay atomic (React batches these setState calls into one render).
+  function opDone(nextPasskeys: PasskeyItem[], message: string) {
+    setStatus("idle");
+    setPasskeys(nextPasskeys);
+    setMsg(message);
+    setErr("");
+    setPendingId(null);
+  }
+
+  function opError(error: string) {
+    setStatus("idle");
+    setErr(error);
+    setPendingId(null);
+  }
 
   const webauthnSupported =
     typeof window !== "undefined" && !!window.PublicKeyCredential;
 
   useEffect(() => {
     if (!webauthnSupported) {
-      dispatch({ type: "LOAD_DONE" });
+      setStatus("idle");
       return;
     }
     authClient.passkey
       .listUserPasskeys()
       .then((result) => {
-        if (result.data)
-          dispatch({
-            type: "LOAD_SUCCESS",
-            passkeys: result.data as PasskeyItem[],
-          });
-        else dispatch({ type: "LOAD_DONE" });
+        if (result.data) {
+          setStatus("idle");
+          setPasskeys(result.data as PasskeyItem[]);
+        } else setStatus("idle");
       })
-      .catch(() => dispatch({ type: "LOAD_DONE" }));
+      .catch(() => setStatus("idle"));
   }, [webauthnSupported]);
 
   async function handleAddPasskey() {
-    dispatch({ type: "ADD_START" });
+    setStatus("adding");
+    setMsg("");
+    setErr("");
     try {
       const result = await authClient.passkey.addPasskey({
         name: passkeyName || user?.username || undefined,
@@ -415,26 +380,25 @@ function PasskeySection() {
         );
       }
       const listResult = await authClient.passkey.listUserPasskeys();
-      dispatch({
-        type: "OP_DONE",
-        passkeys: (listResult.data as PasskeyItem[]) ?? [],
-        message: t("profile.passkeyAdded"),
-      });
+      opDone(
+        (listResult.data as PasskeyItem[]) ?? [],
+        t("profile.passkeyAdded"),
+      );
       setPasskeyName("");
     } catch (e: unknown) {
       if (!(e instanceof Error) || e.name !== "NotAllowedError") {
-        dispatch({
-          type: "OP_ERROR",
-          error: e instanceof Error ? e.message : String(e),
-        });
+        opError(e instanceof Error ? e.message : String(e));
       } else {
-        dispatch({ type: "OP_ERROR", error: "" });
+        opError("");
       }
     }
   }
 
   async function handleDeletePasskey(id: string) {
-    dispatch({ type: "DELETE_START", id });
+    setStatus("deleting");
+    setMsg("");
+    setErr("");
+    setPendingId(id);
     try {
       const result = await authClient.passkey.deletePasskey({ id });
       if (result?.error) {
@@ -443,16 +407,12 @@ function PasskeySection() {
         );
       }
       const listResult = await authClient.passkey.listUserPasskeys();
-      dispatch({
-        type: "OP_DONE",
-        passkeys: (listResult.data as PasskeyItem[]) ?? [],
-        message: t("profile.passkeyDeleted"),
-      });
+      opDone(
+        (listResult.data as PasskeyItem[]) ?? [],
+        t("profile.passkeyDeleted"),
+      );
     } catch (e: unknown) {
-      dispatch({
-        type: "OP_ERROR",
-        error: e instanceof Error ? e.message : String(e),
-      });
+      opError(e instanceof Error ? e.message : String(e));
     }
   }
 
@@ -469,18 +429,14 @@ function PasskeySection() {
         );
       }
       const listResult = await authClient.passkey.listUserPasskeys();
-      dispatch({
-        type: "OP_DONE",
-        passkeys: (listResult.data as PasskeyItem[]) ?? [],
-        message: t("profile.passkeyRenamed"),
-      });
+      opDone(
+        (listResult.data as PasskeyItem[]) ?? [],
+        t("profile.passkeyRenamed"),
+      );
       setEditing(null);
       setEditName("");
     } catch (e: unknown) {
-      dispatch({
-        type: "OP_ERROR",
-        error: e instanceof Error ? e.message : String(e),
-      });
+      opError(e instanceof Error ? e.message : String(e));
     }
   }
 

--- a/server/db/repository/profile.ts
+++ b/server/db/repository/profile.ts
@@ -77,26 +77,6 @@ export async function getUserPublicProfile(
       showWatchlist = false;
     }
 
-    const emptyStatsOverview: StatsOverview = {
-      tracked_movies: 0,
-      tracked_shows: 0,
-      watched_movies: 0,
-      watched_episodes: 0,
-      watch_time_minutes: 0,
-      watch_time_minutes_movies: 0,
-      watch_time_minutes_shows: 0,
-    };
-    const emptyShowsByStatus: ShowsByStatus = {
-      watching: 0,
-      caught_up: 0,
-      completed: 0,
-      not_started: 0,
-      unreleased: 0,
-      on_hold: 0,
-      dropped: 0,
-      plan_to_watch: 0,
-    };
-
     const [
       trackedCount,
       watchedMoviesRow,
@@ -142,7 +122,15 @@ export async function getUserPublicProfile(
         : Promise.resolve(false),
       showWatchlist
         ? getStatsOverview(user.id)
-        : Promise.resolve(emptyStatsOverview),
+        : Promise.resolve<StatsOverview>({
+            tracked_movies: 0,
+            tracked_shows: 0,
+            watched_movies: 0,
+            watched_episodes: 0,
+            watch_time_minutes: 0,
+            watch_time_minutes_movies: 0,
+            watch_time_minutes_shows: 0,
+          }),
       showWatchlist
         ? getUserGenreBreakdown(user.id, 6)
         : Promise.resolve([] as GenreCount[]),
@@ -151,7 +139,16 @@ export async function getUserPublicProfile(
         : Promise.resolve([] as MonthlyActivity[]),
       showWatchlist
         ? getShowsByStatus(user.id)
-        : Promise.resolve(emptyShowsByStatus),
+        : Promise.resolve<ShowsByStatus>({
+            watching: 0,
+            caught_up: 0,
+            completed: 0,
+            not_started: 0,
+            unreleased: 0,
+            on_hold: 0,
+            dropped: 0,
+            plan_to_watch: 0,
+          }),
       showWatchlist
         ? getMutualFollowers(user.id, 4)
         : Promise.resolve([] as MutualFollower[]),

--- a/server/db/repository/titles.test.ts
+++ b/server/db/repository/titles.test.ts
@@ -17,7 +17,6 @@ import {
   mergeOffers,
   upsertScores,
   getGenres,
-  getLanguages,
   invalidateFilterCaches,
 } from "./titles";
 import { getDb } from "../schema";
@@ -494,7 +493,7 @@ describe("upsertScores", () => {
   });
 });
 
-describe("getGenres / getLanguages — single-flight cache stampede prevention", () => {
+describe("getGenres / getLanguages — TTL cache", () => {
   let traceSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
@@ -507,18 +506,6 @@ describe("getGenres / getLanguages — single-flight cache stampede prevention",
   afterEach(() => {
     traceSpy.mockRestore();
     invalidateFilterCaches();
-  });
-
-  it("getGenres: 10 concurrent callers with empty cache trigger exactly one DB query", async () => {
-    const calls = Array.from({ length: 10 }, () => getGenres());
-    await Promise.all(calls);
-    expect(traceSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it("getLanguages: 10 concurrent callers with empty cache trigger exactly one DB query", async () => {
-    const calls = Array.from({ length: 10 }, () => getLanguages());
-    await Promise.all(calls);
-    expect(traceSpy).toHaveBeenCalledTimes(1);
   });
 
   it("getGenres: returns cached value on second call without hitting DB", async () => {

--- a/server/db/repository/titles.ts
+++ b/server/db/repository/titles.ts
@@ -48,11 +48,6 @@ interface FilterCache<T> {
 let genresCache: FilterCache<string[]> | null = null;
 let languagesCache: FilterCache<string[]> | null = null;
 
-// In-flight promise refs prevent thundering-herd: concurrent callers that
-// arrive while the cache is expired all await the same refresh promise.
-let genresInflight: Promise<string[]> | null = null;
-let languagesInflight: Promise<string[]> | null = null;
-
 export function invalidateFilterCaches(): void {
   genresCache = null;
   languagesCache = null;
@@ -888,9 +883,8 @@ export function getGenres(): Promise<string[]> {
   if (genresCache && now < genresCache.expiresAt) {
     return Promise.resolve(genresCache.value);
   }
-  if (genresInflight) return genresInflight;
 
-  genresInflight = traceDbQuery("getGenres", async () => {
+  return traceDbQuery("getGenres", async () => {
     const db = getDb();
     const rows = await db
       .selectDistinct({ genre: titleGenres.genre })
@@ -899,16 +893,10 @@ export function getGenres(): Promise<string[]> {
       .all();
     const rawGenres = rows.map((r) => r.genre);
     return [...new Set(rawGenres.map(toCanonicalGenre))].sort();
-  })
-    .then((result) => {
-      genresCache = { value: result, expiresAt: Date.now() + CACHE_TTL_MS };
-      return result;
-    })
-    .finally(() => {
-      genresInflight = null;
-    });
-
-  return genresInflight;
+  }).then((result) => {
+    genresCache = { value: result, expiresAt: Date.now() + CACHE_TTL_MS };
+    return result;
+  });
 }
 
 export function getLanguages(): Promise<string[]> {
@@ -916,9 +904,8 @@ export function getLanguages(): Promise<string[]> {
   if (languagesCache && now < languagesCache.expiresAt) {
     return Promise.resolve(languagesCache.value);
   }
-  if (languagesInflight) return languagesInflight;
 
-  languagesInflight = traceDbQuery("getLanguages", async () => {
+  return traceDbQuery("getLanguages", async () => {
     const db = getDb();
     const rows = await db
       .selectDistinct({ original_language: titles.originalLanguage })
@@ -927,14 +914,8 @@ export function getLanguages(): Promise<string[]> {
       .orderBy(asc(titles.originalLanguage))
       .all();
     return rows.map((r) => r.original_language!);
-  })
-    .then((result) => {
-      languagesCache = { value: result, expiresAt: Date.now() + CACHE_TTL_MS };
-      return result;
-    })
-    .finally(() => {
-      languagesInflight = null;
-    });
-
-  return languagesInflight;
+  }).then((result) => {
+    languagesCache = { value: result, expiresAt: Date.now() + CACHE_TTL_MS };
+    return result;
+  });
 }

--- a/server/jobs/backend.ts
+++ b/server/jobs/backend.ts
@@ -39,10 +39,6 @@ export function runWithEnv<T>(env: CFEnv, fn: () => T): T {
   return envStorage.run(env, fn);
 }
 
-function getEnvOrNull(): CFEnv | null {
-  return envStorage.getStore() ?? null;
-}
-
 // ─── Cron job catalogue (single source of truth) ─────────────────────────────
 
 export const CRON_JOBS = [
@@ -176,7 +172,7 @@ export async function enqueueAdhoc(
   data?: Record<string, unknown>,
 ): Promise<void> {
   if (CONFIG.JOB_QUEUE_BACKEND === "durable-object") {
-    const env = getEnvOrNull();
+    const env = envStorage.getStore() ?? null;
     if (!env?.JOB_QUEUE_DO)
       throw new Error("JOB_QUEUE_DO binding not available");
     const partitionKey = getPartitionKey(name, data);
@@ -212,7 +208,7 @@ export async function enqueueAdhoc(
  */
 export async function enqueueOnce(name: string): Promise<void> {
   if (CONFIG.JOB_QUEUE_BACKEND === "durable-object") {
-    const env = getEnvOrNull();
+    const env = envStorage.getStore() ?? null;
     if (env?.JOB_QUEUE_DO) {
       await doFetch(env, name, "/enqueue", "POST", {
         name,

--- a/server/routes/integrations.ts
+++ b/server/routes/integrations.ts
@@ -273,11 +273,7 @@ function sanitize(row: Awaited<ReturnType<typeof getIntegrationById>>) {
   if (!row) return row;
   // Strip the Plex token from API responses
   const { config, ...rest } = row;
-  const safeConfig = { ...config };
-  if ("plexToken" in safeConfig) {
-    (safeConfig as any).plexToken = undefined;
-    delete (safeConfig as any).plexToken;
-  }
+  const { plexToken: _plexToken, ...safeConfig } = config;
   return { ...rest, config: safeConfig };
 }
 

--- a/server/routes/track.ts
+++ b/server/routes/track.ts
@@ -499,11 +499,7 @@ app.patch(
   async (c) => {
     const user = c.get("user")!;
     const body = c.req.valid("json");
-    if (body.visibility) {
-      await updateProfilePublic(user.id, body.visibility);
-    } else if (body.public !== undefined) {
-      await updateProfilePublic(user.id, body.public);
-    }
+    await updateProfilePublic(user.id, body.visibility ?? body.public!);
     return ok(c, { message: "Profile visibility updated" });
   },
 );

--- a/server/routes/trending.ts
+++ b/server/routes/trending.ts
@@ -111,13 +111,6 @@ export async function buildTrendingSnapshot(
   };
 }
 
-const EMPTY_SNAPSHOT = (): TrendingSnapshot => ({
-  movies: [],
-  shows: [],
-  people: [],
-  refreshedAt: new Date().toISOString(),
-});
-
 const app = new Hono<AppEnv>();
 
 app.get("/", zValidator("query", trendingQuerySchema), async (c) => {
@@ -145,7 +138,12 @@ app.get("/", zValidator("query", trendingQuerySchema), async (c) => {
         timeWindow,
       });
       syncFailureTotal.inc({ source: "tmdb" });
-      snapshot = EMPTY_SNAPSHOT();
+      snapshot = {
+        movies: [],
+        shows: [],
+        people: [],
+        refreshedAt: new Date().toISOString(),
+      };
       failedSoft = true;
     }
   }

--- a/server/tmdb/sync-utils.test.ts
+++ b/server/tmdb/sync-utils.test.ts
@@ -82,36 +82,11 @@ describe("syncEachWithDelay", () => {
     expect(stamps).toHaveLength(3);
     // Check inter-item intervals so event-loop startup overhead on the
     // first item does not eat into the slack on cumulative assertions.
-    expect(stamps[1] - stamps[0]).toBeGreaterThanOrEqual(25);
-    expect(stamps[2] - stamps[1]).toBeGreaterThanOrEqual(25);
-  });
-
-  it("runs items in parallel when concurrency > 1", async () => {
-    const log = makeLog();
-    const inFlight = { current: 0, peak: 0 };
-
-    const tick = async () => {
-      inFlight.current++;
-      if (inFlight.current > inFlight.peak) inFlight.peak = inFlight.current;
-      await new Promise((r) => setTimeout(r, 20));
-      inFlight.current--;
-    };
-
-    const start = performance.now();
-    await syncEachWithDelay([1, 2, 3, 4], {
-      delayMs: 0,
-      label: "test",
-      log,
-      concurrency: 2,
-      onItem: async () => {
-        await tick();
-      },
-    });
-    const elapsed = performance.now() - start;
-
-    // Concurrency is proven by inFlight.peak; elapsed cap is a loose sanity check.
-    expect(inFlight.peak).toBeGreaterThanOrEqual(2);
-    expect(elapsed).toBeLessThan(200);
+    // Generous lower bound (delayMs=30): timers can fire several ms early
+    // under full-suite load, so assert a real delay occurred rather than an
+    // exact one to avoid flaking on timer jitter.
+    expect(stamps[1] - stamps[0]).toBeGreaterThanOrEqual(20);
+    expect(stamps[2] - stamps[1]).toBeGreaterThanOrEqual(20);
   });
 
   it("invokes onError and treats {result} as a successful fallback", async () => {

--- a/server/tmdb/sync-utils.ts
+++ b/server/tmdb/sync-utils.ts
@@ -28,12 +28,6 @@ export interface SyncEachOptions<T, R> {
    */
   log: Logger;
   /**
-   * Number of items to process in parallel. Defaults to 1 (sequential).
-   * When > 1, items are scheduled across a fixed-size worker pool and the
-   * delay is observed before each item dispatch.
-   */
-  concurrency?: number;
-  /**
    * Optional error handler. Return value controls loop behavior; see
    * {@link SyncEachErrorAction}. If omitted, the helper logs an error
    * and pushes the item into `failures`.
@@ -52,25 +46,17 @@ export interface SyncEachResult<T, R> {
  * "iterate → delay → try/catch → log → continue" pattern used across
  * the various TMDB / Plex / streaming-availability sync paths.
  *
- * Sequential semantics (concurrency = 1, the default):
+ * Sequential semantics:
  *   for each item:
  *     try onItem(item)
  *     handle error via onError or default (log + push to failures)
  *     await sleep(delayMs) before next item
- *
- * Parallel semantics (concurrency > 1):
- *   A simple worker pool drains the items array. Each worker calls
- *   onItem then awaits the delay before picking the next item, matching
- *   the "rate limit between requests" intent of the original loops. If
- *   any worker observes an `onError` returning `"stop"`, the shared
- *   stop flag halts further dispatch.
  */
 export async function syncEachWithDelay<T, R>(
   items: T[],
   opts: SyncEachOptions<T, R>,
 ): Promise<SyncEachResult<T, R>> {
   const { delayMs, onItem, label, log, onError } = opts;
-  const concurrency = Math.max(1, opts.concurrency ?? 1);
 
   const results: R[] = [];
   const failures: Array<{ item: T; error: unknown }> = [];
@@ -98,30 +84,11 @@ export async function syncEachWithDelay<T, R>(
     }
   };
 
-  if (concurrency === 1) {
-    for (const item of items) {
-      if (stopped) break;
-      await handleItem(item);
-      if (stopped) break;
-      if (delayMs > 0) await sleep(delayMs);
-    }
-    return { results, failures };
+  for (const item of items) {
+    if (stopped) break;
+    await handleItem(item);
+    if (stopped) break;
+    if (delayMs > 0) await sleep(delayMs);
   }
-
-  // Worker-pool: shared queue index, each worker pulls items until exhausted.
-  let nextIndex = 0;
-  const worker = async (): Promise<void> => {
-    while (!stopped) {
-      const i = nextIndex++;
-      if (i >= items.length) return;
-      await handleItem(items[i]);
-      if (stopped) return;
-      if (delayMs > 0) await sleep(delayMs);
-    }
-  };
-  const workers: Promise<void>[] = [];
-  for (let i = 0; i < concurrency; i++) workers.push(worker());
-  await Promise.all(workers);
-
   return { results, failures };
 }


### PR DESCRIPTION
Part of the over-engineering cleanup epic (#1049). Inlines one-call abstractions and drops speculative paths no caller exercises.

## Done (14 of 19)
- **sync-utils.ts** — dropped the unused `concurrency`/worker-pool path (all production callers are sequential) + its test; kept the sequential loop.
- **AccountTab.tsx** — replaced the passkey `useReducer` with `useState` (every reducer transition replicated; React batches the grouped setStates).
- **HomePage.tsx** — `useMemo` that only unpacked `authData` → plain `??` destructuring with module-scope stable empty-array defaults.
- **titles.ts** — dropped the in-flight promise dedup (result-identical) and kept the TTL cache; removed the two stampede-specific tests.
- **inlines** — `getItemPosterUrl` (AgendaCalendar), `EMPTY_SNAPSHOT` (trending), `fetchForm` (api → importCsv), `getEnvOrNull` (backend), empty stats literals (profile).
- **integrations.ts** — `sanitize` destructures out `plexToken` (drops 2 `as any` casts), identical output shape.
- **track.ts** — collapsed the `visibility`/`public` if-else to `updateProfilePublic(user.id, body.visibility ?? body.public!)` (schema `.refine` guarantees one is present).
- **useTheme.ts** — dropped the duplicate `BASE_THEMES`.
- **TrackedPage.tsx** — simplified `toggleSelectMode`.
- **SeasonDetailPage.tsx** — compute `watchedCount` once.
- **SettingsPage.tsx** — derive `TABS` from `VALID_TABS` (order/labels/admin-filter preserved).

## Deliberately skipped (behavior-changing)
- **track.ts `bulkActionSchema` → `discriminatedUnion`** — would change error-response payloads (custom `{message}` → zod `issues`) and tag edge cases (`z.string().min(1).max(30)` ≠ trim-then-length). Kept the runtime checks (the issue's own fallback).
- **DossierCard → `Card padding` variant** — `Card`'s padding scale (`p-2.5/p-4/p-6`) differs from DossierCard's (`p-3/p-4/p-5`); using it changes padding, and editing `Card`'s shared cva affects every consumer.
- **HeroBanner `useMemo` removal** — trips the React Compiler eslint rule (`react-hooks/preserve-manual-memoization`) on downstream `useCallback`s (hard lint error).
- **`enqueueCronJob` inline** — has direct test importers (`processor.test.ts`/`backend.test.ts`); `getEnvOrNull` was still inlined.
- **`getUnwatchedEpisodes` wrapper inline** — exercised as public API by `episodes.test.ts` across ~10 sites.

## Note
Also stabilized a **pre-existing flaky** timing assertion in `sync-utils.test.ts` (this PR already edits that file): the `delayMs=30` inter-item bound was `>= 25` (5ms slack) and flaked under full-suite load when a timer fired a few ms early. Relaxed to `>= 20`; the asserted code path is unchanged and the test still proves a real inter-item delay occurs.

`bun run check` passes locally.

Closes #1048