### PR TITLE
fix: bound sync-episodes DO wall time with detached fan-out ticks

### DIFF
--- a/server/jobs/backend.test.ts
+++ b/server/jobs/backend.test.ts
@@ -463,6 +463,81 @@ describe("enqueueAdhoc (DO mode)", () => {
     expect(ns.calls[0].path).toBe("/enqueue");
     expect(ns.calls[1].path).toBe("/tick");
   });
+
+  it("detachTick: resolves while /tick is still pending (#1058)", async () => {
+    CONFIG.JOB_QUEUE_BACKEND = "durable-object";
+    const calls: string[] = [];
+    let resolveTick: ((r: Response) => void) | undefined;
+    const stub = {
+      fetch: (req: Request) => {
+        const path = new URL(req.url).pathname;
+        calls.push(path);
+        if (path === "/tick") {
+          // Simulate the partition DO running its full show sync — never
+          // resolves until the test releases it.
+          return new Promise<Response>((resolve) => {
+            resolveTick = resolve;
+          });
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify({ ok: true }), { status: 200 }),
+        );
+      },
+    };
+    const env = {
+      ...d1Env,
+      JOB_QUEUE_DO: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => stub,
+      } as unknown as DurableObjectNamespace,
+    };
+
+    // enqueueAdhoc must return while the tick is still in flight.
+    await runWithEnv(env, async () => {
+      await enqueueAdhoc(
+        "sync-show-episodes",
+        { titleId: 42, tmdbId: 999, title: "Test" },
+        { detachTick: true },
+      );
+    });
+
+    expect(calls).toEqual(["/enqueue", "/tick"]);
+    expect(resolveTick).toBeDefined();
+    resolveTick!(new Response("{}", { status: 200 }));
+  });
+
+  it("detachTick: a rejecting /tick does not throw", async () => {
+    CONFIG.JOB_QUEUE_BACKEND = "durable-object";
+    const stub = {
+      fetch: (req: Request) => {
+        const path = new URL(req.url).pathname;
+        if (path === "/tick") {
+          return Promise.reject(new Error("DO reset mid-tick"));
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify({ ok: true }), { status: 200 }),
+        );
+      },
+    };
+    const env = {
+      ...d1Env,
+      JOB_QUEUE_DO: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => stub,
+      } as unknown as DurableObjectNamespace,
+    };
+
+    // Resolves despite the tick rejection (logged, not thrown); flush the
+    // detached promise so the rejection is handled inside this test.
+    await runWithEnv(env, async () => {
+      await enqueueAdhoc(
+        "sync-show-episodes",
+        { titleId: 42, tmdbId: 999, title: "Test" },
+        { detachTick: true },
+      );
+    });
+    await Bun.sleep(0);
+  });
 });
 
 // ─── scheduled() bootstrap pattern — arm all CRON_JOBS ───────────────────────

--- a/server/jobs/backend.ts
+++ b/server/jobs/backend.ts
@@ -170,6 +170,7 @@ export async function tickCron(env: CFEnv, name: string): Promise<void> {
 export async function enqueueAdhoc(
   name: string,
   data?: Record<string, unknown>,
+  opts?: { detachTick?: boolean },
 ): Promise<void> {
   if (CONFIG.JOB_QUEUE_BACKEND === "durable-object") {
     const env = envStorage.getStore() ?? null;
@@ -190,7 +191,22 @@ export async function enqueueAdhoc(
     // Drive execution immediately via the working fetch path — ad-hoc DOs cannot
     // rely on alarm() delivery (#795), so without this the job would never run.
     // A single ad-hoc job (e.g. one show's episode sync) fits the 30s DO limit.
-    await doFetch(env, name, "/tick", "POST", {}, partitionKey);
+    // detachTick: fan-out callers (sync-episodes) must NOT await the target DO's
+    // full run — awaited ticks made the dispatcher's runJob take sum-of-all-shows
+    // wall time inside blockConcurrencyWhile and reset the DO (#1058). Pending
+    // I/O keeps the caller DO alive until detached ticks land; a dropped tick
+    // drains on the next daily run.
+    const tick = doFetch(env, name, "/tick", "POST", {}, partitionKey);
+    if (opts?.detachTick) {
+      void tick.catch((err) =>
+        log.warn("Detached DO tick failed", {
+          name,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    } else {
+      await tick;
+    }
   } else {
     const db = getDb();
     await db.insert(jobs).values({

--- a/server/jobs/durable-object.test.ts
+++ b/server/jobs/durable-object.test.ts
@@ -276,17 +276,18 @@ describe("JobQueueDO", () => {
     expect(rows[0].completed_at).not.toBeNull();
   });
 
-  it("runJob still completes the job and writes state when self-heal armCron throws (#1020)", async () => {
-    // Regression: a long sync-episodes run made armCron()'s blockConcurrencyWhile()
-    // exceed the 30s CF limit, resetting the DO before job state was written and
-    // crash-looping. The self-heal re-arm is now best-effort: a throwing armCron
-    // must not abort runJob or leave the job stuck in 'running'.
+  it("runJob does not re-arm the cron itself — re-arm is watchdog-owned (#1058)", async () => {
+    // Regression: the post-run self-heal armCron() (added for #795, made
+    // best-effort for #1020) was removed entirely in #1058. Cron schedules
+    // persist in _actor_alarms, the */5 watchdog re-arms idempotently, and
+    // armCron() recovers dropped alarm handles — so runJob must complete the
+    // job WITHOUT calling armCron and risking a blockConcurrencyWhile reset.
     let called = false;
     processorModule.handlers["sync-titles"] = async () => {
       called = true;
     };
     await do_.armCron("sync-titles", "0 3 * * *");
-    spyOn(do_, "armCron").mockRejectedValue(
+    const armCronSpy = spyOn(do_, "armCron").mockRejectedValue(
       new Error("blockConcurrencyWhile timeout"),
     );
 
@@ -297,16 +298,8 @@ describe("JobQueueDO", () => {
     const rows = do_.getRecentJobs();
     expect(rows[0].status).toBe("completed");
     expect(rows[0].completed_at).not.toBeNull();
-
-    // Failure is recorded as a best-effort breadcrumb, not a captured exception.
+    expect(armCronSpy).not.toHaveBeenCalled();
     expect(captureExceptionSpy).not.toHaveBeenCalled();
-    expect(
-      addBreadcrumbSpy.mock.calls.some(
-        ([crumb]) =>
-          (crumb as { message?: string })?.message ===
-          "Self-heal armCron failed (best-effort)",
-      ),
-    ).toBe(true);
   });
 
   it("runJob auto-creates and runs a job for cron DOs when no pending rows exist", async () => {
@@ -901,9 +894,9 @@ describe("JobQueueDO", () => {
     expect(resp.status).toBe(404);
   });
 
-  // ── self-heal: runJob re-arms cron schedule (#795) ───────────────────────
+  // ── dropped cron schedule recovery is watchdog-owned (#795 → #1058) ──────
 
-  it("runJob re-arms cron schedule on success so a dropped schedule self-heals", async () => {
+  it("a dropped cron schedule is recovered by the next watchdog armCron, not by runJob", async () => {
     processorModule.handlers["sync-titles"] = async () => {};
     await do_.armCron("sync-titles", "0 3 * * *");
 
@@ -919,22 +912,22 @@ describe("JobQueueDO", () => {
         .some((s) => s.callback === "runJob"),
     ).toBe(false);
 
-    addBreadcrumbSpy.mockClear();
+    // runJob no longer self-heals the schedule (#1058) …
     await do_.enqueue("sync-titles", null);
     await do_.runJob(null);
+    expect(
+      do_.alarms
+        .getSchedules({ type: "cron" })
+        .some((s) => s.callback === "runJob"),
+    ).toBe(false);
 
-    // armCron call inside runJob should have re-registered the cron schedule
+    // … the */5 watchdog's idempotent armCron does.
+    await do_.armCron("sync-titles", "0 3 * * *");
     expect(
       do_.alarms
         .getSchedules({ type: "cron" })
         .some((s) => s.callback === "runJob"),
     ).toBe(true);
-    // And emitted the Re-armed breadcrumb
-    const rearmBreadcrumb = addBreadcrumbSpy.mock.calls.find(
-      (args) =>
-        (args[0] as { message?: string }).message === "Re-armed cron schedule",
-    );
-    expect(rearmBreadcrumb).toBeDefined();
   });
 
   it("runJob does NOT call armCron for ad-hoc DOs (no cron set)", async () => {

--- a/server/jobs/durable-object.ts
+++ b/server/jobs/durable-object.ts
@@ -456,34 +456,10 @@ export class JobQueueDO {
       }
     }
 
-    // Self-heal: re-register the cron schedule after every execution so a dropped
-    // schedule (e.g. due to DO eviction or a wrapped entrypoint interfering with
-    // @cloudflare/actors/alarms) recovers within the next alarm cycle (#795).
-    // Best-effort: armCron() calls blockConcurrencyWhile(), which can exceed the
-    // 30s CF limit after a long job and reset the DO before job state is durably
-    // written, crash-looping (#1020). The */5 watchdog re-arms independently, so
-    // swallow failures here rather than abort runJob or leave state inconsistent.
-    if (cron) {
-      try {
-        await this.armCron(name, cron);
-      } catch (err) {
-        Sentry.addBreadcrumb({
-          category: "jobs",
-          message: "Self-heal armCron failed (best-effort)",
-          level: "warning",
-          data: {
-            name,
-            cron,
-            error: err instanceof Error ? err.message : String(err),
-          },
-        });
-        log.warn("Self-heal armCron failed, relying on watchdog", {
-          name,
-          cron,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-    }
+    // No self-heal armCron here (removed in #1058): re-arming after every run
+    // risked a blockConcurrencyWhile() reset after long jobs (#1020), and it is
+    // redundant — cron schedules persist in _actor_alarms, the */5 watchdog
+    // re-arms idempotently, and armCron() itself recovers dropped alarm handles.
     await this.rearmIfPending();
   }
 

--- a/server/jobs/processor.test.ts
+++ b/server/jobs/processor.test.ts
@@ -202,16 +202,24 @@ describe("processPendingJobs", () => {
 
     expect(count).toBe(1);
     expect(mockEnqueueAdhoc).toHaveBeenCalledTimes(2);
-    expect(mockEnqueueAdhoc).toHaveBeenCalledWith("sync-show-episodes", {
-      titleId: "tv-1",
-      tmdbId: "1",
-      title: "Show One",
-    });
-    expect(mockEnqueueAdhoc).toHaveBeenCalledWith("sync-show-episodes", {
-      titleId: "tv-2",
-      tmdbId: "2",
-      title: "Show Two",
-    });
+    expect(mockEnqueueAdhoc).toHaveBeenCalledWith(
+      "sync-show-episodes",
+      {
+        titleId: "tv-1",
+        tmdbId: "1",
+        title: "Show One",
+      },
+      { detachTick: true },
+    );
+    expect(mockEnqueueAdhoc).toHaveBeenCalledWith(
+      "sync-show-episodes",
+      {
+        titleId: "tv-2",
+        tmdbId: "2",
+        title: "Show Two",
+      },
+      { detachTick: true },
+    );
     // Fan-out only — no inline per-show sync in the cron handler.
     expect(mockSyncEpisodesForShow).not.toHaveBeenCalled();
     expect(mockSyncEpisodes).not.toHaveBeenCalled();

--- a/server/jobs/processor.ts
+++ b/server/jobs/processor.ts
@@ -85,13 +85,19 @@ async function handleSyncEpisodes(): Promise<void> {
   // Per-show is the established safe unit (see track.ts) and the partitioned DOs
   // drain via the */5 watchdog; this replaces the sequential EPISODE_SYNC_DELAY_MS
   // pacing. Revisit if TMDB starts rate-limiting the fan-out.
+  // Ticks are detached so this dispatcher's runJob stays under the 30s DO
+  // budget instead of awaiting every show's sync serially (#1058).
   const shows = await listTrackedShowsForEpisodeSync();
   for (const show of shows) {
-    await enqueueAdhoc("sync-show-episodes", {
-      titleId: show.id,
-      tmdbId: show.tmdb_id,
-      title: show.title,
-    });
+    await enqueueAdhoc(
+      "sync-show-episodes",
+      {
+        titleId: show.id,
+        tmdbId: show.tmdb_id,
+        title: show.title,
+      },
+      { detachTick: true },
+    );
   }
   log.info("Dispatched per-show episode sync jobs", { shows: shows.length });
 }


### PR DESCRIPTION
## What

Third recurrence of the `blockConcurrencyWhile()` DO reset → stale `running` row → `sync-episodes` permanent failure (#1020 → #1055 → #1058).

## Root cause

Of the issue's three proposed fixes, (1) watchdog per-job isolation already shipped in #1055 (`035894e`). The real remaining bug is duration: the #1020 refactor fanned `sync-episodes` out to one `sync-show-episodes` partition-DO job per show, but `enqueueAdhoc` **awaits** its `/tick` RPC — and that tick synchronously runs the target DO's entire TMDB season sync. So the dispatcher's `runJob` still blocks for the **sum** of all shows' sync time. When a due alarm executes during DO construction (the `Alarms` constructor wraps due-alarm dispatch in `ctx.blockConcurrencyWhile`), that exceeds the 30s limit → CF resets the DO mid-run → orphaned `running` row → retries exhaust → `failed permanently (id=70, attempts=3/3)`.

## Changes

1. **`enqueueAdhoc` gains opt-in `detachTick`** (`server/jobs/backend.ts`): the `/tick` is fired without awaiting, errors logged not thrown. `handleSyncEpisodes` passes it, so the dispatcher completes in enqueue-RPC time regardless of show count.
   - Safe in a DO: pending I/O keeps the caller DO alive (this is why `DurableObjectState.waitUntil` is a documented no-op); precedent in `triggerCron`'s detached tick.
   - Recovery if a tick is dropped: the enqueued row persists in the partition DO's SQLite and the next daily run re-enqueues + re-ticks the same partition — strictly better than today, where a mid-loop reset drops all remaining shows *and* perma-fails the job.
   - Opt-in, not default: route callers (`track.ts`, `integrations.ts`) run in Worker fetch handlers where a dangling promise dies with the invocation, so they keep the awaited tick.
2. **Remove the post-run self-heal `armCron` in `JobQueueDO.runJob`** (issue's fix 3): redundant three ways — cron schedules persist durably in `_actor_alarms` (rows are UPDATEd on fire, not deleted), the */5 watchdog re-arms idempotently, and `armCron` itself recovers dropped alarm handles. Removes the last post-job `blockConcurrencyWhile` trigger from every cron run.

Bun/D1 mode is untouched (`enqueueAdhoc` is a plain row insert there; `server/jobs/sync.ts` unchanged).

## Tests

- `backend.test.ts`: `detachTick` resolves while `/tick` is still in flight (deferred-promise stub); a rejecting tick does not throw.
- `durable-object.test.ts`: `runJob` completes the job **without** calling `armCron` (replaces the #1020 best-effort test); a dropped cron schedule is recovered by the next watchdog `armCron`, not by `runJob` (replaces the #795 self-heal test).
- `processor.test.ts`: fan-out assertions now pin `{ detachTick: true }`.

`bun run check` passes.

**Post-deploy observable:** no `exceededWallTime` on `POST /arm` around the 03:30 UTC cron; `sync-episodes` job rows complete in seconds; partition DOs drain as before.

Closes #1058

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N65W7aMGAtxDcNthqfYjiy