### PR TITLE
fix: align achievements backfill sentinel key on the CF code path

### DIFF
--- a/server/jobs/durable-object.ts
+++ b/server/jobs/durable-object.ts
@@ -16,6 +16,7 @@ import { CloudflareKvCache } from "../cache/cloudflare-kv";
 import { MemoryCache } from "../cache/memory";
 import { logger, resetLogLevel } from "../logger";
 import Sentry from "../sentry";
+import { BACKFILL_DONE_KEY } from "../achievements/sync";
 import { handlers } from "./processor";
 import { nextRetryAt } from "./time-utils";
 import { patchConfig, cfEnvToConfigOverrides } from "../config";
@@ -369,13 +370,13 @@ export class JobQueueDO {
       }
 
       // backfill-achievements: re-enqueue next page unless the handler marked it done.
-      // The handler writes achievements_backfill_done=1 to D1 settings on last page;
+      // The handler writes BACKFILL_DONE_KEY=1 to D1 settings on last page;
       // processor.ts skips the D1 re-enqueue in DO mode, so we do it here instead.
       if (job.name === "backfill-achievements") {
         const doneSetting = await db
           .select({ value: settings.value })
           .from(settings)
-          .where(eq(settings.key, "achievements_backfill_done"))
+          .where(eq(settings.key, BACKFILL_DONE_KEY))
           .get();
         if (!doneSetting) {
           this.ctx.storage.sql.exec(

--- a/server/jobs/processor.test.ts
+++ b/server/jobs/processor.test.ts
@@ -69,6 +69,8 @@ const mockFetchTrendingPeople = spyOn(
 ).mockResolvedValue(emptyTrendingPage as any);
 
 import { CONFIG } from "../config";
+import { getSetting } from "../db/repository/settings";
+import { BACKFILL_DONE_KEY } from "../achievements/sync";
 import { initCache, getCache } from "../cache";
 import { MemoryCache } from "../cache/memory";
 import { CRON_JOBS } from "./backend";
@@ -735,5 +737,28 @@ describe("sync-trending handler (CF path)", () => {
     expect(mockFetchTrendingMovies).not.toHaveBeenCalled();
     expect(await getCache().get(trendingCacheKey("week"))).toBeNull();
     CONFIG.TMDB_API_KEY = "test-key";
+  });
+});
+
+// ─── backfill-achievements sentinel parity (#1062, recurrence of #980) ───────
+// The #980 fix introduced BACKFILL_DONE_KEY but only updated the Bun writer;
+// the CF writer (this file's handler) and the DO re-enqueue guard kept the old
+// literal, so the registry guard never saw "done" and re-enqueued on every
+// cold isolate. These tests pin writer/reader key parity on the CF path.
+
+describe("backfill-achievements handler (CF path)", () => {
+  it("writes BACKFILL_DONE_KEY so the registry guard finds it (#1062)", async () => {
+    // Zero users in the test DB → handler marks the backfill done immediately.
+    await handlers["backfill-achievements"](null);
+    expect(await getSetting(BACKFILL_DONE_KEY)).toBe("1");
+  });
+
+  it("no stale hardcoded sentinel literal remains in the jobs source", async () => {
+    // ponytail: grep-level guard — cheaper than a DO harness test and catches
+    // any future writer/reader drift in either runtime's code path.
+    for (const file of ["processor.ts", "durable-object.ts"]) {
+      const src = await Bun.file(new URL(file, import.meta.url)).text();
+      expect(src).not.toInclude('"achievements_backfill_done"');
+    }
   });
 });

--- a/server/jobs/processor.ts
+++ b/server/jobs/processor.ts
@@ -42,6 +42,7 @@ import {
   ACHIEVEMENTS,
   type AchievementKind,
 } from "../achievements/definitions";
+import { BACKFILL_DONE_KEY } from "../achievements/sync";
 import {
   evaluateCountMovies,
   evaluateCountEpisodes,
@@ -475,7 +476,7 @@ async function handleBackfillAchievements(
   `);
 
   if (rows.length === 0) {
-    await setSetting("achievements_backfill_done", "1");
+    await setSetting(BACKFILL_DONE_KEY, "1");
     log.info("Backfill complete — no more users");
     return;
   }
@@ -584,7 +585,7 @@ async function handleBackfillAchievements(
     }
     log.info("Backfill: enqueued next batch", { nextCursor: lastUserId });
   } else {
-    await setSetting("achievements_backfill_done", "1");
+    await setSetting(BACKFILL_DONE_KEY, "1");
     log.info("Backfill: complete", { totalProcessed: rows.length });
   }
 }


### PR DESCRIPTION
## What

Recurrence of #980: the achievements backfill was re-enqueued (and logged) on every cold-isolate HTTP request on Cloudflare — including bot scanner probes to `/sitemap.xml`, `/wp-login.php`, etc.

## Root cause

The #980 fix (`49a04ed`) introduced `BACKFILL_DONE_KEY = "achievements_backfill_done_v2"` but only updated the **Bun** writer (`server/jobs/backfill-achievements.ts`). The **CF** code path kept the old literal:

- `server/jobs/processor.ts` — `handleBackfillAchievements` wrote `"achievements_backfill_done"` (no `_v2`) in both completion branches
- `server/jobs/durable-object.ts` — the DO re-enqueue guard checked the same stale literal

So on Cloudflare the backfill completed and wrote the old key, the guard in `syncAchievementRegistry` kept reading the `_v2` key, never found it, and re-enqueued on every cold isolate.

Note: the issue's "sitemap runs sync synchronously ~4s" observation is a misdiagnosis — the registry sync is already deferred via `ctx.waitUntil` (`server/worker.ts`); the key mismatch alone explains the enqueue spam. No middleware change needed.

## Change

Import the shared `BACKFILL_DONE_KEY` in both CF files and replace the three hardcoded literals (~6 lines).

## Tests

- Behavioral: run the CF `backfill-achievements` handler to completion (zero users) and assert `getSetting(BACKFILL_DONE_KEY)` is set — the exact read the registry guard performs.
- Source-level parity guard: asserts no stale `"achievements_backfill_done"` literal remains in `processor.ts` / `durable-object.ts`, catching future writer/reader drift on either runtime.

`bun run check` passes.

Closes #1062

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N65W7aMGAtxDcNthqfYjiy