### PR TITLE
[auto-review] fix(a11y): compute mobile calendar toggle aria-pressed from state

### DIFF
--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -429,6 +429,8 @@ function MobileCalendar({
     setMonthParam(formatMonth(d));
   }
 
+  const mobileMonthActive = mobileView === "month";
+
   return (
     <div className="space-y-0">
       {mobileView === "month" && (
@@ -464,14 +466,14 @@ function MobileCalendar({
           <div className="flex gap-2 px-5 pb-4">
             <button
               onClick={() => setMobileView("month")}
-              aria-pressed={true}
+              aria-pressed={mobileMonthActive}
               className="px-3 py-1.5 rounded-full bg-amber-400 text-black text-[11px] font-bold font-mono"
             >
               Month
             </button>
             <button
               onClick={() => setMobileView("agenda")}
-              aria-pressed={false}
+              aria-pressed={!mobileMonthActive}
               className="px-3 py-1.5 rounded-full bg-white/[0.06] text-zinc-300 text-[11px] font-semibold font-mono"
             >
               Agenda
@@ -493,14 +495,14 @@ function MobileCalendar({
           <div className="flex gap-2 px-4 pt-2 pb-2">
             <button
               onClick={() => setMobileView("month")}
-              aria-pressed={false}
+              aria-pressed={mobileMonthActive}
               className="px-3 py-1.5 rounded-full bg-white/[0.06] text-zinc-300 text-[11px] font-semibold font-mono"
             >
               Month
             </button>
             <button
               onClick={() => setMobileView("agenda")}
-              aria-pressed={true}
+              aria-pressed={!mobileMonthActive}
               className="px-3 py-1.5 rounded-full bg-amber-400 text-black text-[11px] font-bold font-mono"
             >
               Agenda


### PR DESCRIPTION
## What

`CalendarPage.tsx` renders two separate mobile view-toggle button groups (Month / Agenda) inside conditional branches. Each had hardcoded `aria-pressed={true}` / `aria-pressed={false}` values that happened to be correct only because each group appeared in the branch where its values matched.

TypeScript's type narrowing actually validates this: inside `{mobileView === "month" && …}`, comparing `mobileView === "agenda"` is always `false` — TS would flag it as TS2367 if written that way. The hardcoded literals were the only reason this compiled silently.

**The risk:** if the JSX ever gets restructured (e.g. extracting the toggle into a shared component, or adding a third view), the hardcoded `true`/`false` would silently mislead screen readers.

## Change

Hoist `const mobileMonthActive = mobileView === "month"` above the conditional render and use `aria-pressed={mobileMonthActive}` / `aria-pressed={!mobileMonthActive}` in both toggle groups. The `aria-pressed` values are now always derived from the same state variable — correct by construction, not by coincidence.

```diff
+ const mobileMonthActive = mobileView === "month";
  …
  {mobileView === "month" && (
    …
-   <button aria-pressed={true}>Month</button>
-   <button aria-pressed={false}>Agenda</button>
+   <button aria-pressed={mobileMonthActive}>Month</button>
+   <button aria-pressed={!mobileMonthActive}>Agenda</button>
  )}
  {mobileView === "agenda" && (
    …
-   <button aria-pressed={false}>Month</button>
-   <button aria-pressed={true}>Agenda</button>
+   <button aria-pressed={mobileMonthActive}>Month</button>
+   <button aria-pressed={!mobileMonthActive}>Agenda</button>
  )}
```

## Verification

- `bun run check:fast` (tsc + e2e tsc + frontend tsc + ESLint): ✅ clean
- Pre-push hook (changed-tests + types-and-lint): ✅ 49 tests pass

---
_Source: ux_

---
_Generated by [Claude Code](https://claude.ai/code/session_016j6UMwJJmohQz6D4G8mV4Q)_