### PR TITLE
Add TV Time CSV format to watchlist importer

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -97,10 +97,11 @@
   },
   "import": {
     "title": "Import from CSV",
-    "description": "Import your watchlist from Letterboxd, IMDB, or Trakt by uploading a CSV export file. Up to 500 titles will be processed per import.",
+    "description": "Import your watchlist from Letterboxd, IMDB, Trakt, or TV Time by uploading a CSV export file. Up to 500 titles will be processed per import.",
     "letterboxdHint": "Export from letterboxd.com — go to your profile, then Export.",
     "imdbHint": "Export your ratings or watchlist from imdb.com — go to your list, then Export.",
     "traktHint": "Export your watchlist from trakt.tv — go to Settings, then Data Export.",
+    "tvtimeHint": "From a TV Time export ZIP, upload movies_history.csv or tracking-prod-records-series.csv.",
     "dropHint": "Drag and drop a CSV file here, or click to choose a file",
     "importing": "Importing...",
     "chooseFile": "Choose CSV file"

--- a/frontend/src/pages/settings/IntegrationsTab.tsx
+++ b/frontend/src/pages/settings/IntegrationsTab.tsx
@@ -855,11 +855,12 @@ function CsvImportSection() {
         {msg && <SMessage kind="success">{msg}</SMessage>}
         {err && <SMessage kind="error">{err}</SMessage>}
 
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-2.5">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2.5">
           {[
             { n: "Letterboxd", hint: t("import.letterboxdHint") },
             { n: "IMDB", hint: t("import.imdbHint") },
             { n: "Trakt", hint: t("import.traktHint") },
+            { n: "TV Time", hint: t("import.tvtimeHint") },
           ].map((s) => (
             <div
               key={s.n}

--- a/server/routes/import.test.ts
+++ b/server/routes/import.test.ts
@@ -9,7 +9,13 @@ import {
 } from "bun:test";
 import { Hono } from "hono";
 import { setupTestDb, teardownTestDb } from "../test-utils/setup";
-import { makeParsedTitle } from "../test-utils/fixtures";
+import {
+  makeParsedTitle,
+  makeTmdbMovieDetails,
+  makeTmdbTvDetails,
+  makeTmdbSearchMultiMovie,
+  makeTmdbSearchMultiTv,
+} from "../test-utils/fixtures";
 import {
   createUser,
   createSession,
@@ -18,11 +24,14 @@ import {
 import { requireAuth } from "../middleware/auth";
 import * as resolver from "../imdb/resolver";
 import * as repository from "../db/repository";
+import * as tmdbClient from "../tmdb/client";
 import type { AppEnv } from "../types";
 import {
   parseCsv,
   detectCsvFormat,
   extractImdbIdFromRow,
+  extractTvTimeTitleFromRow,
+  collectTvTimeQueries,
   type CsvFormat,
 } from "./import";
 
@@ -107,6 +116,23 @@ describe("detectCsvFormat", () => {
     expect(detectCsvFormat(headers)).toBe("trakt");
   });
 
+  it("detects TV Time movies format", () => {
+    const headers = ["movie_name", "Date", "type"];
+    expect(detectCsvFormat(headers)).toBe("tvtime");
+  });
+
+  it("detects TV Time series format", () => {
+    const headers = [
+      "Series Name",
+      "Season Number",
+      "Episode Number",
+      "Season Name",
+      "Episode Name",
+      "Date",
+    ];
+    expect(detectCsvFormat(headers)).toBe("tvtime");
+  });
+
   it("returns unknown for unrecognized headers", () => {
     expect(detectCsvFormat(["foo", "bar", "baz"])).toBe("unknown");
   });
@@ -169,6 +195,95 @@ describe("extractImdbIdFromRow", () => {
   it("returns null for unknown format", () => {
     const row = { foo: "bar" };
     expect(extractImdbIdFromRow(row, "unknown" as CsvFormat)).toBeNull();
+  });
+
+  it("returns null for TV Time format (no IMDB IDs in export)", () => {
+    const row = {
+      movie_name: "Inception",
+      Date: "2024-01-01",
+      type: "completed",
+    };
+    expect(extractImdbIdFromRow(row, "tvtime")).toBeNull();
+  });
+});
+
+describe("extractTvTimeTitleFromRow", () => {
+  it("extracts movie name from movies_history row", () => {
+    const row = {
+      movie_name: "Inception",
+      Date: "2024-01-01",
+      type: "completed",
+    };
+    expect(extractTvTimeTitleFromRow(row)).toEqual({
+      name: "Inception",
+      mediaType: "movie",
+    });
+  });
+
+  it("extracts series name from tracking-prod-records-series row", () => {
+    const row = {
+      "Series Name": "Breaking Bad",
+      "Season Number": "1",
+      "Episode Number": "1",
+      Date: "2024-01-01",
+    };
+    expect(extractTvTimeTitleFromRow(row)).toEqual({
+      name: "Breaking Bad",
+      mediaType: "tv",
+    });
+  });
+
+  it("returns null when title columns are empty", () => {
+    expect(
+      extractTvTimeTitleFromRow({
+        movie_name: "",
+        Date: "2024-01-01",
+        type: "started",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("collectTvTimeQueries", () => {
+  it("deduplicates series episode rows by show name", () => {
+    const rows = [
+      {
+        "Series Name": "Breaking Bad",
+        "Season Number": "1",
+        "Episode Number": "1",
+      },
+      {
+        "Series Name": "Breaking Bad",
+        "Season Number": "1",
+        "Episode Number": "2",
+      },
+      {
+        "Series Name": "The Wire",
+        "Season Number": "1",
+        "Episode Number": "1",
+      },
+    ];
+    const { queries, skippedEmpty, skippedOverflow } =
+      collectTvTimeQueries(rows);
+    expect(queries).toEqual([
+      { name: "Breaking Bad", mediaType: "tv" },
+      { name: "The Wire", mediaType: "tv" },
+    ]);
+    expect(skippedEmpty).toBe(0);
+    expect(skippedOverflow).toBe(0);
+  });
+
+  it("deduplicates movie rows by name", () => {
+    const rows = [
+      { movie_name: "Dune", Date: "2024-01-01", type: "started" },
+      { movie_name: "Dune", Date: "2024-01-02", type: "completed" },
+      { movie_name: "Parasite", Date: "2024-01-03", type: "completed" },
+    ];
+    const { queries } = collectTvTimeQueries(rows);
+    expect(queries).toEqual([
+      { name: "Dune", mediaType: "movie" },
+      { name: "Parasite", mediaType: "movie" },
+    ]);
   });
 });
 
@@ -374,5 +489,86 @@ describe("POST /import/csv", () => {
     const body = await res.json();
     expect(body.failed).toBe(1);
     expect(body.errors[0]).toContain("TMDB timeout");
+  });
+
+  it("imports a valid TV Time movies CSV via TMDB search", async () => {
+    const searchSpy = spyOn(tmdbClient, "searchMulti").mockResolvedValue({
+      page: 1,
+      results: [makeTmdbSearchMultiMovie({ id: 27205, title: "Inception" })],
+      total_pages: 1,
+      total_results: 1,
+    });
+    const detailsSpy = spyOn(tmdbClient, "fetchMovieDetails").mockResolvedValue(
+      makeTmdbMovieDetails({ id: 27205, title: "Inception" }),
+    );
+    spies.push(searchSpy, detailsSpy);
+
+    const csv = "movie_name,Date,type\nInception,2024-01-01,completed";
+    const form = makeFormData(csv);
+    const res = await app.request("/import/csv", {
+      method: "POST",
+      headers: { Cookie: userCookie },
+      body: form,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.imported).toBe(1);
+    expect(body.failed).toBe(0);
+    expect(searchSpy).toHaveBeenCalledWith("Inception");
+    expect(detailsSpy).toHaveBeenCalledWith(27205);
+  });
+
+  it("imports unique shows from a TV Time series CSV", async () => {
+    const searchSpy = spyOn(tmdbClient, "searchMulti").mockResolvedValue({
+      page: 1,
+      results: [makeTmdbSearchMultiTv({ id: 1396, name: "Breaking Bad" })],
+      total_pages: 1,
+      total_results: 1,
+    });
+    const detailsSpy = spyOn(tmdbClient, "fetchTvDetails").mockResolvedValue(
+      makeTmdbTvDetails({ id: 1396, name: "Breaking Bad" }),
+    );
+    spies.push(searchSpy, detailsSpy);
+
+    const csv =
+      "Series Name,Season Number,Episode Number,Season Name,Episode Name,Date\n" +
+      "Breaking Bad,1,1,Season 1,Pilot,2024-01-01\n" +
+      "Breaking Bad,1,2,Season 1,Cat's in the Bag...,2024-01-02";
+    const form = makeFormData(csv);
+    const res = await app.request("/import/csv", {
+      method: "POST",
+      headers: { Cookie: userCookie },
+      body: form,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.imported).toBe(1);
+    expect(body.failed).toBe(0);
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+    expect(searchSpy).toHaveBeenCalledWith("Breaking Bad");
+    expect(detailsSpy).toHaveBeenCalledWith(1396);
+  });
+
+  it("counts unresolved TV Time titles as failed", async () => {
+    const searchSpy = spyOn(tmdbClient, "searchMulti").mockResolvedValue({
+      page: 1,
+      results: [],
+      total_pages: 0,
+      total_results: 0,
+    });
+    spies.push(searchSpy);
+
+    const csv = "movie_name,Date,type\nUnknown Film,2024-01-01,completed";
+    const form = makeFormData(csv);
+    const res = await app.request("/import/csv", {
+      method: "POST",
+      headers: { Cookie: userCookie },
+      body: form,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.failed).toBe(1);
+    expect(body.imported).toBe(0);
+    expect(body.errors[0]).toContain("Unknown Film");
   });
 });

--- a/server/routes/import.ts
+++ b/server/routes/import.ts
@@ -2,6 +2,12 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { resolveImdbUrl } from "../imdb/resolver";
 import { upsertTitles, trackTitle } from "../db/repository";
+import { searchMulti, fetchMovieDetails, fetchTvDetails } from "../tmdb/client";
+import {
+  parseMovieDetails,
+  parseTvDetails,
+  type ParsedTitle,
+} from "../tmdb/parser";
 import type { AppEnv } from "../types";
 import { ok, err } from "./response";
 import { logger } from "../logger";
@@ -40,7 +46,12 @@ const uploadSchema = z.object({
   file: uploadedFileSchema,
 });
 
-export type CsvFormat = "letterboxd" | "imdb" | "trakt" | "unknown";
+export type CsvFormat = "letterboxd" | "imdb" | "trakt" | "tvtime" | "unknown";
+
+export type TvTimeTitleQuery = {
+  name: string;
+  mediaType: "movie" | "tv";
+};
 
 /**
  * Parse a CSV string into an array of objects keyed by header row.
@@ -142,6 +153,18 @@ export function detectCsvFormat(headers: string[]): CsvFormat {
   ) {
     return "trakt";
   }
+  // TV Time movies_history.csv: movie_name, Date, type
+  if (set.has("movie_name") && set.has("Date")) {
+    return "tvtime";
+  }
+  // TV Time tracking-prod-records-series.csv
+  if (
+    set.has("Series Name") &&
+    set.has("Season Number") &&
+    set.has("Episode Number")
+  ) {
+    return "tvtime";
+  }
   return "unknown";
 }
 
@@ -183,9 +206,70 @@ export function extractImdbIdFromRow(
       if (/^tt\d+$/.test(imdbId)) return imdbId;
       return null;
     }
+    case "tvtime":
+      // TV Time exports have no IMDB/TMDB IDs — resolve via title search.
+      return null;
     default:
       return null;
   }
+}
+
+/** Extract a title query from a TV Time CSV row (movies or series export). */
+export function extractTvTimeTitleFromRow(
+  row: Record<string, string>,
+): TvTimeTitleQuery | null {
+  const movieName = (row["movie_name"] ?? "").trim();
+  if (movieName) return { name: movieName, mediaType: "movie" };
+  const seriesName = (row["Series Name"] ?? "").trim();
+  if (seriesName) return { name: seriesName, mediaType: "tv" };
+  return null;
+}
+
+/**
+ * Deduplicate TV Time rows by title name and cap unique titles at MAX_ROWS.
+ * Series CSVs are episode-level; we only track each show once.
+ */
+export function collectTvTimeQueries(rows: Record<string, string>[]): {
+  queries: TvTimeTitleQuery[];
+  skippedEmpty: number;
+  skippedOverflow: number;
+} {
+  const seen = new Set<string>();
+  const queries: TvTimeTitleQuery[] = [];
+  let skippedEmpty = 0;
+  let skippedOverflow = 0;
+
+  for (const row of rows) {
+    const q = extractTvTimeTitleFromRow(row);
+    if (!q) {
+      skippedEmpty++;
+      continue;
+    }
+    const key = `${q.mediaType}:${q.name.toLowerCase()}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    if (queries.length < MAX_ROWS) {
+      queries.push(q);
+    } else {
+      skippedOverflow++;
+    }
+  }
+
+  return { queries, skippedEmpty, skippedOverflow };
+}
+
+/** Resolve a title via TMDB search (used when CSV has no IMDB/TMDB IDs). */
+export async function resolveTitleByName(
+  name: string,
+  mediaType: "movie" | "tv",
+): Promise<ParsedTitle | null> {
+  const result = await searchMulti(name);
+  const match = result.results.find((r) => r.media_type === mediaType);
+  if (!match) return null;
+  if (mediaType === "movie") {
+    return parseMovieDetails(await fetchMovieDetails(match.id));
+  }
+  return parseTvDetails(await fetchTvDetails(match.id));
 }
 
 const app = new Hono<AppEnv>();
@@ -226,7 +310,7 @@ app.post("/csv", async (c) => {
   if (format === "unknown") {
     return err(
       c,
-      "Unrecognized CSV format. Supported formats: Letterboxd, IMDB, Trakt",
+      "Unrecognized CSV format. Supported formats: Letterboxd, IMDB, Trakt, TV Time",
     );
   }
 
@@ -236,57 +320,106 @@ app.post("/csv", async (c) => {
     userId: user.id,
   });
 
-  const limitedRows = rows.slice(0, MAX_ROWS);
   let imported = 0;
   let failed = 0;
   let skipped = 0;
   const errors: string[] = [];
 
-  for (
-    let batchStart = 0;
-    batchStart < limitedRows.length;
-    batchStart += BATCH_SIZE
-  ) {
-    if (batchStart > 0) {
-      await sleep(BATCH_DELAY_MS);
-    }
+  if (format === "tvtime") {
+    const { queries, skippedEmpty, skippedOverflow } =
+      collectTvTimeQueries(rows);
+    skipped = skippedEmpty + skippedOverflow;
 
-    const batch = limitedRows.slice(batchStart, batchStart + BATCH_SIZE);
-
-    for (const row of batch) {
-      const imdbId = extractImdbIdFromRow(row, format);
-      if (!imdbId) {
-        skipped++;
-        continue;
+    for (
+      let batchStart = 0;
+      batchStart < queries.length;
+      batchStart += BATCH_SIZE
+    ) {
+      if (batchStart > 0) {
+        await sleep(BATCH_DELAY_MS);
       }
 
-      try {
-        const title = await resolveImdbUrl(imdbId);
-        if (!title) {
+      const batch = queries.slice(batchStart, batchStart + BATCH_SIZE);
+
+      for (const query of batch) {
+        try {
+          const title = await resolveTitleByName(query.name, query.mediaType);
+          if (!title) {
+            failed++;
+            errors.push(`Could not resolve title: ${query.name}`);
+            continue;
+          }
+
+          await upsertTitles([title]);
+          await trackTitle(title.id, user.id);
+          imported++;
+          log.info("Imported title from CSV", {
+            query: query.name,
+            mediaType: query.mediaType,
+            titleId: title.id,
+            title: title.title,
+          });
+        } catch (e: unknown) {
           failed++;
-          errors.push(`Could not resolve IMDB ID: ${imdbId}`);
+          const msg = e instanceof Error ? e.message : String(e);
+          errors.push(`Failed to import ${query.name}: ${msg}`);
+          log.warn("Failed to import CSV row", {
+            query: query.name,
+            err: msg,
+          });
+        }
+      }
+    }
+  } else {
+    const limitedRows = rows.slice(0, MAX_ROWS);
+
+    for (
+      let batchStart = 0;
+      batchStart < limitedRows.length;
+      batchStart += BATCH_SIZE
+    ) {
+      if (batchStart > 0) {
+        await sleep(BATCH_DELAY_MS);
+      }
+
+      const batch = limitedRows.slice(batchStart, batchStart + BATCH_SIZE);
+
+      for (const row of batch) {
+        const imdbId = extractImdbIdFromRow(row, format);
+        if (!imdbId) {
+          skipped++;
           continue;
         }
 
-        await upsertTitles([title]);
-        await trackTitle(title.id, user.id);
-        imported++;
-        log.info("Imported title from CSV", {
-          imdbId,
-          titleId: title.id,
-          title: title.title,
-        });
-      } catch (e: unknown) {
-        failed++;
-        const msg = e instanceof Error ? e.message : String(e);
-        errors.push(`Failed to import ${imdbId}: ${msg}`);
-        log.warn("Failed to import CSV row", { imdbId, err: msg });
+        try {
+          const title = await resolveImdbUrl(imdbId);
+          if (!title) {
+            failed++;
+            errors.push(`Could not resolve IMDB ID: ${imdbId}`);
+            continue;
+          }
+
+          await upsertTitles([title]);
+          await trackTitle(title.id, user.id);
+          imported++;
+          log.info("Imported title from CSV", {
+            imdbId,
+            titleId: title.id,
+            title: title.title,
+          });
+        } catch (e: unknown) {
+          failed++;
+          const msg = e instanceof Error ? e.message : String(e);
+          errors.push(`Failed to import ${imdbId}: ${msg}`);
+          log.warn("Failed to import CSV row", { imdbId, err: msg });
+        }
       }
     }
-  }
 
-  const totalSkippedRows = rows.length > MAX_ROWS ? rows.length - MAX_ROWS : 0;
-  skipped += totalSkippedRows;
+    const totalSkippedRows =
+      rows.length > MAX_ROWS ? rows.length - MAX_ROWS : 0;
+    skipped += totalSkippedRows;
+  }
 
   log.info("CSV import complete", {
     format,


### PR DESCRIPTION
## Summary
- Add `tvtime` CSV format detection for TV Time export files (`movies_history.csv` and `tracking-prod-records-series.csv`)
- Resolve titles via TMDB search (no IMDB/TMDB IDs in exports); dedupe series episode rows to unique shows; respect `MAX_ROWS` (500 unique titles)
- Update Integrations import UI/copy to list TV Time alongside Letterboxd, IMDB, and Trakt

Closes #1071

## Test plan
- [x] `bun test server/routes/import.test.ts` (35 pass)
- [x] `bun run check:fast`
- [ ] Upload a real `movies_history.csv` from a TV Time ZIP and confirm movies are tracked
- [ ] Upload `tracking-prod-records-series.csv` and confirm unique shows are tracked (episode watch history deferred)