### PR TITLE
fix: breadcrumb nav landmark + locale-aware watched date on detail pages

### DIFF
--- a/frontend/src/pages/EpisodeDetailPage.test.tsx
+++ b/frontend/src/pages/EpisodeDetailPage.test.tsx
@@ -249,6 +249,43 @@ describe("EpisodeDetailPage", () => {
     });
   });
 
+  it("renders breadcrumb as a nav landmark with aria-current on the last crumb (#1060)", async () => {
+    render(<EpisodeDetailPage />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByText("Pilot")).toBeDefined());
+
+    const nav = screen.getByRole("navigation", { name: "breadcrumb" });
+    expect(nav).toBeDefined();
+    const current = screen.getByText("Episode 1");
+    expect(current.getAttribute("aria-current")).toBe("page");
+  });
+
+  it("renders watched date in the browser locale, not hardcoded en-US (#1061)", async () => {
+    apiMock.getSeasonEpisodeStatus.mockImplementation(() =>
+      Promise.resolve({
+        episodes: [{ episode_number: 1, id: 10, is_watched: true }],
+      }),
+    );
+    apiMock.getWatchHistory.mockImplementation(() =>
+      Promise.resolve({
+        history: [{ id: "wh1", watchedAt: "2026-06-28 14:30:00" }],
+        playCount: 1,
+      }),
+    );
+
+    render(<EpisodeDetailPage />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByText("Pilot")).toBeDefined());
+
+    const expected = new Date("2026-06-28T14:30:00Z").toLocaleDateString(
+      undefined,
+      { year: "numeric", month: "short", day: "numeric" },
+    );
+    await waitFor(() =>
+      expect(screen.getByText(`Watched ${expected}`)).toBeDefined(),
+    );
+  });
+
   it("shows toast on toggle error and reverts", async () => {
     const toastErrorSpy = spyOn(sonner.toast, "error").mockImplementation(
       () => "1" as any,

--- a/frontend/src/pages/EpisodeDetailPage.tsx
+++ b/frontend/src/pages/EpisodeDetailPage.tsx
@@ -161,7 +161,10 @@ export default function EpisodeDetailPage() {
   return (
     <div className="max-w-4xl mx-auto space-y-8 pb-12">
       {/* Breadcrumb */}
-      <div className="flex items-center gap-2 text-sm text-zinc-400 flex-wrap">
+      <nav
+        aria-label="breadcrumb"
+        className="flex items-center gap-2 text-sm text-zinc-400 flex-wrap"
+      >
         <Link
           to={`/title/${title.id}`}
           className="hover:text-white transition-colors"
@@ -176,8 +179,10 @@ export default function EpisodeDetailPage() {
           Season {seasonNumber}
         </Link>
         <span className="text-zinc-600">/</span>
-        <span className="text-white">Episode {episodeNumber}</span>
-      </div>
+        <span className="text-white" aria-current="page">
+          Episode {episodeNumber}
+        </span>
+      </nav>
 
       {/* Still image */}
       <div className="rounded-xl overflow-hidden">
@@ -249,12 +254,8 @@ export default function EpisodeDetailPage() {
             className="text-xs text-emerald-400 hover:text-emerald-300 transition-colors underline-offset-2 hover:underline cursor-pointer"
           >
             Watched{" "}
-            {new Date(
-              watchHistoryEntries[0].watchedAt.replace(" ", "T") + "Z",
-            ).toLocaleDateString("en-US", {
-              year: "numeric",
-              month: "short",
-              day: "numeric",
+            {formatDate(watchHistoryEntries[0].watchedAt.replace(" ", "T"), {
+              utcAssumed: true,
             })}
           </button>
         )}

--- a/frontend/src/pages/SeasonDetailPage.test.tsx
+++ b/frontend/src/pages/SeasonDetailPage.test.tsx
@@ -6,6 +6,7 @@ import {
   waitFor,
   cleanup,
   act,
+  within,
 } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -162,6 +163,16 @@ afterEach(() => {
 });
 
 describe("SeasonDetailPage", () => {
+  it("renders breadcrumb as a nav landmark with aria-current on the last crumb (#1060)", async () => {
+    render(<SeasonDetailPage />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByText("Pilot")).toBeDefined());
+
+    const nav = screen.getByRole("navigation", { name: "breadcrumb" });
+    const current = within(nav).getByText("Season 1");
+    expect(current.getAttribute("aria-current")).toBe("page");
+  });
+
   it("renders episodes with watched icons when authenticated", async () => {
     render(<SeasonDetailPage />, { wrapper: Wrapper });
 

--- a/frontend/src/pages/SeasonDetailPage.tsx
+++ b/frontend/src/pages/SeasonDetailPage.tsx
@@ -286,7 +286,10 @@ export default function SeasonDetailPage() {
   return (
     <div className="space-y-8 pb-12 overflow-x-hidden">
       {/* Breadcrumb */}
-      <div className="flex items-center gap-2 text-sm text-zinc-400">
+      <nav
+        aria-label="breadcrumb"
+        className="flex items-center gap-2 text-sm text-zinc-400"
+      >
         <Link
           to={`/title/${title.id}`}
           className="hover:text-white transition-colors"
@@ -294,10 +297,10 @@ export default function SeasonDetailPage() {
           {title.title}
         </Link>
         <span className="text-zinc-600">/</span>
-        <span className="text-white">
+        <span className="text-white" aria-current="page">
           {tmdb?.name || `Season ${seasonNumber}`}
         </span>
-      </div>
+      </nav>
 
       {/* Header */}
       <div className="flex flex-col sm:flex-row gap-6">


### PR DESCRIPTION
## What

- **#1060**: Breadcrumbs on `SeasonDetailPage` and `EpisodeDetailPage` were plain `<div>`s. They are now `<nav aria-label="breadcrumb">` landmarks with `aria-current="page"` on the terminal crumb, so assistive tech can jump to the breadcrumb by landmark and identify the current location (WCAG 1.3.1 / 2.4.6).
- **#1061**: The "Watched …" date label on `EpisodeDetailPage` hardcoded `"en-US"` in `toLocaleDateString`. It now uses the shared locale-aware `formatDate` helper (already imported on the page, `undefined` locale → browser locale) with `utcAssumed: true` for the SQLite UTC timestamp.

## Tests

- Both pages: breadcrumb renders as a `navigation` landmark named "breadcrumb" and the last crumb has `aria-current="page"`.
- EpisodeDetailPage: watched date renders in the browser locale (asserted against `toLocaleDateString(undefined, ...)` output for the same timestamp).

`bun run check` passes (full pipeline incl. build + wrangler dry-run + bundle budget).

Closes #1060
Closes #1061

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N65W7aMGAtxDcNthqfYjiy