### PR TITLE
[auto-review] fix(ux): show 'No poster' fallback when poster image fails to load

### DIFF
--- a/frontend/src/components/TitleCard.test.tsx
+++ b/frontend/src/components/TitleCard.test.tsx
@@ -7,7 +7,7 @@ import {
   beforeEach,
   spyOn,
 } from "bun:test";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import "../i18n";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -126,6 +126,17 @@ describe("TitleCard", () => {
     render(<TitleCard title={title} />, { wrapper: NoUserWrapper });
 
     expect(screen.getByText("No poster")).toBeDefined();
+  });
+
+  it("falls back to 'No poster' when the poster image fails to load", () => {
+    const title = makeTitle({ poster_url: "https://example.com/poster.jpg" });
+    render(<TitleCard title={title} />, { wrapper: NoUserWrapper });
+
+    const img = screen.getByAltText("Test Movie");
+    fireEvent.error(img);
+
+    expect(screen.getByText("No poster")).toBeDefined();
+    expect(screen.queryByAltText("Test Movie")).toBeNull();
   });
 
   it("shows TV badge for shows", () => {

--- a/frontend/src/components/TitleCard.tsx
+++ b/frontend/src/components/TitleCard.tsx
@@ -73,6 +73,7 @@ const TitleCard = memo(function TitleCard({
     title.remind_on_release ?? false,
   );
   const [tags, setTags] = useState<string[]>(title.tags ?? []);
+  const [posterError, setPosterError] = useState(false);
 
   // Re-sync local state when the card is reused for a different title.
   // Pattern from https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
@@ -83,6 +84,7 @@ const TitleCard = memo(function TitleCard({
     setSnoozeUntil(title.snooze_until);
     setRemindOnRelease(title.remind_on_release ?? false);
     setTags(title.tags ?? []);
+    setPosterError(false);
   }
 
   const isSnoozed = snoozeUntil != null && new Date(snoozeUntil) > new Date();
@@ -99,7 +101,7 @@ const TitleCard = memo(function TitleCard({
           data-title-link
           className="block w-full h-full focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/70 focus-visible:ring-inset"
         >
-          {title.poster_url ? (
+          {title.poster_url && !posterError ? (
             <img
               src={title.poster_url}
               alt={title.title}
@@ -107,6 +109,7 @@ const TitleCard = memo(function TitleCard({
               loading="lazy"
               width={342}
               height={513}
+              onError={() => setPosterError(true)}
             />
           ) : (
             <div className="w-full h-full flex items-center justify-center text-zinc-600 text-sm">


### PR DESCRIPTION
## Summary

- `TitleCard` had a gap in its poster fallback: when `title.poster_url` is a non-null URL but the TMDB CDN fails to serve it (404, network error), the browser displayed a broken-image icon instead of the existing "No poster" text placeholder.
- Adds a `posterError` boolean state that flips to `true` on the `<img onError>` event, which routes rendering to the same `"No poster"` div already shown for `poster_url: null`.
- `posterError` resets to `false` when the card is reused for a different title (via the existing `title.id !== prevTitleId` guard), preventing stale error state in virtualised lists.
- Adds a regression test: `fireEvent.error(img)` → "No poster" is shown and the broken img is removed.

## Files changed

| File | Change |
|---|---|
| `frontend/src/components/TitleCard.tsx` | +2 state, +1 `onError` handler, condition widened to `poster_url && !posterError` |
| `frontend/src/components/TitleCard.test.tsx` | +1 regression test (27 tests, 0 fail) |

## Test plan

- [x] `bun run check` passes (2292 server + 1138 frontend tests, 0 failures)
- [x] Pre-push hooks (types + lint + changed-tests) pass
- [x] `fireEvent.error` regression test added to `TitleCard.test.tsx`
- [x] Bundle size within budget

---
_Source: ux_

---
_Generated by [Claude Code](https://claude.ai/code/session_015Jq9AqtK1rn3PuGkAGMStX)_