### PR TITLE
[auto-review] fix: show error state in TrackedPage and StatsView on fetch failure

### DIFF
--- a/frontend/src/pages/StatsPage.test.tsx
+++ b/frontend/src/pages/StatsPage.test.tsx
@@ -56,6 +56,18 @@ afterEach(() => {
 });
 
 describe("StatsPage", () => {
+  it("shows error message when stats fetch fails", async () => {
+    apiMock.getStats.mockImplementation(() =>
+      Promise.reject(new Error("Server error")),
+    );
+    render(<StatsPage />, { wrapper: Wrapper });
+    await waitFor(() =>
+      expect(
+        screen.getByText("Failed to load stats. Please try again."),
+      ).toBeDefined(),
+    );
+  });
+
   it("renders the Watchlist ETA tile with dash when pace is undefined", async () => {
     render(<StatsPage />, { wrapper: Wrapper });
     await waitFor(() => {

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -177,10 +177,22 @@ function languageLabel(code: string): string {
 }
 
 export function StatsView() {
-  const { data, isLoading: loading } = useQuery({
+  const {
+    data,
+    isLoading: loading,
+    isError,
+  } = useQuery({
     queryKey: ["stats"],
     queryFn: ({ signal }) => api.getStats(signal),
   });
+
+  if (isError) {
+    return (
+      <p className="text-zinc-400 text-sm py-12 text-center">
+        Failed to load stats. Please try again.
+      </p>
+    );
+  }
 
   if (loading || !data) {
     return (

--- a/frontend/src/pages/TrackedPage.test.tsx
+++ b/frontend/src/pages/TrackedPage.test.tsx
@@ -133,6 +133,16 @@ describe("TrackedPage", () => {
     expect(container.querySelector(".animate-pulse")).toBeDefined();
   });
 
+  it("shows error message when fetch fails", async () => {
+    apiMock.getTrackedTitles.mockImplementation(() =>
+      Promise.reject(new Error("Network error")),
+    );
+    render(<TrackedPage />, { wrapper: Wrapper });
+    await waitFor(() =>
+      expect(screen.getByText("An error occurred")).toBeDefined(),
+    );
+  });
+
   it("shows empty message when no tracked titles", async () => {
     apiMock.getTrackedTitles.mockImplementation(() =>
       Promise.resolve({ titles: [], count: 0, profile_public: false }),

--- a/frontend/src/pages/TrackedPage.tsx
+++ b/frontend/src/pages/TrackedPage.tsx
@@ -126,7 +126,11 @@ function sortTitles(titles: Title[], sort: SortKey): Title[] {
 
 export default function TrackedPage() {
   const qc = useQueryClient();
-  const { data, isLoading: loading } = useQuery({
+  const {
+    data,
+    isLoading: loading,
+    isError,
+  } = useQuery({
     queryKey: ["tracked"],
     queryFn: ({ signal }) => api.getTrackedTitles(signal),
   });
@@ -299,6 +303,10 @@ export default function TrackedPage() {
         >
           {loading ? (
             <TitleGridSkeleton />
+          ) : isError ? (
+            <p className="text-zinc-400 text-sm py-12 text-center">
+              {t("common.error")}
+            </p>
           ) : filteredTitles.length === 0 ? (
             <TitleList
               titles={EMPTY_TITLES}


### PR DESCRIPTION
## Problem

Both `TrackedPage` and `StatsView` failed to handle the `isError` state from `useQuery`. When the API call failed:

- **TrackedPage**: `allTitles` fell back to `[]`, `filteredTitles` was empty, and the user saw the "no tracked titles" empty message — misleading them into thinking their library was empty rather than alerting them to a network/server failure.
- **StatsView**: the `if (loading || !data)` check caught the error case (since `data` is `undefined` on error) and left the user stuck on the pulse skeleton animation indefinitely.

This is the same class of issue fixed in `UserProfilePage` (see #998 — now closed).

## Changes

| File | Change |
|---|---|
| `TrackedPage.tsx` | Destructure `isError`; add error branch before the empty-state check |
| `StatsPage.tsx` (StatsView) | Destructure `isError`; split `if (loading \|\| !data)` into a distinct `if (isError)` guard that returns a message |
| `TrackedPage.test.tsx` | Add test: fetch failure → "An error occurred" |
| `StatsPage.test.tsx` | Add test: fetch failure → "Failed to load stats. Please try again." |

`bun run check` passes (tsc + ESLint + all tests + build + wrangler dry-run).

---
_Source: ux_

---
_Generated by [Claude Code](https://claude.ai/code/session_019jYg83sgZh6V3jMe81kw4a)_