### PR TITLE
Add zValidator path-param validation across invitations and related routes

### DIFF
--- a/server/routes/integrations.test.ts
+++ b/server/routes/integrations.test.ts
@@ -214,11 +214,14 @@ describe("PUT /integrations/:id", () => {
   });
 
   it("returns 404 for non-existent integration", async () => {
-    const res = await app.request("/integrations/nonexistent", {
-      method: "PUT",
-      headers: jsonHeaders(),
-      body: JSON.stringify({ enabled: false }),
-    });
+    const res = await app.request(
+      "/integrations/00000000-0000-4000-8000-000000000000",
+      {
+        method: "PUT",
+        headers: jsonHeaders(),
+        body: JSON.stringify({ enabled: false }),
+      },
+    );
     expect(res.status).toBe(404);
   });
 });
@@ -244,15 +247,87 @@ describe("DELETE /integrations/:id", () => {
   });
 
   it("returns 404 for non-existent integration", async () => {
-    const res = await app.request("/integrations/nonexistent", {
-      method: "DELETE",
-      headers: headers(),
-    });
+    const res = await app.request(
+      "/integrations/00000000-0000-4000-8000-000000000000",
+      {
+        method: "DELETE",
+        headers: headers(),
+      },
+    );
     expect(res.status).toBe(404);
   });
 });
 
+describe("GET /integrations/:id/status", () => {
+  it("returns sync status for own integration", async () => {
+    const createRes = await app.request("/integrations", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify(validPlexIntegration),
+    });
+    const { integration } = (await createRes.json()) as any;
+
+    const res = await app.request(`/integrations/${integration.id}/status`, {
+      headers: headers(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body).toHaveProperty("last_sync_at");
+    expect(body).toHaveProperty("last_sync_error");
+    expect(body.enabled).toBe(true);
+  });
+});
+
+describe("POST /integrations/:id/sync", () => {
+  it("triggers sync for a plex integration", async () => {
+    const createRes = await app.request("/integrations", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify(validPlexIntegration),
+    });
+    const { integration } = (await createRes.json()) as any;
+
+    const syncWatched = await import("../plex/sync");
+    const syncLibrary = await import("../plex/library-sync");
+    spies.push(
+      spyOn(syncWatched, "syncPlexWatched").mockResolvedValue({
+        synced: 0,
+      } as any),
+      spyOn(syncLibrary, "syncPlexLibrary").mockResolvedValue({
+        synced: 0,
+      } as any),
+    );
+
+    const res = await app.request(`/integrations/${integration.id}/sync`, {
+      method: "POST",
+      headers: headers(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.success).toBe(true);
+  });
+});
+
 describe("validation", () => {
+  it("rejects :id path params that are not UUIDs", async () => {
+    for (const [method, path] of [
+      ["DELETE", "/integrations/not-a-uuid"],
+      ["POST", "/integrations/not-a-uuid/sync"],
+      ["GET", "/integrations/not-a-uuid/status"],
+      ["PUT", "/integrations/not-a-uuid"],
+    ] as const) {
+      const res = await app.request(path, {
+        method,
+        headers: jsonHeaders(),
+        body: method === "PUT" ? JSON.stringify({ enabled: false }) : undefined,
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as any;
+      expect(body.error).toBe("Validation failed");
+      expect(Array.isArray(body.issues)).toBe(true);
+    }
+  });
+
   it("rejects POST /integrations with missing config", async () => {
     const res = await app.request("/integrations", {
       method: "POST",

--- a/server/routes/integrations.ts
+++ b/server/routes/integrations.ts
@@ -21,6 +21,8 @@ import { ok, err } from "./response";
 import { zValidator } from "../lib/validator";
 import Sentry from "../sentry";
 
+const idParamSchema = z.object({ id: z.string().uuid() });
+
 const plexServersSchema = z.object({
   authToken: z.string().min(1),
 });
@@ -165,38 +167,43 @@ app.post("/", zValidator("json", createIntegrationSchema), async (c) => {
 });
 
 // PUT /:id — update integration
-app.put("/:id", zValidator("json", updateIntegrationSchema), async (c) => {
-  const user = c.get("user")!;
-  const id = c.req.param("id");
-  const body = c.req.valid("json");
+app.put(
+  "/:id",
+  zValidator("param", idParamSchema),
+  zValidator("json", updateIntegrationSchema),
+  async (c) => {
+    const user = c.get("user")!;
+    const { id } = c.req.valid("param");
+    const body = c.req.valid("json");
 
-  const existing = await getIntegrationById(id, user.id);
-  if (!existing) return err(c, "Integration not found", 404);
+    const existing = await getIntegrationById(id, user.id);
+    if (!existing) return err(c, "Integration not found", 404);
 
-  const updates: Parameters<typeof updateIntegration>[2] = {};
-  if (body.name !== undefined) updates.name = body.name;
-  if (body.enabled !== undefined) updates.enabled = body.enabled;
-  if (body.config !== undefined) {
-    const merged = {
-      ...existing.config,
-      ...body.config,
-      serverUrl: (body.config.serverUrl ?? existing.config.serverUrl).replace(
-        /\/$/,
-        "",
-      ),
-    };
-    updates.config = merged;
-  }
+    const updates: Parameters<typeof updateIntegration>[2] = {};
+    if (body.name !== undefined) updates.name = body.name;
+    if (body.enabled !== undefined) updates.enabled = body.enabled;
+    if (body.config !== undefined) {
+      const merged = {
+        ...existing.config,
+        ...body.config,
+        serverUrl: (body.config.serverUrl ?? existing.config.serverUrl).replace(
+          /\/$/,
+          "",
+        ),
+      };
+      updates.config = merged;
+    }
 
-  await updateIntegration(id, user.id, updates);
-  const integration = await getIntegrationById(id, user.id);
-  return ok(c, { integration: sanitize(integration!) });
-});
+    await updateIntegration(id, user.id, updates);
+    const integration = await getIntegrationById(id, user.id);
+    return ok(c, { integration: sanitize(integration!) });
+  },
+);
 
 // DELETE /:id — delete integration
-app.delete("/:id", async (c) => {
+app.delete("/:id", zValidator("param", idParamSchema), async (c) => {
   const user = c.get("user")!;
-  const id = c.req.param("id");
+  const { id } = c.req.valid("param");
 
   const existing = await getIntegrationById(id, user.id);
   if (!existing) return err(c, "Integration not found", 404);
@@ -206,9 +213,9 @@ app.delete("/:id", async (c) => {
 });
 
 // POST /:id/sync — trigger manual Plex sync
-app.post("/:id/sync", async (c) => {
+app.post("/:id/sync", zValidator("param", idParamSchema), async (c) => {
   const user = c.get("user")!;
-  const id = c.req.param("id");
+  const { id } = c.req.valid("param");
 
   const integration = await getIntegrationById(id, user.id);
   if (!integration) return err(c, "Integration not found", 404);
@@ -255,9 +262,9 @@ app.post("/:id/sync", async (c) => {
 });
 
 // GET /:id/status — get last sync status
-app.get("/:id/status", async (c) => {
+app.get("/:id/status", zValidator("param", idParamSchema), async (c) => {
   const user = c.get("user")!;
-  const id = c.req.param("id");
+  const { id } = c.req.valid("param");
 
   const integration = await getIntegrationById(id, user.id);
   if (!integration) return err(c, "Integration not found", 404);

--- a/server/routes/invitations.test.ts
+++ b/server/routes/invitations.test.ts
@@ -302,9 +302,68 @@ describe("DELETE /invitations/:id", () => {
   });
 
   it("returns 401 without auth", async () => {
-    const res = await app.request("/invitations/some-id", {
-      method: "DELETE",
-    });
+    const res = await app.request(
+      "/invitations/00000000-0000-4000-8000-000000000000",
+      {
+        method: "DELETE",
+      },
+    );
     expect(res.status).toBe(401);
+  });
+});
+
+describe("validation", () => {
+  it("rejects POST /redeem/:code with oversized code", async () => {
+    const res = await app.request(`/invitations/redeem/${"x".repeat(65)}`, {
+      method: "POST",
+      headers: authHeaders(userBToken),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects DELETE /:id with non-UUID id", async () => {
+    const res = await app.request("/invitations/not-a-uuid", {
+      method: "DELETE",
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("happy path — redeem valid code", async () => {
+    const createRes = await app.request("/invitations", {
+      method: "POST",
+      headers: authHeaders(userAToken),
+    });
+    const { code } = await createRes.json();
+
+    const res = await app.request(`/invitations/redeem/${code}`, {
+      method: "POST",
+      headers: authHeaders(userBToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  it("happy path — revoke valid UUID", async () => {
+    const createRes = await app.request("/invitations", {
+      method: "POST",
+      headers: authHeaders(userAToken),
+    });
+    const { id } = await createRes.json();
+
+    const res = await app.request(`/invitations/${id}`, {
+      method: "DELETE",
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
   });
 });

--- a/server/routes/invitations.ts
+++ b/server/routes/invitations.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { z } from "zod";
 import {
   createInvitation,
   getInvitation,
@@ -11,8 +12,12 @@ import {
 import type { AppEnv } from "../types";
 import { logger } from "../logger";
 import { ok, err } from "./response";
+import { zValidator } from "../lib/validator";
 
 const log = logger.child({ module: "invitations" });
+
+const redeemParamSchema = z.object({ code: z.string().min(1).max(64) });
+const revokeParamSchema = z.object({ id: z.string().uuid() });
 
 const app = new Hono<AppEnv>();
 
@@ -82,13 +87,13 @@ app.get("/", async (c) => {
 });
 
 // POST /redeem/:code — Redeem an invitation
-app.post("/redeem/:code", async (c) => {
+app.post("/redeem/:code", zValidator("param", redeemParamSchema), async (c) => {
   const user = c.get("user");
   if (!user) {
     return err(c, "Authentication required", 401);
   }
 
-  const code = c.req.param("code");
+  const { code } = c.req.valid("param");
   const invitation = await getInvitation(code);
 
   if (!invitation) {
@@ -132,13 +137,13 @@ app.post("/redeem/:code", async (c) => {
 });
 
 // DELETE /:id — Revoke an invitation
-app.delete("/:id", async (c) => {
+app.delete("/:id", zValidator("param", revokeParamSchema), async (c) => {
   const user = c.get("user");
   if (!user) {
     return err(c, "Authentication required", 401);
   }
 
-  const id = c.req.param("id");
+  const { id } = c.req.valid("param");
   await revokeInvitation(id, user.id);
   log.info("Invitation revoked", { invitationId: id, userId: user.id });
   return ok(c, { success: true });

--- a/server/routes/notifiers.test.ts
+++ b/server/routes/notifiers.test.ts
@@ -203,11 +203,14 @@ describe("PUT /notifiers/:id", () => {
   });
 
   it("returns 404 for non-existent notifier", async () => {
-    const res = await app.request("/notifiers/nonexistent", {
-      method: "PUT",
-      headers: jsonHeaders(),
-      body: JSON.stringify({ notify_time: "10:00" }),
-    });
+    const res = await app.request(
+      "/notifiers/00000000-0000-4000-8000-000000000000",
+      {
+        method: "PUT",
+        headers: jsonHeaders(),
+        body: JSON.stringify({ notify_time: "10:00" }),
+      },
+    );
     expect(res.status).toBe(404);
   });
 });
@@ -246,10 +249,13 @@ describe("POST /notifiers/:id/test", () => {
   }
 
   it("returns 404 for non-existent notifier", async () => {
-    const res = await app.request("/notifiers/nonexistent/test", {
-      method: "POST",
-      headers: headers(),
-    });
+    const res = await app.request(
+      "/notifiers/00000000-0000-4000-8000-000000000000/test",
+      {
+        method: "POST",
+        headers: headers(),
+      },
+    );
     expect(res.status).toBe(404);
   });
 
@@ -600,6 +606,44 @@ describe("digest_mode", () => {
 });
 
 describe("validation", () => {
+  it("rejects :id path params that are not UUIDs", async () => {
+    for (const [method, path] of [
+      ["DELETE", "/notifiers/not-a-uuid"],
+      ["POST", "/notifiers/not-a-uuid/test"],
+      ["GET", "/notifiers/not-a-uuid/preview"],
+      ["GET", "/notifiers/not-a-uuid/history"],
+      ["PUT", "/notifiers/not-a-uuid"],
+    ] as const) {
+      const res = await app.request(path, {
+        method,
+        headers: jsonHeaders(),
+        body:
+          method === "PUT"
+            ? JSON.stringify({ notify_time: "10:00" })
+            : undefined,
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("Validation failed");
+      expect(Array.isArray(body.issues)).toBe(true);
+    }
+  });
+
+  it("happy path — DELETE /:id with valid UUID", async () => {
+    const createRes = await app.request("/notifiers", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify(validNotifier),
+    });
+    const { notifier } = await createRes.json();
+
+    const res = await app.request(`/notifiers/${notifier.id}`, {
+      method: "DELETE",
+      headers: headers(),
+    });
+    expect(res.status).toBe(200);
+  });
+
   it("rejects POST / when provider is missing", async () => {
     const res = await app.request("/notifiers", {
       method: "POST",
@@ -697,9 +741,12 @@ describe("GET /notifiers/:id/history", () => {
   });
 
   it("returns 404 for a non-existent notifier", async () => {
-    const res = await app.request("/notifiers/nonexistent-id/history", {
-      headers: headers(),
-    });
+    const res = await app.request(
+      "/notifiers/00000000-0000-4000-8000-000000000000/history",
+      {
+        headers: headers(),
+      },
+    );
     expect(res.status).toBe(404);
   });
 });
@@ -842,9 +889,12 @@ describe("GET /notifiers/:id/preview", () => {
   });
 
   it("returns 404 for non-existent notifier", async () => {
-    const res = await app.request("/notifiers/nonexistent/preview", {
-      headers: headers(),
-    });
+    const res = await app.request(
+      "/notifiers/00000000-0000-4000-8000-000000000000/preview",
+      {
+        headers: headers(),
+      },
+    );
     expect(res.status).toBe(404);
   });
 

--- a/server/routes/notifiers.ts
+++ b/server/routes/notifiers.ts
@@ -22,6 +22,8 @@ import Sentry from "../sentry";
 import { ok, err } from "./response";
 import { zValidator } from "../lib/validator";
 
+const idParamSchema = z.object({ id: z.string().uuid() });
+
 const app = new Hono<AppEnv>();
 
 function isValidTimezone(tz: string): boolean {
@@ -252,79 +254,89 @@ app.post(
 );
 
 // PUT /:id — update notifier
-app.put("/:id", zValidator("json", updateNotifierSchema), async (c) => {
-  const user = c.get("user")!;
-  const id = c.req.param("id");
-  const body = c.req.valid("json");
+app.put(
+  "/:id",
+  zValidator("param", idParamSchema),
+  zValidator("json", updateNotifierSchema),
+  async (c) => {
+    const user = c.get("user")!;
+    const { id } = c.req.valid("param");
+    const body = c.req.valid("json");
 
-  const existing = await getNotifierById(id, user.id);
-  if (!existing) {
-    return err(c, "Notifier not found", 404);
-  }
+    const existing = await getNotifierById(id, user.id);
+    if (!existing) {
+      return err(c, "Notifier not found", 404);
+    }
 
-  // Validate config if provided (provider-specific)
-  if (body.config) {
-    const provider = getProvider(body.provider || existing.provider);
-    if (provider) {
-      const validation = provider.validateConfig(body.config);
-      if (!validation.valid) {
-        return err(c, validation.error ?? "Invalid config");
+    // Validate config if provided (provider-specific)
+    if (body.config) {
+      const provider = getProvider(body.provider || existing.provider);
+      if (provider) {
+        const validation = provider.validateConfig(body.config);
+        if (!validation.valid) {
+          return err(c, validation.error ?? "Invalid config");
+        }
       }
     }
-  }
 
-  const digestMode = "digest_mode" in body ? body.digest_mode : undefined;
-  const digestDay = "digest_day" in body ? body.digest_day : undefined;
+    const digestMode = "digest_mode" in body ? body.digest_mode : undefined;
+    const digestDay = "digest_day" in body ? body.digest_day : undefined;
 
-  if (
-    digestMode === "weekly" &&
-    (digestDay === null || digestDay === undefined)
-  ) {
-    // Check if existing notifier already has a digest_day set
-    if (existing.digest_day === null || existing.digest_day === undefined) {
-      return err(c, "digest_day is required when digest_mode is 'weekly'");
+    if (
+      digestMode === "weekly" &&
+      (digestDay === null || digestDay === undefined)
+    ) {
+      // Check if existing notifier already has a digest_day set
+      if (existing.digest_day === null || existing.digest_day === undefined) {
+        return err(c, "digest_day is required when digest_mode is 'weekly'");
+      }
     }
-  }
 
-  await updateNotifier(id, user.id, {
-    config: body.config,
-    notifyTime: body.notify_time,
-    timezone: body.timezone,
-    enabled: body.enabled,
-    ...("digest_mode" in body ? { digestMode: body.digest_mode ?? null } : {}),
-    ...("digest_day" in body ? { digestDay: body.digest_day ?? null } : {}),
-    ...("streaming_alerts_enabled" in body
-      ? { streamingAlertsEnabled: body.streaming_alerts_enabled !== false }
-      : {}),
-    ...("quiet_hours_start" in body
-      ? { quietHoursStart: body.quiet_hours_start ?? null }
-      : {}),
-    ...("quiet_hours_end" in body
-      ? { quietHoursEnd: body.quiet_hours_end ?? null }
-      : {}),
-    ...(body.quiet_hours_days !== undefined
-      ? { quietHoursDays: body.quiet_hours_days }
-      : {}),
-    ...(body.leaving_soon_alerts_enabled !== undefined
-      ? { leavingSoonAlertsEnabled: body.leaving_soon_alerts_enabled !== false }
-      : {}),
-    ...(body.friend_activity_alerts_enabled !== undefined
-      ? {
-          friendActivityAlertsEnabled:
-            body.friend_activity_alerts_enabled === true,
-        }
-      : {}),
-  });
-  await refreshNotificationSchedule();
+    await updateNotifier(id, user.id, {
+      config: body.config,
+      notifyTime: body.notify_time,
+      timezone: body.timezone,
+      enabled: body.enabled,
+      ...("digest_mode" in body
+        ? { digestMode: body.digest_mode ?? null }
+        : {}),
+      ...("digest_day" in body ? { digestDay: body.digest_day ?? null } : {}),
+      ...("streaming_alerts_enabled" in body
+        ? { streamingAlertsEnabled: body.streaming_alerts_enabled !== false }
+        : {}),
+      ...("quiet_hours_start" in body
+        ? { quietHoursStart: body.quiet_hours_start ?? null }
+        : {}),
+      ...("quiet_hours_end" in body
+        ? { quietHoursEnd: body.quiet_hours_end ?? null }
+        : {}),
+      ...(body.quiet_hours_days !== undefined
+        ? { quietHoursDays: body.quiet_hours_days }
+        : {}),
+      ...(body.leaving_soon_alerts_enabled !== undefined
+        ? {
+            leavingSoonAlertsEnabled:
+              body.leaving_soon_alerts_enabled !== false,
+          }
+        : {}),
+      ...(body.friend_activity_alerts_enabled !== undefined
+        ? {
+            friendActivityAlertsEnabled:
+              body.friend_activity_alerts_enabled === true,
+          }
+        : {}),
+    });
+    await refreshNotificationSchedule();
 
-  const notifier = await getNotifierById(id, user.id);
-  return ok(c, { notifier });
-});
+    const notifier = await getNotifierById(id, user.id);
+    return ok(c, { notifier });
+  },
+);
 
 // DELETE /:id — delete notifier
-app.delete("/:id", async (c) => {
+app.delete("/:id", zValidator("param", idParamSchema), async (c) => {
   const user = c.get("user")!;
-  const id = c.req.param("id");
+  const { id } = c.req.valid("param");
 
   const existing = await getNotifierById(id, user.id);
   if (!existing) {
@@ -337,9 +349,9 @@ app.delete("/:id", async (c) => {
 });
 
 // POST /:id/test — send test notification
-app.post("/:id/test", async (c) => {
+app.post("/:id/test", zValidator("param", idParamSchema), async (c) => {
   const user = c.get("user")!;
-  const id = c.req.param("id");
+  const { id } = c.req.valid("param");
 
   const notifier = await getNotifierById(id, user.id);
   if (!notifier) {
@@ -381,34 +393,44 @@ app.post("/:id/test", async (c) => {
 });
 
 // GET /:id/preview — preview today's digest content (not dispatched)
-app.get("/:id/preview", requireAuth, async (c) => {
-  const user = c.get("user")!;
-  const id = c.req.param("id");
+app.get(
+  "/:id/preview",
+  requireAuth,
+  zValidator("param", idParamSchema),
+  async (c) => {
+    const user = c.get("user")!;
+    const { id } = c.req.valid("param");
 
-  const notifier = await getNotifierById(id, user.id);
-  if (!notifier) {
-    return err(c, "Notifier not found", 404);
-  }
+    const notifier = await getNotifierById(id, user.id);
+    if (!notifier) {
+      return err(c, "Notifier not found", 404);
+    }
 
-  const today = new Date().toISOString().slice(0, 10);
-  const content = await buildPreviewContent(user.id, today);
+    const today = new Date().toISOString().slice(0, 10);
+    const content = await buildPreviewContent(user.id, today);
 
-  return c.json(content);
-});
+    return c.json(content);
+  },
+);
 
 // GET /:id/history — delivery history for a notifier (owner only)
-app.get("/:id/history", requireAuth, async (c) => {
-  const user = c.get("user")!;
-  const id = c.req.param("id");
+app.get(
+  "/:id/history",
+  requireAuth,
+  zValidator("param", idParamSchema),
+  async (c) => {
+    const user = c.get("user")!;
+    const { id } = c.req.valid("param");
 
-  const notifier = await getNotifierById(id, user.id);
-  if (!notifier) {
-    return err(c, "Notifier not found", 404);
-  }
+    const notifier = await getNotifierById(id, user.id);
+    if (!notifier) {
+      return err(c, "Notifier not found", 404);
+    }
 
-  const rows = await getRecentForNotifier(id, 5);
-  const successRate = await getSuccessRateForNotifier(id, 7);
-  return ok(c, { rows, successRate });
-});
+    const rows = await getRecentForNotifier(id, 5);
+    const successRate = await getSuccessRateForNotifier(id, 7);
+    return ok(c, { rows, successRate });
+  },
+);
 
 export default app;

--- a/server/routes/profile-activity.test.ts
+++ b/server/routes/profile-activity.test.ts
@@ -580,3 +580,31 @@ describe("PATCH /user/me/activity-settings", () => {
     });
   });
 });
+
+describe("DELETE /user/me/activity/hide/:event_kind/:event_key", () => {
+  it("rejects invalid event_kind", async () => {
+    const res = await app.request("/user/me/activity/hide/not_a_kind/rt:m1", {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("unhides an event (happy path)", async () => {
+    await hideActivityEvent(userId, "rating_title", "rt:m1");
+
+    const res = await app.request(
+      "/user/me/activity/hide/rating_title/rt%3Am1",
+      {
+        method: "DELETE",
+        headers: authHeaders(),
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.hidden).toBe(false);
+  });
+});

--- a/server/routes/profile.test.ts
+++ b/server/routes/profile.test.ts
@@ -1092,6 +1092,41 @@ describe("PATCH /user/me/profile", () => {
   });
 });
 
+describe("validation — path params", () => {
+  it("rejects POST /me/pinned/:titleId with oversized titleId", async () => {
+    const res = await app.request(`/user/me/pinned/${"x".repeat(129)}`, {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as AnyRecord;
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects DELETE /me/pinned/:titleId with oversized titleId", async () => {
+    const res = await app.request(`/user/me/pinned/${"x".repeat(129)}`, {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as AnyRecord;
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("happy path — POST /me/pinned/:titleId with valid titleId", async () => {
+    await upsertTitles([makeParsedTitle({ id: "movie-123" })]);
+    const res = await app.request("/user/me/pinned/movie-123", {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as AnyRecord;
+    expect(body.pinned).toBe(true);
+  });
+});
+
 describe("validation — profile extras", () => {
   it("returns 400 for invalid country_code (lowercase)", async () => {
     const res = await app.request("/user/me/profile", {

--- a/server/routes/profile.ts
+++ b/server/routes/profile.ts
@@ -152,6 +152,15 @@ const hideEventSchema = z.object({
   event_key: z.string().min(1).max(200),
 });
 
+const hideEventParamSchema = z.object({
+  event_kind: activityKindEnum,
+  event_key: z.string().min(1).max(200),
+});
+
+const pinnedTitleParamSchema = z.object({
+  titleId: z.string().min(1).max(128),
+});
+
 app.post(
   "/me/activity/hide",
   zValidator("json", hideEventSchema),
@@ -164,16 +173,17 @@ app.post(
   },
 );
 
-app.delete("/me/activity/hide/:event_kind/:event_key", async (c) => {
-  const user = c.get("user");
-  if (!user) return err(c, "Authentication required", 401);
-  const rawKind = c.req.param("event_kind");
-  const eventKey = c.req.param("event_key");
-  const parsed = activityKindEnum.safeParse(rawKind);
-  if (!parsed.success) return err(c, "Invalid event_kind", 400);
-  await unhideActivityEvent(user.id, parsed.data, eventKey);
-  return ok(c, { hidden: false });
-});
+app.delete(
+  "/me/activity/hide/:event_kind/:event_key",
+  zValidator("param", hideEventParamSchema),
+  async (c) => {
+    const user = c.get("user");
+    if (!user) return err(c, "Authentication required", 401);
+    const { event_kind, event_key } = c.req.valid("param");
+    await unhideActivityEvent(user.id, event_kind, event_key);
+    return ok(c, { hidden: false });
+  },
+);
 
 const searchQuerySchema = z.object({ q: z.string().min(1) });
 
@@ -283,29 +293,39 @@ const reorderSchema = z.object({
 });
 
 // POST /me/pinned/:titleId — pin a title (auth required)
-app.post("/me/pinned/:titleId", requireAuth, async (c) => {
-  const user = c.get("user")!;
-  const titleId = c.req.param("titleId");
+app.post(
+  "/me/pinned/:titleId",
+  requireAuth,
+  zValidator("param", pinnedTitleParamSchema),
+  async (c) => {
+    const user = c.get("user")!;
+    const { titleId } = c.req.valid("param");
 
-  const result = await pinTitle(user.id, titleId);
-  if (!result.ok) {
-    return err(c, result.error, 400);
-  }
+    const result = await pinTitle(user.id, titleId);
+    if (!result.ok) {
+      return err(c, result.error, 400);
+    }
 
-  log.info("Title pinned", { userId: user.id, titleId });
-  return ok(c, { pinned: true });
-});
+    log.info("Title pinned", { userId: user.id, titleId });
+    return ok(c, { pinned: true });
+  },
+);
 
 // DELETE /me/pinned/:titleId — unpin a title (auth required)
-app.delete("/me/pinned/:titleId", requireAuth, async (c) => {
-  const user = c.get("user")!;
-  const titleId = c.req.param("titleId");
+app.delete(
+  "/me/pinned/:titleId",
+  requireAuth,
+  zValidator("param", pinnedTitleParamSchema),
+  async (c) => {
+    const user = c.get("user")!;
+    const { titleId } = c.req.valid("param");
 
-  await unpinTitle(user.id, titleId);
+    await unpinTitle(user.id, titleId);
 
-  log.info("Title unpinned", { userId: user.id, titleId });
-  return ok(c, { pinned: false });
-});
+    log.info("Title unpinned", { userId: user.id, titleId });
+    return ok(c, { pinned: false });
+  },
+);
 
 // PUT /me/pinned/order — reorder pinned titles (auth required)
 app.put(

--- a/server/routes/recommendations.test.ts
+++ b/server/routes/recommendations.test.ts
@@ -362,9 +362,12 @@ describe("POST /recommendations/:id/read", () => {
   });
 
   it("returns 401 without auth", async () => {
-    const res = await app.request("/recommendations/some-id/read", {
-      method: "POST",
-    });
+    const res = await app.request(
+      "/recommendations/00000000-0000-4000-8000-000000000000/read",
+      {
+        method: "POST",
+      },
+    );
     expect(res.status).toBe(401);
   });
 });
@@ -424,14 +427,58 @@ describe("DELETE /recommendations/:id", () => {
   });
 
   it("returns 401 without auth", async () => {
-    const res = await app.request("/recommendations/some-id", {
-      method: "DELETE",
-    });
+    const res = await app.request(
+      "/recommendations/00000000-0000-4000-8000-000000000000",
+      {
+        method: "DELETE",
+      },
+    );
     expect(res.status).toBe(401);
   });
 });
 
 describe("validation", () => {
+  it("rejects GET /check/:titleId with oversized titleId", async () => {
+    const res = await app.request(`/recommendations/check/${"x".repeat(129)}`, {
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects POST /:id/read with non-UUID id", async () => {
+    const res = await app.request("/recommendations/not-a-uuid/read", {
+      method: "POST",
+      headers: authHeaders(userBToken),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects DELETE /:id with non-UUID id", async () => {
+    const res = await app.request("/recommendations/not-a-uuid", {
+      method: "DELETE",
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("happy path — GET /check/:titleId with valid titleId", async () => {
+    const res = await app.request("/recommendations/check/movie-123", {
+      headers: authHeaders(userAToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("recommended");
+  });
+
   it("rejects POST / with empty titleId via zod", async () => {
     const res = await app.request("/recommendations", {
       method: "POST",

--- a/server/routes/recommendations.ts
+++ b/server/routes/recommendations.ts
@@ -30,6 +30,11 @@ const discoveryFeedQuerySchema = z.object({
   offset: z.coerce.number().int().min(0).default(0),
 });
 
+const titleIdParamSchema = z.object({
+  titleId: z.string().min(1).max(128),
+});
+const idParamSchema = z.object({ id: z.string().uuid() });
+
 const app = new Hono<AppEnv>();
 
 // POST / — Send a recommendation (broadcast to all followers, or targeted to one user)
@@ -129,16 +134,20 @@ app.get("/sent", async (c) => {
 });
 
 // GET /check/:titleId — Check if user already recommended a title
-app.get("/check/:titleId", async (c) => {
-  const user = c.get("user");
-  if (!user) {
-    return err(c, "Authentication required", 401);
-  }
+app.get(
+  "/check/:titleId",
+  zValidator("param", titleIdParamSchema),
+  async (c) => {
+    const user = c.get("user");
+    if (!user) {
+      return err(c, "Authentication required", 401);
+    }
 
-  const titleId = c.req.param("titleId");
-  const existing = await getUserRecommendation(user.id, titleId);
-  return ok(c, { recommended: !!existing, id: existing?.id ?? null });
-});
+    const { titleId } = c.req.valid("param");
+    const existing = await getUserRecommendation(user.id, titleId);
+    return ok(c, { recommended: !!existing, id: existing?.id ?? null });
+  },
+);
 
 // GET / — Discovery feed (recommendations from followed users)
 app.get("/", zValidator("query", discoveryFeedQuerySchema), async (c) => {
@@ -178,25 +187,25 @@ app.get("/", zValidator("query", discoveryFeedQuerySchema), async (c) => {
 });
 
 // POST /:id/read — Mark as read (per-user tracking)
-app.post("/:id/read", async (c) => {
+app.post("/:id/read", zValidator("param", idParamSchema), async (c) => {
   const user = c.get("user");
   if (!user) {
     return err(c, "Authentication required", 401);
   }
 
-  const id = c.req.param("id");
+  const { id } = c.req.valid("param");
   await markAsRead(id, user.id);
   return ok(c, { success: true });
 });
 
 // DELETE /:id — Delete a recommendation (only creator can delete)
-app.delete("/:id", async (c) => {
+app.delete("/:id", zValidator("param", idParamSchema), async (c) => {
   const user = c.get("user");
   if (!user) {
     return err(c, "Authentication required", 401);
   }
 
-  const id = c.req.param("id");
+  const { id } = c.req.valid("param");
   await deleteRecommendation(id, user.id);
   log.info("Recommendation deleted", { id, userId: user.id });
   return ok(c, { success: true });

--- a/server/routes/track.test.ts
+++ b/server/routes/track.test.ts
@@ -1465,6 +1465,56 @@ describe("validation", () => {
     await upsertTitles([makeParsedTitle()]);
   });
 
+  it("rejects POST /track/:id with oversized title id", async () => {
+    const res = await app.request(`/track/${"x".repeat(129)}`, {
+      method: "POST",
+      headers: { ...headers(), "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("rejects DELETE /track/:id with oversized title id", async () => {
+    const res = await app.request(`/track/${"x".repeat(129)}`, {
+      method: "DELETE",
+      headers: headers(),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(Array.isArray(body.issues)).toBe(true);
+  });
+
+  it("happy path — POST /track/:id with valid title id", async () => {
+    const res = await app.request("/track/movie-123", {
+      method: "POST",
+      headers: { ...headers(), "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.message).toContain("Tracking");
+  });
+
+  it("happy path — DELETE /track/:id with valid title id", async () => {
+    await app.request("/track/movie-123", {
+      method: "POST",
+      headers: { ...headers(), "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    const res = await app.request("/track/movie-123", {
+      method: "DELETE",
+      headers: headers(),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.message).toContain("Untracked");
+  });
+
   it("rejects PATCH /track/:id/status with invalid enum", async () => {
     const res = await app.request("/track/movie-123/status", {
       method: "PATCH",

--- a/server/routes/track.ts
+++ b/server/routes/track.ts
@@ -72,6 +72,8 @@ const VALID_USER_STATUSES = [
 ] as const;
 const VALID_NOTIFICATION_MODES = ["all", "premieres_only", "none"] as const;
 
+const titleIdParamSchema = z.object({ id: z.string().min(1).max(128) });
+
 const frontendOfferSchema = z.object({
   provider_id: z.number(),
   provider_name: z.string(),
@@ -453,9 +455,9 @@ app.post("/bulk", zValidator("json", bulkActionSchema), async (c) => {
 // `trackPostBodySchema` is `.optional()` per-field, so an empty body `{}` is
 // valid. We safe-parse against an empty-object fallback so a totally absent
 // body (no Content-Type, no payload) is still accepted.
-app.post("/:id", async (c) => {
+app.post("/:id", zValidator("param", titleIdParamSchema), async (c) => {
   const user = c.get("user")!;
-  const titleId = c.req.param("id");
+  const { id: titleId } = c.req.valid("param");
   const raw = await c.req.json().catch(() => ({}));
   const parsed = trackPostBodySchema.safeParse(raw);
   if (!parsed.success) {
@@ -553,9 +555,9 @@ app.patch("/:id/tags", zValidator("json", tagsSchema), async (c) => {
   return ok(c, { message: "Tags updated" });
 });
 
-app.delete("/:id", async (c) => {
+app.delete("/:id", zValidator("param", titleIdParamSchema), async (c) => {
   const user = c.get("user")!;
-  const titleId = c.req.param("id");
+  const { id: titleId } = c.req.valid("param");
   await untrackTitle(titleId, user.id);
   return ok(c, { message: `Untracked ${titleId}` });
 });


### PR DESCRIPTION
## Summary
- Add `zValidator("param", ...)` to invitations `/:code` and `/:id` (#1072), plus notifiers, integrations, track POST/DELETE `/:id`, profile hide/pinned, and recommendations path params (#1080).
- Handlers now read validated params via `c.req.valid("param")`; malformed UUIDs / oversized title IDs / invalid activity kinds return standard `400 + issues[]`.
- Colocated rejection + happy-path tests added/updated for each touched route file (302 tests passing).

## Test plan
- [x] `bun test server/routes/invitations.test.ts server/routes/notifiers.test.ts server/routes/integrations.test.ts server/routes/track.test.ts server/routes/recommendations.test.ts server/routes/profile.test.ts server/routes/profile-activity.test.ts`
- [ ] Spot-check API: invalid UUID on `DELETE /api/notifiers/not-a-uuid` → 400 with `issues`
- [ ] Spot-check API: valid UUID missing notifier → 404

Closes #1072
Closes #1080