### PR TITLE
fix: isolate per-job armCron failures in cron watchdog (#1055)

### DIFF
--- a/server/worker.test.ts
+++ b/server/worker.test.ts
@@ -432,6 +432,56 @@ describe("scheduled() bootstrap KV timestamp", () => {
     expect(new Date(bootstrapPut![1]).getTime()).toBeGreaterThan(0);
   });
 
+  it("isolates a failing armCron so remaining cron jobs still tick (#1055)", async () => {
+    // sync-episodes' /arm hits a blockConcurrencyWhile() timeout; the loop must
+    // not abort the remaining jobs.
+    const armed: string[] = [];
+    const ticked: string[] = [];
+    const armSpy = spyOn(backendModule, "armCron").mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      async (_env: any, name: string) => {
+        armed.push(name);
+        if (name === "sync-episodes")
+          throw new Error("blockConcurrencyWhile() waited for too long");
+      },
+    );
+    const tickSpy = spyOn(backendModule, "tickCron").mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      async (_env: any, name: string) => {
+        ticked.push(name);
+      },
+    );
+    spies.push(armSpy, tickSpy);
+
+    const fakeEnv = {
+      DB: {} as D1Database,
+      CACHE_KV: {
+        put: async () => {},
+        get: async () => null,
+      } as unknown as KVNamespace,
+      TMDB_COUNTRY: "HR",
+      TMDB_LANGUAGE: "hr-HR",
+      LOG_LEVEL: "info",
+    } as unknown as Parameters<typeof handler.scheduled>[1];
+
+    const fakeCtx = {
+      waitUntil: () => {},
+      passThroughOnException: () => {},
+    } as unknown as ExecutionContext;
+
+    await handler.scheduled(
+      { cron: "*/5 * * * *", type: "scheduled", scheduledTime: Date.now() },
+      fakeEnv,
+      fakeCtx,
+    );
+
+    // Every job was armed (loop never aborted), only the failing one skipped tick.
+    expect(armed).toHaveLength(6);
+    expect(ticked).not.toContain("sync-episodes");
+    expect(ticked).toContain("send-notifications");
+    expect(ticked).toContain("cleanup");
+  });
+
   it("does NOT put to CACHE_KV when CACHE_KV is absent", async () => {
     const puts: Array<[string, string]> = [];
 

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -831,7 +831,18 @@ export const handler = {
             // proven-working DO fetch RPC. Cron timing is honored inside the DO —
             // daily jobs only run once/day while send-notifications runs each tick.
             for (const { name, cron } of CRON_JOBS) {
-              await armCron(cfEnv, name, cron);
+              // Isolate each job: a blockConcurrencyWhile() timeout on /arm when
+              // the DO is mid-execution of a long job (#1055) must not abort
+              // ticks for the remaining cron jobs. tickCron has its own catch.
+              try {
+                await armCron(cfEnv, name, cron);
+              } catch (err) {
+                logger.warn("armCron failed, skipping tick", {
+                  name,
+                  error: err instanceof Error ? err.message : String(err),
+                });
+                continue;
+              }
               await tickCron(cfEnv, name);
             }
 


### PR DESCRIPTION
## What

A `blockConcurrencyWhile()` wall-time timeout on `POST /arm` (when the `sync-episodes` DO is mid-execution of a long job) propagated out of the `for...of CRON_JOBS` loop in `server/worker.ts`, aborting `tickCron` for every remaining cron job in that watchdog tick. The #1020 fix only isolated the *self-heal* `armCron` inside the DO; the *watchdog-level* `armCron` was still unprotected.

## Fix

Wrap each `armCron` call in try/catch and `continue` on failure (option 1 from #1055). `tickCron` already guards itself. One job's DO timeout no longer drops ticks for the others.

The underlying root cause — `sync-episodes` running long enough to hold the DO event loop past 30s — is separate (job time-boxing) and out of scope here.

## Test

`server/worker.test.ts`: regression test driving `handler.scheduled()` with `armCron` throwing for `sync-episodes`; asserts all 6 jobs are armed, only the failing one skips tick, and the rest still tick.

`bun run check:fast` passes.

Closes #1055

🤖 Generated with [Claude Code](https://claude.com/claude-code)