### PR TITLE
fix: move achievement sync off fetch; make DO /arm non-blocking

### DIFF
--- a/server/jobs/durable-object.test.ts
+++ b/server/jobs/durable-object.test.ts
@@ -1188,13 +1188,16 @@ describe("JobQueueDO", () => {
     expect(await state.storage.getAlarm()).not.toBeNull();
 
     // Simulate a dropped CF alarm handle: the _actor_alarms cron row persists
-    // (so getSchedules still reports it) but the underlying alarm is gone.
+    // but the underlying alarm is gone. Query SQL directly — touching
+    // do_.alarms would construct Alarms and re-set the alarm handle via
+    // _scheduleNextAlarm (#1073 lazy-init).
     state.storage.scheduledAlarm = null;
-    expect(
-      do_.alarms
-        .getSchedules({ type: "cron" })
-        .some((s) => s.callback === "runJob"),
-    ).toBe(true);
+    const cronRows = state.rawDb
+      .prepare(
+        `SELECT id FROM _actor_alarms WHERE type = 'cron' AND callback = 'runJob'`,
+      )
+      .all();
+    expect(cronRows.length).toBeGreaterThan(0);
 
     addBreadcrumbSpy.mockClear();
     await do_.armCron("sync-titles", "0 3 * * *");
@@ -1208,6 +1211,64 @@ describe("JobQueueDO", () => {
         "Recovered dropped cron alarm",
     );
     expect(recoveryBreadcrumb).toBeDefined();
+  });
+
+  // ── /arm non-blocking w.r.t. in-flight work (#1073) ───────────────────────
+
+  it("POST /arm returns skipped:busy when a job is running (#1073)", async () => {
+    await do_.armCron("sync-titles", "0 3 * * *");
+    state.rawDb
+      .prepare(
+        `INSERT INTO jobs (name, status, run_at, started_at, attempts, max_attempts)
+         VALUES ('sync-titles', 'running', datetime('now'), datetime('now'), 1, 3)`,
+      )
+      .run();
+
+    const res = await do_.fetch(
+      new Request("https://do/arm", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "sync-titles", cron: "0 3 * * *" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; skipped?: string };
+    expect(body.ok).toBe(true);
+    expect(body.skipped).toBe("busy");
+  });
+
+  it("armCron on a cold DO does not dispatch a due runJob via Alarms BCW (#1073)", async () => {
+    let handlerRuns = 0;
+    processorModule.handlers["sync-titles"] = async () => {
+      handlerRuns++;
+    };
+
+    await do_.armCron("sync-titles", "0 3 * * *");
+    // Make the cron schedule row due (as after hibernation across a fire time).
+    state.rawDb
+      .prepare("UPDATE _actor_alarms SET time = 0 WHERE callback = 'runJob'")
+      .run();
+
+    // Fresh DO on the same storage — simulates cold wake on POST /arm.
+    const cold = new JobQueueDO(state as any, fakeEnv as any);
+    const res = await cold.fetch(
+      new Request("https://do/arm", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "sync-titles", cron: "0 3 * * *" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    // Must not have run the job inside Alarms constructor blockConcurrencyWhile.
+    expect(handlerRuns).toBe(0);
+
+    // /tick remains the load-bearing path and still runs due work.
+    const tickRes = await cold.fetch(
+      new Request("https://do/tick", { method: "POST", body: "{}" }),
+    );
+    expect(tickRes.status).toBe(200);
+    expect(handlerRuns).toBe(1);
   });
 });
 

--- a/server/jobs/durable-object.ts
+++ b/server/jobs/durable-object.ts
@@ -109,9 +109,10 @@ export class JobQueueDO {
   private ctx: DurableObjectState;
   private env: DOEnv;
   private initialized = false;
-  // Cast to any: Alarms<P> requires P extends DurableObject, but P only needs
-  // callable methods by name at runtime. The constraint is TS-only.
-  alarms: Alarms<JobQueueDO>;
+  // Lazy: Alarms' constructor runs due callbacks inside blockConcurrencyWhile.
+  // Constructing it on every DO wake made POST /arm wait on long runJob and
+  // hit CF's BCW wall-time limit (#1073). Created on first schedule/alarm use.
+  private _alarms: Alarms<JobQueueDO> | null = null;
 
   constructor(ctx: DurableObjectState, env: DOEnv) {
     this.ctx = ctx;
@@ -124,12 +125,89 @@ export class JobQueueDO {
     if (env.LOG_LEVEL) {
       resetLogLevel(env.LOG_LEVEL as "debug" | "info" | "warn" | "error");
     }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    this.alarms = new Alarms(ctx, this as any);
   }
 
   /** Required stub — Alarms calls setName() on the parent before each callback. */
   setName(_name: string): void {}
+
+  /** Lazy Alarms accessor (tests + internal). Safe after catch-up in ensureAlarms. */
+  get alarms(): Alarms<JobQueueDO> {
+    return this.ensureAlarms();
+  }
+
+  /**
+   * Lazily construct Alarms after advancing past-due cron rows so its
+   * constructor blockConcurrencyWhile is a cheap schema/no-op pass (#1073).
+   * Watchdog /tick remains the load-bearing runner via isCronDue().
+   */
+  private ensureAlarms(): Alarms<JobQueueDO> {
+    if (!this._alarms) {
+      this.catchUpDueCronSchedules();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      this._alarms = new Alarms(this.ctx, this as any);
+    }
+    return this._alarms;
+  }
+
+  /** Create `_actor_alarms` without constructing Alarms (avoids BCW due-dispatch). */
+  private ensureActorAlarmsTable(): void {
+    this.ctx.storage.sql.exec(`
+      CREATE TABLE IF NOT EXISTS _actor_alarms (
+        id TEXT PRIMARY KEY NOT NULL DEFAULT (randomblob(9)),
+        callback TEXT,
+        payload TEXT,
+        type TEXT NOT NULL CHECK(type IN ('scheduled', 'delayed', 'cron')),
+        time INTEGER,
+        delayInSeconds INTEGER,
+        cron TEXT,
+        created_at INTEGER DEFAULT (unixepoch())
+      )
+    `);
+    try {
+      this.ctx.storage.sql.exec(`SELECT identifier FROM _actor_alarms LIMIT 1`);
+    } catch {
+      try {
+        this.ctx.storage.sql.exec(
+          `ALTER TABLE _actor_alarms ADD COLUMN identifier TEXT DEFAULT 'default'`,
+        );
+      } catch {
+        // Column add raced or unsupported — ignore; Alarms will retry.
+      }
+    }
+  }
+
+  /**
+   * Move past-due cron schedule rows to their next fire time without running
+   * callbacks. Prevents Alarms constructor BCW from dispatching long jobs when
+   * ensureAlarms() is first called after a hibernation (#1073).
+   */
+  private catchUpDueCronSchedules(): void {
+    this.ensureActorAlarmsTable();
+    const nowSec = Math.floor(Date.now() / 1000);
+    const due = this.ctx.storage.sql
+      .exec(
+        `SELECT id, cron FROM _actor_alarms WHERE type = 'cron' AND time <= ?`,
+        nowSec,
+      )
+      .toArray() as Array<{ id: string; cron: string | null }>;
+    for (const row of due) {
+      if (!row.cron) continue;
+      try {
+        const next = CronExpressionParser.parse(row.cron, {
+          currentDate: new Date(),
+        })
+          .next()
+          .toDate();
+        this.ctx.storage.sql.exec(
+          `UPDATE _actor_alarms SET time = ? WHERE id = ?`,
+          Math.floor(next.getTime() / 1000),
+          row.id,
+        );
+      } catch {
+        // Invalid cron — leave row alone.
+      }
+    }
+  }
 
   // ─── Schema bootstrap ────────────────────────────────────────────────────
 
@@ -176,6 +254,16 @@ export class JobQueueDO {
       }
       if (request.method === "POST" && path === "/arm") {
         const body = (await request.json()) as { name: string; cron: string };
+        // Non-blocking when a job is in flight: queueing /arm behind a long
+        // runJob (or Alarms BCW) is what produced exceededWallTime (#1073).
+        // Watchdog retries on the next */5 tick; cron rows persist meanwhile.
+        const busy =
+          this.ctx.storage.sql
+            .exec("SELECT 1 FROM jobs WHERE status = 'running' LIMIT 1")
+            .toArray().length > 0;
+        if (busy) {
+          return Response.json({ ok: true, skipped: "busy" });
+        }
         await this.armCron(body.name, body.cron);
         return Response.json({ ok: true });
       }
@@ -224,7 +312,7 @@ export class JobQueueDO {
   async alarm(): Promise<void> {
     this.initSchema();
     try {
-      await this.alarms.alarm();
+      await this.ensureAlarms().alarm();
     } finally {
       await this.ctx.storage.put(
         "alarm_last_completed_at",
@@ -542,19 +630,49 @@ export class JobQueueDO {
 
   // ─── Internal methods (also used by tests via subclass) ──────────────────
 
-  /** Arm this DO as a cron singleton. Idempotent — only schedules if no cron alarm exists. */
+  /**
+   * Arm this DO as a cron singleton. Idempotent — only schedules if no cron alarm exists.
+   *
+   * Does NOT construct Alarms: that library's constructor dispatches due alarms
+   * inside blockConcurrencyWhile, so a due long job on cold wake would reset the
+   * DO before /arm returns (#1073). Writes `_actor_alarms` + setAlarm directly;
+   * /tick is the load-bearing execution path.
+   */
   async armCron(name: string, cron: string): Promise<void> {
     this.initSchema();
     await this.ctx.storage.put("name", name);
     await this.ctx.storage.put("cron", cron);
-    const existing = this.alarms.getSchedules({ type: "cron" });
-    if (!existing.some((s) => s.callback === "runJob")) {
-      await this.alarms.schedule(cron, "runJob" as keyof JobQueueDO, null);
+    this.ensureActorAlarmsTable();
+
+    const existing = this.ctx.storage.sql
+      .exec(
+        `SELECT id FROM _actor_alarms WHERE type = 'cron' AND callback = 'runJob' LIMIT 1`,
+      )
+      .toArray();
+    if (existing.length === 0) {
+      let next: Date;
+      try {
+        next = CronExpressionParser.parse(cron, { currentDate: new Date() })
+          .next()
+          .toDate();
+      } catch {
+        return;
+      }
+      const id = crypto.randomUUID().replace(/-/g, "").slice(0, 9);
+      const nextTs = Math.floor(next.getTime() / 1000);
+      this.ctx.storage.sql.exec(
+        `INSERT INTO _actor_alarms (id, callback, payload, type, time, cron, identifier)
+         VALUES (?, 'runJob', 'null', 'cron', ?, ?, 'default')`,
+        id,
+        nextTs,
+        cron,
+      );
+      await this.ctx.storage.setAlarm(next);
       Sentry.addBreadcrumb({
         category: "jobs",
         message: "Re-armed cron schedule",
         level: "info",
-        data: { name, cron, priorScheduleCount: String(existing.length) },
+        data: { name, cron, priorScheduleCount: "0" },
       });
       return;
     }
@@ -562,10 +680,8 @@ export class JobQueueDO {
     // Defense-in-depth: a cron schedule row persists in DO SQL storage across
     // evictions, but the underlying CF storage alarm handle can be dropped (DO
     // eviction, or a wrapped entrypoint interfering with @cloudflare/actors/alarms,
-    // #795). When that happens getSchedules() still reports the schedule, so the
-    // guard above skips re-scheduling and the native alarm never fires again.
-    // Detect a missing alarm handle and force-set it to the next cron fire time so
-    // the alarm path self-recovers (the watchdog /tick is the primary driver).
+    // #795). Detect a missing alarm handle and force-set it to the next cron fire
+    // time so the alarm path self-recovers (the watchdog /tick is the primary driver).
     const pendingAlarm = await this.ctx.storage.getAlarm();
     if (pendingAlarm === null) {
       try {
@@ -621,9 +737,10 @@ export class JobQueueDO {
       .toArray() as Array<{ id: number }>;
 
     // Only schedule if no delayed runJob alarm is already pending
-    const existingAlarms = this.alarms.getSchedules({ type: "delayed" });
+    const alarms = this.ensureAlarms();
+    const existingAlarms = alarms.getSchedules({ type: "delayed" });
     if (!existingAlarms.some((s) => s.callback === "runJob")) {
-      await this.alarms.schedule(1, "runJob" as keyof JobQueueDO, null);
+      await alarms.schedule(1, "runJob" as keyof JobQueueDO, null);
     }
     return rows[0].id;
   }
@@ -708,7 +825,7 @@ export class JobQueueDO {
     const cron = (await this.ctx.storage.get<string>("cron")) ?? null;
     // nextRun is read from the Alarms table (authoritative next execution time)
     let nextRun: string | null = null;
-    const cronSchedules = this.alarms.getSchedules({ type: "cron" });
+    const cronSchedules = this.ensureAlarms().getSchedules({ type: "cron" });
     if (cronSchedules.length > 0) {
       const schedule = cronSchedules[0] as { time: number };
       nextRun = new Date(schedule.time * 1000).toISOString();
@@ -736,9 +853,10 @@ export class JobQueueDO {
       .exec("SELECT COUNT(*) as count FROM jobs WHERE status = 'pending'")
       .toArray() as Array<{ count: number }>;
     if ((rows[0]?.count ?? 0) > 0) {
-      const existing = this.alarms.getSchedules({ type: "delayed" });
+      const alarms = this.ensureAlarms();
+      const existing = alarms.getSchedules({ type: "delayed" });
       if (!existing.some((s) => s.callback === "runJob")) {
-        await this.alarms.schedule(1, "runJob" as keyof JobQueueDO, null);
+        await alarms.schedule(1, "runJob" as keyof JobQueueDO, null);
       }
     }
   }

--- a/server/worker.test.ts
+++ b/server/worker.test.ts
@@ -5,13 +5,14 @@ import Sentry from "./sentry";
 import { classifyError } from "./lib/error-classifier";
 import { errorsByCategory } from "./metrics";
 import {
-  maybeDeferRegistrySync,
+  maybeSyncAchievementRegistry,
   resetAchievementRegistrySync,
   handler,
 } from "./worker";
 import { logger } from "./logger";
 import { rateLimiter, type RateLimitStore } from "./middleware/rate-limit";
 import * as backendModule from "./jobs/backend";
+import * as achievementsModule from "./achievements";
 import * as schema from "./db/schema";
 import { withConfigGuard } from "./test-utils/config";
 
@@ -281,21 +282,9 @@ describe("unknown /api/* paths fall through to 404", () => {
   });
 });
 
-// ─── maybeDeferRegistrySync — deferral contract (#799) ───────────────────────
+// ─── maybeSyncAchievementRegistry — once-per-isolate cron/startup (#1067) ───
 
-describe("maybeDeferRegistrySync (#799 deferral contract)", () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  function makeCtx(): { ctx: any; captured: Promise<unknown>[] } {
-    const captured: Promise<unknown>[] = [];
-    const ctx = {
-      waitUntil: (p: Promise<unknown>) => {
-        captured.push(p);
-      },
-      passThroughOnException: () => {},
-    };
-    return { ctx, captured };
-  }
-
+describe("maybeSyncAchievementRegistry (#1067 cron/startup contract)", () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let logSpy: ReturnType<typeof spyOn<any, any>>;
 
@@ -309,57 +298,34 @@ describe("maybeDeferRegistrySync (#799 deferral contract)", () => {
     logSpy.mockRestore();
   });
 
-  it("returns synchronously without awaiting run", () => {
-    const { ctx, captured } = makeCtx();
-    let runStarted = false;
-    let resolveRun!: () => void;
-    const run = () =>
-      new Promise<void>((resolve) => {
-        runStarted = true;
-        resolveRun = resolve;
-      });
+  it("awaits run and sets the stampede guard", async () => {
+    let ran = 0;
+    await maybeSyncAchievementRegistry(async () => {
+      ran++;
+    });
+    expect(ran).toBe(1);
 
-    maybeDeferRegistrySync(ctx, run);
-
-    // run was invoked synchronously (promise created) but not yet resolved
-    expect(runStarted).toBe(true);
-    // ctx.waitUntil received exactly one promise
-    expect(captured).toHaveLength(1);
-    // function itself returned without awaiting — resolveRun still pending
-    resolveRun();
+    await maybeSyncAchievementRegistry(async () => {
+      ran++;
+    });
+    expect(ran).toBe(1);
   });
 
-  it("passes a promise to ctx.waitUntil, not void", () => {
-    const { ctx, captured } = makeCtx();
-    maybeDeferRegistrySync(ctx, () => Promise.resolve());
-    expect(captured[0]).toBeInstanceOf(Promise);
-  });
+  it("resets the flag on error so a later call retries", async () => {
+    await maybeSyncAchievementRegistry(() =>
+      Promise.reject(new Error("sync failed")),
+    );
 
-  it("does not call ctx.waitUntil a second time (stampede guard)", () => {
-    const { ctx, captured } = makeCtx();
-    maybeDeferRegistrySync(ctx, () => Promise.resolve());
-    maybeDeferRegistrySync(ctx, () => Promise.resolve());
-
-    expect(captured).toHaveLength(1);
-  });
-
-  it("resets the flag on error so a later request retries", async () => {
-    const { ctx, captured } = makeCtx();
-    maybeDeferRegistrySync(ctx, () => Promise.reject(new Error("sync failed")));
-
-    // Await the captured waitUntil promise (the .catch wrapper)
-    await captured[0];
-
-    // Error was logged
     expect(logSpy).toHaveBeenCalledWith(
       "Achievement registry sync failed",
       expect.objectContaining({ error: "sync failed" }),
     );
 
-    // Flag was reset — a subsequent call fires again
-    const { ctx: ctx2, captured: captured2 } = makeCtx();
-    maybeDeferRegistrySync(ctx2, () => Promise.resolve());
-    expect(captured2).toHaveLength(1);
+    let ran = false;
+    await maybeSyncAchievementRegistry(async () => {
+      ran = true;
+    });
+    expect(ran).toBe(true);
   });
 });
 
@@ -371,12 +337,21 @@ describe("scheduled() bootstrap KV timestamp", () => {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let spies: ReturnType<typeof spyOn<any, any>>[] = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let syncSpy: ReturnType<typeof spyOn<any, any>>;
 
   beforeEach(() => {
+    resetAchievementRegistrySync();
     // Stub out all heavy backend functions so scheduled() completes without a
     // real D1 DB or job infrastructure.
+    syncSpy = spyOn(
+      achievementsModule,
+      "syncAchievementRegistry",
+    ).mockResolvedValue(undefined);
     spies = [
+      syncSpy,
       spyOn(backendModule, "armCron").mockResolvedValue(undefined as any),
+      spyOn(backendModule, "tickCron").mockResolvedValue(undefined),
       spyOn(backendModule, "recoverStale").mockResolvedValue(0),
       spyOn(backendModule, "processPending").mockResolvedValue(0),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -394,6 +369,7 @@ describe("scheduled() bootstrap KV timestamp", () => {
   afterEach(() => {
     for (const spy of spies) spy.mockRestore();
     spies = [];
+    resetAchievementRegistrySync();
   });
 
   it("puts cron_bootstrap_last_seen_at into CACHE_KV when the scheduled handler runs", async () => {
@@ -430,6 +406,39 @@ describe("scheduled() bootstrap KV timestamp", () => {
     expect(bootstrapPut).toBeDefined();
     // Value should be a valid ISO timestamp
     expect(new Date(bootstrapPut![1]).getTime()).toBeGreaterThan(0);
+  });
+
+  it("syncs achievement registry on scheduled, not via fetch waitUntil (#1067)", async () => {
+    const fakeEnv = {
+      DB: {} as D1Database,
+      CACHE_KV: {
+        put: async () => {},
+        get: async () => null,
+      } as unknown as KVNamespace,
+      TMDB_COUNTRY: "HR",
+      TMDB_LANGUAGE: "hr-HR",
+      LOG_LEVEL: "info",
+    } as unknown as Parameters<typeof handler.scheduled>[1];
+
+    const fakeCtx = {
+      waitUntil: () => {},
+      passThroughOnException: () => {},
+    } as unknown as ExecutionContext;
+
+    await handler.scheduled(
+      { cron: "*/5 * * * *", type: "scheduled", scheduledTime: Date.now() },
+      fakeEnv,
+      fakeCtx,
+    );
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+
+    // Stampede guard — second tick in the same isolate does not re-sync.
+    await handler.scheduled(
+      { cron: "*/5 * * * *", type: "scheduled", scheduledTime: Date.now() },
+      fakeEnv,
+      fakeCtx,
+    );
+    expect(syncSpy).toHaveBeenCalledTimes(1);
   });
 
   it("isolates a failing armCron so remaining cron jobs still tick (#1055)", async () => {

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -201,25 +201,27 @@ function invalidateOidcConfig(): void {
 }
 
 /**
- * Defer achievement registry sync via ctx.waitUntil so it never blocks a
- * response. The per-isolate flag prevents stampedes; on error the flag resets
- * so the next request retries (#799).
+ * Sync the achievement registry once per isolate. Called from scheduled()
+ * (CF) and at process startup (Bun) — never from the fetch path.
+ *
+ * ctx.waitUntil on fetch still counts toward CF wallTimeMs, so deferring the
+ * UPSERT loop from the first request inflated p95 (#1067 / #799 recurrence).
+ * On error the flag resets so the next cron tick retries.
  */
-export function maybeDeferRegistrySync(
-  ctx: ExecutionContext,
+export async function maybeSyncAchievementRegistry(
   run: () => Promise<void>,
-): void {
+): Promise<void> {
   if (achievementRegistrySynced) return;
   achievementRegistrySynced = true;
-  ctx.waitUntil(
-    run().catch((err) => {
-      achievementRegistrySynced = false;
-      logger.error("Achievement registry sync failed", {
-        error: err instanceof Error ? err.message : String(err),
-        stack: err instanceof Error ? err.stack : undefined,
-      });
-    }),
-  );
+  try {
+    await run();
+  } catch (err) {
+    achievementRegistrySynced = false;
+    logger.error("Achievement registry sync failed", {
+      error: err instanceof Error ? err.message : String(err),
+      stack: err instanceof Error ? err.stack : undefined,
+    });
+  }
 }
 
 /** Reset the per-isolate achievement sync flag — test seam only. */
@@ -767,17 +769,6 @@ export const handler = {
         );
       }
 
-      // Sync achievement registry once per isolate, deferred so it never blocks
-      // the response — the first request to a cold isolate must not pay the ~4s
-      // UPSERT loop cost (#799). Runs in both DO and D1 modes.
-      maybeDeferRegistrySync(ctx, () =>
-        runWithEnv(cfEnv, () =>
-          runWithCache(cache, () =>
-            runWithDb(db, () => syncAchievementRegistry()),
-          ),
-        ),
-      );
-
       return response;
     } catch (err) {
       Sentry.captureException(err);
@@ -822,6 +813,11 @@ export const handler = {
                 new Date().toISOString(),
               );
             }
+
+            // Once per isolate — cron/startup only so fetch wallTimeMs stays
+            // clean (#1067). Bun still syncs at process boot in index.ts.
+            // BACKFILL_DONE_KEY sentinel (#1064) is unchanged inside sync.
+            await maybeSyncAchievementRegistry(() => syncAchievementRegistry());
 
             // Arm every cron-singleton DO, then drive it via /tick. armCron keeps
             // the native alarm schedule (and recovers a dropped alarm handle, #795),


### PR DESCRIPTION
## Summary
- **#1067**: Stop attaching achievement registry sync to fetch via `ctx.waitUntil` (still counted in CF `wallTimeMs`). Sync once per isolate from `scheduled()` instead; Bun still syncs at process startup. `BACKFILL_DONE_KEY` / #1064 sentinel alignment unchanged.
- **#1073**: Make `POST /arm` non-blocking w.r.t. in-flight work — lazy-init `@cloudflare/actors` `Alarms` (its constructor runs due jobs inside `blockConcurrencyWhile`), implement `armCron` via raw `_actor_alarms` + `setAlarm`, and return `{ skipped: "busy" }` when a job is already `running`. `/tick` remains the load-bearing runner.
- **#1066**: No app-side fix — `cpuTimeMs=0` / empty JS stack is a platform-level DO init failure, distinct from the #1073 BCW path. Left open for CF/Sentry re-auth monitoring.

## Test plan
- [x] `bun test server/jobs/durable-object.test.ts server/worker.test.ts`
- [x] `bun test server/jobs/backend.test.ts server/achievements/sync.test.ts server/jobs/backfill-achievements.test.ts`
- [ ] After deploy: confirm fetch p95 no longer shows "Syncing achievement registry" on cold HTTP; confirm fingerprint `2ffa1092…` (#1073) stays quiet; fingerprint `d2d3a715…` (#1066) still expected at low rate until platform investigation

Closes #1067
Closes #1073